### PR TITLE
fix(buildings): handle new building Build button

### DIFF
--- a/fg-tasks/src/main/java/dev/frostguard/tasks/city/UpgradeBuildingsRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/city/UpgradeBuildingsRoutine.java
@@ -31,6 +31,10 @@ private static final AreaData QUEUE_AREA_1_VALUE = new AreaData(new PointData(95
 
 private static final AreaData QUEUE_AREA_2_VALUE = new AreaData(new PointData(95, 450), new PointData(358, 474));
 
+private static final AreaData BUILDING_ACTION_BUTTON_AREA_VALUE = new AreaData(new PointData(190, 1160), new PointData(530, 1250));
+
+private static final AreaData BUILDING_CONFIRM_BUTTON_AREA_VALUE = new AreaData(new PointData(489, 1034), new PointData(500, 1050));
+
 private final List<AreaData> queues = new ArrayList<>(Arrays.asList(QUEUE_AREA_1_VALUE, QUEUE_AREA_2_VALUE));
 
 public UpgradeBuildingsRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDailyTaskEnum) {
@@ -396,17 +400,55 @@ private void handleCityBuilding() {
         }
 
 
-        tapRandomPoint(upgradeButton.getPoint(), upgradeButton.getPoint());
+        startBuildingAction("upgrade", upgradeButton.getPoint(), upgradeButton.getPoint());
+    }
+
+private void handleNewBuilding() {
+        logInfo(routineLogUpgradeBuildingsLine("Handling New Building"));
+
+        if (!isBuildButtonVisible()) {
+            logWarning(routineLogUpgradeBuildingsLine("Build button not detected"));
+            return;
+        }
+
+        startBuildingAction("build", BUILDING_ACTION_BUTTON_AREA_VALUE.topLeft(), BUILDING_ACTION_BUTTON_AREA_VALUE.bottomRight());
+    }
+
+private void startBuildingAction(String actionName, PointData buttonTopLeft, PointData buttonBottomRight) {
+        logInfo(routineLogUpgradeBuildingsLine("Starting building " + actionName + "..."));
+
+        tapRandomPoint(buttonTopLeft, buttonBottomRight);
         sleepTask(1000);
 
 
         refillResourcesIfNeededFlow();
 
 
-        tapRandomPoint(new PointData(489, 1034), new PointData(500, 1050));
+        tapRandomPoint(BUILDING_CONFIRM_BUTTON_AREA_VALUE.topLeft(), BUILDING_CONFIRM_BUTTON_AREA_VALUE.bottomRight());
 
 
         requestHelpFlow();
+    }
+
+private boolean isBuildButtonVisible() {
+        try {
+            emuManager.captureScreen(EMULATOR_NUMBER);
+            String buttonText = emuManager.readText(
+                    EMULATOR_NUMBER,
+                    BUILDING_ACTION_BUTTON_AREA_VALUE.topLeft(),
+                    BUILDING_ACTION_BUTTON_AREA_VALUE.bottomRight(),
+                    WHITE_SETTINGS);
+            String normalized = buttonText == null ? "" : buttonText.toLowerCase().replaceAll("[^a-z]", "");
+            logDebug(routineLogUpgradeBuildingsLine("Build button OCR result: '" + buttonText + "'"));
+            boolean detected = normalized.contains("build") || normalized.contains("bui");
+            if (detected) {
+                logInfo(routineLogUpgradeBuildingsLine("Build button detected via OCR: '" + buttonText + "'"));
+            }
+            return detected;
+        } catch (Exception e) {
+            logWarning(routineLogUpgradeBuildingsLine("Build button OCR failed: " + e.getMessage()));
+            return false;
+        }
     }
 
 private void logQueueStateFlow(int queueIndex, UpgradeBuildingsRoutine.QueueSnapshot state) {
@@ -627,6 +669,10 @@ private LocalDateTime handleQueue(UpgradeBuildingsRoutine.QueueReadout queueResu
                 return null;
             } else {
 
+                if (isBuildButtonVisible()) {
+                    handleNewBuilding();
+                    return null;
+                }
 
                 return handleTroopBuilding();
             }


### PR DESCRIPTION
## 🩹 Fix new-building construction getting skipped

### 📖 Summary

`UpgradeBuildingsRoutine` only handled existing building upgrades, survivor upgrades and troop training. When an idle construction queue opened a new-building detail screen, the available action was **Build** instead of **Upgrade**. No existing template matched that state, so the routine silently fell through to the training path and left the idle queue unused.

Observed live on a new account flow with Shelter / Research Center style construction screens: prerequisites and resources were satisfied, but the routine did not start the building because it was only looking for `upgradeButton.png`.

### ✨ Change

- Detect the bottom action button text with OCR when the normal Upgrade button is absent.
- Add a `handleNewBuilding` branch for `Build` screens.
- Share the existing resource-refill, confirm and alliance-help flow between Upgrade and Build actions.
- Keep the existing Upgrade / Survivor / Training paths unchanged.

### 🛡️ Behaviour / risk

The new branch only runs after the Upgrade button is not found and the bottom action button OCR reads like `Build`, so existing upgrade handling keeps priority. The Build button uses the same fixed bottom action area as the existing building confirm flow.

A live smoke test confirmed the intended scope: the routine detected `Build` and successfully started a new Research Center build. Follow-up behaviour after that exposed a separate issue where the routine continues processing the second initially-idle queue from the old queue snapshot; that is intentionally not bundled into this fix.

### ✅ Testing

- `mvn -pl fg-tasks -am package -DskipTests` -> `BUILD SUCCESS`.
- Live smoke test: new-building `Build` path was reached and the building was started.