### PR TITLE
feat(stamina): add configurable stamina reserve for overflow sinks

### DIFF
--- a/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
+++ b/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
@@ -122,6 +122,8 @@ public enum ConfigurationKeyEnum {
     BEAST_HUNTING_ENABLED_BOOL                  ("false",   Boolean.class,       ConfigCategory.EVENTS),
     BEAST_HUNTING_LEVEL_INT                     ("30",      Integer.class,       ConfigCategory.EVENTS),
     BEAST_HUNTING_MARCHES_INT                   ("3",       Integer.class,       ConfigCategory.EVENTS),
+    // Shared stamina reserve kept back for Intel/Rally; overflow sinks (Beast/Polar Terror) only spend above it.
+    STAMINA_RESERVE_INT                         ("130",     Integer.class,       ConfigCategory.EVENTS),
     BOOL_CHIEF_ORDER_PRODUCTIVITY_DAY           ("false",   Boolean.class,       ConfigCategory.EVENTS),
     BOOL_CHIEF_ORDER_RUSH_JOB                   ("false",   Boolean.class,       ConfigCategory.EVENTS),
     BOOL_CHIEF_ORDER_URGENT_MOBILISATION        ("false",   Boolean.class,       ConfigCategory.EVENTS),

--- a/fg-app/src/main/java/dev/frostguard/app/panel/combat/BeastHuntingLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/combat/BeastHuntingLayoutController.java
@@ -5,6 +5,7 @@ import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextField;
 
 public class BeastHuntingLayoutController extends AbstractProfileController {
 
@@ -16,6 +17,9 @@ public class BeastHuntingLayoutController extends AbstractProfileController {
 
     @FXML
     private ComboBox<Integer> comboBoxBeastHuntingLevel;
+
+    @FXML
+    private TextField textFieldBeastStaminaReserve;
 
     @FXML
     private void initialize() {
@@ -32,9 +36,13 @@ public class BeastHuntingLayoutController extends AbstractProfileController {
         }
         comboBoxMappings.put(comboBoxBeastHuntingLevel, ConfigurationKeyEnum.BEAST_HUNTING_LEVEL_INT);
 
+        // Shared stamina reserve kept back for Intel/Rally
+        registerTextField(textFieldBeastStaminaReserve, ConfigurationKeyEnum.STAMINA_RESERVE_INT);
+
         // Disable controls when checkbox is not selected
         comboBoxBeastHuntingMarches.disableProperty().bind(checkBoxEnableBeastHunting.selectedProperty().not());
         comboBoxBeastHuntingLevel.disableProperty().bind(checkBoxEnableBeastHunting.selectedProperty().not());
+        textFieldBeastStaminaReserve.disableProperty().bind(checkBoxEnableBeastHunting.selectedProperty().not());
 
         // Initialize change events (inherited from AbstractProfileController)
         initializeChangeEvents();

--- a/fg-app/src/main/java/dev/frostguard/app/panel/combat/PolarTerrorLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/combat/PolarTerrorLayoutController.java
@@ -7,6 +7,7 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 
@@ -24,6 +25,9 @@ public class PolarTerrorLayoutController extends AbstractProfileController {
 
     @FXML
     private ComboBox<Integer> comboBoxPolarTerrorMarches;
+
+    @FXML
+    private TextField textFieldPolarStaminaReserve;
 
     @FXML
     private Label labelPolarTerrorMarch1Flag;
@@ -155,6 +159,9 @@ public class PolarTerrorLayoutController extends AbstractProfileController {
         comboBoxMappings.put(comboBoxPolarTerrorLevel, ConfigurationKeyEnum.POLAR_TERROR_LEVEL_INT);
         comboBoxMappings.put(comboBoxPolarTerrorMode, ConfigurationKeyEnum.POLAR_TERROR_MODE_STRING);
         comboBoxMappings.put(comboBoxPolarTerrorMarches, ConfigurationKeyEnum.POLAR_TERROR_MARCHES_INT);
+
+        // Shared stamina reserve kept back for Intel/Rally (same key as Beast Hunting)
+        registerTextField(textFieldPolarStaminaReserve, ConfigurationKeyEnum.STAMINA_RESERVE_INT);
 
         comboBoxMappings.put(comboBoxPolarTerrorMarch1Flag, ConfigurationKeyEnum.POLAR_TERROR_MARCH_1_FLAG_STRING);
         comboBoxMappings.put(comboBoxPolarTerrorMarch2Flag, ConfigurationKeyEnum.POLAR_TERROR_MARCH_2_FLAG_STRING);

--- a/fg-app/src/main/resources/layout/BeastHuntingLayout.fxml
+++ b/fg-app/src/main/resources/layout/BeastHuntingLayout.fxml
@@ -33,6 +33,14 @@
                             <Label styleClass="task-field-label" text="Beast Level" minWidth="120" />
                             <ComboBox fx:id="comboBoxBeastHuntingLevel" prefWidth="140" />
                         </HBox>
+
+                        <HBox alignment="CENTER_LEFT" spacing="14">
+                            <Label styleClass="task-field-label" text="Stamina Reserve" minWidth="120" />
+                            <TextField fx:id="textFieldBeastStaminaReserve" prefWidth="140" />
+                        </HBox>
+                        <Label styleClass="task-card-note"
+                               text="Stamina kept back for Intel/Rally. Beast Hunting only spends stamina above this value."
+                               wrapText="true" />
                     </VBox>
                 </VBox>
 

--- a/fg-app/src/main/resources/layout/PolarTerrorLayout.fxml
+++ b/fg-app/src/main/resources/layout/PolarTerrorLayout.fxml
@@ -37,6 +37,13 @@
                         <Label styleClass="task-field-label" text="Number of Marches" minWidth="140" />
                         <ComboBox fx:id="comboBoxPolarTerrorMarches" prefWidth="150.0" />
                     </HBox>
+                    <HBox alignment="CENTER_LEFT" spacing="14">
+                        <Label styleClass="task-field-label" text="Stamina Reserve" minWidth="140" />
+                        <TextField fx:id="textFieldPolarStaminaReserve" prefWidth="150.0" />
+                    </HBox>
+                    <Label styleClass="task-card-note"
+                           text="Stamina kept back for Intel/Rally. Polar Terror only spends stamina above this value."
+                           wrapText="true" />
 
                     <Separator style="-fx-opacity: 0.25;" />
 

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/combat/BeastSlayRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/combat/BeastSlayRoutine.java
@@ -1,6 +1,7 @@
 package dev.frostguard.tasks.combat;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import dev.frostguard.api.configs.TemplatesEnum;
@@ -8,18 +9,25 @@ import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.data.entity.DailyTask;
+import dev.frostguard.data.repository.DailyTaskRepository;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
 import dev.frostguard.engine.helper.TemplateSearchHelper.SearchConfig;
 import dev.frostguard.engine.service.StatisticsService;
+import dev.frostguard.engine.service.TaskManagementService;
 
 public class BeastSlayRoutine extends DelayedTask {
 
-	private static final int MIN_STAMINA = 10;
+	private static final int DEFAULT_STAMINA_RESERVE = 130;
 	private static final int STAMINA_COST_PER_ATTACK = 10;
+
+	private final DailyTaskRepository iDailyTaskRepository = DailyTaskRepository.getRepository();
+	private final TaskManagementService taskManagementService = TaskManagementService.shared();
 
 	private int maxQueues;
 	private int beastLevel;
+	private int staminaReserve;
 
 	/** Tracks the earliest time this task should resume (like GatherRoutine pattern). */
 	private LocalDateTime earliestReschedule;
@@ -42,20 +50,32 @@ public class BeastSlayRoutine extends DelayedTask {
 		this.maxQueues = (configMarches != null) ? configMarches : 3;
 		Integer configLevel = profile.getConfig(ConfigurationKeyEnum.BEAST_HUNTING_LEVEL_INT, Integer.class);
 		this.beastLevel = (configLevel != null) ? configLevel : 30;
+		Integer configReserve = profile.getConfig(ConfigurationKeyEnum.STAMINA_RESERVE_INT, Integer.class);
+		this.staminaReserve = (configReserve != null) ? configReserve : DEFAULT_STAMINA_RESERVE;
+
+		// Yield to Intel if it is about to run, so Beast Hunting never starves it.
+		if (shouldDeferToIntel()) {
+			logInfo("Intel task is scheduled to run soon. Planning next Beast run 5 min later.");
+			reschedule(LocalDateTime.now().plusMinutes(5));
+			return;
+		}
+
+		// Only spend stamina above the reserve, so at least `staminaReserve` stays for Intel/Rally.
+		int minToAct = staminaReserve + STAMINA_COST_PER_ATTACK;
 
 		// Use staminaHelper to check stamina (already read during initialization/validation)
-		if (!staminaHelper.checkStaminaAndMarchesOrReschedule(MIN_STAMINA, MIN_STAMINA, this::reschedule)) {
+		if (!staminaHelper.checkStaminaAndMarchesOrReschedule(minToAct, minToAct, this::reschedule)) {
 			return;
 		}
 
 		int currentStamina = staminaHelper.getCurrentStamina();
-		logInfo("Initiating beast attacks. Stamina: " + currentStamina
+		logInfo("Initiating beast attacks. Stamina: " + currentStamina + ", Reserve: " + staminaReserve
 				+ ", Max queues: " + maxQueues + ", Beast level: " + beastLevel);
 
 		int attacksDone = 0;
 
-		// Fill available queues with beast attacks
-		while (currentStamina >= MIN_STAMINA && attacksDone < maxQueues) {
+		// Fill available queues with beast attacks, never dipping below the reserve
+		while (currentStamina - staminaReserve >= STAMINA_COST_PER_ATTACK && attacksDone < maxQueues) {
 
 			sleepTask(6000);
 			// go to the beast search menu
@@ -127,6 +147,23 @@ public class BeastSlayRoutine extends DelayedTask {
 	@Override
 	protected LaunchPoint getRequiredStartLocation() {
 		return LaunchPoint.WORLD;
+	}
+
+	/**
+	 * Mirrors PolarTerrorHuntingRoutine: if Intel is enabled and scheduled to run
+	 * within the next 5 minutes, Beast Hunting defers so it doesn't consume stamina
+	 * Intel is about to need.
+	 */
+	private boolean shouldDeferToIntel() {
+		if (!Boolean.TRUE.equals(profile.getConfig(ConfigurationKeyEnum.INTEL_BOOL, Boolean.class))) {
+			return false;
+		}
+		if (!taskManagementService.lookupTaskState(profile.getId(), TpDailyTaskEnum.INTEL.getId()).isScheduled()) {
+			return false;
+		}
+		DailyTask intel = iDailyTaskRepository.findByAccountIdAndTaskType(profile.getId(), TpDailyTaskEnum.INTEL);
+		return intel != null
+				&& ChronoUnit.MINUTES.between(LocalDateTime.now(), intel.getScheduledAt()) < 5;
 	}
 
 	// ========================================================================

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarTerrorHuntingRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarTerrorHuntingRoutine.java
@@ -22,9 +22,13 @@ import java.util.Map;
 
 public class PolarTerrorHuntingRoutine extends DelayedTask {
 
-private final int refreshStaminaLevel = 180;
+private static final int DEFAULT_STAMINA_RESERVE = 130;
 
-private final int minStaminaLevel = 100;
+// Loaded from STAMINA_RESERVE_INT in hydrateConfiguration(): the reserve kept back
+// for Intel/Rally (minStaminaLevel) and the level to regen back up to (refreshStaminaLevel).
+private int refreshStaminaLevel = DEFAULT_STAMINA_RESERVE + 50;
+
+private int minStaminaLevel = DEFAULT_STAMINA_RESERVE;
 
 private final DailyTaskRepository iDailyTaskRepository = DailyTaskRepository.getRepository();
 
@@ -293,6 +297,10 @@ private void hydrateConfiguration() {
         this.limitedHunting = profile.getConfig(ConfigurationKeyEnum.POLAR_TERROR_MODE_STRING, String.class)
                 .equals("Limited (10)");
         this.maxMarches = profile.getConfig(ConfigurationKeyEnum.POLAR_TERROR_MARCHES_INT, Integer.class);
+
+        Integer configReserve = profile.getConfig(ConfigurationKeyEnum.STAMINA_RESERVE_INT, Integer.class);
+        this.minStaminaLevel = (configReserve != null) ? configReserve : DEFAULT_STAMINA_RESERVE;
+        this.refreshStaminaLevel = this.minStaminaLevel + 50;
 
 
         if (this.maxMarches < 1)


### PR DESCRIPTION
## ⚡ Configurable Stamina Reserve for Overflow Sinks

### 📖 Summary

Adds a shared, per-profile **Stamina Reserve** so the two "stamina sink" tasks — **Beast Hunting** and **Polar Terror** — only spend stamina *above* a configurable floor. This keeps a guaranteed buffer for **Intel missions** and **rallies**, while still letting the sinks burn the excess so stamina never idles at the cap (wasting the +1/5 min regeneration).

Previously:
- **Beast Hunting** drained down to a hard-coded floor of `10`, which could starve Intel (needs ≥ 30) and rallies.
- **Polar Terror** kept a hard-coded reserve of `100` — sensible, but not adjustable.

Now both honour a single user-configurable value, and the choice of *which* sink burns the overflow is simply which task you enable (e.g. Polar Terror normally, Beast Hunting during a cryptid event).

### ✨ Changes

| Area | Change |
|:-----|:-------|
| **Config** | New `STAMINA_RESERVE_INT` key (default `130`), shared by both tasks |
| **Beast Hunting** | Spends only above the reserve; defers when an Intel run is due within 5 min (mirrors Polar Terror's existing Intel-yield) |
| **Polar Terror** | Replaces the hard-coded `100`/`180` thresholds with the configurable reserve |
| **UI** | Adds a **Stamina Reserve** field to both the Beast Hunting and Polar Terror panels, bound to the shared key |

### 🧩 How it works

- The reserve is the amount of stamina always kept back for Intel/rallies.
- A sink only attacks/rallies while `currentStamina − reserve ≥ cost`, so it burns the overflow but never dips into the buffer.
- Because both sinks read the **same** config key, the value stays consistent no matter which panel you edit it in.

### 🔧 Configuration

- **Combat → Beast Hunting → Stamina Reserve**, or
- **Combat → Polar Terror → Stamina Reserve**

Default `130`. Raise it to protect more stamina for Intel; lower it to feed the sinks more.

### ✅ Testing

- `mvn -o compile` → `BUILD SUCCESS`
- Verified the new field loads/saves against the shared key from both panels.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
