### PR TITLE
superseded: old stamina OCR consensus

### DIFF
--- a/fg-engine/src/main/java/dev/frostguard/engine/emulator/EmulatorInstance.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/emulator/EmulatorInstance.java
@@ -247,8 +247,12 @@ public abstract class EmulatorInstance {
             byte[] raw = buf.toByteArray();
             if (raw.length < 12) throw new RuntimeException("screencap too small");
             int w = le32(raw, 0), h = le32(raw, 4), fmt = le32(raw, 8);
-            byte[] px = new byte[raw.length - 12];
-            System.arraycopy(raw, 12, px, 0, px.length);
+            // header is 12 bytes on old Android, 16 on newer; derive from pixel size
+            int bytesPerPixel = (fmt == 1) ? 4 : 2;
+            int headerLen = raw.length - (w * h * bytesPerPixel);
+            if (headerLen < 12 || headerLen > 64) headerLen = 12; // fallback
+            byte[] px = new byte[raw.length - headerLen];
+            System.arraycopy(raw, headerLen, px, 0, px.length);
             RawImageData frame = RawImageData.capture(px, w, h, fmt == 1 ? 32 : 16);
             lastFrame.put(idx, frame);
             return frame;

--- a/fg-engine/src/main/java/dev/frostguard/engine/helper/StaminaHelper.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/helper/StaminaHelper.java
@@ -14,6 +14,9 @@ import dev.frostguard.vision.ocr.ResilientOcrExecutor;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
 
 // Orchestrates stamina tracking: OCR reads, regen delay computation,
 // availability gating, and travel time parsing.
@@ -62,23 +65,65 @@ public class StaminaHelper {
                 CommonGameAreas.STAMINA_BUTTON.topLeft(),
                 CommonGameAreas.STAMINA_BUTTON.bottomRight(), 1, 500);
 
-        Integer reading = numberReader.attemptRecognition(
-                CommonGameAreas.STAMINA_OCR_AREA.topLeft(),
-                CommonGameAreas.STAMINA_OCR_AREA.bottomRight(),
-                5, 200L,
-                CommonOCRSettings.STAMINA_FRACTION_SETTINGS,
-                RegexNumberParser::hasFractionSyntax,
-                RegexNumberParser::numerator);
+        Integer reading = readStableStamina();
 
         if (reading == null) {
-            emitWarn("OCR could not parse stamina");
+            emitWarn("OCR could not reach a stable stamina reading; keeping previous value");
         } else {
-            emitInfo("Stamina read: " + reading);
+            emitInfo("Stamina read (consensus): " + reading);
             persistence.setStamina(accountKey, reading);
         }
 
         device.pressBack(deviceSlot);
         device.pressBack(deviceSlot);
+    }
+
+    // How many independent OCR samples to take, and how many must agree.
+    private static final int STAMINA_SAMPLE_COUNT = 5;
+    private static final int STAMINA_MIN_AGREEMENT = 2;
+    private static final int STAMINA_SAMPLE_PAUSE_MS = 120;
+    private static final int STAMINA_MIN_DENOMINATOR = 100;
+
+    // Reads the stamina fraction across several frames and returns the value the
+    // majority agree on (with a denominator/numerator sanity check), so a transient
+    // mid-animation frame can't poison the model. Returns null when none agree.
+    private Integer readStableStamina() {
+        // only require a plausible max; stamina can overfill above it (e.g. 260/200)
+        Predicate<String> saneFraction = text -> {
+            Integer numerator = RegexNumberParser.numerator(text);
+            Integer denominator = RegexNumberParser.denominator(text);
+            return numerator != null && denominator != null
+                    && denominator >= STAMINA_MIN_DENOMINATOR;
+        };
+
+        Map<Integer, Integer> tally = new HashMap<>();
+        for (int sample = 0; sample < STAMINA_SAMPLE_COUNT; sample++) {
+            Integer value = numberReader.attemptRecognition(
+                    CommonGameAreas.STAMINA_OCR_AREA.topLeft(),
+                    CommonGameAreas.STAMINA_OCR_AREA.bottomRight(),
+                    1, 0L,
+                    CommonOCRSettings.STAMINA_FRACTION_SETTINGS,
+                    saneFraction,
+                    RegexNumberParser::numerator);
+            if (value != null) {
+                tally.merge(value, 1, Integer::sum);
+            }
+            pauseBetweenSamples();
+        }
+
+        return tally.entrySet().stream()
+                .filter(entry -> entry.getValue() >= STAMINA_MIN_AGREEMENT)
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+    }
+
+    private void pauseBetweenSamples() {
+        try {
+            Thread.sleep(STAMINA_SAMPLE_PAUSE_MS);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     // Reads stamina cost from the deployment confirmation screen.


### PR DESCRIPTION
Superseded by #26 after the branch was renamed and the change was rebuilt on current main.

The old 5-sample stamina OCR consensus approach is no longer the active PR direction.