### PR TITLE
feat(research): prioritize research categories

### DIFF
--- a/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
+++ b/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
@@ -90,6 +90,7 @@ public enum ConfigurationKeyEnum {
     RESEARCH_ECONOMY_BOOL                       ("false",   Boolean.class,  ConfigCategory.CITY),
     RESEARCH_ENABLED_BOOL                       ("false",   Boolean.class,  ConfigCategory.CITY),
     RESEARCH_GROWTH_BOOL                        ("false",   Boolean.class,  ConfigCategory.CITY),
+    RESEARCH_PRIORITIES_STRING                  ("growth:Growth:1:true|economy:Economy:2:true|battle:Battle:3:true", String.class, ConfigCategory.CITY),
 
     /* ─────────── dailies ─────────── */
 

--- a/fg-api/src/main/java/dev/frostguard/api/configs/ResearchCategoryEnum.java
+++ b/fg-api/src/main/java/dev/frostguard/api/configs/ResearchCategoryEnum.java
@@ -1,0 +1,43 @@
+package dev.frostguard.api.configs;
+
+/**
+ * Research tech-tree categories eligible for priority-ordered automation.
+ */
+public enum ResearchCategoryEnum implements PrioritizableItemData {
+
+    GROWTH("growth", "Growth"),
+    ECONOMY("economy", "Economy"),
+    BATTLE("battle", "Battle");
+
+    private final String key;
+    private final String caption;
+
+    ResearchCategoryEnum(String key, String caption) {
+        this.key = key;
+        this.caption = caption;
+    }
+
+    @Override
+    public String configKey() {
+        return key;
+    }
+
+    @Override
+    public String label() {
+        return caption;
+    }
+
+    public static ResearchCategoryEnum fromKey(String identifier) {
+        for (ResearchCategoryEnum category : values()) {
+            if (category.matchesKey(identifier)) {
+                return category;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return caption;
+    }
+}

--- a/fg-app/src/main/java/dev/frostguard/app/panel/training/ResearchLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/training/ResearchLayoutController.java
@@ -3,7 +3,9 @@ package dev.frostguard.app.panel.training;
 import java.util.Map;
 
 import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.configs.ResearchCategoryEnum;
 import dev.frostguard.app.shared.AbstractProfileController;
+import dev.frostguard.app.shared.PriorityListView;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
 
@@ -13,13 +15,7 @@ public class ResearchLayoutController extends AbstractProfileController {
 	private CheckBox checkBoxEnableResearch;
 
 	@FXML
-	private CheckBox checkBoxGrowth;
-
-	@FXML
-	private CheckBox checkBoxEconomy;
-
-	@FXML
-	private CheckBox checkBoxBattle;
+	private PriorityListView researchPriorities;
 
 	@FXML
 	private void initialize() {
@@ -29,10 +25,8 @@ public class ResearchLayoutController extends AbstractProfileController {
 
 	private void registerResearchControls() {
 		Map.of(
-				checkBoxEnableResearch, ConfigurationKeyEnum.RESEARCH_ENABLED_BOOL,
-				checkBoxGrowth, ConfigurationKeyEnum.RESEARCH_GROWTH_BOOL,
-				checkBoxEconomy, ConfigurationKeyEnum.RESEARCH_ECONOMY_BOOL,
-				checkBoxBattle, ConfigurationKeyEnum.RESEARCH_BATTLE_BOOL)
+				checkBoxEnableResearch, ConfigurationKeyEnum.RESEARCH_ENABLED_BOOL)
 				.forEach(this::registerCheckBox);
+		registerPriorityList(researchPriorities, ConfigurationKeyEnum.RESEARCH_PRIORITIES_STRING, ResearchCategoryEnum.class);
 	}
 }

--- a/fg-app/src/main/resources/layout/ResearchLayout.fxml
+++ b/fg-app/src/main/resources/layout/ResearchLayout.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
+<?import dev.frostguard.app.shared.PriorityListView?>
 
 <!-- Research — AnchorPane root with FlowPane research categories -->
 <AnchorPane maxHeight="Infinity" maxWidth="Infinity"
@@ -27,14 +28,12 @@
 
                     <Separator style="-fx-opacity: 0.25;" />
 
-                    <Label text="Research Categories"
+                    <Label text="Research Priorities"
                            style="-fx-font-size: 12px; -fx-font-weight: bold; -fx-text-fill: #9eaab6;" />
 
-                    <FlowPane hgap="20" vgap="10" alignment="CENTER_LEFT">
-                        <CheckBox fx:id="checkBoxGrowth" mnemonicParsing="false" text="Growth" />
-                        <CheckBox fx:id="checkBoxEconomy" mnemonicParsing="false" text="Economy" />
-                        <CheckBox fx:id="checkBoxBattle" mnemonicParsing="false" text="Battle" />
-                    </FlowPane>
+                    <dev.frostguard.app.shared.PriorityListView fx:id="researchPriorities"
+                                                                 prefHeight="160"
+                                                                 maxWidth="Infinity" />
                 </VBox>
             </VBox>
 

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
@@ -1,11 +1,15 @@
 package dev.frostguard.tasks.city;
 
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.configs.ResearchCategoryEnum;
 import dev.frostguard.api.configs.TemplatesEnum;
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
+import dev.frostguard.api.domain.PriorityItemData;
 import dev.frostguard.api.domain.RawImageData;
+import dev.frostguard.engine.config.PriorityConfigResolver;
 import dev.frostguard.engine.nav.SearchConfigConstants;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
@@ -145,112 +149,14 @@ public ResearchRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask) {
         sleepTask(300);
 
 
-        boolean growthSelected = profile.getConfig(dev.frostguard.api.configs.ConfigurationKeyEnum.RESEARCH_GROWTH_BOOL, Boolean.class);
-        boolean economySelected = profile.getConfig(dev.frostguard.api.configs.ConfigurationKeyEnum.RESEARCH_ECONOMY_BOOL, Boolean.class);
-        boolean battleSelected = profile.getConfig(dev.frostguard.api.configs.ConfigurationKeyEnum.RESEARCH_BATTLE_BOOL, Boolean.class);
-
-        java.util.List<java.lang.Runnable> clickActions = new java.util.ArrayList<>();
-
-        if (growthSelected) {
-            clickActions.add(() -> tapPoint(new PointData(java.util.concurrent.ThreadLocalRandom.current().nextInt(58, 211), java.util.concurrent.ThreadLocalRandom.current().nextInt(88, 137))));
-        }
-        if (economySelected) {
-            clickActions.add(() -> tapPoint(new PointData(java.util.concurrent.ThreadLocalRandom.current().nextInt(274, 445), java.util.concurrent.ThreadLocalRandom.current().nextInt(84, 142))));
-        }
-        if (battleSelected) {
-            clickActions.add(() -> tapPoint(new PointData(java.util.concurrent.ThreadLocalRandom.current().nextInt(499, 671), java.util.concurrent.ThreadLocalRandom.current().nextInt(99, 139))));
+        ImageSearchResultData researchTextResult = findResearchInPriorityCategories();
+        if (researchTextResult == null) {
+            logWarning(routineLogResearchLine("No enabled category had an available research. Planning next run in 1 hour."));
+            this.reschedule(LocalDateTime.now().plusHours(1));
+            return;
         }
 
-
-        if (clickActions.isEmpty()) {
-            clickActions.add(() -> tapPoint(new PointData(java.util.concurrent.ThreadLocalRandom.current().nextInt(58, 211), java.util.concurrent.ThreadLocalRandom.current().nextInt(88, 137))));
-            clickActions.add(() -> tapPoint(new PointData(java.util.concurrent.ThreadLocalRandom.current().nextInt(274, 445), java.util.concurrent.ThreadLocalRandom.current().nextInt(84, 142))));
-            clickActions.add(() -> tapPoint(new PointData(java.util.concurrent.ThreadLocalRandom.current().nextInt(499, 671), java.util.concurrent.ThreadLocalRandom.current().nextInt(99, 139))));
-        }
-
-        if (!clickActions.isEmpty()) {
-            int randomIndex = java.util.concurrent.ThreadLocalRandom.current().nextInt(clickActions.size());
-            clickActions.get(randomIndex).run();
-            sleepTask(500);
-        }
-
-
-        logDebug(routineLogResearchLine("Normalizing research menu with swipes..."));
-        for (int i = 0; i < 3; i++) {
-            swipe(new PointData(489, 320), new PointData(489, 1156));
-            sleepTask(500);
-        }
-
-
-        TemplatesEnum[] researchTemplates = {
-                TemplatesEnum.RESEARCH_0_3,
-                TemplatesEnum.RESEARCH_1_3,
-                TemplatesEnum.RESEARCH_2_3
-        };
-
-        for (int scrollAttempt = 0; scrollAttempt < MAX_SCROLL_ATTEMPTS_LIMIT; scrollAttempt++) {
-            checkPreemption();
-            sleepTask(500);
-
-            RawImageData researchScreenshot = emuManager.captureScreen(EMULATOR_NUMBER);
-            if (researchScreenshot == null) {
-                logWarning(routineLogResearchLine("Could not capture screenshot for research template search."));
-                continue;
-            }
-
-
-            List<ImageSearchResultData> foundResults = new ArrayList<>();
-            for (TemplatesEnum template : researchTemplates) {
-                // Single-hit search would return only the single best-correlated occurrence
-                // across the whole screen. An untouched tree renders several nodes with the
-                // identical "X/3" badge at once, so it must find ALL of them here for
-                // "topmost of foundResults" below to actually mean the topmost node on screen
-                // (the earliest still-incomplete one, which prerequisite-ordering guarantees is
-                // always the unlocked one) instead of an arbitrary same-looking match.
-                List<ImageSearchResultData> templateResults = emuManager.locateAllPatterns(
-                        EMULATOR_NUMBER, researchScreenshot, template,
-                        new PointData(0, 0), new PointData(720, 1280), 90.0, 10);
-                if (!templateResults.isEmpty()) {
-                    logInfo(routineLogResearchLine("Detected " + templateResults.size()
-                            + " node(s) with template: " + template.name()));
-                    foundResults.addAll(templateResults);
-                }
-            }
-
-            if (!foundResults.isEmpty()) {
-
-
-                ImageSearchResultData highest = foundResults.stream()
-                        .min(Comparator.comparingInt(r -> r.getPoint().getY()))
-                        .get();
-                logInfo(routineLogResearchLine("Pressing research template at position: (" + highest.getPoint().getX() + ", "
-                        + highest.getPoint().getY() + ") with offset"));
-
-                PointData researchPoint = highest.getPoint();
-                PointData adjustedResearchPoint = new PointData(researchPoint.getX() + RESEARCH_CLICK_OFFSET_X_VALUE,
-                        researchPoint.getY() + RESEARCH_CLICK_OFFSET_Y_VALUE);
-
-                tapPoint(adjustedResearchPoint);
-                sleepTask(300);
-                break;
-            }
-
-
-            logDebug(routineLogResearchLine("Zero research templates detected, scrolling up (attempt " + (scrollAttempt + 1) + "/"
-                    + MAX_SCROLL_ATTEMPTS_LIMIT + ")"));
-            swipe(new PointData(489, 800), new PointData(489, 300));
-        }
-
-        sleepTask(1000);
-
-
-        RawImageData researchTextScreenshot = emuManager.captureScreen(EMULATOR_NUMBER);
-        if (researchTextScreenshot != null) {
-            ImageSearchResultData researchTextResult = emuManager.locatePattern(
-                    EMULATOR_NUMBER, researchTextScreenshot, TemplatesEnum.RESEARCH_TEXT, 80.0);
-
-            if (researchTextResult != null && researchTextResult.isFound()) {
-                logInfo(routineLogResearchLine("Research text template detected."));
+        logInfo(routineLogResearchLine("Research text template detected."));
 
 
                 tapPoint(researchTextResult.getPoint());
@@ -323,12 +229,121 @@ public ResearchRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask) {
                 } else {
                     logWarning(routineLogResearchLine("Could not OCR research time. Falling back to 1 hour reschedule."));
                 }
-            } else {
-                logWarning(routineLogResearchLine("Research text template not detected."));
-            }
-        }
 
         this.reschedule(LocalDateTime.now().plusHours(1));
+    }
+
+private ImageSearchResultData findResearchInPriorityCategories() {
+        List<PriorityItemData> priorities = PriorityConfigResolver.activeRankings(
+                profile, ConfigurationKeyEnum.RESEARCH_PRIORITIES_STRING);
+        if (priorities.isEmpty()) {
+            logWarning(routineLogResearchLine("No research categories enabled."));
+            return null;
+        }
+
+        for (PriorityItemData priority : priorities) {
+            ResearchCategoryEnum category = ResearchCategoryEnum.fromKey(priority.getIdentifier());
+            if (category == null) {
+                logWarning(routineLogResearchLine("Ignoring unknown research category priority: " + priority.getIdentifier()));
+                continue;
+            }
+
+            logInfo(routineLogResearchLine("Trying category '" + category.label()
+                    + "' (priority " + priority.getPriority() + ")."));
+            tapCategoryTab(category);
+            sleepTask(500);
+
+            if (!findAndTapResearchNode()) {
+                logInfo(routineLogResearchLine("No available tech node in '" + category.label()
+                        + "'. Trying next category."));
+                continue;
+            }
+
+            sleepTask(1000);
+            RawImageData researchTextScreenshot = emuManager.captureScreen(EMULATOR_NUMBER);
+            ImageSearchResultData candidate = researchTextScreenshot == null ? null
+                    : emuManager.locatePattern(EMULATOR_NUMBER, researchTextScreenshot,
+                            TemplatesEnum.RESEARCH_TEXT, 80.0);
+            if (candidate != null && candidate.isFound()) {
+                logInfo(routineLogResearchLine("'" + category.label() + "' has an available research."));
+                return candidate;
+            }
+
+            logInfo(routineLogResearchLine("'" + category.label()
+                    + "' node did not open a research. Trying next category."));
+            pressBack();
+            sleepTask(500);
+        }
+        return null;
+    }
+
+private void tapCategoryTab(ResearchCategoryEnum category) {
+        switch (category) {
+            case GROWTH -> tapRandomPoint(new PointData(58, 88), new PointData(211, 137));
+            case ECONOMY -> tapRandomPoint(new PointData(274, 84), new PointData(445, 142));
+            case BATTLE -> tapRandomPoint(new PointData(499, 99), new PointData(671, 139));
+        }
+    }
+
+private boolean findAndTapResearchNode() {
+        logDebug(routineLogResearchLine("Normalizing research menu with swipes..."));
+        for (int i = 0; i < 3; i++) {
+            swipe(new PointData(489, 320), new PointData(489, 1156));
+            sleepTask(500);
+        }
+
+        TemplatesEnum[] researchTemplates = {
+                TemplatesEnum.RESEARCH_0_3,
+                TemplatesEnum.RESEARCH_1_3,
+                TemplatesEnum.RESEARCH_2_3
+        };
+
+        for (int scrollAttempt = 0; scrollAttempt < MAX_SCROLL_ATTEMPTS_LIMIT; scrollAttempt++) {
+            checkPreemption();
+            sleepTask(500);
+
+            RawImageData researchScreenshot = emuManager.captureScreen(EMULATOR_NUMBER);
+            if (researchScreenshot == null) {
+                logWarning(routineLogResearchLine("Could not capture screenshot for research template search."));
+                continue;
+            }
+
+            List<ImageSearchResultData> foundResults = new ArrayList<>();
+            for (TemplatesEnum template : researchTemplates) {
+                // Single-hit search would return only the single best-correlated occurrence
+                // across the whole screen. An untouched tree renders several nodes with the
+                // identical "X/3" badge at once, so it must find ALL of them here for
+                // "topmost of foundResults" below to actually mean the topmost node on screen
+                // instead of an arbitrary same-looking match.
+                List<ImageSearchResultData> templateResults = emuManager.locateAllPatterns(
+                        EMULATOR_NUMBER, researchScreenshot, template,
+                        new PointData(0, 0), new PointData(720, 1280), 90.0, 10);
+                if (!templateResults.isEmpty()) {
+                    logInfo(routineLogResearchLine("Detected " + templateResults.size()
+                            + " node(s) with template: " + template.name()));
+                    foundResults.addAll(templateResults);
+                }
+            }
+
+            if (!foundResults.isEmpty()) {
+                ImageSearchResultData highest = foundResults.stream()
+                        .min(Comparator.comparingInt(r -> r.getPoint().getY()))
+                        .get();
+                logInfo(routineLogResearchLine("Pressing research template at position: ("
+                        + highest.getPoint().getX() + ", " + highest.getPoint().getY() + ") with offset"));
+
+                PointData researchPoint = highest.getPoint();
+                tapPoint(new PointData(researchPoint.getX() + RESEARCH_CLICK_OFFSET_X_VALUE,
+                        researchPoint.getY() + RESEARCH_CLICK_OFFSET_Y_VALUE));
+                sleepTask(300);
+                return true;
+            }
+
+            logDebug(routineLogResearchLine("Zero research templates detected, scrolling up (attempt "
+                    + (scrollAttempt + 1) + "/" + MAX_SCROLL_ATTEMPTS_LIMIT + ")"));
+            swipe(new PointData(489, 800), new PointData(489, 300));
+        }
+        return false;
     }
 
 private String routineLogResearchLine(String note) {


### PR DESCRIPTION
## Summary
- add a shared `ResearchCategoryEnum` and persisted `RESEARCH_PRIORITIES_STRING` for Growth, Economy, and Battle
- replace the old random checkbox category choice with the existing reorderable `PriorityListView`
- make `ResearchRoutine` try enabled categories in priority order and start the first category with an available research node

## Why
There was an older implementation idea on `fix/research-replenish` (`e6b90a3`), but that branch is mixed with unrelated resource-replenish and stale history. This PR recuts only category prioritization from current `main` and keeps resource replenish separate.

## Testing
- `mvn -pl fg-app -am package -DskipTests`
- `mvn -pl fg-app -am test -DskipTests=false` (6 tests)
- Integrated into bot1 test stack as `local/staging` commit `ce658a1`
- Live-tested by David on bot1

## Remaining risk
- Research category tab coordinates are the existing fixed regions, now used deterministically by configured order instead of random selection.