### PR TITLE
fix(buildings): reserve production blockers for construction

### DIFF
--- a/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
+++ b/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
@@ -85,6 +85,8 @@ public enum ConfigurationKeyEnum {
     CITY_ACCEPT_NEW_SURVIVORS_BOOL              ("false",   Boolean.class,  ConfigCategory.CITY),
     CITY_ACCEPT_NEW_SURVIVORS_OFFSET_INT        ("60",      Integer.class,  ConfigCategory.CITY),
     CITY_UPGRADE_FURNACE_BOOL                   ("false",   Boolean.class,  ConfigCategory.CITY),
+    CITY_UPGRADE_RESERVE_PRODUCTION_BOOL        ("true",    Boolean.class,  ConfigCategory.CITY),
+    CITY_UPGRADE_CONSTRUCTION_LOCK_STRING       ("",        String.class,   ConfigCategory.CITY),
     CITY_UPGRADE_PRIORITISE_FURNACE_BOOL        ("false",   Boolean.class,  ConfigCategory.CITY),
     RESEARCH_BATTLE_BOOL                        ("false",   Boolean.class,  ConfigCategory.CITY),
     RESEARCH_ECONOMY_BOOL                       ("false",   Boolean.class,  ConfigCategory.CITY),

--- a/fg-app/src/main/java/dev/frostguard/app/panel/city/CityUpgradesLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/city/CityUpgradesLayoutController.java
@@ -14,6 +14,9 @@ public class CityUpgradesLayoutController extends AbstractProfileController {
 	private CheckBox checkBoxUpgradeFurnace;
 
 	@FXML
+	private CheckBox checkBoxReserveProduction;
+
+	@FXML
 	private CheckBox checkBoxPrioritiseFurnace;
 
 	@FXML
@@ -31,6 +34,7 @@ public class CityUpgradesLayoutController extends AbstractProfileController {
 	private void registerCityUpgradeControls() {
 		Map.of(
 				checkBoxUpgradeFurnace, ConfigurationKeyEnum.CITY_UPGRADE_FURNACE_BOOL,
+				checkBoxReserveProduction, ConfigurationKeyEnum.CITY_UPGRADE_RESERVE_PRODUCTION_BOOL,
 				checkBoxPrioritiseFurnace, ConfigurationKeyEnum.CITY_UPGRADE_PRIORITISE_FURNACE_BOOL,
 				checkboxAcceptNewSurvivors, ConfigurationKeyEnum.CITY_ACCEPT_NEW_SURVIVORS_BOOL)
 				.forEach(this::registerCheckBox);

--- a/fg-app/src/main/resources/layout/CityUpgradesLayout.fxml
+++ b/fg-app/src/main/resources/layout/CityUpgradesLayout.fxml
@@ -27,6 +27,12 @@
                         <VBox spacing="10">
                             <CheckBox fx:id="checkBoxUpgradeFurnace" mnemonicParsing="false"
                                       text="Upgrade Furnace" />
+                            <CheckBox fx:id="checkBoxReserveProduction" mnemonicParsing="false"
+                                      text="Reserve training/research for required upgrades">
+                                <tooltip>
+                                    <Tooltip text="When a required camp or Research Center is busy, pause only that production queue until construction can start. The reservation remains active after resource or build failures." />
+                                </tooltip>
+                            </CheckBox>
                             <CheckBox fx:id="checkBoxPrioritiseFurnace" mnemonicParsing="false"
                                       text="Prioritise Furnace" />
                         </VBox>

--- a/fg-tasks/pom.xml
+++ b/fg-tasks/pom.xml
@@ -42,5 +42,12 @@
 			<artifactId>logback-classic</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+
+		<!-- Tests -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/city/ConstructionBlockerRegistry.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/city/ConstructionBlockerRegistry.java
@@ -1,0 +1,121 @@
+package dev.frostguard.tasks.city;
+
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.engine.service.ConfigService;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+final class ConstructionBlockerRegistry {
+
+    private static final String VERSION = "v1";
+
+    enum Consumer {
+        INFANTRY,
+        LANCER,
+        MARKSMAN,
+        RESEARCH
+    }
+
+    record Reservation(Set<Consumer> consumers, int constructionQueue, LocalDateTime retryAt) {
+
+        Reservation {
+            consumers = consumers.isEmpty() ? Set.of() : Set.copyOf(consumers);
+        }
+
+        boolean blocks(Consumer consumer) {
+            return consumers.contains(consumer);
+        }
+    }
+
+    private ConstructionBlockerRegistry() {
+    }
+
+    static Optional<Reservation> reservation(AccountDescriptor profile) {
+        if (profile == null) {
+            return Optional.empty();
+        }
+        if (!isEnabled(profile)) {
+            if (!profile.getConfig(ConfigurationKeyEnum.CITY_UPGRADE_CONSTRUCTION_LOCK_STRING, String.class).isBlank()) {
+                clear(profile);
+            }
+            return Optional.empty();
+        }
+        return decode(profile.getConfig(ConfigurationKeyEnum.CITY_UPGRADE_CONSTRUCTION_LOCK_STRING, String.class));
+    }
+
+    static Optional<Reservation> reservationFor(AccountDescriptor profile, Consumer consumer) {
+        return reservation(profile).filter(value -> value.blocks(consumer));
+    }
+
+    static void reserve(AccountDescriptor profile, Set<Consumer> consumers, int constructionQueue,
+            LocalDateTime retryAt) {
+        if (profile == null || consumers == null || consumers.isEmpty() || constructionQueue < 1 || retryAt == null) {
+            return;
+        }
+        if (!isEnabled(profile)) {
+            clear(profile);
+            return;
+        }
+        write(profile, encode(new Reservation(consumers, constructionQueue, retryAt)));
+    }
+
+    static void clear(AccountDescriptor profile) {
+        if (profile != null) {
+            write(profile, "");
+        }
+    }
+
+    static String encode(Reservation reservation) {
+        String consumers = reservation.consumers().stream()
+                .map(Enum::name)
+                .sorted()
+                .collect(Collectors.joining(","));
+        long retryEpochMillis = reservation.retryAt().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        return String.join(";", VERSION, Integer.toString(reservation.constructionQueue()),
+                Long.toString(retryEpochMillis), consumers);
+    }
+
+    static Optional<Reservation> decode(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            String[] fields = raw.split(";", -1);
+            if (fields.length != 4 || !VERSION.equals(fields[0])) {
+                return Optional.empty();
+            }
+            int queue = Integer.parseInt(fields[1]);
+            long retryEpochMillis = Long.parseLong(fields[2]);
+            EnumSet<Consumer> consumers = Arrays.stream(fields[3].split(","))
+                    .filter(value -> !value.isBlank())
+                    .map(Consumer::valueOf)
+                    .collect(Collectors.toCollection(() -> EnumSet.noneOf(Consumer.class)));
+            if (queue < 1 || consumers.isEmpty()) {
+                return Optional.empty();
+            }
+            LocalDateTime retryAt = LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(retryEpochMillis), ZoneId.systemDefault());
+            return Optional.of(new Reservation(consumers, queue, retryAt));
+        } catch (RuntimeException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private static void write(AccountDescriptor profile, String value) {
+        ConfigService.obtain().writeAccountSetting(
+                profile, ConfigurationKeyEnum.CITY_UPGRADE_CONSTRUCTION_LOCK_STRING, value);
+    }
+
+    private static boolean isEnabled(AccountDescriptor profile) {
+        return Boolean.TRUE.equals(profile.getConfig(ConfigurationKeyEnum.CITY_UPGRADE_FURNACE_BOOL, Boolean.class))
+                && Boolean.TRUE.equals(profile.getConfig(
+                        ConfigurationKeyEnum.CITY_UPGRADE_RESERVE_PRODUCTION_BOOL, Boolean.class));
+    }
+}

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
@@ -43,8 +43,23 @@ public ResearchRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask) {
         return LaunchPoint.HOME;
     }
 
-@Override
+    @Override
     protected void execute() {
+
+        var constructionReservation = ConstructionBlockerRegistry.reservationFor(
+                profile, ConstructionBlockerRegistry.Consumer.RESEARCH);
+        if (constructionReservation.isPresent()) {
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime retryAt = constructionReservation.get().retryAt();
+            if (!retryAt.isAfter(now)) {
+                retryAt = now.plusMinutes(5);
+            }
+            logInfo(routineLogResearchLine(
+                    "Research Center remains reserved until construction start is verified. Next check at "
+                            + retryAt + "; training camps remain independent."));
+            this.reschedule(retryAt);
+            return;
+        }
 
 
         navigationHelper.ensureCorrectScreenLocation(LaunchPoint.HOME);

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/city/TrainingRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/city/TrainingRoutine.java
@@ -171,6 +171,13 @@ protected void loadConfiguration() {
 
         List<QueueSlot> analyzedQueues = inspectAllQueues();
 
+        enabledTroopTypes.stream()
+                .map(type -> Map.entry(type, reservationUntil(type)))
+                .filter(entry -> entry.getValue().isPresent())
+                .forEach(entry -> logInfo(routineLogTrainingLine(
+                        "Skipping " + entry.getKey() + " training while reserved for construction; next check at "
+                                + entry.getValue().orElseThrow().format(DATETIME_FORMATTER))));
+
         if (manageSoonReadyQueue(analyzedQueues))
             return;
 
@@ -321,6 +328,7 @@ private void refreshMinistryAppointmentIfNeeded() {
 private List<LocalDateTime> extractExistingCompletionTimesFlow(List<QueueSlot> queues) {
         return queues.stream()
                 .filter(q -> q.status() == QueueMood.TRAINING)
+                .filter(q -> !isReservedForConstruction(q.type()))
                 .map(QueueSlot::readyAt)
                 .filter(Objects::nonNull)
                 .toList();
@@ -711,13 +719,16 @@ private List<Integer> locateUnknownQueueIndices(List<QueueSlot> results) {
     }
 
 private void deferToEarliestCompletion(List<LocalDateTime> completionTimes) {
-        if (completionTimes.isEmpty()) {
+        List<LocalDateTime> candidates = new ArrayList<>(completionTimes);
+        earliestReservationCheck().ifPresent(candidates::add);
+
+        if (candidates.isEmpty()) {
             logInfo(routineLogTrainingLine("Zero completion times extracted. Planning next run retry soon."));
             reschedule(LocalDateTime.now().plusMinutes(TRAINING_BUTTON_RETRY_MINUTES_VALUE));
             return;
         }
 
-        LocalDateTime earliest = completionTimes.stream()
+        LocalDateTime earliest = candidates.stream()
                 .filter(Objects::nonNull)
                 .min(LocalDateTime::compareTo)
                 .orElse(LocalDateTime.now().plusMinutes(TRAINING_BUTTON_RETRY_MINUTES_VALUE));
@@ -811,16 +822,23 @@ private boolean openUpTrainingInterface() {
 
 private boolean manageAllTrainingQueues(List<QueueSlot> queues) {
         boolean allTraining = queues.stream()
-                .allMatch(q -> q.status() == QueueMood.TRAINING);
+                .allMatch(q -> q.status() == QueueMood.TRAINING || isReservedForConstruction(q.type()));
 
         if (!allTraining) {
             return false;
         }
 
         Optional<LocalDateTime> nextReadyTime = queues.stream()
+                .filter(q -> !isReservedForConstruction(q.type()))
                 .map(QueueSlot::readyAt)
                 .filter(Objects::nonNull)
                 .min(LocalDateTime::compareTo);
+
+        Optional<LocalDateTime> reservationRelease = earliestReservationCheck();
+        if (reservationRelease.isPresent()
+                && (nextReadyTime.isEmpty() || reservationRelease.get().isBefore(nextReadyTime.get()))) {
+            nextReadyTime = reservationRelease;
+        }
 
         if (nextReadyTime.isPresent()) {
             logInfo(routineLogTrainingLine("All queues TRAINING. Planning next run to earliest completion: " +
@@ -1094,6 +1112,7 @@ private boolean manageUpgradingQueues(List<QueueSlot> queues) {
 private List<QueueSlot> filterReadyQueuesFlow(List<QueueSlot> queues) {
         return queues.stream()
                 .filter(q -> q.status() == QueueMood.COMPLETE || q.status() == QueueMood.IDLE)
+                .filter(q -> !isReservedForConstruction(q.type()))
                 .toList();
     }
 
@@ -1134,6 +1153,7 @@ private void resetTabPositionFlow() {
 private boolean manageSoonReadyQueue(List<QueueSlot> queues) {
         Optional<QueueSlot> soonReady = queues.stream()
                 .filter(q -> q.status() == QueueMood.TRAINING && q.readyAt() != null)
+                .filter(q -> !isReservedForConstruction(q.type()))
                 .filter(q -> Duration.between(LocalDateTime.now(), q.readyAt())
                         .toMinutes() <= SOON_READY_THRESHOLD_MINUTES_VALUE)
                 .findFirst();
@@ -1150,6 +1170,33 @@ private boolean manageSoonReadyQueue(List<QueueSlot> queues) {
         }
 
         return false;
+    }
+
+private boolean isReservedForConstruction(TroopTypeShape type) {
+        return reservationUntil(type).isPresent();
+    }
+
+private Optional<LocalDateTime> reservationUntil(TroopTypeShape type) {
+        ConstructionBlockerRegistry.Consumer consumer = switch (type) {
+            case INFANTRY -> ConstructionBlockerRegistry.Consumer.INFANTRY;
+            case LANCER -> ConstructionBlockerRegistry.Consumer.LANCER;
+            case MARKSMAN -> ConstructionBlockerRegistry.Consumer.MARKSMAN;
+        };
+        return ConstructionBlockerRegistry.reservationFor(profile, consumer)
+                .map(ConstructionBlockerRegistry.Reservation::retryAt)
+                .map(this::normalizeConstructionRetry);
+    }
+
+private LocalDateTime normalizeConstructionRetry(LocalDateTime retryAt) {
+        LocalDateTime minimumRetry = LocalDateTime.now().plusMinutes(TRAINING_BUTTON_RETRY_MINUTES_VALUE);
+        return retryAt.isAfter(minimumRetry) ? retryAt : minimumRetry;
+}
+
+private Optional<LocalDateTime> earliestReservationCheck() {
+        return enabledTroopTypes.stream()
+                .map(this::reservationUntil)
+                .flatMap(Optional::stream)
+                .min(LocalDateTime::compareTo);
     }
 
 private AreaData resolvePipelineArea(TroopTypeShape type) {

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/city/UpgradeBuildingsRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/city/UpgradeBuildingsRoutine.java
@@ -10,10 +10,15 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import static dev.frostguard.api.configs.TemplatesEnum.BUILDING_BUTTON_INFO;
+import static dev.frostguard.api.configs.TemplatesEnum.BUILDING_BUTTON_RESEARCH;
 import static dev.frostguard.api.configs.TemplatesEnum.BUILDING_BUTTON_SPEED;
 import static dev.frostguard.api.configs.TemplatesEnum.BUILDING_BUTTON_TRAIN;
 import static dev.frostguard.api.configs.TemplatesEnum.BUILDING_BUTTON_UPGRADE;
@@ -33,6 +38,16 @@ private static final AreaData BUILDING_ACTION_BUTTON_AREA_VALUE = new AreaData(n
 
 private static final AreaData BUILDING_CONFIRM_BUTTON_AREA_VALUE = new AreaData(new PointData(489, 1034), new PointData(500, 1050));
 
+private static final AreaData BUILDING_NAME_AREA_VALUE = new AreaData(new PointData(260, 510), new PointData(510, 575));
+
+private static final int BLOCKER_RELEASE_GRACE_MINUTES = 5;
+
+private static final int COMPLETION_SETTLE_SECONDS = 2;
+
+private static final int MAX_RECOMMENDED_BUILDING_ATTEMPTS = 2;
+
+private static final int TEMPLATE_TAP_RADIUS = 8;
+
 private final List<AreaData> queues = new ArrayList<>(Arrays.asList(QUEUE_AREA_1_VALUE, QUEUE_AREA_2_VALUE));
 
 public UpgradeBuildingsRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDailyTaskEnum) {
@@ -50,6 +65,7 @@ public UpgradeBuildingsRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDail
 
 
         logQueueSummaryFlow(queueResults);
+        clearConstructionReservationWhenStarted(queueResults);
 
 
         boolean hasIdleQueue = queueResults.stream()
@@ -59,18 +75,21 @@ public UpgradeBuildingsRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDail
         if (hasIdleQueue) {
 
 
-            List<LocalDateTime> troopTrainingTimes = new ArrayList<>();
+            List<ProductionBlocker> productionBlockers = new ArrayList<>();
+            Set<Integer> attemptedQueues = new java.util.HashSet<>();
 
 
             for (UpgradeBuildingsRoutine.QueueReadout result : queueResults) {
                 if (result.state.status == UpgradeBuildingsRoutine.QueueMood.IDLE ||
                         result.state.status == UpgradeBuildingsRoutine.QueueMood.IDLE_TEMP) {
                     logInfo(routineLogUpgradeBuildingsLine("Processing queue " + result.queueNumber + " (Status: " + result.state.status + ")"));
-                    LocalDateTime trainingTime = handleQueue(result);
+                    QueueHandlingResult handlingResult = handleQueue(result);
 
-
-                    if (trainingTime != null) {
-                        troopTrainingTimes.add(trainingTime);
+                    if (handlingResult.constructionAttempted()) {
+                        attemptedQueues.add(result.queueNumber());
+                    }
+                    if (handlingResult.blocker() != null) {
+                        productionBlockers.add(handlingResult.blocker());
                     }
                 }
             }
@@ -87,37 +106,35 @@ public UpgradeBuildingsRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDail
 
             logInfo(routineLogUpgradeBuildingsLine("=== Updated Queue Analysis After Processing ==="));
             logQueueSummaryFlow(updatedResults);
+            clearConstructionReservationWhenStarted(updatedResults);
 
 
-            if (!troopTrainingTimes.isEmpty()) {
-                logInfo(routineLogUpgradeBuildingsLine("Adding troop training times to scheduling calculation:"));
-                for (LocalDateTime trainingTime : troopTrainingTimes) {
-                    LocalDateTime now = LocalDateTime.now();
-                    Duration duration = Duration.between(now, trainingTime);
+            if (!productionBlockers.isEmpty()) {
+                LocalDateTime retryAt = productionBlockers.stream()
+                        .map(ProductionBlocker::completionTime)
+                        .min(LocalDateTime::compareTo)
+                        .orElse(LocalDateTime.now().plusMinutes(5))
+                        .plusSeconds(COMPLETION_SETTLE_SECONDS);
+                logInfo(routineLogUpgradeBuildingsLine(
+                        "Recommended building is blocked by production. Planning exact handoff retry for: " + retryAt));
+                this.reschedule(retryAt);
+                marchHelper.closeLeftMenu();
+                return;
+            }
 
-                    long totalMinutes = duration.toMinutes();
-                    logInfo(routineLogUpgradeBuildingsLine("- Training time: " + totalMinutes + " minutes"));
-
-                    int hours = (int) duration.toHours();
-                    int minutes = (int) (duration.toMinutes() % 60);
-                    int seconds = (int) (duration.getSeconds() % 60);
-                    String timeString = String.format("%02d%02d%02d", hours, minutes, seconds);
-
-                    UpgradeBuildingsRoutine.QueueSnapshot trainingState = new UpgradeBuildingsRoutine.QueueSnapshot(
-                            UpgradeBuildingsRoutine.QueueMood.BUSY, timeString);
-                    UpgradeBuildingsRoutine.QueueReadout trainingResult = new UpgradeBuildingsRoutine.QueueReadout(
-                            -1, null, trainingState);
-
-                    updatedResults.add(trainingResult);
-                }
+            if (rescheduleForRetainedReservation(attemptedQueues)) {
+                marchHelper.closeLeftMenu();
+                return;
             }
 
 
             deferBasedOnBusyQueues(updatedResults);
             marchHelper.closeLeftMenu();
         } else {
-
-
+            if (rescheduleForRetainedReservation(Set.of())) {
+                marchHelper.closeLeftMenu();
+                return;
+            }
             deferBasedOnBusyQueues(queueResults);
         }
     }
@@ -154,6 +171,28 @@ private record QueueReadout(int queueNumber, AreaData queueArea, UpgradeBuilding
                 sb.append(" (").append(state.timeRemaining).append(")");
             }
             return sb.toString();
+        }
+    }
+
+private record ProductionBlocker(Set<ConstructionBlockerRegistry.Consumer> consumers,
+        int constructionQueue, LocalDateTime completionTime) {
+    }
+
+private record QueueHandlingResult(boolean constructionAttempted, ProductionBlocker blocker) {
+    }
+
+private record QueueAttemptResult(boolean handled, ProductionBlocker blocker) {
+
+        private static QueueAttemptResult completed() {
+            return new QueueAttemptResult(true, null);
+        }
+
+        private static QueueAttemptResult blockedBy(ProductionBlocker blocker) {
+            return new QueueAttemptResult(true, blocker);
+        }
+
+        private static QueueAttemptResult unresolved() {
+            return new QueueAttemptResult(false, null);
         }
     }
 
@@ -264,40 +303,165 @@ private void logQueueSummaryFlow(List<UpgradeBuildingsRoutine.QueueReadout> queu
         }
     }
 
-private LocalDateTime handleTroopBuilding() {
+private ProductionBlocker handleProductionBlocker(int constructionQueue) {
         ImageSearchResultData train = templateSearchHelper.locatePattern(BUILDING_BUTTON_TRAIN,
                 SearchConfigConstants.DEFAULT_SINGLE);
+        ImageSearchResultData research = train.isFound()
+                ? null
+                : templateSearchHelper.locatePattern(BUILDING_BUTTON_RESEARCH,
+                        SearchConfigConstants.DEFAULT_SINGLE);
 
+        if (!train.isFound() && (research == null || !research.isFound())) {
+            return null;
+        }
+
+        Set<ConstructionBlockerRegistry.Consumer> consumers;
         if (train.isFound()) {
-            logInfo(routineLogUpgradeBuildingsLine("A troop training building was detected. Planning next run the task until the training is complete."));
-
-            ImageSearchResultData speedupButton = templateSearchHelper.locatePattern(BUILDING_BUTTON_SPEED,
-                    SearchConfigConstants.DEFAULT_SINGLE);
-
-            if (speedupButton.isFound()) {
-                tapRandomPoint(speedupButton.getPoint(), speedupButton.getPoint(), 1, 500);
-
-                Duration trainingTime = durationHelper.attemptRecognition(
-                        new PointData(292, 284),
-                        new PointData(432, 314),
-                        5,
-                        300,
-                        null,
-                        GameTimeUtils::isAcceptedFormat,
-                        GameTimeUtils::parseDuration);
-
-                if (trainingTime == null) {
-                    return null;
-                }
-
-                LocalDateTime completionTime = LocalDateTime.now().plus(trainingTime);
-
-                logInfo(routineLogUpgradeBuildingsLine("Building will complete training at approximately: " + completionTime));
-
-                return completionTime.minusSeconds(5);
+            String buildingName = readSelectedBuildingName();
+            ConstructionBlockerRegistry.Consumer identified = identifyTrainingConsumer(buildingName);
+            if (identified == null) {
+                consumers = EnumSet.of(
+                        ConstructionBlockerRegistry.Consumer.INFANTRY,
+                        ConstructionBlockerRegistry.Consumer.LANCER,
+                        ConstructionBlockerRegistry.Consumer.MARKSMAN);
+                logWarning(routineLogUpgradeBuildingsLine(
+                        "Training building name was unreadable. Reserving all training queues as a safe fallback."));
+            } else {
+                consumers = EnumSet.of(identified);
             }
+        } else {
+            consumers = EnumSet.of(ConstructionBlockerRegistry.Consumer.RESEARCH);
+        }
+
+        ImageSearchResultData speedupButton = templateSearchHelper.locatePattern(BUILDING_BUTTON_SPEED,
+                SearchConfigConstants.DEFAULT_SINGLE);
+        if (!speedupButton.isFound()) {
+            logWarning(routineLogUpgradeBuildingsLine(
+                    "Production blocker detected, but its speedup button was not found. Retrying in 5 minutes."));
+            LocalDateTime retryAt = LocalDateTime.now().plusMinutes(BLOCKER_RELEASE_GRACE_MINUTES);
+            reserveConsumers(consumers, constructionQueue, retryAt);
+            return new ProductionBlocker(consumers, constructionQueue, retryAt);
+        }
+
+        tapAround(speedupButton.getPoint(), TEMPLATE_TAP_RADIUS, 500);
+        Duration remaining = durationHelper.attemptRecognition(
+                new PointData(292, 284),
+                new PointData(432, 314),
+                5,
+                300,
+                null,
+                GameTimeUtils::isAcceptedFormat,
+                GameTimeUtils::parseDuration);
+
+        if (remaining == null) {
+            logWarning(routineLogUpgradeBuildingsLine(
+                    "Could not read the production blocker timer. Retrying in 5 minutes."));
+            LocalDateTime retryAt = LocalDateTime.now().plusMinutes(BLOCKER_RELEASE_GRACE_MINUTES);
+            reserveConsumers(consumers, constructionQueue, retryAt);
+            return new ProductionBlocker(consumers, constructionQueue, retryAt);
+        }
+
+        LocalDateTime completionTime = LocalDateTime.now().plus(remaining);
+        reserveConsumers(consumers, constructionQueue, completionTime);
+        logInfo(routineLogUpgradeBuildingsLine("Production blocker " + consumers
+                + " completes at approximately " + completionTime
+                + "; consumer remains reserved until construction start is verified"));
+        return new ProductionBlocker(consumers, constructionQueue, completionTime);
+    }
+
+private String readSelectedBuildingName() {
+        try {
+            String text = emuManager.readText(
+                    EMULATOR_NUMBER,
+                    BUILDING_NAME_AREA_VALUE.topLeft(),
+                    BUILDING_NAME_AREA_VALUE.bottomRight(),
+                    WHITE_SETTINGS).trim();
+            logInfo(routineLogUpgradeBuildingsLine("Selected building name OCR: '" + text + "'"));
+            return text;
+        } catch (Exception e) {
+            logWarning(routineLogUpgradeBuildingsLine("Could not read selected building name: " + e.getMessage()));
+            return "";
+        }
+    }
+
+static ConstructionBlockerRegistry.Consumer identifyTrainingConsumer(String buildingName) {
+        String normalized = buildingName == null
+                ? ""
+                : buildingName.toLowerCase(Locale.ROOT).replaceAll("[^a-z]", "");
+        if (normalized.contains("infantry")) {
+            return ConstructionBlockerRegistry.Consumer.INFANTRY;
+        }
+        if (normalized.contains("lancer")) {
+            return ConstructionBlockerRegistry.Consumer.LANCER;
+        }
+        if (normalized.contains("marksman")) {
+            return ConstructionBlockerRegistry.Consumer.MARKSMAN;
         }
         return null;
+    }
+
+private void reserveConsumers(Set<ConstructionBlockerRegistry.Consumer> consumers, int constructionQueue,
+        LocalDateTime retryAt) {
+        ConstructionBlockerRegistry.reserve(profile, consumers, constructionQueue, retryAt);
+}
+
+private void clearConstructionReservationWhenStarted(List<QueueReadout> queueResults) {
+        boolean hasIdleQueue = queueResults.stream()
+                .anyMatch(result -> result.state().status() == QueueMood.IDLE
+                        || result.state().status() == QueueMood.IDLE_TEMP);
+        Optional<QueueReadout> busyQueue = queueResults.stream()
+                .filter(result -> result.state().status() == QueueMood.BUSY)
+                .findFirst();
+        if (!shouldReleaseReservation(hasIdleQueue, busyQueue.isPresent())) {
+            return;
+        }
+
+        ConstructionBlockerRegistry.reservation(profile).ifPresent(reservation -> busyQueue
+                .ifPresent(result -> {
+                    logInfo(routineLogUpgradeBuildingsLine(
+                            "No construction queue is free and queue " + result.queueNumber()
+                                    + " is BUSY; clearing production consumer lock "
+                                    + reservation.consumers()));
+                    ConstructionBlockerRegistry.clear(profile);
+                }));
+    }
+
+static boolean shouldReleaseReservation(boolean hasIdleQueue, boolean hasBusyQueue) {
+        return !hasIdleQueue && hasBusyQueue;
+}
+
+private boolean rescheduleForRetainedReservation(Set<Integer> attemptedQueues) {
+        Optional<ConstructionBlockerRegistry.Reservation> retainedReservation =
+                ConstructionBlockerRegistry.reservation(profile);
+        if (retainedReservation.isEmpty()) {
+            return false;
+        }
+
+        ConstructionBlockerRegistry.Reservation reservation = retainedReservation.get();
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime retryAt = reservation.retryAt().isAfter(now)
+                ? reservation.retryAt()
+                : now.plusMinutes(BLOCKER_RELEASE_GRACE_MINUTES);
+        if (!retryAt.equals(reservation.retryAt())) {
+            ConstructionBlockerRegistry.reserve(profile, reservation.consumers(),
+                    reservation.constructionQueue(), retryAt);
+        }
+        String attemptEvidence = attemptedQueues.contains(reservation.constructionQueue())
+                ? "the construction attempt did not make the queue BUSY"
+                : "the reserved queue did not provide start evidence";
+        logWarning(routineLogUpgradeBuildingsLine(
+                "Keeping production consumer lock because " + attemptEvidence
+                        + ". Retrying construction at " + retryAt));
+        this.reschedule(retryAt);
+        return true;
+}
+
+private void tapAround(PointData center, int radius, int delayMs) {
+        tapRandomPoint(
+                new PointData(center.getX() - radius, center.getY() - radius),
+                new PointData(center.getX() + radius, center.getY() + radius),
+                1,
+                delayMs);
     }
 
 private long decodeTimeToMinutes(String timeString) {
@@ -395,7 +559,10 @@ private void handleCityBuilding() {
         }
 
 
-        startBuildingAction("upgrade", upgradeButton.getPoint(), upgradeButton.getPoint());
+        PointData center = upgradeButton.getPoint();
+        startBuildingAction("upgrade",
+                new PointData(center.getX() - TEMPLATE_TAP_RADIUS, center.getY() - TEMPLATE_TAP_RADIUS),
+                new PointData(center.getX() + TEMPLATE_TAP_RADIUS, center.getY() + TEMPLATE_TAP_RADIUS));
     }
 
 private void handleNewBuilding() {
@@ -618,7 +785,26 @@ private void reachCityView() {
                 1000);
     }
 
-private LocalDateTime handleQueue(UpgradeBuildingsRoutine.QueueReadout queueResult) {
+private QueueHandlingResult handleQueue(UpgradeBuildingsRoutine.QueueReadout queueResult) {
+        for (int attempt = 1; attempt <= MAX_RECOMMENDED_BUILDING_ATTEMPTS; attempt++) {
+            QueueAttemptResult result = handleQueueAttempt(queueResult);
+            if (result.handled()) {
+                return new QueueHandlingResult(result.blocker() == null, result.blocker());
+            }
+            if (attempt < MAX_RECOMMENDED_BUILDING_ATTEMPTS) {
+                logInfo(routineLogUpgradeBuildingsLine(
+                        "Recommended building had no actionable button. Reopening it once in case the first tap claimed completed production."));
+                navigationHelper.ensureCorrectScreenLocation(LaunchPoint.HOME);
+                sleepTask(500);
+            }
+        }
+
+        logWarning(routineLogUpgradeBuildingsLine(
+                "Recommended building remained unresolved after " + MAX_RECOMMENDED_BUILDING_ATTEMPTS + " attempts."));
+        return new QueueHandlingResult(false, null);
+    }
+
+private QueueAttemptResult handleQueueAttempt(UpgradeBuildingsRoutine.QueueReadout queueResult) {
 
 
         reachCityView();
@@ -640,7 +826,7 @@ private LocalDateTime handleQueue(UpgradeBuildingsRoutine.QueueReadout queueResu
 
             tapPoint(new PointData(lowBuilding.getPoint().getX() + 100, lowBuilding.getPoint().getY()));
             handleSurvivorBuilding();
-            return null;
+            return QueueAttemptResult.completed();
         } else {
 
 
@@ -650,15 +836,18 @@ private LocalDateTime handleQueue(UpgradeBuildingsRoutine.QueueReadout queueResu
 
             if (upgradeButton.isFound()) {
                 handleCityBuilding();
-                return null;
+                return QueueAttemptResult.completed();
             } else {
 
                 if (isBuildButtonVisible()) {
                     handleNewBuilding();
-                    return null;
+                    return QueueAttemptResult.completed();
                 }
 
-                return handleTroopBuilding();
+                ProductionBlocker blocker = handleProductionBlocker(queueResult.queueNumber());
+                return blocker == null
+                        ? QueueAttemptResult.unresolved()
+                        : QueueAttemptResult.blockedBy(blocker);
             }
         }
     }

--- a/fg-tasks/src/test/java/dev/frostguard/tasks/city/ConstructionBlockerRegistryTest.java
+++ b/fg-tasks/src/test/java/dev/frostguard/tasks/city/ConstructionBlockerRegistryTest.java
@@ -1,0 +1,64 @@
+package dev.frostguard.tasks.city;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.EnumSet;
+import org.junit.jupiter.api.Test;
+
+class ConstructionBlockerRegistryTest {
+
+    @Test
+    void persistsQueueConsumersAndRetryAnchorAsOneValue() {
+        LocalDateTime retryAt = LocalDateTime.of(2026, 7, 15, 20, 13, 25);
+        var original = new ConstructionBlockerRegistry.Reservation(
+                EnumSet.of(ConstructionBlockerRegistry.Consumer.INFANTRY), 1, retryAt);
+
+        var restored = ConstructionBlockerRegistry.decode(
+                ConstructionBlockerRegistry.encode(original)).orElseThrow();
+
+        assertEquals(original, restored);
+        assertTrue(restored.blocks(ConstructionBlockerRegistry.Consumer.INFANTRY));
+        assertTrue(!restored.blocks(ConstructionBlockerRegistry.Consumer.MARKSMAN));
+    }
+
+    @Test
+    void elapsedRetryAnchorDoesNotExpireTheReservation() {
+        LocalDateTime elapsed = LocalDateTime.of(2026, 7, 15, 19, 0);
+        var original = new ConstructionBlockerRegistry.Reservation(
+                EnumSet.of(ConstructionBlockerRegistry.Consumer.RESEARCH), 2, elapsed);
+
+        var restored = ConstructionBlockerRegistry.decode(
+                ConstructionBlockerRegistry.encode(original)).orElseThrow();
+
+        assertEquals(elapsed, restored.retryAt());
+        assertTrue(restored.blocks(ConstructionBlockerRegistry.Consumer.RESEARCH));
+    }
+
+    @Test
+    void rejectsMalformedPersistedReservationsConservatively() {
+        assertTrue(ConstructionBlockerRegistry.decode("").isEmpty());
+        assertTrue(ConstructionBlockerRegistry.decode("v1;0;123;INFANTRY").isEmpty());
+        assertTrue(ConstructionBlockerRegistry.decode("v1;1;123;NOT_A_CONSUMER").isEmpty());
+    }
+
+    @Test
+    void releasesOnlyWhenConstructionIsBusyAndNoQueueIsFree() {
+        assertTrue(UpgradeBuildingsRoutine.shouldReleaseReservation(false, true));
+        assertTrue(!UpgradeBuildingsRoutine.shouldReleaseReservation(true, true));
+        assertTrue(!UpgradeBuildingsRoutine.shouldReleaseReservation(true, false));
+        assertTrue(!UpgradeBuildingsRoutine.shouldReleaseReservation(false, false));
+    }
+
+    @Test
+    void identifiesTrainingCampFromVisibleBuildingTitle() {
+        assertEquals(ConstructionBlockerRegistry.Consumer.INFANTRY,
+                UpgradeBuildingsRoutine.identifyTrainingConsumer("Infantry Camp"));
+        assertEquals(ConstructionBlockerRegistry.Consumer.LANCER,
+                UpgradeBuildingsRoutine.identifyTrainingConsumer("Lancer Camp"));
+        assertEquals(ConstructionBlockerRegistry.Consumer.MARKSMAN,
+                UpgradeBuildingsRoutine.identifyTrainingConsumer("Marksman-Camp"));
+        assertTrue(UpgradeBuildingsRoutine.identifyTrainingConsumer("Camp") == null);
+    }
+}


### PR DESCRIPTION
## What changed
- reserve the specific training camp or Research Center when it blocks a recommended City Upgrade
- read the blocker countdown and schedule City Upgrade at the exact handoff while allowing unrelated camps to keep training
- retain the reservation after resource shortages or failed construction starts because construction has priority
- clear the reservation when no usable construction queue is free and construction is confirmed BUSY
- add a default-on per-profile UI option to disable this behavior
- randomize taps in the decisive detected areas

## Why
Continuous training or research could restart just before City Upgrade retried, indefinitely preventing a required Furnace prerequisite from upgrading.

## Verification
- live Default-profile run identified Infantry Camp, scheduled the handoff, skipped only Infantry, then cleared the lock after construction became BUSY
- manual speedup/forced scheduling flow verified training resumes after construction starts
- `mvn -pl fg-tasks -am test -DskipTests=false`: 38 engine + 5 task tests passed, including the two-queue release matrix
- `mvn -pl fg-app -am package -DskipTests`: full reactor package succeeded
- rebuilt desktop app started successfully and loaded native OpenCV

## Remaining risk
- persistent UNKNOWN construction-queue reads retain the lock conservatively instead of risking production restart