### PR TITLE
fix(stamina): preserve overfilled stamina tracking

### DIFF
--- a/fg-engine/src/main/java/dev/frostguard/engine/emulator/EmulatorInstance.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/emulator/EmulatorInstance.java
@@ -247,9 +247,15 @@ public abstract class EmulatorInstance {
             byte[] raw = buf.toByteArray();
             if (raw.length < 12) throw new RuntimeException("screencap too small");
             int w = le32(raw, 0), h = le32(raw, 4), fmt = le32(raw, 8);
-            byte[] px = new byte[raw.length - 12];
-            System.arraycopy(raw, 12, px, 0, px.length);
-            RawImageData frame = RawImageData.capture(px, w, h, fmt == 1 ? 32 : 16);
+            int bitsPerPixel = (fmt == 1) ? 32 : 16;
+            int bytesPerPixel = bitsPerPixel / 8;
+            int headerLength = raw.length - (w * h * bytesPerPixel);
+            if (headerLength < 12 || headerLength > 64) {
+                headerLength = 12;
+            }
+            byte[] px = new byte[raw.length - headerLength];
+            System.arraycopy(raw, headerLength, px, 0, px.length);
+            RawImageData frame = RawImageData.capture(px, w, h, bitsPerPixel);
             lastFrame.put(idx, frame);
             return frame;
         } catch (com.android.ddmlib.TimeoutException e) { throw new RuntimeException("screencap timeout", e); }

--- a/fg-engine/src/main/java/dev/frostguard/engine/service/StaminaService.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/service/StaminaService.java
@@ -30,9 +30,9 @@ public final class StaminaService {
 
     private static final Duration TICK_INTERVAL = Duration.ofMinutes(5);
     private static final Duration STALE_THRESHOLD = Duration.ofMinutes(30);
+    // Passive regeneration stops at the normal bar cap. Explicit sources such as items and events
+    // can overfill stamina, so stored values are intentionally not capped at this ceiling.
     private static final int REGEN_CEILING = 200;
-    // Changed by pernerch | Date: 2026-07-02 | Why: cap stored stamina to stop over-reported values from skewing scheduling.
-    private static final int MAX_STAMINA = 200;
 
     /** Compact snapshot of a single account's energy state. */
     private record EnergySlot(int level, Instant lastTouched) {
@@ -99,9 +99,7 @@ public final class StaminaService {
 
     public void setStamina(Long profileId, int stamina) {
         requireId(profileId);
-        // Changed by pernerch | Date: 2026-07-02 | Why: clamp OCR/config writes to valid in-game stamina bounds.
-        int clamped = clampStamina(stamina);
-        EnergySlot fresh = new EnergySlot(clamped, Instant.now());
+        EnergySlot fresh = new EnergySlot(Math.max(0, stamina), Instant.now());
         slots.put(profileId, fresh);
         broadcastChange(profileId, fresh.level());
     }
@@ -138,16 +136,11 @@ public final class StaminaService {
         AtomicInteger result = new AtomicInteger();
         slots.compute(profileId, (id, existing) -> {
             int base = (existing != null) ? existing.level() : 0;
-            int clamped = clampStamina(base + delta);
-            result.set(clamped);
-            return new EnergySlot(clamped, (existing != null) ? existing.lastTouched() : Instant.now());
+            int updated = Math.max(0, base + delta);
+            result.set(updated);
+            return new EnergySlot(updated, (existing != null) ? existing.lastTouched() : Instant.now());
         });
         return result.get();
-    }
-
-    private int clampStamina(int value) {
-        // Changed by pernerch | Date: 2026-07-02 | Why: keep one shared clamp path for consistent set/add/subtract behavior.
-        return Math.max(0, Math.min(MAX_STAMINA, value));
     }
 
     private void runRegenTick() {

--- a/fg-engine/src/test/java/dev/frostguard/engine/service/StaminaServiceTest.java
+++ b/fg-engine/src/test/java/dev/frostguard/engine/service/StaminaServiceTest.java
@@ -5,24 +5,32 @@ import org.junit.jupiter.api.Test;
 
 class StaminaServiceTest {
 
-    // Changed by pernerch | Date: 2026-07-02 | Why: protect against over-reported stamina entering runtime state.
     @Test
-    void setStaminaCapsValuesAboveTheGameLimit() {
+    void setStaminaKeepsOverfilledValues() {
         StaminaService service = StaminaService.getServices();
 
         service.setStamina(1001L, 250);
 
-        assertEquals(200, service.getCurrentStamina(1001L));
+        assertEquals(250, service.getCurrentStamina(1001L));
     }
 
-    // Changed by pernerch | Date: 2026-07-02 | Why: ensure additive updates cannot exceed the stamina cap.
     @Test
-    void addStaminaDoesNotExceedTheGameLimit() {
+    void addStaminaCanOverfillAbovePassiveRegenLimit() {
         StaminaService service = StaminaService.getServices();
 
         service.setStamina(1002L, 190);
         service.addStamina(1002L, 25);
 
-        assertEquals(200, service.getCurrentStamina(1002L));
+        assertEquals(215, service.getCurrentStamina(1002L));
+    }
+
+    @Test
+    void subtractStaminaDoesNotGoBelowZero() {
+        StaminaService service = StaminaService.getServices();
+
+        service.setStamina(1003L, 10);
+        service.subtractStamina(1003L, 25);
+
+        assertEquals(0, service.getCurrentStamina(1003L));
     }
 }


### PR DESCRIPTION
## Summary
- preserve tracked stamina values above the passive 200 regeneration ceiling, so real overfill from items/events is not collapsed to 200
- keep passive regeneration capped at 200 and keep deductions floored at zero
- derive Android screencap header length from the captured frame size so newer emulator captures do not shift the pixel buffer

## Why this replaces the old direction
The old #14 tried to solve stamina OCR instability with a 5-sample consensus read. After checking current `local/staging` patterns in Arena and Polar, that is not how the newer routines handle fragile reads: they use normal `ResilientOcrExecutor` retries, targeted fallback reads, color/template checks, and plausibility guards. So this branch drops the 5-read consensus entirely.

## Correction to PR #12
PR #12 ("Several fixes") introduced a hard 200 cap for stored stamina in commit `37b683e`, with the goal of protecting scheduling from over-reported OCR values. That protection was too broad: the game can legitimately hold more than 200 stamina after explicit sources such as Chief Stamina items, Storehouse/event rewards, or other injections.

This PR keeps the valid part of that intent: impossible negative values are still rejected, and passive regeneration still stops at the normal 200 bar ceiling. It only removes the incorrect assumption that the stored stamina model itself must never exceed 200.

References:
- #12
- supersedes the old closed #14

## Verification
- `mvn -pl fg-engine -am test`
