### PR TITLE
fix(research): use multi-hit badge search so the topmost node is actually found

### DIFF
--- a/fg-tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
@@ -201,11 +201,19 @@ public ResearchRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask) {
 
             List<ImageSearchResultData> foundResults = new ArrayList<>();
             for (TemplatesEnum template : researchTemplates) {
-                ImageSearchResultData templateResult = emuManager.locatePattern(
-                        EMULATOR_NUMBER, researchScreenshot, template, 90.0);
-                if (templateResult != null && templateResult.isFound()) {
-                    logInfo(routineLogResearchLine("Detected research template: " + template.name()));
-                    foundResults.add(templateResult);
+                // Single-hit search would return only the single best-correlated occurrence
+                // across the whole screen. An untouched tree renders several nodes with the
+                // identical "X/3" badge at once, so it must find ALL of them here for
+                // "topmost of foundResults" below to actually mean the topmost node on screen
+                // (the earliest still-incomplete one, which prerequisite-ordering guarantees is
+                // always the unlocked one) instead of an arbitrary same-looking match.
+                List<ImageSearchResultData> templateResults = emuManager.locateAllPatterns(
+                        EMULATOR_NUMBER, researchScreenshot, template,
+                        new PointData(0, 0), new PointData(720, 1280), 90.0, 10);
+                if (!templateResults.isEmpty()) {
+                    logInfo(routineLogResearchLine("Detected " + templateResults.size()
+                            + " node(s) with template: " + template.name()));
+                    foundResults.addAll(templateResults);
                 }
             }
 


### PR DESCRIPTION
## Problem

Research got stuck in an endless 1h-reschedule loop and never made progress — specifically on the **first node of a fresh research tree** (i.e. a brand-new account/branch that hasn't researched anything yet). Once the first node is done, only one node is ever incomplete at a time and the bug never triggers again, so this looked fine on established accounts researching mid-tree.

Real log excerpt (`Default`, two separate runs):

```
ResearchRoutine | Detected research template: RESEARCH_0_3
ResearchRoutine | Pressing research template at position: (140, 579) with offset
...
ResearchRoutine | Research text template not detected.
ResearchRoutine | Completed: Research scheduled=... (1h later)
```

No dialog ever opens after the tap, so the routine logs the warning above and reschedules an hour later — repeating forever, since the tapped node was never actually researchable.

## Root cause

`ResearchRoutine` searched for the "X/3" badge via `emuManager.locatePattern` — a **single-hit** search that returns only the one globally best-correlated match across the *entire* screenshot. On a fresh tree, every node (Meat Output I, Wood Output I, Food Gathering I, Wood Gathering I, Coal Output I) renders the **identical** "0/3" badge at the same time. Matching against several pixel-identical occurrences returns whichever one scores marginally highest due to rendering noise — essentially arbitrary, not the topmost one. The already-existing "pick the topmost of the results" selection (`.min(Y)`) never actually had more than one candidate to compare, so it just tapped wherever the single-hit search happened to land — usually a locked node further down the tree, since the true topmost (unlocked) node was never even part of the candidate set.

Confirmed live: reproduced the exact tree state on a second emulator instance (fully untouched Economy tree) and verified the single-hit search does land away from the actual top, unlocked node (Meat Output I).

## Fix

- Switch from `emuManager.locatePattern` (single-hit) to `emuManager.locateAllPatterns` (multi-hit) for each of the three "X/3" badge templates, collecting every visible badge instead of just one.
- The existing topmost-selection logic then works exactly as intended: since a node's prerequisite always sits above it in the tree, the topmost still-incomplete badge found is guaranteed to be the unlocked one — no separate lock-detection needed.

## Testing

Verified live against the real Tech Research → Economy screen on a completely untouched tree (all five nodes showing "0/3" at once) — the routine now correctly finds and taps the topmost node (Meat Output I) instead of a locked one further down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)