### PR TITLE
setting only one location for task start/stop, to make it easier to read in log

### DIFF
--- a/docs/task/taks_nomadic_merchant.md
+++ b/docs/task/taks_nomadic_merchant.md
@@ -1,0 +1,51 @@
+# Introduction 
+
+Explain the expected nomadic merchant task execution.
+
+# Task Pre-requesite
+
+Must be on the world or home screen, to have shop button appear.
+
+# Task Execution
+
+Action : Tap the shop Button.  
+Result : The nomadic Marchant screen appear.
+
+    do
+        do
+            for each (wood, coal, meat, iron) search for a card . if found tap it
+            (option) Search for a VIP card. if found tap it.
+        while (a card was found)
+
+        if(free refresh available) tap it.
+    while(free refresh was taped)
+
+# Task End
+
+reschedule for next day after reset.
+
+# Exit cases : 
+
+Success - a search has been executed, for a free resources, a vip point, a free refresh. The task exit without purchase.  
+Success - a search has been executed, for a free resources, a vip point, a free refresh. The task exit with at least one purchase.  
+Fail - shop button not found.
+
+# Failure case not handled :
+
+- Free Ressource purchase failed.
+- VIP point purchase tap failed.
+
+To avoid unamaged error leading to endless loop, task limits its execution to 2 minutes.
+
+- Tap daily refresh failed (not refreshed). In that case the task will end without purchasing all it could.
+
+# Stat
+
+A log will display at each execution : 
+  - How many card not paid were taped
+  - How many VIP card were taped.
+  - Hown many refresh called.
+
+The statistic screen will display the stat for the last run.
+Those stat help appreciate the task efficiency, and detect issue by anyone.
+

--- a/wos-hmi/src/main/java/cl/camodev/wosbot/statistics/view/StatisticsLayoutController.java
+++ b/wos-hmi/src/main/java/cl/camodev/wosbot/statistics/view/StatisticsLayoutController.java
@@ -51,6 +51,10 @@ public class StatisticsLayoutController extends AbstractProfileController {
         COUNTER_CATEGORIES.put("Daily Refreshes Used", "Economy");
         COUNTER_CATEGORIES.put("Alliance Shop Purchases", "Economy");
         COUNTER_CATEGORIES.put("Gather Marches Deployed", "Economy");
+        COUNTER_CATEGORIES.put("Nomadic Merchant Free Resources Claimed", "Economy");
+        COUNTER_CATEGORIES.put("Nomadic Merchant VIP Points Purchased", "Economy");
+        COUNTER_CATEGORIES.put("Nomadic Merchant Daily Refresh Used", "Economy");
+
         // Training & Research
         COUNTER_CATEGORIES.put("Training Batches Started", "Training & Research");
         COUNTER_CATEGORIES.put("Research Started", "Training & Research");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/DelayedTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/DelayedTask.java
@@ -207,6 +207,7 @@ public abstract class DelayedTask implements Runnable, Delayed {
         int initialTemplateFailures = this.templateSearchHelper.getFailedSearches();
 
         try {
+
             // InitializeTask, SkipTutorialTask, and CreateCharacterTask have special handling
             if (this instanceof InitializeTask || this instanceof SkipTutorialTask || this instanceof CreateCharacterTask) {
                 execute();
@@ -443,8 +444,7 @@ public abstract class DelayedTask implements Runnable, Delayed {
     // ========================================================================
 
     public void logInfo(String message) {
-        String prefixedMessage = profile.getName() + " - " + message;
-        logger.info(prefixedMessage);
+        logger.info(message);
         servLogs.appendLog(EnumTpMessageSeverity.INFO, taskName, profile.getName(), message);
     }
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/TaskQueue.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/TaskQueue.java
@@ -44,6 +44,7 @@ public class TaskQueue {
 
     private static final Logger logger = LoggerFactory.getLogger(TaskQueue.class);
     private static final long IDLE_WAIT_TIME = 999; // milliseconds to wait between task checking cycles
+    protected static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss");
 
     private final TaskPriorityProvider priorityProvider = new DefaultTaskPriorityProvider();
 
@@ -338,7 +339,7 @@ public class TaskQueue {
 
             task.setLastExecutionTime(LocalDateTime.now());
             task.run();
-
+            logInfoWithTask(task, "Task Completed: " + task.getTaskName() + ", scheduled : " + task.getScheduled().format(DATETIME_FORMATTER));
             executionSuccessful = true;
 
             // Check if daily missions should be scheduled

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceAutojoinTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceAutojoinTask.java
@@ -147,7 +147,6 @@ public class AllianceAutojoinTask extends DelayedTask {
 	 */
 	@Override
 	protected void execute() {
-		logInfo("Starting Alliance auto-join configuration");
 
 		loadConfiguration();
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceChampionshipTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceChampionshipTask.java
@@ -212,7 +212,6 @@ public class AllianceChampionshipTask extends DelayedTask {
      */
     @Override
     protected void execute() {
-        logInfo("Starting Alliance Championship task execution");
 
         if (!verifyExecutionWindow()) {
             // Outside window - reschedule for next window

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceChestTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceChestTask.java
@@ -25,7 +25,6 @@ public class AllianceChestTask extends DelayedTask {
 
 	@Override
 	protected void execute() {
-		logInfo("Starting alliance chest collection task.");
 
 		if (!navigateToAllianceScreen()) {
 			rescheduleAndExit("Failed to navigate to alliance screen");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceMobilizationTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceMobilizationTask.java
@@ -472,8 +472,6 @@ public class AllianceMobilizationTask extends DelayedTask {
         initializeOCRHelpers();
         loadConfiguration();
 
-        logInfo("Starting Alliance Mobilization task execution");
-
         if (!navigateWithRetry()) {
             handleNavigationFailure();
             return;
@@ -491,7 +489,6 @@ public class AllianceMobilizationTask extends DelayedTask {
             applyFallbackReschedule();
         }
 
-        logInfo("Alliance Mobilization - Task completed");
     }
 
     /**

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceShopTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceShopTask.java
@@ -242,8 +242,6 @@ public class AllianceShopTask extends DelayedTask {
     protected void execute() {
         loadConfiguration();
 
-        logInfo("Starting Alliance Shop purchase task.");
-
         if (!navigateToShopAndReadCoins()) {
             logWarning("Failed to navigate to shop or read coins. Task ending.");
             setRecurring(false);
@@ -268,7 +266,7 @@ public class AllianceShopTask extends DelayedTask {
         processPurchases(enabledPriorities);
 
         setRecurring(false);
-        logInfo("Alliance Shop task completed.");
+
     }
 
     // ========================================================================

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceTechTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/AllianceTechTask.java
@@ -161,7 +161,6 @@ public class AllianceTechTask extends DelayedTask {
 	 */
 	@Override
 	protected void execute() {
-		logInfo("Starting Alliance Tech donation task");
 
 		donationsSuccessful = false;
 		loadConfiguration();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ArenaTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ArenaTask.java
@@ -187,8 +187,6 @@ public class ArenaTask extends DelayedTask {
             return; // Reschedule handled inside validation
         }
 
-        logInfo("Starting arena task.");
-
         if (!navigateToArena()) {
             logWarning("Failed to navigate to arena.");
             rescheduleWithActivationHour();
@@ -213,7 +211,6 @@ public class ArenaTask extends DelayedTask {
 
         processChallenges();
 
-        logInfo("Arena task completed successfully.");
         rescheduleWithActivationHour();
     }
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/BankTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/BankTask.java
@@ -138,7 +138,6 @@ public class BankTask extends DelayedTask {
 	 */
 	@Override
 	protected void execute() {
-		logInfo("Starting bank task");
 
 		loadBankConfiguration();
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/BearTrapTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/BearTrapTask.java
@@ -418,7 +418,6 @@ public class BearTrapTask extends DelayedTask {
      */
     @Override
     protected void execute() {
-        logInfo("Starting Bear Trap task execution");
         loadConfiguration();
 
         // Early exit if outside window - no execution, no cleanup needed
@@ -465,9 +464,6 @@ public class BearTrapTask extends DelayedTask {
             } else {
                 logInfo("Trap already ended for this window");
             }
-
-            logInfo("Bear Trap cycle completed successfully");
-
         } catch (Exception e) {
             logError("Error during Bear Trap execution: " + e.getMessage(), e);
         } finally {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ChiefOrderTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ChiefOrderTask.java
@@ -140,7 +140,7 @@ public class ChiefOrderTask extends DelayedTask {
 	 */
 	@Override
 	protected void execute() {
-		logInfo("Starting Chief Order task: " + chiefOrderType.getDescription() +
+		logInfo("Starting Chief Order : " + chiefOrderType.getDescription() +
 				" (Cooldown: " + chiefOrderType.getCooldownHours() + " hours)");
 
 		if (!openChiefOrderMenu()) {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/CreateCharacterTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/CreateCharacterTask.java
@@ -66,7 +66,6 @@ public class CreateCharacterTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("Start");
 
         Integer maxAgeMinutes = profile.getConfig(
                 EnumConfigurationKey.CREATE_CHARACTER_MAX_AGE_MINUTES_INT,

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/CrystalLaboratoryTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/CrystalLaboratoryTask.java
@@ -154,7 +154,7 @@ public class CrystalLaboratoryTask extends DelayedTask {
      */
     @Override
     protected void execute() {
-        logInfo("Starting Crystal Laboratory task");
+
         loadConfiguration();
 
         if (!navigateToCrystalLaboratory()) {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/DailyLabyrinthTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/DailyLabyrinthTask.java
@@ -58,7 +58,6 @@ public class DailyLabyrinthTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("Starting Daily Labyrinth task for profile: " + profile.getName());
 
         try {
             // Step 1: Navigate to labyrinth menu
@@ -70,7 +69,6 @@ public class DailyLabyrinthTask extends DelayedTask {
             // Step 2: Execute challenges based on current day
             executeLabyrinthChallenges();
 
-            logInfo("Daily Labyrinth task completed successfully for profile: " + profile.getName());
             reschedule(UtilTime.getGameReset());
 
         } catch (Exception e) {

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/DailyMissionTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/DailyMissionTask.java
@@ -104,7 +104,6 @@ public class DailyMissionTask extends DelayedTask {
 	 */
 	@Override
 	protected void execute() {
-		logInfo("Starting daily mission task");
 
 		loadTaskConfiguration();
 		navigateToDailyMissions();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/DoExplorationTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/DoExplorationTask.java
@@ -20,7 +20,6 @@ public class DoExplorationTask extends DelayedTask {
     @Override
 
     protected void execute() {
-        logInfo("Starting Do Exploration task...");
 
         tapRandomPoint(new DTOPoint(40, 1190), new DTOPoint(100, 1250));
         sleepTask(500);
@@ -79,11 +78,10 @@ public class DoExplorationTask extends DelayedTask {
                 }
             }
 
-            logInfo("Exploration loop ended. Rescheduling.");
             this.reschedule(LocalDateTime.now().plusHours(1));
 
         } else {
-            logWarning("Exploration button not found. Stopping task.");
+            logWarning("Exploration button not found");
             this.reschedule(LocalDateTime.now().plusHours(1));
         }
     }

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/DummyTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/DummyTask.java
@@ -22,7 +22,7 @@ public class DummyTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("Starting Dummy Task - Searching for GO image...");
+        logInfo("Searching for GO image...");
 
         while (true) {
             // Check for preemption or stop signals relative to the task framework

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExpertSkillTrainingTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExpertSkillTrainingTask.java
@@ -27,7 +27,6 @@ public class ExpertSkillTrainingTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("Starting Expert Skill Training task.");
 
         // Get priority list configuration
         List<DTOPriorityItem> enabledPriorities = PriorityItemUtil.getEnabledPriorities(

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExpertsAgnesIntelTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExpertsAgnesIntelTask.java
@@ -151,7 +151,6 @@ public class ExpertsAgnesIntelTask extends DelayedTask {
      */
     @Override
     protected void execute() {
-        logInfo("Attempting to claim extra intel from Agnes");
 
         intelScreenHelper.ensureOnIntelScreen();
 
@@ -163,7 +162,6 @@ public class ExpertsAgnesIntelTask extends DelayedTask {
         }
 
         rescheduleToGameReset();
-        logInfo("Agnes intel task completed");
     }
 
     // ========================================================================

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExpertsRomulusTagTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExpertsRomulusTagTask.java
@@ -161,7 +161,6 @@ public class ExpertsRomulusTagTask extends DelayedTask {
      */
     @Override
     protected void execute() {
-        logInfo("Attempting to claim loyalty tags from Romulus");
 
         if (!navigateToRomulusIcon()) {
             return; // Navigation failed, already rescheduled
@@ -175,7 +174,7 @@ public class ExpertsRomulusTagTask extends DelayedTask {
         }
 
         rescheduleToGameReset();
-        logInfo("Romulus tags task completed");
+
     }
 
     // ========================================================================

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExpertsRomulusTroopsTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExpertsRomulusTroopsTask.java
@@ -182,7 +182,6 @@ public class ExpertsRomulusTroopsTask extends DelayedTask {
      */
     @Override
     protected void execute() {
-        logInfo("Attempting to claim troops from Romulus");
 
         // Load and validate troop type configuration
         String troopType = loadTroopTypeConfiguration();
@@ -211,7 +210,6 @@ public class ExpertsRomulusTroopsTask extends DelayedTask {
         }
 
         rescheduleToGameReset();
-        logInfo("Romulus troops task completed");
     }
 
     // ========================================================================

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExplorationTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ExplorationTask.java
@@ -19,7 +19,6 @@ public class ExplorationTask extends DelayedTask {
 
 	@Override
 	protected void execute() {
-		logInfo("Starting exploration task.");
 		tapRandomPoint(new DTOPoint(40, 1190), new DTOPoint(100, 1250));
 		sleepTask(500);
 		DTOImageSearchResult claimResult = templateSearchHelper.searchTemplate(
@@ -48,7 +47,7 @@ public class ExplorationTask extends DelayedTask {
 			Integer minutes = profile.getConfig(EnumConfigurationKey.INT_EXPLORATION_CHEST_OFFSET, Integer.class);
 			LocalDateTime nextSchedule = LocalDateTime.now().plusMinutes(minutes);
 			this.reschedule(nextSchedule);
-			logInfo("Exploration task completed. Next execution scheduled in " + minutes + " minutes.");
+			logInfo("Next execution scheduled in " + minutes + " minutes.");
 
 		}
 		tapBackButton();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/FishingMinigameTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/FishingMinigameTask.java
@@ -114,7 +114,6 @@ public class FishingMinigameTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("Fishing Minigame: PCV algorithm started.");
         trackedFish.clear();
         nextTrackId = 0;
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherSpeedTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/GatherSpeedTask.java
@@ -98,7 +98,7 @@ public class GatherSpeedTask extends DelayedTask {
 	protected void execute() {
 		loadConfiguration();
 
-		logInfo(String.format("Starting gather speed boost task (%s).", boostType.getName()));
+		logInfo(String.format("Starting gather speed boost (%s).", boostType.getName()));
 
 		if (!navigateToGatheringSpeed()) {
 			logWarning("Failed to navigate to gathering speed menu. Rescheduling in 5 minutes.");
@@ -114,7 +114,6 @@ public class GatherSpeedTask extends DelayedTask {
 
 		closeMenuAndReturn();
 
-		logInfo("Gather speed boost activated successfully.");
 		rescheduleForBoostDuration();
 	}
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/HeroMissionEventTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/HeroMissionEventTask.java
@@ -38,7 +38,6 @@ public class HeroMissionEventTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("=== Starting Hero's Mission ===");
 
         flagNumber = profile.getConfig(EnumConfigurationKey.HERO_MISSION_FLAG_INT, Integer.class);
         useFlag = flagNumber > 0;

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/HeroRecruitmentTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/HeroRecruitmentTask.java
@@ -128,7 +128,6 @@ public class HeroRecruitmentTask extends DelayedTask {
      */
     @Override
     protected void execute() {
-        logInfo("Starting hero recruitment task");
 
         navigateToHeroRecruitment();
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/InitializeTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/InitializeTask.java
@@ -109,7 +109,6 @@ public class InitializeTask extends DelayedTask {
 	@Override
 	protected void execute() {
 		setRecurring(false);
-		logInfo("Starting initialization task...");
 
 		ensureEmulatorRunning();
 		ensureGameInstalled();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/IntelligenceTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/IntelligenceTask.java
@@ -77,7 +77,6 @@ public class IntelligenceTask extends DelayedTask {
 
 	@Override
 	protected void execute() {
-		logInfo("Starting Intel task.");
 
 		// Load configuration fresh after profile refresh
 		loadConfiguration();
@@ -160,7 +159,6 @@ public class IntelligenceTask extends DelayedTask {
 			handleRescheduling(anyIntelProcessed, nonBeastIntelProcessed, marchesAvailable);
 		}
 
-		logInfo("Intel Task finished");
 	}
 
 	/**

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/JourneyofLightTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/JourneyofLightTask.java
@@ -26,8 +26,6 @@ public class JourneyofLightTask extends DelayedTask {
     @Override
     protected void execute() {
 
-        logInfo("Starting Journey of Light task.");
-
         this.textHelper = new TextRecognitionRetrier<>(provider);
 
         DTOImageSearchResult dealsResult = templateSearchHelper.searchTemplate(
@@ -103,9 +101,7 @@ public class JourneyofLightTask extends DelayedTask {
             logInfo("Next queue time for queue " + profile.getName() + ": "
                     + UtilTime.localDateTimeToDDHHMMSS(nextQueueTime));
         }
-
-        // set for when the next one is ready
-        logInfo("Next task scheduled to run in: " + UtilTime.localDateTimeToDDHHMMSS(nextScheduleTime));
+;
         reschedule(nextScheduleTime);
 
         sleepTask(200);

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/LifeEssenceCaringTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/LifeEssenceCaringTask.java
@@ -42,7 +42,6 @@ public class LifeEssenceCaringTask extends DelayedTask {
 
 	@Override
 	protected void execute() {
-		logInfo("=== Starting Life Essence Caring Task ===");
 
 		// Load configuration
 		loadConfiguration();
@@ -77,7 +76,7 @@ public class LifeEssenceCaringTask extends DelayedTask {
 		}
 
 		// No island found - retry later
-		logInfo("No island needing care found. Rescheduling in " + retryOffsetMinutes + " minutes.");
+
 		closeAllMenus();
 		reschedule(LocalDateTime.now().plusMinutes(retryOffsetMinutes));
 	}

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/LifeEssenceTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/LifeEssenceTask.java
@@ -59,7 +59,6 @@ public class LifeEssenceTask extends DelayedTask {
 
 	@Override
 	protected void execute() {
-		logInfo("=== Starting Life Essence Task ===");
 
 		// Load configuration
 		loadConfiguration();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ManualRallyJoin.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ManualRallyJoin.java
@@ -24,7 +24,6 @@ public class ManualRallyJoin extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("=== Starting Manual Rally Join Task ===");
 
         // Search for the rally indicator
         logInfo("Searching for rally indicator...");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/MercenaryEventTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/MercenaryEventTask.java
@@ -42,7 +42,6 @@ public class MercenaryEventTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("=== Starting Mercenary Event ===");
 
         flagNumber = profile.getConfig(EnumConfigurationKey.MERCENARY_FLAG_INT, Integer.class);
         useFlag = flagNumber > 0;

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/MyriadBazaarEventTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/MyriadBazaarEventTask.java
@@ -82,7 +82,6 @@ public class MyriadBazaarEventTask extends DelayedTask {
                             .withCoordinates(topLeft, bottomRight)
                             .build());
         }
-        logInfo("Finished claiming Myriad Bazaar free rewards");
         reschedule(UtilTime.getGameReset());
 
     }

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/NewSurvivorsTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/NewSurvivorsTask.java
@@ -20,7 +20,6 @@ public class NewSurvivorsTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("Starting the New Survivors task.");
 
         // I need to search for New Survivors Template
         logInfo("Searching for the 'New Survivors' notification.");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/NomadicMerchantTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/NomadicMerchantTask.java
@@ -7,6 +7,7 @@ import cl.camodev.wosbot.console.enumerable.TpDailyTaskEnum;
 import cl.camodev.wosbot.ot.DTOImageSearchResult;
 import cl.camodev.wosbot.ot.DTOPoint;
 import cl.camodev.wosbot.ot.DTOProfiles;
+import cl.camodev.wosbot.serv.impl.ServStatistics;
 import cl.camodev.wosbot.serv.task.DelayedTask;
 import cl.camodev.wosbot.serv.task.EnumStartLocation;
 import cl.camodev.wosbot.serv.task.constants.SearchConfigConstants;
@@ -15,6 +16,8 @@ import cl.camodev.wosbot.serv.task.helper.TemplateSearchHelper;
 import java.time.LocalDateTime;
 
 public class NomadicMerchantTask extends DelayedTask {
+
+    private static final long MAX_TASK_EXECUTION_MS = 2 * 60 * 1000L;
 
     private final EnumTemplates[] TEMPLATES = { EnumTemplates.NOMADIC_MERCHANT_COAL,
             EnumTemplates.NOMADIC_MERCHANT_MEAT, EnumTemplates.NOMADIC_MERCHANT_STONE,
@@ -46,13 +49,17 @@ public class NomadicMerchantTask extends DelayedTask {
 
         // STEP 2: Main loop to handle all nomadic merchant operations
         boolean continueOperations = true;
+        int freeResourcesClaimedCount = 0;
+        int vipPointsPurchasedCount = 0;
+        int dailyRefreshUsedCount = 0;
+        long executionDeadlineMs = System.currentTimeMillis() + MAX_TASK_EXECUTION_MS;
 
-        while (continueOperations) {
+        while (continueOperations && System.currentTimeMillis() < executionDeadlineMs) {
             // PHASE 1: Search for resource templates until none are found
             boolean foundResourceTemplate = true;
             logInfo("Searching for free resources to claim.");
 
-            while (foundResourceTemplate) {
+            while (foundResourceTemplate && System.currentTimeMillis() < executionDeadlineMs) {
                 foundResourceTemplate = false;
 
                 // Iterate through each resource template
@@ -70,10 +77,16 @@ public class NomadicMerchantTask extends DelayedTask {
                         logInfo("Found resource: " + template.name() + ". Purchasing it.");
                         tapPoint(result.getPoint());
                         sleepTask(500);
+                        freeResourcesClaimedCount++;
                         foundResourceTemplate = true;
                         break; // Restart resource search from beginning
                     }
                 }
+            }
+
+            if (System.currentTimeMillis() >= executionDeadlineMs) {
+                continueOperations = false;
+                break;
             }
 
             // PHASE 2: Check if VIP purchase is enabled and search for VIP templates
@@ -103,6 +116,7 @@ public class NomadicMerchantTask extends DelayedTask {
                     tapPoint(new DTOPoint(355, 788));
                     sleepTask(1000);
 
+                    vipPointsPurchasedCount++;
                     foundVipTemplate = true;
                 }
             }
@@ -123,6 +137,7 @@ public class NomadicMerchantTask extends DelayedTask {
                 logInfo("Daily refresh is available. Using it now.");
                 tapRandomPoint(dailyRefreshResult.getPoint(), dailyRefreshResult.getPoint());
                 sleepTask(2000); // Wait longer for refresh to complete
+                dailyRefreshUsedCount++;
                 // Continue the main loop to check for new items after refresh
             } else {
                 // PHASE 5: No refresh available, operations complete
@@ -130,6 +145,21 @@ public class NomadicMerchantTask extends DelayedTask {
                 continueOperations = false;
             }
         }
+
+        if (System.currentTimeMillis() <= executionDeadlineMs) {
+            ServStatistics.getServices().increment(profile, "Nomadic Merchant Free Resources Claimed", freeResourcesClaimedCount);
+            ServStatistics.getServices().increment(profile, "Nomadic Merchant VIP Points Purchased", vipPointsPurchasedCount);
+            ServStatistics.getServices().increment(profile, "Nomadic Merchant Daily Refresh Used", dailyRefreshUsedCount);
+
+            logInfo("Nomadic Merchant stats - free resources claimed: " + freeResourcesClaimedCount
+                    + ", VIP points purchased: " + vipPointsPurchasedCount
+                    + ", daily refresh used: " + dailyRefreshUsedCount);
+        }
+        else
+        {
+            logWarning("Nomadic Merchant task reached execution limit. Ending current cycle to avoid infinite loop.");
+        }
+
         // Final step: schedule task till game reset
         reschedule(UtilTime.getGameReset());
     }

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/NomadicMerchantTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/NomadicMerchantTask.java
@@ -26,7 +26,6 @@ public class NomadicMerchantTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("Starting the Nomadic Merchant task.");
 
         // STEP 1: Navigate to shop - Search for the bottom bar shop button
         DTOImageSearchResult shopButtonResult = templateSearchHelper.searchTemplate(
@@ -132,7 +131,6 @@ public class NomadicMerchantTask extends DelayedTask {
             }
         }
         // Final step: schedule task till game reset
-        logInfo("Rescheduling Nomadic Merchant task for the next game reset.");
         reschedule(UtilTime.getGameReset());
     }
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetAdventureChestTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetAdventureChestTask.java
@@ -139,7 +139,6 @@ public class PetAdventureChestTask extends DelayedTask {
 	 */
 	@Override
 	protected void execute() {
-		logInfo("Starting pet adventure chest management");
 
 		// Validate stamina before proceeding
 		if (!staminaHelper.checkStaminaOrReschedule(

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetAllianceTreasuresTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetAllianceTreasuresTask.java
@@ -100,7 +100,6 @@ public class PetAllianceTreasuresTask extends DelayedTask {
 	 */
 	@Override
 	protected void execute() {
-		logInfo("Starting alliance treasure claim process");
 
 		if (!navigateToBeastCage()) {
 			rescheduleForRetry();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetSkillsTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PetSkillsTask.java
@@ -239,7 +239,7 @@ public class PetSkillsTask extends DelayedTask {
             return;
         }
 
-        logInfo(String.format("Starting Pet Skills task for %d skill(s).", enabledSkills.size()));
+        logInfo(String.format("Pet Skills for %d skill(s).", enabledSkills.size()));
 
         if (!openPetsMenu()) {
             handleMenuOpenFailure();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PolarTerrorHuntingTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PolarTerrorHuntingTask.java
@@ -344,27 +344,25 @@ public class PolarTerrorHuntingTask extends DelayedTask {
             return false;
         }
 
+        // Polar terror slider positions, exists only from level 4.
         DTOPoint[] levelPoints = {
-                new DTOPoint(129, 1052), // Level 1
-                new DTOPoint(173, 1052), // Level 2
-                new DTOPoint(217, 1052), // Level 3
-                new DTOPoint(261, 1052), // Level 4
-                new DTOPoint(305, 1052), // Level 5
-                new DTOPoint(349, 1052), // Level 6
-                new DTOPoint(393, 1052), // Level 7
-                new DTOPoint(437, 1052) // Level 8
+                new DTOPoint(129, 1052), // Level 4
+                new DTOPoint(200, 1052), // Level 5
+                new DTOPoint(280, 1052), // Level 6
+                new DTOPoint(357, 1052), // Level 7
+                new DTOPoint(432, 1052), // Level 8
         };
         // Need to tap on the polar terror icon and set the level
         tapPoint(polarTerror.getPoint());
         sleepTask(100);
         if (polarLevel != -1) {
             logInfo(String.format("Adjusting Polar Terror level to %d", polarLevel));
-            if (polarLevel < 1 || polarLevel > levelPoints.length) {
-                logError(String.format("Invalid Polar Terror level configured: %d. Must be between 1 and %d.",
+            if (polarLevel < 4 || polarLevel > levelPoints.length + 3) {
+                logError(String.format("Invalid Polar Terror level configured: %d. Must be between 4 and %d.",
                         polarLevel, MAX_POLAR_LEVEL));
                 return false;
             }
-            tapRandomPoint(levelPoints[polarLevel - 1], levelPoints[polarLevel - 1], 3, 100);
+            tapRandomPoint(levelPoints[polarLevel - 4], levelPoints[polarLevel - 4], 3, 100);
         }
         // tap on search button
         logDebug("Tapping on search button...");

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PolarTerrorHuntingTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PolarTerrorHuntingTask.java
@@ -63,7 +63,6 @@ public class PolarTerrorHuntingTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("=== Starting Polar Terror Hunting Task ===");
 
         // Load configuration fresh after profile refresh
         loadConfiguration();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PrioritiseFurnaceTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/PrioritiseFurnaceTask.java
@@ -44,7 +44,6 @@ public class PrioritiseFurnaceTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("Starting Prioritise Furnace task");
 
         DTOImageSearchResult worldResult = templateSearchHelper.searchTemplate(GAME_HOME_WORLD,
                 SearchConfigConstants.DEFAULT_SINGLE);

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ResearchTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/ResearchTask.java
@@ -39,7 +39,6 @@ public class ResearchTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("Starting Research task...");
 
         // Ensure we start on the HOME screen before doing anything else
         navigationHelper.ensureCorrectScreenLocation(EnumStartLocation.HOME);
@@ -314,7 +313,6 @@ public class ResearchTask extends DelayedTask {
             }
         }
 
-        logInfo("Research task ended. Rescheduling in 1 hour.");
         this.reschedule(LocalDateTime.now().plusHours(1));
     }
 }

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/SkipTutorialTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/SkipTutorialTask.java
@@ -55,7 +55,6 @@ public class SkipTutorialTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("Starting Skip Tutorial Task...");
 
         // Ensure emulator and game are running since InitializeTask might have been skipped
         ensureEmulatorRunning();
@@ -129,6 +128,5 @@ public class SkipTutorialTask extends DelayedTask {
             
         }
         
-        logInfo("Finishing Skip Tutorial Task.");
     }
 }

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/StorehouseChest.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/StorehouseChest.java
@@ -122,8 +122,6 @@ public class StorehouseChest extends DelayedTask {
         loadConfiguration();
         resetExecutionState();
 
-        logInfo("Starting Storehouse task.");
-
         if (!openStorehouse()) {
             logWarning("Failed to open Storehouse.");
             reschedule(LocalDateTime.now().plusMinutes(FALLBACK_RESCHEDULE_MINUTES));
@@ -138,7 +136,6 @@ public class StorehouseChest extends DelayedTask {
 
         scheduleToNearestTime();
 
-        logInfo("Storehouse task completed successfully.");
     }
 
     /**

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TestHookLoopTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TestHookLoopTask.java
@@ -66,7 +66,7 @@ public class TestHookLoopTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("=== Test Hook Loop started ===");
+
         logInfo("Will run for up to " + (MAX_DURATION_MS / 1000) + " seconds.");
 
         // ── Pre-cache the template Mat once ──────────────────────────────

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TrainingTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TrainingTask.java
@@ -220,7 +220,6 @@ public class TrainingTask extends DelayedTask {
      */
     @Override
     protected void execute() {
-        logInfo("=== Starting Training Task ===");
 
         loadConfiguration();
         buildQueuesList();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TriumphTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TriumphTask.java
@@ -30,8 +30,7 @@ public class TriumphTask extends DelayedTask {
 	}
 
 	@Override
-	protected void execute() {
-		logInfo("Starting Alliance Triumph task to claim rewards");
+	protected void execute() {;
 
 		// Navigate to alliance menu
 		logInfo("Tapping alliance button at bottom of screen");
@@ -120,7 +119,6 @@ public class TriumphTask extends DelayedTask {
 			reschedule(nextSchedule);
 		}
 
-		logInfo("Alliance Triumph task completed");
 	}
 
 }

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TundraTrekAutoTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TundraTrekAutoTask.java
@@ -57,7 +57,6 @@ public class TundraTrekAutoTask extends DelayedTask {
 
     @Override
     protected void execute() {
-        logInfo("=== Starting Tundra Trek Auto Task ===");
 
         try {
             // Navigate to tundra menu

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TundraTruckEventTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/TundraTruckEventTask.java
@@ -86,7 +86,6 @@ public class TundraTruckEventTask extends DelayedTask {
 
 	@Override
 	protected void execute() {
-		logInfo("=== Starting Tundra Truck Event Task ===");
 
 		// Load configuration
 		loadConfiguration();
@@ -128,7 +127,7 @@ public class TundraTruckEventTask extends DelayedTask {
 
 		// All navigation attempts failed
 		logWarning("Could not find Tundra Truck event after " + MAX_NAVIGATION_ATTEMPTS +
-				" attempts. Rescheduling for next activation time.");
+				" attempts.");
 		rescheduleWithActivationTime();
 	}
 

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/UpgradeBuildingsTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/UpgradeBuildingsTask.java
@@ -54,7 +54,6 @@ public class UpgradeBuildingsTask extends DelayedTask {
      */
     @Override
     protected void execute() {
-        logInfo("Starting Upgrade Minor Buildings task");
 
         // Navigate to city view
         navigateToCityView();

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/VipTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/VipTask.java
@@ -112,8 +112,6 @@ public class VipTask extends DelayedTask {
 	protected void execute() {
 		loadConfiguration();
 
-		logInfo("Starting VIP task.");
-
 		if (!openVipMenu()) {
 			logWarning("Failed to open VIP menu.");
 			scheduleNextExecution();
@@ -131,7 +129,7 @@ public class VipTask extends DelayedTask {
 		closeVipMenu();
 
 		scheduleNextExecution();
-		logInfo("VIP task completed successfully.");
+
 	}
 
 	/**

--- a/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/WarAcademyTask.java
+++ b/wos-serv/src/main/java/cl/camodev/wosbot/serv/task/impl/WarAcademyTask.java
@@ -74,8 +74,6 @@ public class WarAcademyTask extends DelayedTask {
     @Override
     protected void execute() {
 
-        logInfo("Starting War Academy task.");
-
         if (!navigateToWarAcademy()) {
             logWarning("Failed to navigate to War Academy.");
             reschedule(LocalDateTime.now().plusMinutes(RETRY_DELAY_MINUTES));

--- a/wos-utiles/src/main/java/cl/camodev/wosbot/logging/ProfileLogger.java
+++ b/wos-utiles/src/main/java/cl/camodev/wosbot/logging/ProfileLogger.java
@@ -199,7 +199,7 @@ public class ProfileLogger {
     private String formatLogMessage(String level, String message) {
         StringBuilder sb = new StringBuilder();
         sb.append(dateFormat.format(new Date()));
-        sb.append(" [").append(level).append("] ");
+        sb.append(" - ").append(level).append(" - ");
         sb.append(className).append(" - ");
         sb.append(message);
         return sb.toString();
@@ -212,7 +212,8 @@ public class ProfileLogger {
      */
     public void info(String message) {
         // Log to the main logger
-        logger.info(message);
+        String loggerMessage = (profile != null) ? profile.getName() + " - " + message : message;
+        logger.info(loggerMessage);
         
         // Also log to the profile log file if a profile is set
         if (profile != null) {


### PR DESCRIPTION
It was very difficult to read task log execution trace, because there was multiple location for that, and even not Always the task completed was traced.

This commit aimed at harmonizing the task execution at one place, with alsways the same messages.

The profile log was also re-writing the profile name, which is not useful, since the filename holds it.



