### PR TITLE
feat(gift-codes): automate region-aware claims

### DIFF
--- a/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
+++ b/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
@@ -280,6 +280,7 @@ public enum ConfigurationKeyEnum {
     TELEGRAM_ALLOWED_CHAT_ID_STRING     ("",            String.class,   ConfigCategory.SYSTEM),
     TELEGRAM_BOT_ENABLED_BOOL          ("false",       Boolean.class,  ConfigCategory.SYSTEM),
     TELEGRAM_BOT_TOKEN_STRING           ("",            String.class,   ConfigCategory.SYSTEM),
+    GIFT_CODE_STATE_JSON                ("{}",          String.class,   ConfigCategory.SYSTEM, true),
 
     /* ─────────── testing ─────────── */
 

--- a/fg-app/pom.xml
+++ b/fg-app/pom.xml
@@ -81,6 +81,10 @@
 		</dependency>
 		<dependency>
 			<groupId>dev.frostguard</groupId>
+			<artifactId>fg-data</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>dev.frostguard</groupId>
 			<artifactId>fg-tasks</artifactId>
 		</dependency>
 		<dependency>
@@ -97,6 +101,12 @@
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/fg-app/src/main/java/dev/frostguard/app/bootstrap/FXApp.java
+++ b/fg-app/src/main/java/dev/frostguard/app/bootstrap/FXApp.java
@@ -3,6 +3,7 @@ package dev.frostguard.app.bootstrap;
 import atlantafx.base.theme.PrimerDark;
 import dev.frostguard.app.panel.launcher.ILauncherConstants;
 import dev.frostguard.app.panel.launcher.LauncherLayoutController;
+import dev.frostguard.app.panel.misc.GiftCodeAutomationService;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
@@ -51,6 +52,7 @@ public class FXApp extends Application {
 
         configureStage(stage, scene);
         stage.show();
+        GiftCodeAutomationService.getInstance().start();
         restoreWindowBounds(stage);
         maybeAutoStart(controller);
         stage.setOnCloseRequest(event -> shutdownFromUi(stage));

--- a/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftCodeAutomationService.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftCodeAutomationService.java
@@ -1,0 +1,679 @@
+package dev.frostguard.app.panel.misc;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.app.panel.misc.GiftCodeClient.GiftCodeEntry;
+import dev.frostguard.app.panel.misc.GiftCodeRedeemer.RedeemResult;
+import dev.frostguard.app.panel.misc.GiftCodeRedeemer.RedeemOutcome;
+import dev.frostguard.app.panel.misc.GiftCodeStore.LegacyClaim;
+import dev.frostguard.app.panel.misc.GiftCodeStore.GiftCodeRecipient;
+import dev.frostguard.engine.service.ProfileService;
+
+public final class GiftCodeAutomationService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GiftCodeAutomationService.class);
+    private static final GiftCodeAutomationService INSTANCE = new GiftCodeAutomationService();
+    private static final int MAX_ATTEMPTS_PER_CLAIM = 3;
+    private static final Duration AUTO_CHECK_INTERVAL = Duration.ofHours(1);
+    private static final Duration MIN_CLAIM_REQUEST_INTERVAL = Duration.ofSeconds(1);
+
+    private final GiftCodeClient client = new GiftCodeClient();
+    private final GiftCodeRedeemer redeemer = new GiftCodeRedeemer();
+    private final GiftCodeStore store = new GiftCodeStore();
+    private final GiftCodeHistoryStore history = new GiftCodeHistoryStore();
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "gift-code-automation");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private final CopyOnWriteArrayList<Consumer<GiftCodeState>> listeners = new CopyOnWriteArrayList<>();
+    private final AtomicBoolean busy = new AtomicBoolean();
+    private final AtomicBoolean manualClaimRunning = new AtomicBoolean();
+    private final AtomicBoolean manualStopRequested = new AtomicBoolean();
+    private final Set<Long> cancelledAutoProfiles = ConcurrentHashMap.newKeySet();
+    private final Set<Long> activeAutoProfiles = ConcurrentHashMap.newKeySet();
+
+    private volatile List<GiftCodeEntry> activeCodes = List.of();
+    private volatile String status = "Gift codes have not been checked yet.";
+    private volatile String manualClaimStatus = "";
+    private volatile boolean started;
+
+    private GiftCodeAutomationService() {}
+
+    public static GiftCodeAutomationService getInstance() {
+        return INSTANCE;
+    }
+
+    public synchronized void start() {
+        if (started) {
+            return;
+        }
+        started = true;
+        migrateLegacyData();
+        ProfileService.obtain().registerDataObserver(ignored -> {
+            if (isProfileRefreshAllowed()) {
+                refreshProfileState();
+            }
+        });
+        scheduleHourlyChecks();
+        if (hasEnabledAutoProfiles()) {
+            runAutomatedCheck();
+        }
+    }
+
+    public GiftCodeState snapshot() {
+        List<AccountDescriptor> accounts = profiles();
+        List<GiftCodeProfile> giftProfiles = accounts.stream().map(this::toGiftCodeProfile).toList();
+        List<GiftCodeRecipient> recipients = giftProfiles.stream()
+                .flatMap(profile -> profile.recipients().stream())
+                .toList();
+        return new GiftCodeState(activeCodes, giftProfiles, recipients, busy.get(), manualClaimRunning.get(),
+                manualStopRequested.get(), status, manualClaimStatus);
+    }
+
+    public void addListener(Consumer<GiftCodeState> listener) {
+        if (listener != null) {
+            listeners.addIfAbsent(listener);
+            listener.accept(snapshot());
+        }
+    }
+
+    public void removeListener(Consumer<GiftCodeState> listener) {
+        listeners.remove(listener);
+    }
+
+    public void fetchNow() {
+        submitExclusive(() -> fetchCodes("Fetched"));
+    }
+
+    public void claimAllUnchecked() {
+        if (!busy.compareAndSet(false, true)) {
+            status = "A gift code operation is already running.";
+            publish();
+            return;
+        }
+        manualStopRequested.set(false);
+        manualClaimRunning.set(true);
+        status = "Starting manual gift code claim...";
+        manualClaimStatus = status;
+        publish();
+        executor.execute(() -> {
+            try {
+                if (fetchCodes("Fetched") && !manualStopRequested.get()) {
+                    claimUncheckedCodes(profiles(), false);
+                } else if (manualStopRequested.get()) {
+                    status = "Manual gift code claim stopped.";
+                    manualClaimStatus = status;
+                } else {
+                    manualClaimStatus = status;
+                }
+            } finally {
+                manualClaimRunning.set(false);
+                manualStopRequested.set(false);
+                busy.set(false);
+                publish();
+            }
+        });
+    }
+
+    public void stopManualClaim() {
+        if (!manualClaimRunning.get()) {
+            return;
+        }
+        manualStopRequested.set(true);
+        status = "Stopping manual gift code claim...";
+        manualClaimStatus = status;
+        LOG.info("Manual gift code claim stop requested");
+        publish();
+    }
+
+    public boolean setAutoEnabled(Long profileId, boolean enabled) {
+        AccountDescriptor profile = findProfile(profileId);
+        if (profile == null) {
+            status = "The selected profile no longer exists.";
+            publish();
+            return false;
+        }
+        if (enabled && !hasValidProfileIdentity(profile)) {
+            store.setAutoEnabled(profile, false);
+            status = "Add the Player ID and Server/Region to " + profileName(profile)
+                    + " before enabling auto claim.";
+            publish();
+            return false;
+        }
+        boolean wasRunning = activeAutoProfiles.contains(profileId);
+        if (!store.setAutoEnabled(profile, enabled)) {
+            status = "Could not save auto claim for " + profileName(profile) + ".";
+            publish();
+            return false;
+        }
+        if (enabled) {
+            cancelledAutoProfiles.remove(profileId);
+            store.setLastCheckUtc(profile, null);
+        } else {
+            cancelledAutoProfiles.add(profileId);
+        }
+        status = enabled
+                ? "Auto claim enabled for " + profileName(profile) + ". Checks run hourly."
+                : wasRunning
+                        ? "Stopping automatic gift code claim for " + profileName(profile) + "..."
+                        : "Auto claim disabled for " + profileName(profile) + ".";
+        LOG.info("Gift code auto claim {} for profile {}",
+                enabled ? "enabled" : wasRunning ? "stop requested" : "disabled", profileName(profile));
+        publish();
+        if (enabled) {
+            runAutomatedCheck();
+        }
+        return true;
+    }
+
+    public boolean addExtraRecipient(Long ownerProfileId, String playerId, String alias, String region) {
+        AccountDescriptor owner = findProfile(ownerProfileId);
+        String normalized = playerId == null ? "" : playerId.trim();
+        String normalizedRegion = region == null ? "" : region.trim();
+        if (owner == null) {
+            status = "Select an owning profile first.";
+        } else if (!normalized.matches("\\d+")) {
+            status = "Player ID must contain digits only.";
+        } else if (!normalizedRegion.matches("\\d+")) {
+            status = "Region must contain digits only.";
+        } else if (store.saveExtraRecipient(owner, normalized, alias, normalizedRegion)) {
+            status = "Added gift code recipient to " + profileName(owner) + ".";
+            publish();
+            return true;
+        } else {
+            status = "Could not save the additional recipient.";
+        }
+        publish();
+        return false;
+    }
+
+    public void removeExtraRecipient(Long ownerProfileId, String playerId) {
+        AccountDescriptor owner = findProfile(ownerProfileId);
+        if (owner == null || !store.removeExtraRecipient(owner, playerId)) {
+            status = "Could not remove the additional recipient.";
+        } else {
+            status = "Removed gift code recipient from " + profileName(owner) + ".";
+        }
+        publish();
+    }
+
+    private void runAutomatedCheck() {
+        submitExclusive(() -> {
+            LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            List<AccountDescriptor> due = profiles().stream()
+                    .filter(this::isAutoEnabledAndValid)
+                    .toList();
+            if (due.isEmpty()) {
+                return;
+            }
+            due.forEach(profile -> activeAutoProfiles.add(profile.getId()));
+            publish();
+            try {
+                if (fetchCodes("Hourly check found")) {
+                    List<AccountDescriptor> activeDue = due.stream()
+                            .filter(profile -> !cancelledAutoProfiles.contains(profile.getId()))
+                            .toList();
+                    if (activeDue.isEmpty()) {
+                        status = "Automatic gift code claim stopped.";
+                        publish();
+                        return;
+                    }
+                    activeDue.forEach(profile -> store.setLastCheckUtc(profile, today));
+                    claimUncheckedCodes(activeDue, true);
+                }
+            } finally {
+                due.forEach(profile -> activeAutoProfiles.remove(profile.getId()));
+                publish();
+            }
+        });
+    }
+
+    private boolean fetchCodes(String verb) {
+        status = "Fetching active gift codes...";
+        publish();
+        try {
+            activeCodes = List.copyOf(client.fetchActiveCodes());
+            status = verb + " " + activeCodes.size() + " active gift code(s).";
+            LOG.info("{} {} active gift code(s)", verb, activeCodes.size());
+            publish();
+            return true;
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            status = "Gift code fetch was interrupted.";
+        } catch (Exception exception) {
+            status = "Gift code fetch failed: " + safeMessage(exception);
+            LOG.warn("Gift code fetch failed", exception);
+        }
+        publish();
+        return false;
+    }
+
+    private void claimUncheckedCodes(List<AccountDescriptor> owners, boolean autoRun) {
+        Map<PlayerCodeKey, MutableClaimWork> grouped = new LinkedHashMap<>();
+        int validAssignments = 0;
+        int configurationErrors = 0;
+        for (GiftCodeEntry code : activeCodes) {
+            for (AccountDescriptor owner : owners) {
+                for (GiftCodeRecipient recipient : recipients(owner)) {
+                    if (!hasValidRecipientIdentity(recipient)) {
+                        configurationErrors++;
+                        LOG.warn("Gift code claim result status=CONFIG_ERROR player={} region={} profiles={} "
+                                        + "message=Player ID or region is missing",
+                                recipient.playerId(), recipient.region(), profileName(owner));
+                        continue;
+                    }
+                    validAssignments++;
+                    PlayerCodeKey key = new PlayerCodeKey(recipient.playerId(), code.code());
+                    grouped.computeIfAbsent(key, ignored -> new MutableClaimWork(recipient, code))
+                            .add(owner, recipient.region());
+                }
+            }
+        }
+
+        List<ClaimWork> pending = new ArrayList<>();
+        int skipped = 0;
+        for (MutableClaimWork work : grouped.values()) {
+            if (work.hasRegionConflict()) {
+                configurationErrors++;
+                LOG.warn("Gift code claim result status=CONFIG_ERROR code={} player={} regions={} profiles={} "
+                                + "message=Conflicting regions for the same player",
+                        work.code.code(), work.recipient.playerId(), work.regions, profileNames(work.owners.values()));
+            } else if (history.wasTerminallyChecked(work.recipient.playerId(), work.code.code())) {
+                skipped++;
+            } else {
+                pending.add(work.toClaimWork());
+            }
+        }
+        int deduplicated = Math.max(0, validAssignments - grouped.size());
+        if (pending.isEmpty()) {
+            String result = skipped == 0
+                    ? configurationErrors == 0 ? "No profile recipients are configured."
+                            : "No claims started because recipient configuration is incomplete."
+                    : "All active codes are already checked in this bot's shared claim history.";
+            updateClaimStatus(result, autoRun);
+            LOG.info(result);
+            return;
+        }
+
+        int attempted = 0;
+        int redeemed = 0;
+        int alreadyRedeemed = 0;
+        int failed = 0;
+        int retryable = 0;
+        int cancelled = 0;
+        long lastClaimRequestStartedNanos = 0L;
+        while (!pending.isEmpty() && !Thread.currentThread().isInterrupted()) {
+            if (autoRun) {
+                int before = pending.size();
+                pending.removeIf(work -> work.owners().stream()
+                        .allMatch(owner -> cancelledAutoProfiles.contains(owner.getId())));
+                cancelled += before - pending.size();
+                if (pending.isEmpty()) {
+                    break;
+                }
+            } else if (manualStopRequested.get()) {
+                cancelled += pending.size();
+                pending.clear();
+                break;
+            }
+            ClaimWork work = pending.remove(0);
+            if (!waitForClaimRequestSlot(lastClaimRequestStartedNanos, autoRun, work.owners())) {
+                cancelled += pending.size() + 1;
+                pending.clear();
+                break;
+            }
+            attempted++;
+            updateClaimStatus("Claiming " + work.code().code() + " for " + work.recipient().alias()
+                    + " [" + profileNames(work.owners()) + "] (attempt " + work.attempt() + ")...", autoRun);
+            lastClaimRequestStartedNanos = System.nanoTime();
+            RedeemResult result = redeemer.redeem(
+                    work.recipient().playerId(), work.recipient().region(), work.code().code());
+            LOG.info("Gift code claim result status={} code={} player={} region={} profiles={} message={}",
+                    result.outcome(), work.code().code(), work.recipient().playerId(), work.recipient().region(),
+                    profileNames(work.owners()), result.message());
+            if (result.terminal()) {
+                if (history.remember(work.recipient().playerId(), work.recipient().region(),
+                        work.code().code(), result)) {
+                    if (result.outcome() == RedeemOutcome.REDEEMED) {
+                        redeemed++;
+                    } else if (result.outcome() == RedeemOutcome.ALREADY_REDEEMED) {
+                        alreadyRedeemed++;
+                    } else {
+                        failed++;
+                    }
+                } else {
+                    retryable++;
+                    LOG.warn("Could not persist canonical gift code result code={} player={}",
+                            work.code().code(), work.recipient().playerId());
+                }
+            } else if (work.attempt() < MAX_ATTEMPTS_PER_CLAIM) {
+                LOG.warn("Gift code claim retry status={} code={} player={} attempt={}/{} message={}",
+                        result.outcome(), work.code().code(), work.recipient().playerId(),
+                        work.attempt(), MAX_ATTEMPTS_PER_CLAIM, result.message());
+                if (!pauseWhileClaimActive(retryDelayMillis(work.attempt()), autoRun, work.owners())) {
+                    cancelled += pending.size() + 1;
+                    pending.clear();
+                    break;
+                }
+                pending.add(work.nextAttempt());
+            } else {
+                retryable++;
+                LOG.warn("Gift code claim result status=RETRY_EXHAUSTED code={} player={} attempts={} message={}",
+                        work.code().code(), work.recipient().playerId(), work.attempt(), result.message());
+            }
+        }
+        String outcome = !autoRun && manualStopRequested.get() ? "Claim run stopped: " : "Claim run complete: ";
+        String result = outcome + redeemed + " redeemed, " + alreadyRedeemed + " already redeemed, "
+                + failed + " failed, " + retryable + " retryable, " + skipped + " history skips, "
+                + deduplicated + " duplicate assignments merged, " + configurationErrors
+                + " configuration errors, " + cancelled + " cancelled (" + attempted + " API calls).";
+        updateClaimStatus(result, autoRun);
+        LOG.info(result);
+    }
+
+    private GiftCodeProfile toGiftCodeProfile(AccountDescriptor profile) {
+        return new GiftCodeProfile(profile.getId(), profileName(profile), normalizedPlayerId(profile),
+                normalizedRegion(profile),
+                store.isAutoEnabled(profile), activeAutoProfiles.contains(profile.getId()),
+                store.lastCheckUtc(profile), recipients(profile));
+    }
+
+    private List<GiftCodeRecipient> recipients(AccountDescriptor profile) {
+        Map<String, GiftCodeRecipient> unique = new LinkedHashMap<>();
+        if (hasValidPlayerId(profile)) {
+            String playerId = normalizedPlayerId(profile);
+            unique.put(playerId, new GiftCodeRecipient(profile.getId(), profileName(profile), playerId,
+                    profileName(profile), normalizedRegion(profile), true));
+        }
+        for (GiftCodeRecipient extra : store.extraRecipients(profile)) {
+            unique.putIfAbsent(extra.playerId(), extra);
+        }
+        return new ArrayList<>(unique.values());
+    }
+
+    private List<AccountDescriptor> profiles() {
+        try {
+            List<AccountDescriptor> profiles = ProfileService.obtain().fetchAllAccounts();
+            return profiles == null ? List.of() : profiles;
+        } catch (RuntimeException exception) {
+            LOG.warn("Could not load profiles for gift codes", exception);
+            return List.of();
+        }
+    }
+
+    private AccountDescriptor findProfile(Long profileId) {
+        return profiles().stream()
+                .filter(profile -> profileId != null && profileId.equals(profile.getId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private boolean hasEnabledAutoProfiles() {
+        return profiles().stream().anyMatch(this::isAutoEnabledAndValid);
+    }
+
+    private boolean isAutoEnabledAndValid(AccountDescriptor profile) {
+        return store.isAutoEnabled(profile) && hasValidProfileIdentity(profile);
+    }
+
+    private boolean hasValidPlayerId(AccountDescriptor profile) {
+        return normalizedPlayerId(profile).matches("\\d+");
+    }
+
+    private boolean hasValidProfileIdentity(AccountDescriptor profile) {
+        return hasValidPlayerId(profile) && normalizedRegion(profile).matches("\\d+");
+    }
+
+    private boolean hasValidRecipientIdentity(GiftCodeRecipient recipient) {
+        return recipient.playerId() != null && recipient.playerId().matches("\\d+")
+                && recipient.region() != null && recipient.region().matches("\\d+");
+    }
+
+    private String normalizedPlayerId(AccountDescriptor profile) {
+        return profile.getCharacterId() == null ? "" : profile.getCharacterId().trim();
+    }
+
+    private String normalizedRegion(AccountDescriptor profile) {
+        return profile.getCharacterServer() == null ? "" : profile.getCharacterServer().trim();
+    }
+
+    private String profileName(AccountDescriptor profile) {
+        return profile.getName() == null || profile.getName().isBlank()
+                ? "Profile " + profile.getId()
+                : profile.getName();
+    }
+
+    private String profileNames(Collection<AccountDescriptor> profiles) {
+        return profiles.stream().map(this::profileName).distinct().sorted().toList().toString();
+    }
+
+    private void migrateLegacyData() {
+        int imported = 0;
+        int failed = 0;
+        for (AccountDescriptor profile : profiles()) {
+            if (!store.migrateLegacyRecipients(profile)) {
+                failed++;
+                LOG.warn("Could not migrate legacy gift code recipients for profile {}", profileName(profile));
+            }
+            for (LegacyClaim claim : store.legacyClaims(profile)) {
+                if (history.importLegacy(claim.playerId(), claim.region(), claim.giftCode(), claim.result())) {
+                    imported++;
+                } else {
+                    failed++;
+                    LOG.warn("Could not import legacy gift code history code={} player={} profile={}",
+                            claim.giftCode(), claim.playerId(), profileName(profile));
+                }
+            }
+        }
+        if (imported > 0 || failed > 0) {
+            LOG.info("Gift code history migration processed {} legacy entries with {} failures; "
+                    + "canonical history is bot-local and shared across profiles", imported, failed);
+        }
+    }
+
+    private void submitExclusive(Runnable task) {
+        if (!busy.compareAndSet(false, true)) {
+            status = "A gift code operation is already running.";
+            publish();
+            return;
+        }
+        publish();
+        executor.execute(() -> {
+            try {
+                task.run();
+            } finally {
+                busy.set(false);
+                publish();
+            }
+        });
+    }
+
+    private void scheduleHourlyChecks() {
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        long initialDelay = delayUntilNextHourlyCheck(now).toMillis();
+        executor.scheduleAtFixedRate(this::runAutomatedCheck, initialDelay,
+                AUTO_CHECK_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    static Duration delayUntilNextHourlyCheck(ZonedDateTime now) {
+        ZonedDateTime nextHour = now.withMinute(0).withSecond(0).withNano(0).plusHours(1);
+        return Duration.between(now, nextHour);
+    }
+
+    static long retryDelayMillis(int completedAttempt) {
+        return switch (completedAttempt) {
+            case 1 -> Duration.ofSeconds(5).toMillis();
+            default -> Duration.ofSeconds(15).toMillis();
+        };
+    }
+
+    private void refreshProfileState() {
+        for (AccountDescriptor profile : profiles()) {
+            if (store.isAutoEnabled(profile) && !hasValidProfileIdentity(profile)) {
+                store.setAutoEnabled(profile, false);
+                status = "Auto claim was disabled for " + profileName(profile)
+                        + " because its Player ID or Server/Region is missing.";
+            }
+        }
+        publish();
+    }
+
+    static boolean isProfileRefreshAllowed() {
+        return !Thread.currentThread().isInterrupted();
+    }
+
+    private boolean pause(long millis) {
+        try {
+            Thread.sleep(Math.max(1L, millis));
+            return true;
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private boolean waitForClaimRequestSlot(long lastRequestStartedNanos, boolean autoRun,
+                                            List<AccountDescriptor> owners) {
+        if (lastRequestStartedNanos == 0L) {
+            return true;
+        }
+        long elapsedNanos = System.nanoTime() - lastRequestStartedNanos;
+        long remainingNanos = MIN_CLAIM_REQUEST_INTERVAL.toNanos() - elapsedNanos;
+        if (remainingNanos <= 0L) {
+            return true;
+        }
+        long remainingMillis = Math.max(1L, TimeUnit.NANOSECONDS.toMillis(remainingNanos));
+        return pauseWhileClaimActive(remainingMillis, autoRun, owners);
+    }
+
+    private boolean pauseWhileClaimActive(long millis, boolean autoRun, List<AccountDescriptor> owners) {
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(Math.max(1L, millis));
+        while (true) {
+            if ((!autoRun && manualStopRequested.get())
+                    || (autoRun && owners.stream().allMatch(owner -> cancelledAutoProfiles.contains(owner.getId())))) {
+                return false;
+            }
+            long remainingNanos = deadline - System.nanoTime();
+            if (remainingNanos <= 0L) {
+                return true;
+            }
+            long sliceMillis = Math.min(250L,
+                    Math.max(1L, TimeUnit.NANOSECONDS.toMillis(remainingNanos)));
+            if (!pause(sliceMillis)) {
+                return false;
+            }
+        }
+    }
+
+    private String safeMessage(Exception exception) {
+        return exception.getMessage() == null ? exception.getClass().getSimpleName() : exception.getMessage();
+    }
+
+    private void updateClaimStatus(String message, boolean autoRun) {
+        status = message;
+        if (!autoRun) {
+            manualClaimStatus = message;
+        }
+        publish();
+    }
+
+    private void publish() {
+        GiftCodeState state = snapshot();
+        listeners.forEach(listener -> listener.accept(state));
+    }
+
+    public record GiftCodeProfile(Long profileId,
+                                  String profileName,
+                                  String playerId,
+                                  String region,
+                                  boolean autoEnabled,
+                                  boolean autoRunning,
+                                  LocalDate lastCheckUtc,
+                                  List<GiftCodeRecipient> recipients) {
+        public GiftCodeProfile {
+            recipients = List.copyOf(recipients);
+        }
+
+        @Override
+        public String toString() {
+            return profileName;
+        }
+    }
+
+    public record GiftCodeState(List<GiftCodeEntry> activeCodes,
+                                List<GiftCodeProfile> profiles,
+                                List<GiftCodeRecipient> recipients,
+                                boolean busy,
+                                boolean manualClaimRunning,
+                                boolean manualStopRequested,
+                                String status,
+                                String manualClaimStatus) {
+        public GiftCodeState {
+            activeCodes = List.copyOf(activeCodes);
+            profiles = List.copyOf(profiles);
+            recipients = List.copyOf(recipients);
+        }
+    }
+
+    private record ClaimWork(List<AccountDescriptor> owners,
+                             GiftCodeRecipient recipient,
+                             GiftCodeEntry code,
+                             int attempt) {
+        private ClaimWork {
+            owners = List.copyOf(owners);
+        }
+
+        ClaimWork nextAttempt() {
+            return new ClaimWork(owners, recipient, code, attempt + 1);
+        }
+    }
+
+    private record PlayerCodeKey(String playerId, String giftCode) {}
+
+    private static final class MutableClaimWork {
+        private final GiftCodeRecipient recipient;
+        private final GiftCodeEntry code;
+        private final Map<Long, AccountDescriptor> owners = new LinkedHashMap<>();
+        private final Set<String> regions = new LinkedHashSet<>();
+
+        private MutableClaimWork(GiftCodeRecipient recipient, GiftCodeEntry code) {
+            this.recipient = recipient;
+            this.code = code;
+        }
+
+        private void add(AccountDescriptor owner, String region) {
+            owners.putIfAbsent(owner.getId(), owner);
+            regions.add(region);
+        }
+
+        private boolean hasRegionConflict() {
+            return regions.size() > 1;
+        }
+
+        private ClaimWork toClaimWork() {
+            return new ClaimWork(new ArrayList<>(owners.values()), recipient, code, 1);
+        }
+    }
+}

--- a/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftCodeClient.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftCodeClient.java
@@ -1,0 +1,91 @@
+package dev.frostguard.app.panel.misc;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+final class GiftCodeClient {
+
+    static final String SOURCE_URL = "https://gift-code-api.whiteout-bot.com/giftcode_api.php";
+    private static final String API_KEY = "super_secret_bot_token_nobody_will_ever_find";
+    private static final DateTimeFormatter SOURCE_DATE = DateTimeFormatter.ofPattern("dd.MM.uuuu");
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    GiftCodeClient() {
+        this(HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build(), new ObjectMapper());
+    }
+
+    GiftCodeClient(HttpClient httpClient, ObjectMapper objectMapper) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    List<GiftCodeEntry> fetchActiveCodes() throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(SOURCE_URL))
+                .timeout(Duration.ofSeconds(15))
+                .header("X-API-Key", API_KEY)
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new IOException("Gift code source returned HTTP " + response.statusCode());
+        }
+        return parseResponse(response.body());
+    }
+
+    List<GiftCodeEntry> parseResponse(String json) throws IOException {
+        JsonNode codes = objectMapper.readTree(json).path("codes");
+        if (!codes.isArray()) {
+            throw new IOException("Gift code source response has no codes array");
+        }
+
+        Map<String, GiftCodeEntry> unique = new LinkedHashMap<>();
+        for (JsonNode item : codes) {
+            GiftCodeEntry entry = parseEntry(item.asText(""));
+            if (entry != null) {
+                unique.putIfAbsent(entry.code(), entry);
+            }
+        }
+        return new ArrayList<>(unique.values());
+    }
+
+    private GiftCodeEntry parseEntry(String raw) {
+        String value = raw == null ? "" : raw.trim();
+        if (value.isEmpty()) {
+            return null;
+        }
+        int split = value.lastIndexOf(' ');
+        if (split < 1) {
+            return new GiftCodeEntry(value, null);
+        }
+        String code = value.substring(0, split).trim();
+        String rawDate = value.substring(split + 1).trim();
+        try {
+            return new GiftCodeEntry(code, LocalDate.parse(rawDate, SOURCE_DATE));
+        } catch (DateTimeParseException ignored) {
+            return new GiftCodeEntry(value, null);
+        }
+    }
+
+    record GiftCodeEntry(String code, LocalDate discoveredOn) {
+        String displayDate() {
+            return discoveredOn == null ? "Discovery date unknown" : "Discovered " + SOURCE_DATE.format(discoveredOn);
+        }
+    }
+}

--- a/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftCodeHistoryStore.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftCodeHistoryStore.java
@@ -1,0 +1,75 @@
+package dev.frostguard.app.panel.misc;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import dev.frostguard.app.panel.misc.GiftCodeRedeemer.RedeemResult;
+import dev.frostguard.data.entity.GiftCodeClaim;
+import dev.frostguard.data.repository.GiftCodeClaimRepository;
+
+/** Bot-local source of truth for terminal gift-code results across all profiles. */
+final class GiftCodeHistoryStore {
+
+    private final Backend backend;
+
+    GiftCodeHistoryStore() {
+        this(new RepositoryBackend());
+    }
+
+    GiftCodeHistoryStore(Backend backend) {
+        this.backend = backend;
+    }
+
+    boolean wasTerminallyChecked(String playerId, String giftCode) {
+        return backend.find(playerId, giftCode).isPresent();
+    }
+
+    boolean remember(String playerId, String region, String giftCode, RedeemResult result) {
+        if (result == null || !result.terminal()) {
+            return false;
+        }
+        return backend.insertIfAbsent(new HistoryEntry(playerId, region, giftCode,
+                result.outcome().name(), result.message(), LocalDateTime.now()));
+    }
+
+    boolean importLegacy(String playerId, String region, String giftCode, String rawResult) {
+        RedeemResult classified = GiftCodeRedeemer.classify(rawResult);
+        if (!classified.terminal()) {
+            classified = RedeemResult.failed(rawResult == null ? "Legacy terminal result" : rawResult);
+        }
+        return backend.insertIfAbsent(new HistoryEntry(playerId, region, giftCode,
+                classified.outcome().name(), classified.message(), LocalDateTime.now()));
+    }
+
+    interface Backend {
+        Optional<HistoryEntry> find(String playerId, String giftCode);
+        boolean insertIfAbsent(HistoryEntry entry);
+    }
+
+    record HistoryEntry(String playerId,
+                        String region,
+                        String giftCode,
+                        String outcome,
+                        String message,
+                        LocalDateTime recordedAt) {}
+
+    private static final class RepositoryBackend implements Backend {
+        @Override
+        public Optional<HistoryEntry> find(String playerId, String giftCode) {
+            return GiftCodeClaimRepository.getRepository().find(playerId, giftCode)
+                    .map(claim -> new HistoryEntry(claim.getPlayerId(), claim.getRegion(), claim.getGiftCode(),
+                            claim.getOutcome(), claim.getMessage(), claim.getRecordedAt()));
+        }
+
+        @Override
+        public boolean insertIfAbsent(HistoryEntry entry) {
+            try {
+                return GiftCodeClaimRepository.getRepository().insertIfAbsent(new GiftCodeClaim(
+                        entry.playerId(), entry.giftCode(), entry.region(), entry.outcome(),
+                        entry.message(), entry.recordedAt()));
+            } catch (RuntimeException exception) {
+                return false;
+            }
+        }
+    }
+}

--- a/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftCodeRedeemer.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftCodeRedeemer.java
@@ -1,0 +1,157 @@
+package dev.frostguard.app.panel.misc;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+final class GiftCodeRedeemer {
+
+    private static final URI REDEEM_URI = URI.create(
+            "https://wos-giftcode-api.centurygame.com/api/gift_code");
+    private static final String SIGNING_SECRET = "tB87#kPtkxqOS2";
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    GiftCodeRedeemer() {
+        this(HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build(), new ObjectMapper());
+    }
+
+    GiftCodeRedeemer(HttpClient httpClient, ObjectMapper objectMapper) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    RedeemResult redeem(String playerId, String region, String giftCode) {
+        if (!isDigits(playerId) || !isDigits(region) || giftCode == null || giftCode.isBlank()) {
+            return RedeemResult.failed("Invalid player ID, region, or gift code");
+        }
+
+        try {
+            JsonNode response = post(signed(requestFields(
+                    playerId, region, giftCode, Instant.now().getEpochSecond())));
+            return classify(response.path("msg").asText("Unknown redemption response"));
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            return RedeemResult.retryable("Redemption interrupted");
+        } catch (Exception exception) {
+            return RedeemResult.retryable(exception.getMessage() == null
+                    ? exception.getClass().getSimpleName()
+                    : exception.getMessage());
+        }
+    }
+
+    Map<String, String> requestFields(String playerId, String region, String giftCode, long epochSeconds) {
+        return Map.of(
+                "fid", playerId,
+                "cdk", giftCode,
+                "kid", region,
+                "time", String.valueOf(epochSeconds));
+    }
+
+    Map<String, String> signed(Map<String, String> fields) {
+        Map<String, String> sorted = new LinkedHashMap<>();
+        fields.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey(Comparator.naturalOrder()))
+                .forEach(entry -> sorted.put(entry.getKey(), entry.getValue()));
+        String payload = sorted.entrySet().stream()
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .reduce((left, right) -> left + "&" + right)
+                .orElse("");
+        Map<String, String> signed = new LinkedHashMap<>();
+        signed.put("sign", md5(payload + SIGNING_SECRET));
+        signed.putAll(fields);
+        return signed;
+    }
+
+    static RedeemResult classify(String rawMessage) {
+        String message = rawMessage == null || rawMessage.isBlank() ? "Unknown response" : rawMessage.trim();
+        String normalized = message.toUpperCase().replace('_', ' ');
+        if (normalized.startsWith("SUCCESS")) {
+            return new RedeemResult(message, RedeemOutcome.REDEEMED, true);
+        }
+        if (normalized.startsWith("RECEIVED") || normalized.contains("SAME TYPE EXCHANGE")
+                || normalized.contains("ALREADY")) {
+            return new RedeemResult(message, RedeemOutcome.ALREADY_REDEEMED, true);
+        }
+        if (normalized.contains("EXPIRED") || normalized.contains("NOT FOUND")
+                || normalized.contains("LIMIT") || normalized.contains("REQUIREMENT")
+                || normalized.contains("SPEND MORE") || normalized.contains("TIME ERROR")
+                || normalized.contains("ROLE NOT EXIST") || normalized.contains("PLAYER NOT EXIST")) {
+            return RedeemResult.failed(message);
+        }
+        return RedeemResult.retryable(message);
+    }
+
+    private JsonNode post(Map<String, String> fields) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(REDEEM_URI)
+                .timeout(Duration.ofSeconds(15))
+                .header("Accept", "application/json, text/plain, */*")
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("Origin", "https://wos-giftcode.centurygame.com")
+                .header("Referer", "https://wos-giftcode.centurygame.com/")
+                .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                        + "AppleWebKit/537.36 Chrome/134 Safari/537.36")
+                .POST(HttpRequest.BodyPublishers.ofString(formBody(fields)))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new IOException("gift_code returned HTTP " + response.statusCode());
+        }
+        return objectMapper.readTree(response.body());
+    }
+
+    private String formBody(Map<String, String> fields) {
+        return fields.entrySet().stream()
+                .map(entry -> urlEncode(entry.getKey()) + "=" + urlEncode(entry.getValue()))
+                .reduce((left, right) -> left + "&" + right)
+                .orElse("");
+    }
+
+    private String urlEncode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private String md5(String value) {
+        try {
+            byte[] digest = MessageDigest.getInstance("MD5").digest(value.getBytes(StandardCharsets.UTF_8));
+            return java.util.HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("MD5 is unavailable", impossible);
+        }
+    }
+
+    private boolean isDigits(String value) {
+        return value != null && value.matches("\\d+");
+    }
+
+    enum RedeemOutcome {
+        REDEEMED,
+        ALREADY_REDEEMED,
+        FAILED,
+        RETRYABLE_ERROR
+    }
+
+    record RedeemResult(String message, RedeemOutcome outcome, boolean terminal) {
+        static RedeemResult failed(String message) {
+            return new RedeemResult(message, RedeemOutcome.FAILED, true);
+        }
+
+        static RedeemResult retryable(String message) {
+            return new RedeemResult(message, RedeemOutcome.RETRYABLE_ERROR, false);
+        }
+    }
+}

--- a/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftCodeStore.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftCodeStore.java
@@ -1,0 +1,193 @@
+package dev.frostguard.app.panel.misc;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.engine.service.ConfigService;
+
+/** Persists gift-code state inside each owning profile's local database config. */
+final class GiftCodeStore {
+
+    private static final String AUTO_ENABLED = "autoEnabled";
+    private static final String LAST_CHECK_UTC = "lastCheckUtc";
+    private static final String RECIPIENTS = "recipients";
+    private static final String CLAIMS = "claims";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Function<AccountDescriptor, String> reader;
+    private final BiFunction<AccountDescriptor, String, Boolean> writer;
+
+    GiftCodeStore() {
+        this(profile -> profile.getConfig(ConfigurationKeyEnum.GIFT_CODE_STATE_JSON, String.class),
+                (profile, json) -> ConfigService.obtain().writeAccountSetting(
+                        profile, ConfigurationKeyEnum.GIFT_CODE_STATE_JSON, json));
+    }
+
+    GiftCodeStore(Function<AccountDescriptor, String> reader,
+                  BiFunction<AccountDescriptor, String, Boolean> writer) {
+        this.reader = reader;
+        this.writer = writer;
+    }
+
+    boolean isAutoEnabled(AccountDescriptor profile) {
+        return read(profile).path(AUTO_ENABLED).asBoolean(false);
+    }
+
+    boolean setAutoEnabled(AccountDescriptor profile, boolean enabled) {
+        ObjectNode root = read(profile);
+        root.put(AUTO_ENABLED, enabled);
+        return write(profile, root);
+    }
+
+    LocalDate lastCheckUtc(AccountDescriptor profile) {
+        String stored = read(profile).path(LAST_CHECK_UTC).asText("");
+        try {
+            return stored.isBlank() ? null : LocalDate.parse(stored);
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    boolean setLastCheckUtc(AccountDescriptor profile, LocalDate date) {
+        ObjectNode root = read(profile);
+        if (date == null) {
+            root.remove(LAST_CHECK_UTC);
+        } else {
+            root.put(LAST_CHECK_UTC, date.toString());
+        }
+        return write(profile, root);
+    }
+
+    boolean saveExtraRecipient(AccountDescriptor owner, String playerId, String alias, String region) {
+        ObjectNode root = read(owner);
+        ObjectNode recipients = root.withObject(RECIPIENTS);
+        ObjectNode recipient = recipients.putObject(playerId);
+        recipient.put("alias", alias == null || alias.isBlank() ? "Player " + playerId : alias.trim());
+        recipient.put("region", region == null ? "" : region.trim());
+        return write(owner, root);
+    }
+
+    boolean removeExtraRecipient(AccountDescriptor owner, String playerId) {
+        ObjectNode root = read(owner);
+        root.withObject(RECIPIENTS).remove(playerId);
+        return write(owner, root);
+    }
+
+    List<GiftCodeRecipient> extraRecipients(AccountDescriptor owner) {
+        List<GiftCodeRecipient> result = new ArrayList<>();
+        JsonNode recipients = read(owner).path(RECIPIENTS);
+        recipients.fields().forEachRemaining(entry -> {
+            JsonNode value = entry.getValue();
+            String alias = value.isObject()
+                    ? value.path("alias").asText(entry.getKey())
+                    : value.asText(entry.getKey());
+            String region = value.isObject()
+                    ? value.path("region").asText("")
+                    : normalizedRegion(owner);
+            result.add(new GiftCodeRecipient(owner.getId(), owner.getName(), entry.getKey(),
+                    alias, region, false));
+        });
+        result.sort(Comparator.comparing(GiftCodeRecipient::alias, String.CASE_INSENSITIVE_ORDER));
+        return result;
+    }
+
+    boolean migrateLegacyRecipients(AccountDescriptor owner) {
+        ObjectNode root = read(owner);
+        ObjectNode recipients = root.withObject(RECIPIENTS);
+        boolean changed = false;
+        Iterator<Map.Entry<String, JsonNode>> fields = recipients.fields();
+        List<Map.Entry<String, String>> legacy = new ArrayList<>();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> entry = fields.next();
+            if (!entry.getValue().isObject()) {
+                legacy.add(Map.entry(entry.getKey(), entry.getValue().asText(entry.getKey())));
+            }
+        }
+        for (Map.Entry<String, String> entry : legacy) {
+            ObjectNode migrated = recipients.putObject(entry.getKey());
+            migrated.put("alias", entry.getValue());
+            migrated.put("region", normalizedRegion(owner));
+            changed = true;
+        }
+        return !changed || write(owner, root);
+    }
+
+    List<LegacyClaim> legacyClaims(AccountDescriptor owner) {
+        List<LegacyClaim> result = new ArrayList<>();
+        JsonNode claims = read(owner).path(CLAIMS);
+        claims.fields().forEachRemaining(player -> player.getValue().fields().forEachRemaining(code -> {
+            try {
+                String decodedCode = new String(Base64.getUrlDecoder().decode(code.getKey()), StandardCharsets.UTF_8);
+                String region = regionForPlayer(owner, player.getKey());
+                result.add(new LegacyClaim(player.getKey(), region, decodedCode, code.getValue().asText("")));
+            } catch (IllegalArgumentException ignored) {
+                // Preserve valid legacy entries while ignoring an unreadable key.
+            }
+        }));
+        return result;
+    }
+
+    private ObjectNode read(AccountDescriptor profile) {
+        try {
+            JsonNode parsed = objectMapper.readTree(reader.apply(profile));
+            return parsed instanceof ObjectNode object ? object : objectMapper.createObjectNode();
+        } catch (Exception ignored) {
+            return objectMapper.createObjectNode();
+        }
+    }
+
+    private boolean write(AccountDescriptor profile, ObjectNode root) {
+        try {
+            return Boolean.TRUE.equals(writer.apply(profile, objectMapper.writeValueAsString(root)));
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private String regionForPlayer(AccountDescriptor owner, String playerId) {
+        if (playerId != null && playerId.equals(normalizedPlayerId(owner))) {
+            return normalizedRegion(owner);
+        }
+        return extraRecipients(owner).stream()
+                .filter(recipient -> recipient.playerId().equals(playerId))
+                .map(GiftCodeRecipient::region)
+                .findFirst()
+                .orElse(normalizedRegion(owner));
+    }
+
+    private String normalizedPlayerId(AccountDescriptor owner) {
+        return owner.getCharacterId() == null ? "" : owner.getCharacterId().trim();
+    }
+
+    private String normalizedRegion(AccountDescriptor owner) {
+        return owner.getCharacterServer() == null ? "" : owner.getCharacterServer().trim();
+    }
+
+    record GiftCodeRecipient(Long ownerProfileId,
+                             String ownerProfileName,
+                             String playerId,
+                             String alias,
+                             String region,
+                             boolean managedProfile) {
+        String label() {
+            return alias + " (" + playerId + ", region "
+                    + (region == null || region.isBlank() ? "missing" : region) + ")";
+        }
+    }
+
+    record LegacyClaim(String playerId, String region, String giftCode, String result) {}
+}

--- a/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftcodeLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/misc/GiftcodeLayoutController.java
@@ -1,20 +1,22 @@
 package dev.frostguard.app.panel.misc;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import dev.frostguard.app.panel.misc.GiftCodeAutomationService.GiftCodeProfile;
+import dev.frostguard.app.panel.misc.GiftCodeAutomationService.GiftCodeState;
+import dev.frostguard.app.panel.misc.GiftCodeClient.GiftCodeEntry;
+import dev.frostguard.app.panel.misc.GiftCodeStore.GiftCodeRecipient;
 import javafx.animation.PauseTransition;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.HBox;
@@ -24,235 +26,247 @@ import javafx.scene.layout.VBox;
 
 public class GiftcodeLayoutController {
 
-	private static final String API_URL = "http://gift-code-api.whiteout-bot.com/giftcode_api.php";
-	private static final String API_KEY = "super_secret_bot_token_nobody_will_ever_find";
+    private final GiftCodeAutomationService automation = GiftCodeAutomationService.getInstance();
+    private final Consumer<GiftCodeState> stateListener = state -> Platform.runLater(() -> render(state));
 
-	@FXML
-	private Button buttonFetch;
+    @FXML private Button buttonFetch;
+    @FXML private Button buttonCopyAll;
+    @FXML private Button buttonClaimAll;
+    @FXML private Label labelStatus;
+    @FXML private Label labelClaimStatus;
+    @FXML private Label labelAccountHint;
+    @FXML private VBox giftcodeListContainer;
+    @FXML private VBox recipientListContainer;
+    @FXML private ComboBox<GiftCodeProfile> comboRecipientProfile;
+    @FXML private TextField textfieldRecipientAlias;
+    @FXML private TextField textfieldRecipientId;
+    @FXML private TextField textfieldRecipientRegion;
 
-	@FXML
-	private Button buttonCopyAll;
+    @FXML
+    private void initialize() {
+        textfieldRecipientId.textProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue != null && !newValue.matches("\\d*")) {
+                textfieldRecipientId.setText(oldValue);
+            }
+        });
+        textfieldRecipientRegion.textProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue != null && !newValue.matches("\\d*")) {
+                textfieldRecipientRegion.setText(oldValue);
+            }
+        });
+        automation.start();
+        automation.addListener(stateListener);
+        GiftCodeState initial = automation.snapshot();
+        render(initial);
+        if (initial.activeCodes().isEmpty() && !initial.busy()) {
+            automation.fetchNow();
+        }
+    }
 
-	@FXML
-	private Label labelStatus;
+    @FXML
+    private void handleFetch() {
+        automation.fetchNow();
+    }
 
-	@FXML
-	private VBox giftcodeListContainer;
+    @FXML
+    private void handleCopyAll() {
+        GiftCodeState state = automation.snapshot();
+        if (state.activeCodes().isEmpty()) {
+            return;
+        }
+        String allCodes = state.activeCodes().stream()
+                .map(GiftCodeEntry::code)
+                .collect(Collectors.joining("\n"));
+        copyToClipboard(allCodes);
+        showCopiedFeedback(buttonCopyAll, "Copy All Active", "Copied All!");
+    }
 
-	private final List<GiftcodeEntry> currentEntries = new ArrayList<>();
+    @FXML
+    private void handleClaimAll() {
+        GiftCodeState state = automation.snapshot();
+        if (state.manualClaimRunning()) {
+            automation.stopManualClaim();
+        } else {
+            automation.claimAllUnchecked();
+        }
+    }
 
-	@FXML
-	private void initialize() {
-		// Initial state set by FXML
-	}
+    @FXML
+    private void handleAddRecipient() {
+        GiftCodeProfile owner = comboRecipientProfile.getValue();
+        if (owner != null && automation.addExtraRecipient(owner.profileId(),
+                textfieldRecipientId.getText(), textfieldRecipientAlias.getText(),
+                textfieldRecipientRegion.getText())) {
+            textfieldRecipientId.clear();
+            textfieldRecipientAlias.clear();
+            textfieldRecipientRegion.clear();
+        }
+    }
 
-	@FXML
-	private void handleFetch() {
-		buttonFetch.setDisable(true);
-		labelStatus.setText("Fetching gift codes...");
-		giftcodeListContainer.getChildren().clear();
-		currentEntries.clear();
-		buttonCopyAll.setVisible(false);
-		buttonCopyAll.setManaged(false);
+    private void render(GiftCodeState state) {
+        labelStatus.setText(state.status());
+        buttonFetch.setDisable(state.busy());
+        buttonCopyAll.setDisable(state.busy() || state.activeCodes().isEmpty());
+        buttonCopyAll.setVisible(!state.activeCodes().isEmpty());
+        buttonCopyAll.setManaged(!state.activeCodes().isEmpty());
+        buttonClaimAll.setText(state.manualClaimRunning()
+                ? state.manualStopRequested() ? "Stopping Claim..." : "Stop Claiming"
+                : "Claim All for All Recipients");
+        buttonClaimAll.setDisable((state.busy() && !state.manualClaimRunning())
+                || state.manualStopRequested() || state.recipients().stream()
+                        .noneMatch(recipient -> recipient.playerId().matches("\\d+")
+                                && recipient.region().matches("\\d+")));
+        labelClaimStatus.setText(state.manualClaimStatus());
+        labelClaimStatus.setVisible(!state.manualClaimStatus().isBlank());
+        labelClaimStatus.setManaged(!state.manualClaimStatus().isBlank());
 
-		Label loadingLabel = new Label("Loading...");
-		loadingLabel.getStyleClass().add("giftcode-placeholder");
-		giftcodeListContainer.getChildren().add(loadingLabel);
+        boolean hasCompleteProfile = state.profiles().stream().anyMatch(profile ->
+                profile.playerId().matches("\\d+") && profile.region().matches("\\d+"));
+        labelAccountHint.setVisible(!hasCompleteProfile);
+        labelAccountHint.setManaged(!hasCompleteProfile);
+        updateProfileSelector(state);
+        populateGiftCodeCards(state);
+        populateRecipients(state);
+    }
 
-		Thread fetchThread = new Thread(() -> {
-			try {
-				HttpClient client = HttpClient.newBuilder()
-						.connectTimeout(Duration.ofSeconds(10))
-						.build();
+    private void updateProfileSelector(GiftCodeState state) {
+        Long selectedId = comboRecipientProfile.getValue() == null
+                ? null : comboRecipientProfile.getValue().profileId();
+        comboRecipientProfile.getItems().setAll(state.profiles());
+        state.profiles().stream()
+                .filter(profile -> profile.profileId().equals(selectedId))
+                .findFirst()
+                .ifPresentOrElse(comboRecipientProfile::setValue, () -> {
+                    if (!state.profiles().isEmpty()) {
+                        comboRecipientProfile.getSelectionModel().selectFirst();
+                    }
+                });
+        comboRecipientProfile.setDisable(state.busy() || state.profiles().isEmpty());
+    }
 
-				HttpRequest request = HttpRequest.newBuilder()
-						.uri(URI.create(API_URL))
-						.header("X-API-Key", API_KEY)
-						.header("Content-Type", "application/json")
-						.GET()
-						.build();
+    private void populateGiftCodeCards(GiftCodeState state) {
+        giftcodeListContainer.getChildren().clear();
+        if (state.activeCodes().isEmpty()) {
+            Label empty = new Label(state.busy() ? "Loading active gift codes..." : "No active gift codes loaded.");
+            empty.getStyleClass().add("giftcode-placeholder");
+            giftcodeListContainer.getChildren().add(empty);
+            return;
+        }
+        for (int i = 0; i < state.activeCodes().size(); i++) {
+            giftcodeListContainer.getChildren().add(createGiftCodeRow(state.activeCodes().get(i), i + 1));
+        }
+    }
 
-				HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+    private HBox createGiftCodeRow(GiftCodeEntry entry, int index) {
+        Label indexLabel = new Label("#" + index);
+        indexLabel.getStyleClass().add("giftcode-index-label");
+        Label codeLabel = new Label(entry.code());
+        codeLabel.getStyleClass().add("giftcode-code-label");
+        Label dateLabel = new Label(entry.displayDate());
+        dateLabel.getStyleClass().add("giftcode-date-label");
+        VBox codeInfo = new VBox(2, codeLabel, dateLabel);
+        codeInfo.setAlignment(Pos.CENTER_LEFT);
 
-				if (response.statusCode() == 200) {
-					List<GiftcodeEntry> entries = parseResponse(response.body());
-					Platform.runLater(() -> {
-						currentEntries.clear();
-						currentEntries.addAll(entries);
-						populateGiftcodeCards(entries);
-						labelStatus.setText("Fetched " + entries.size() + " gift code(s) successfully.");
-						buttonFetch.setDisable(false);
-						if (!entries.isEmpty()) {
-							buttonCopyAll.setVisible(true);
-							buttonCopyAll.setManaged(true);
-						}
-					});
-				} else {
-					Platform.runLater(() -> {
-						giftcodeListContainer.getChildren().clear();
-						Label errorLabel = new Label("Failed to fetch gift codes (HTTP " + response.statusCode() + ")");
-						errorLabel.getStyleClass().add("giftcode-placeholder");
-						giftcodeListContainer.getChildren().add(errorLabel);
-						labelStatus.setText("Error: HTTP " + response.statusCode());
-						buttonFetch.setDisable(false);
-					});
-				}
-			} catch (Exception e) {
-				Platform.runLater(() -> {
-					giftcodeListContainer.getChildren().clear();
-					Label errorLabel = new Label("Connection error: " + e.getMessage());
-					errorLabel.getStyleClass().add("giftcode-placeholder");
-					giftcodeListContainer.getChildren().add(errorLabel);
-					labelStatus.setText("Error: " + e.getMessage());
-					buttonFetch.setDisable(false);
-				});
-			}
-		});
-		fetchThread.setDaemon(true);
-		fetchThread.start();
-	}
+        Button copy = new Button("Copy");
+        copy.getStyleClass().add("giftcode-copy-btn");
+        copy.setOnAction(event -> {
+            copyToClipboard(entry.code());
+            showCopiedFeedback(copy, "Copy", "Copied!");
+        });
 
-	@FXML
-	private void handleCopyAll() {
-		if (currentEntries.isEmpty()) {
-			return;
-		}
-		String allCodes = currentEntries.stream()
-				.map(GiftcodeEntry::code)
-				.collect(Collectors.joining("\n"));
-		copyToClipboard(allCodes);
-		showCopiedFeedback(buttonCopyAll, "Copy All", "Copied All!");
-		labelStatus.setText("All " + currentEntries.size() + " gift code(s) copied to clipboard.");
-	}
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        HBox row = new HBox(10, indexLabel, codeInfo, spacer, copy);
+        row.setAlignment(Pos.CENTER_LEFT);
+        row.getStyleClass().add("giftcode-row");
+        return row;
+    }
 
-	/**
-	 * Builds the card-based UI rows for each gift code entry.
-	 */
-	private void populateGiftcodeCards(List<GiftcodeEntry> entries) {
-		giftcodeListContainer.getChildren().clear();
+    private void populateRecipients(GiftCodeState state) {
+        recipientListContainer.getChildren().clear();
+        if (state.profiles().isEmpty()) {
+            Label empty = new Label("No profiles configured yet.");
+            empty.getStyleClass().add("giftcode-placeholder");
+            recipientListContainer.getChildren().add(empty);
+            return;
+        }
+        for (GiftCodeProfile profile : state.profiles()) {
+            recipientListContainer.getChildren().add(createProfileRow(profile, state.busy()));
+            if (profile.recipients().isEmpty()) {
+                Label empty = new Label("No Player ID configured for this profile.");
+                empty.getStyleClass().addAll("giftcode-placeholder", "giftcode-recipient-child");
+                recipientListContainer.getChildren().add(empty);
+            } else {
+                profile.recipients().forEach(recipient ->
+                        recipientListContainer.getChildren().add(createRecipientRow(recipient)));
+            }
+        }
+    }
 
-		if (entries.isEmpty()) {
-			Label emptyLabel = new Label("No gift codes available at this time.");
-			emptyLabel.getStyleClass().add("giftcode-placeholder");
-			giftcodeListContainer.getChildren().add(emptyLabel);
-			return;
-		}
+    private HBox createProfileRow(GiftCodeProfile profile, boolean busy) {
+        Label name = new Label(profile.profileName());
+        name.getStyleClass().add("giftcode-profile-label");
+        String identity = profile.playerId().isBlank() ? "Player ID missing" : "Player ID " + profile.playerId();
+        identity += profile.region().isBlank() ? " | Region missing" : " | Region " + profile.region();
+        Label id = new Label(identity);
+        id.getStyleClass().add("giftcode-recipient-source");
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+        String autoLabel = profile.autoEnabled()
+                ? profile.autoRunning() ? "Auto Claim Running - Stop" : "Stop Auto Claim"
+                : profile.autoRunning() ? "Stopping Auto Claim..." : "Auto claim hourly";
+        CheckBox auto = new CheckBox(autoLabel);
+        auto.setSelected(profile.autoEnabled());
+        auto.setDisable(profile.playerId().isBlank() || profile.region().isBlank()
+                || (busy && !profile.autoEnabled()));
+        if (profile.playerId().isBlank() || profile.region().isBlank()) {
+            auto.setTooltip(new Tooltip(
+                    "Enter this profile's Player ID and Server/Region in Character Information first."));
+        }
+        auto.setOnAction(event -> automation.setAutoEnabled(profile.profileId(), auto.isSelected()));
+        HBox row = new HBox(10, name, id, spacer, auto);
+        row.setAlignment(Pos.CENTER_LEFT);
+        row.getStyleClass().add("giftcode-profile-row");
+        return row;
+    }
 
-		for (int i = 0; i < entries.size(); i++) {
-			GiftcodeEntry entry = entries.get(i);
-			HBox row = createGiftcodeRow(entry, i + 1);
-			giftcodeListContainer.getChildren().add(row);
-		}
-	}
+    private HBox createRecipientRow(GiftCodeRecipient recipient) {
+        Label identity = new Label(recipient.label());
+        identity.getStyleClass().add("giftcode-recipient-label");
+        Label source = new Label(recipient.managedProfile() ? "Profile account" : "Additional");
+        source.getStyleClass().add("giftcode-recipient-source");
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
 
-	/**
-	 * Creates a single styled row card for a gift code.
-	 */
-	private HBox createGiftcodeRow(GiftcodeEntry entry, int index) {
-		// Left side: index + code + date
-		Label indexLabel = new Label("#" + index);
-		indexLabel.setStyle("-fx-text-fill: #555555; -fx-font-size: 11px; -fx-min-width: 28;");
+        HBox row;
+        if (recipient.managedProfile()) {
+            row = new HBox(10, identity, spacer, source);
+        } else {
+            Button remove = new Button("Remove");
+            remove.getStyleClass().add("giftcode-copy-btn");
+            remove.setOnAction(event -> automation.removeExtraRecipient(
+                    recipient.ownerProfileId(), recipient.playerId()));
+            row = new HBox(10, identity, spacer, source, remove);
+        }
+        row.setAlignment(Pos.CENTER_LEFT);
+        row.getStyleClass().addAll("giftcode-recipient-row", "giftcode-recipient-child");
+        return row;
+    }
 
-		Label codeLabel = new Label(entry.code());
-		codeLabel.getStyleClass().add("giftcode-code-label");
+    private void copyToClipboard(String text) {
+        ClipboardContent content = new ClipboardContent();
+        content.putString(text);
+        Clipboard.getSystemClipboard().setContent(content);
+    }
 
-		Label dateLabel = new Label(entry.date());
-		dateLabel.getStyleClass().add("giftcode-date-label");
-
-		VBox codeInfo = new VBox(2, codeLabel, dateLabel);
-		codeInfo.setAlignment(Pos.CENTER_LEFT);
-
-		// Spacer
-		Region spacer = new Region();
-		HBox.setHgrow(spacer, Priority.ALWAYS);
-
-		// Copy button
-		Button copyBtn = new Button("Copy");
-		copyBtn.getStyleClass().add("giftcode-copy-btn");
-		copyBtn.setOnAction(e -> {
-			copyToClipboard(entry.code());
-			showCopiedFeedback(copyBtn, "Copy", "Copied!");
-			labelStatus.setText("Copied: " + entry.code());
-		});
-
-		HBox row = new HBox(10, indexLabel, codeInfo, spacer, copyBtn);
-		row.setAlignment(Pos.CENTER_LEFT);
-		row.getStyleClass().add("giftcode-row");
-
-		return row;
-	}
-
-	/**
-	 * Copies text to the system clipboard.
-	 */
-	private void copyToClipboard(String text) {
-		ClipboardContent content = new ClipboardContent();
-		content.putString(text);
-		Clipboard.getSystemClipboard().setContent(content);
-	}
-
-	/**
-	 * Shows a brief "Copied!" feedback on a button, then reverts.
-	 */
-	private void showCopiedFeedback(Button button, String originalText, String feedbackText) {
-		String originalStyle = button.getStyle();
-		button.setText(feedbackText);
-		button.getStyleClass().add("giftcode-copy-btn-copied");
-
-		PauseTransition pause = new PauseTransition(javafx.util.Duration.millis(1200));
-		pause.setOnFinished(e -> {
-			button.setText(originalText);
-			button.getStyleClass().remove("giftcode-copy-btn-copied");
-		});
-		pause.play();
-	}
-
-	/**
-	 * Parses the JSON response to extract gift codes.
-	 * Expected format: {"codes":["CODE1 DD.MM.YYYY","CODE2 DD.MM.YYYY",...]}
-	 */
-	private List<GiftcodeEntry> parseResponse(String json) {
-		List<GiftcodeEntry> entries = new ArrayList<>();
-
-		int codesStart = json.indexOf("\"codes\"");
-		if (codesStart == -1) {
-			return entries;
-		}
-
-		int arrayStart = json.indexOf('[', codesStart);
-		int arrayEnd = json.indexOf(']', arrayStart);
-		if (arrayStart == -1 || arrayEnd == -1) {
-			return entries;
-		}
-
-		String arrayContent = json.substring(arrayStart + 1, arrayEnd);
-
-		String[] items = arrayContent.split(",");
-		for (String item : items) {
-			String trimmed = item.trim();
-			if (trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
-				trimmed = trimmed.substring(1, trimmed.length() - 1);
-			}
-			if (trimmed.isEmpty()) {
-				continue;
-			}
-
-			int lastSpace = trimmed.lastIndexOf(' ');
-			if (lastSpace > 0) {
-				String code = trimmed.substring(0, lastSpace).trim();
-				String date = trimmed.substring(lastSpace + 1).trim();
-				entries.add(new GiftcodeEntry(code, date));
-			} else {
-				entries.add(new GiftcodeEntry(trimmed, "N/A"));
-			}
-		}
-
-		return entries;
-	}
-
-	/**
-	 * Represents a single gift code entry with code and date.
-	 */
-	public record GiftcodeEntry(String code, String date) {
-	}
+    private void showCopiedFeedback(Button button, String originalText, String feedbackText) {
+        button.setText(feedbackText);
+        button.getStyleClass().add("giftcode-copy-btn-copied");
+        PauseTransition pause = new PauseTransition(javafx.util.Duration.millis(1_200));
+        pause.setOnFinished(event -> {
+            button.setText(originalText);
+            button.getStyleClass().remove("giftcode-copy-btn-copied");
+        });
+        pause.play();
+    }
 }

--- a/fg-app/src/main/resources/layout/GiftcodeLayout.fxml
+++ b/fg-app/src/main/resources/layout/GiftcodeLayout.fxml
@@ -3,53 +3,65 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
-<VBox stylesheets="@giftcode.css" maxHeight="Infinity" maxWidth="Infinity" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1">
-    <children>
-        <ScrollPane fitToWidth="true" hbarPolicy="NEVER" styleClass="task-page-scroll" vbarPolicy="AS_NEEDED" VBox.vgrow="ALWAYS">
-            <content>
-                <VBox styleClass="task-page-root" maxHeight="Infinity" maxWidth="Infinity" VBox.vgrow="ALWAYS">
-                    <children>
-                        <!-- Gift Codes Card -->
-                        <VBox styleClass="content-card">
-                            <children>
-                                <!-- Header -->
-                                <HBox alignment="CENTER_LEFT" maxWidth="Infinity" styleClass="header-red">
-                                    <children>
-                                        <Label text="Gift Codes" />
-                                    </children>
-                                </HBox>
-                                <!-- Body -->
-                                <VBox styleClass="task-section-inner">
-                                    <children>
-                                        <Label styleClass="task-card-description" text="Fetch the latest available gift codes from the server. Click the copy button next to any code to copy it to your clipboard." wrapText="true" />
-
-                                        <Separator style="-fx-opacity: 0.25;" />
-
-                                        <!-- Controls row -->
-                                        <HBox spacing="10" alignment="CENTER_LEFT">
-                                            <children>
-                                                <Button fx:id="buttonFetch" mnemonicParsing="false" onAction="#handleFetch" styleClass="giftcode-fetch-btn" text="Fetch Codes" />
-                                                <Button fx:id="buttonCopyAll" mnemonicParsing="false" onAction="#handleCopyAll" styleClass="giftcode-copy-all-btn" text="Copy All" visible="false" managed="false" />
-                                                <Region HBox.hgrow="ALWAYS" />
-                                                <Label fx:id="labelStatus" styleClass="giftcode-status" text="Click 'Fetch Codes' to load gift codes." />
-                                            </children>
-                                        </HBox>
-
-                                        <Separator style="-fx-opacity: 0.25;" />
-
-                                        <!-- Gift code list container -->
-                                        <VBox fx:id="giftcodeListContainer" spacing="6" VBox.vgrow="ALWAYS">
-                                            <children>
-                                                <Label styleClass="giftcode-placeholder" text="No gift codes loaded yet." />
-                                            </children>
-                                        </VBox>
-                                    </children>
-                                </VBox>
-                            </children>
-                        </VBox>
-                    </children>
+<VBox stylesheets="@giftcode.css" maxHeight="Infinity" maxWidth="Infinity" VBox.vgrow="ALWAYS"
+      xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1">
+    <ScrollPane fitToWidth="true" hbarPolicy="NEVER" styleClass="task-page-scroll" vbarPolicy="AS_NEEDED" VBox.vgrow="ALWAYS">
+        <VBox styleClass="task-page-root" maxWidth="Infinity" spacing="14">
+            <VBox styleClass="content-card">
+                <HBox alignment="CENTER_LEFT" maxWidth="Infinity" styleClass="header-red">
+                    <Label text="Gift Codes" />
+                </HBox>
+                <VBox styleClass="task-section-inner" spacing="10">
+                    <Label styleClass="task-card-description"
+                           text="Active codes are loaded from the Frostguard gift code source. Discovery dates show when a code entered the list, not when it expires."
+                           wrapText="true" />
+                    <HBox spacing="10" alignment="CENTER_LEFT">
+                        <Button fx:id="buttonFetch" onAction="#handleFetch" styleClass="giftcode-fetch-btn" text="Refresh" />
+                        <Button fx:id="buttonCopyAll" onAction="#handleCopyAll" styleClass="giftcode-copy-all-btn"
+                                text="Copy All Active" visible="false" managed="false" />
+                        <Region HBox.hgrow="ALWAYS" />
+                        <Label fx:id="labelStatus" styleClass="giftcode-status" text="Gift codes have not been checked yet." wrapText="true" />
+                    </HBox>
+                    <Separator style="-fx-opacity: 0.25;" />
+                    <VBox fx:id="giftcodeListContainer" spacing="6">
+                        <Label styleClass="giftcode-placeholder" text="No active gift codes loaded." />
+                    </VBox>
                 </VBox>
-            </content>
-        </ScrollPane>
-    </children>
+            </VBox>
+
+            <VBox styleClass="content-card">
+                <HBox alignment="CENTER_LEFT" maxWidth="Infinity" styleClass="header-red">
+                    <Label text="Recipients &amp; Claims" />
+                </HBox>
+                <VBox styleClass="task-section-inner" spacing="10">
+                    <Label styleClass="task-card-description"
+                           text="Each profile keeps its own auto-claim setting and additional recipients. Redeemed-code history is shared across profiles in this bot's local database."
+                           wrapText="true" />
+                    <Label fx:id="labelAccountHint" styleClass="giftcode-warning"
+                           text="No complete profile identity found. In Profile Manager, enter both ID and Server/Region under Character Information before enabling auto claim."
+                           wrapText="true" />
+                    <VBox fx:id="recipientListContainer" spacing="6">
+                        <Label styleClass="giftcode-placeholder" text="No Player IDs configured yet." />
+                    </VBox>
+                    <HBox spacing="8" alignment="CENTER_LEFT">
+                        <ComboBox fx:id="comboRecipientProfile" promptText="Owning profile" prefWidth="180" />
+                        <TextField fx:id="textfieldRecipientAlias" promptText="Alias (e.g. Alex)" HBox.hgrow="ALWAYS" />
+                        <TextField fx:id="textfieldRecipientId" promptText="Player ID" HBox.hgrow="ALWAYS" />
+                        <TextField fx:id="textfieldRecipientRegion" promptText="Region" prefWidth="100" />
+                        <Button onAction="#handleAddRecipient" styleClass="giftcode-copy-all-btn" text="Add" />
+                    </HBox>
+                    <Separator style="-fx-opacity: 0.25;" />
+                    <HBox spacing="12" alignment="CENTER_LEFT">
+                        <Button fx:id="buttonClaimAll" onAction="#handleClaimAll" styleClass="giftcode-fetch-btn"
+                                text="Claim All for All Recipients" disable="true" />
+                        <Label fx:id="labelClaimStatus" styleClass="giftcode-status" wrapText="true"
+                               visible="false" managed="false" HBox.hgrow="ALWAYS" />
+                    </HBox>
+                    <Label styleClass="giftcode-description"
+                           text="Manual claim refreshes the code list first. Each Player ID and code is redeemed at most once per bot instance, even when the recipient appears in multiple profiles."
+                           wrapText="true" />
+                </VBox>
+            </VBox>
+        </VBox>
+    </ScrollPane>
 </VBox>

--- a/fg-app/src/main/resources/layout/giftcode.css
+++ b/fg-app/src/main/resources/layout/giftcode.css
@@ -184,3 +184,50 @@
     -fx-background-color: #c0392b;
     -fx-border-color: #c0392b;
 }
+
+.giftcode-index-label {
+    -fx-text-fill: #666666;
+    -fx-font-size: 11px;
+    -fx-min-width: 28;
+}
+
+.giftcode-warning {
+    -fx-text-fill: #f0ad4e;
+    -fx-background-color: rgba(240, 173, 78, 0.10);
+    -fx-background-radius: 5;
+    -fx-padding: 8 10;
+}
+
+.giftcode-recipient-row {
+    -fx-background-color: #2a2a2a;
+    -fx-background-radius: 5;
+    -fx-padding: 8 10;
+}
+
+.giftcode-profile-row {
+    -fx-background-color: #222833;
+    -fx-background-radius: 5;
+    -fx-padding: 9 10;
+    -fx-border-color: #3a4658;
+    -fx-border-radius: 5;
+}
+
+.giftcode-profile-label {
+    -fx-text-fill: #ffffff;
+    -fx-font-weight: bold;
+}
+
+.giftcode-recipient-child {
+    -fx-translate-x: 14;
+    -fx-max-width: 100000;
+}
+
+.giftcode-recipient-label {
+    -fx-text-fill: #dddddd;
+    -fx-font-weight: bold;
+}
+
+.giftcode-recipient-source {
+    -fx-text-fill: #888888;
+    -fx-font-size: 10px;
+}

--- a/fg-app/src/test/java/dev/frostguard/app/panel/misc/GiftCodeAutomationServiceTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/misc/GiftCodeAutomationServiceTest.java
@@ -1,0 +1,40 @@
+package dev.frostguard.app.panel.misc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+class GiftCodeAutomationServiceTest {
+
+    @Test
+    void profileRefreshIsSkippedWhenTheCallingThreadIsInterrupted() {
+        assertTrue(GiftCodeAutomationService.isProfileRefreshAllowed());
+
+        Thread.currentThread().interrupt();
+        try {
+            assertFalse(GiftCodeAutomationService.isProfileRefreshAllowed());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void hourlyCheckIsAlignedToTheNextFullUtcHour() {
+        ZonedDateTime now = ZonedDateTime.of(2026, 7, 29, 7, 58, 57, 123_000_000, ZoneOffset.UTC);
+
+        assertEquals(Duration.ofMinutes(1).plusSeconds(2).plusMillis(877),
+                GiftCodeAutomationService.delayUntilNextHourlyCheck(now));
+    }
+
+    @Test
+    void retryBackoffAvoidsRapidRepeatedCenturyRequests() {
+        assertEquals(5_000L, GiftCodeAutomationService.retryDelayMillis(1));
+        assertEquals(15_000L, GiftCodeAutomationService.retryDelayMillis(2));
+    }
+}

--- a/fg-app/src/test/java/dev/frostguard/app/panel/misc/GiftCodeClientTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/misc/GiftCodeClientTest.java
@@ -1,0 +1,34 @@
+package dev.frostguard.app.panel.misc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.frostguard.app.panel.misc.GiftCodeClient.GiftCodeEntry;
+
+class GiftCodeClientTest {
+
+    private final GiftCodeClient client = new GiftCodeClient();
+
+    @Test
+    void parsesDatesAndRemovesDuplicateCodes() throws Exception {
+        List<GiftCodeEntry> result = client.parseResponse(
+                "{\"codes\":[\"WOS0715 15.07.2026\",\"WOS0715 15.07.2026\",\"4PWagqPw4 15.07.2026\"]}");
+
+        assertEquals(2, result.size());
+        assertEquals("WOS0715", result.get(0).code());
+        assertEquals(LocalDate.of(2026, 7, 15), result.get(0).discoveredOn());
+    }
+
+    @Test
+    void keepsUndatedCodesWithoutInventingAnExpiry() throws Exception {
+        List<GiftCodeEntry> result = client.parseResponse("{\"codes\":[\"SURVIVAL\"]}");
+
+        assertEquals("SURVIVAL", result.get(0).code());
+        assertNull(result.get(0).discoveredOn());
+    }
+}

--- a/fg-app/src/test/java/dev/frostguard/app/panel/misc/GiftCodeHistoryStoreTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/misc/GiftCodeHistoryStoreTest.java
@@ -1,0 +1,57 @@
+package dev.frostguard.app.panel.misc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import dev.frostguard.app.panel.misc.GiftCodeHistoryStore.HistoryEntry;
+import dev.frostguard.app.panel.misc.GiftCodeRedeemer.RedeemOutcome;
+import dev.frostguard.app.panel.misc.GiftCodeRedeemer.RedeemResult;
+
+class GiftCodeHistoryStoreTest {
+
+    private final Map<String, HistoryEntry> entries = new LinkedHashMap<>();
+    private final GiftCodeHistoryStore history = new GiftCodeHistoryStore(new GiftCodeHistoryStore.Backend() {
+        @Override
+        public Optional<HistoryEntry> find(String playerId, String giftCode) {
+            return Optional.ofNullable(entries.get(key(playerId, giftCode)));
+        }
+
+        @Override
+        public boolean insertIfAbsent(HistoryEntry entry) {
+            entries.putIfAbsent(key(entry.playerId(), entry.giftCode()), entry);
+            return true;
+        }
+    });
+
+    @Test
+    void onePlayerAndCodeHasOneCanonicalResultAcrossProfiles() {
+        assertTrue(history.remember("123", "4508", "CODE",
+                new RedeemResult("SUCCESS", RedeemOutcome.REDEEMED, true)));
+        assertTrue(history.remember("123", "4508", "CODE",
+                new RedeemResult("RECEIVED.", RedeemOutcome.ALREADY_REDEEMED, true)));
+
+        assertTrue(history.wasTerminallyChecked("123", "CODE"));
+        assertEquals(1, entries.size());
+        assertEquals("REDEEMED", entries.values().iterator().next().outcome());
+        assertFalse(history.wasTerminallyChecked("456", "CODE"));
+    }
+
+    @Test
+    void importsLegacyTerminalResultIntoCanonicalHistory() {
+        assertTrue(history.importLegacy("123", "4508", "OLD", "RECEIVED."));
+
+        assertTrue(history.wasTerminallyChecked("123", "OLD"));
+        assertEquals("ALREADY_REDEEMED", entries.values().iterator().next().outcome());
+    }
+
+    private String key(String playerId, String giftCode) {
+        return playerId + "\u0000" + giftCode;
+    }
+}

--- a/fg-app/src/test/java/dev/frostguard/app/panel/misc/GiftCodeRedeemerTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/misc/GiftCodeRedeemerTest.java
@@ -1,0 +1,40 @@
+package dev.frostguard.app.panel.misc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import dev.frostguard.app.panel.misc.GiftCodeRedeemer.RedeemOutcome;
+
+class GiftCodeRedeemerTest {
+
+    private final GiftCodeRedeemer redeemer = new GiftCodeRedeemer();
+
+    @Test
+    void matchesTheCurrentOfficialRegionAwareRequestSignature() {
+        Map<String, String> fields = redeemer.requestFields(
+                "797458026", "1", "TESTONLY", 1784683335L);
+        Map<String, String> signed = redeemer.signed(fields);
+
+        assertEquals("797458026", signed.get("fid"));
+        assertEquals("1", signed.get("kid"));
+        assertEquals("TESTONLY", signed.get("cdk"));
+        assertEquals("1784683335", signed.get("time"));
+        assertEquals("b2cb433cb3972f812f6b323c9336b669", signed.get("sign"));
+        assertFalse(signed.containsKey("captcha_code"));
+    }
+
+    @Test
+    void distinguishesRedeemedAlreadyRedeemedFailedAndRetryableResults() {
+        assertEquals(RedeemOutcome.REDEEMED, GiftCodeRedeemer.classify("SUCCESS").outcome());
+        assertEquals(RedeemOutcome.ALREADY_REDEEMED, GiftCodeRedeemer.classify("RECEIVED.").outcome());
+        assertEquals(RedeemOutcome.FAILED, GiftCodeRedeemer.classify("Gift code expired").outcome());
+        assertEquals(RedeemOutcome.RETRYABLE_ERROR, GiftCodeRedeemer.classify("Server busy").outcome());
+        assertTrue(GiftCodeRedeemer.classify("SUCCESS").terminal());
+        assertFalse(GiftCodeRedeemer.classify("Server busy").terminal());
+    }
+}

--- a/fg-app/src/test/java/dev/frostguard/app/panel/misc/GiftCodeStoreTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/misc/GiftCodeStoreTest.java
@@ -1,0 +1,67 @@
+package dev.frostguard.app.panel.misc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import dev.frostguard.api.domain.AccountDescriptor;
+
+class GiftCodeStoreTest {
+
+    private final Map<Long, String> persisted = new HashMap<>();
+    private final GiftCodeStore store = new GiftCodeStore(
+            profile -> persisted.getOrDefault(profile.getId(), "{}"),
+            (profile, json) -> {
+                persisted.put(profile.getId(), json);
+                profile.setConfig(dev.frostguard.api.configs.ConfigurationKeyEnum.GIFT_CODE_STATE_JSON, json);
+                return true;
+            });
+    private final AccountDescriptor profileOne = profile(1L, "One", "4508");
+    private final AccountDescriptor profileTwo = profile(2L, "Two", "4509");
+
+    @Test
+    void storesAutoCheckAndRegionAwareRecipientsPerProfile() {
+        store.setAutoEnabled(profileOne, true);
+        store.setLastCheckUtc(profileOne, LocalDate.of(2026, 7, 16));
+        store.saveExtraRecipient(profileOne, "123456", "Alex", "4508");
+
+        assertTrue(store.isAutoEnabled(profileOne));
+        assertFalse(store.isAutoEnabled(profileTwo));
+        assertEquals(LocalDate.of(2026, 7, 16), store.lastCheckUtc(profileOne));
+        assertEquals("4508", store.extraRecipients(profileOne).get(0).region());
+        assertTrue(store.extraRecipients(profileTwo).isEmpty());
+    }
+
+    @Test
+    void migratesLegacyRecipientAndExposesLegacyClaimsWithoutDataLoss() {
+        persisted.put(profileOne.getId(), """
+                {"autoEnabled":true,"lastCheckUtc":"2026-07-21",
+                 "recipients":{"797458026":"Zorome"},
+                 "claims":{"797458026":{"Z29nb1dPUw":"RECEIVED."}}}
+                """);
+
+        assertTrue(store.migrateLegacyRecipients(profileOne));
+
+        var recipient = store.extraRecipients(profileOne).get(0);
+        assertEquals("Zorome", recipient.alias());
+        assertEquals("4508", recipient.region());
+        var claim = store.legacyClaims(profileOne).get(0);
+        assertEquals("797458026", claim.playerId());
+        assertEquals("4508", claim.region());
+        assertEquals("gogoWOS", claim.giftCode());
+        assertEquals("RECEIVED.", claim.result());
+        assertTrue(persisted.get(profileOne.getId()).contains("\"claims\""));
+    }
+
+    private AccountDescriptor profile(Long id, String name, String region) {
+        AccountDescriptor profile = new AccountDescriptor(id, name, "1", true, 50L, 0L);
+        profile.setCharacterServer(region);
+        return profile;
+    }
+}

--- a/fg-data/src/main/java/dev/frostguard/data/entity/GiftCodeClaim.java
+++ b/fg-data/src/main/java/dev/frostguard/data/entity/GiftCodeClaim.java
@@ -1,0 +1,72 @@
+package dev.frostguard.data.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+/** Canonical terminal gift-code result for one player in this bot instance. */
+@Entity
+@Table(name = "gift_code_claim",
+        uniqueConstraints = @UniqueConstraint(name = "uk_gift_code_claim_player_code",
+                columnNames = {"player_id", "gift_code"}))
+@Access(AccessType.FIELD)
+public class GiftCodeClaim {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, unique = true)
+    private Long id;
+
+    @Column(name = "player_id", nullable = false)
+    private String playerId;
+
+    @Column(name = "gift_code", nullable = false)
+    private String giftCode;
+
+    @Column(name = "region", nullable = false)
+    private String region;
+
+    @Column(name = "outcome", nullable = false)
+    private String outcome;
+
+    @Column(name = "message", nullable = false)
+    private String message;
+
+    @Column(name = "recorded_at", nullable = false)
+    private LocalDateTime recordedAt;
+
+    public GiftCodeClaim() {}
+
+    public GiftCodeClaim(String playerId, String giftCode, String region,
+                         String outcome, String message, LocalDateTime recordedAt) {
+        this.playerId = playerId;
+        this.giftCode = giftCode;
+        this.region = region == null ? "" : region;
+        this.outcome = outcome;
+        this.message = message;
+        this.recordedAt = recordedAt == null ? LocalDateTime.now() : recordedAt;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getPlayerId() { return playerId; }
+    public void setPlayerId(String playerId) { this.playerId = playerId; }
+    public String getGiftCode() { return giftCode; }
+    public void setGiftCode(String giftCode) { this.giftCode = giftCode; }
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+    public String getOutcome() { return outcome; }
+    public void setOutcome(String outcome) { this.outcome = outcome; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public LocalDateTime getRecordedAt() { return recordedAt; }
+    public void setRecordedAt(LocalDateTime recordedAt) { this.recordedAt = recordedAt; }
+}

--- a/fg-data/src/main/java/dev/frostguard/data/repository/GiftCodeClaimRepository.java
+++ b/fg-data/src/main/java/dev/frostguard/data/repository/GiftCodeClaimRepository.java
@@ -1,0 +1,48 @@
+package dev.frostguard.data.repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import dev.frostguard.data.access.DataStore;
+import dev.frostguard.data.entity.GiftCodeClaim;
+
+/** Persistence gateway for the bot-local canonical gift-code history. */
+public final class GiftCodeClaimRepository {
+
+    private static GiftCodeClaimRepository instance;
+    private final DataStore store = DataStore.getInstance();
+
+    private GiftCodeClaimRepository() {}
+
+    public static synchronized GiftCodeClaimRepository getRepository() {
+        if (instance == null) {
+            instance = new GiftCodeClaimRepository();
+        }
+        return instance;
+    }
+
+    public Optional<GiftCodeClaim> find(String playerId, String giftCode) {
+        List<GiftCodeClaim> results = store.executeQuery(
+                "SELECT g FROM GiftCodeClaim g WHERE g.playerId = :playerId AND g.giftCode = :giftCode",
+                GiftCodeClaim.class, Map.of("playerId", playerId, "giftCode", giftCode));
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
+
+    public boolean insertIfAbsent(GiftCodeClaim claim) {
+        return store.withinTransaction(entityManager -> {
+            List<GiftCodeClaim> existing = entityManager.createQuery(
+                            "SELECT g FROM GiftCodeClaim g WHERE g.playerId = :playerId AND g.giftCode = :giftCode",
+                            GiftCodeClaim.class)
+                    .setParameter("playerId", claim.getPlayerId())
+                    .setParameter("giftCode", claim.getGiftCode())
+                    .setMaxResults(1)
+                    .getResultList();
+            if (!existing.isEmpty()) {
+                return true;
+            }
+            entityManager.persist(claim);
+            return true;
+        });
+    }
+}

--- a/fg-data/src/main/resources/META-INF/persistence.xml
+++ b/fg-data/src/main/resources/META-INF/persistence.xml
@@ -17,6 +17,7 @@
         <class>dev.frostguard.data.entity.ConfigTemplate</class>
         <class>dev.frostguard.data.entity.DailyTask</class>
         <class>dev.frostguard.data.entity.DailyTaskTemplate</class>
+        <class>dev.frostguard.data.entity.GiftCodeClaim</class>
         <class>dev.frostguard.data.entity.Profile</class>
         <class>dev.frostguard.data.entity.ProfileBuilding</class>
 

--- a/fg-engine/src/main/java/dev/frostguard/engine/service/ConfigService.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/service/ConfigService.java
@@ -176,6 +176,10 @@ public class ConfigService {
 		if (isHiddenStatisticsUpdate(key)) {
 			return;
 		}
+		if (key == ConfigurationKeyEnum.GIFT_CODE_STATE_JSON) {
+			LOG.debug("Profile gift code state {}", updatedExisting ? "updated" : "created");
+			return;
+		}
 		LOG.info("Profile config {} {}: {}", key.name(), updatedExisting ? "updated" : "created", value);
 	}
 


### PR DESCRIPTION
## Summary

- refresh and copy active gift codes from the existing Frostguard code source
- manage profile recipients and additional alias/Player ID/Region recipients
- redeem directly through Century Games' current region-aware `/api/gift_code` endpoint
- remove the obsolete player-login/CAPTCHA flow, downloaded model, and its third-party notice
- keep auto-claim settings and additional recipients per profile while storing terminal claim history once per bot database
- migrate legacy per-profile recipients and claim results without deleting their rollback data
- merge the same Player ID/code across profiles before submission, so one bot instance makes at most one API call for that pair
- check the shared gift-code source once per bot instance at startup and every full UTC hour when auto claim is enabled
- submit only Player ID/code pairs absent from canonical history, pace Century requests at least one second apart, and back off retries by 5 then 15 seconds
- distinguish `REDEEMED`, `ALREADY_REDEEMED`, `FAILED`, retry exhaustion, history skips, duplicates, and configuration errors in logs and run summaries
- retain manual/automatic running, stop, retry, and completion feedback in the Gift Codes UI

### Persistence and migration

- canonical terminal history is stored in the existing local `database.db` table `gift_code_claim`, uniquely keyed by Player ID and gift code
- the history is shared across profiles within one bot instance, but not across separate worktrees/installations
- existing profile JSON remains the source for per-profile settings and recipient ownership
- legacy recipient strings are upgraded with the owning profile's Server/Region
- legacy claim entries are imported into the canonical table on startup; the original JSON entries are retained as rollback data
- the three Dave Main profiles currently use Region `4508`, including all duplicated recipients

## Why

Century Games changed the official form on 21 July 2026. The browser now submits `fid`, `cdk`, `kid` (Region), Unix-seconds `time`, and the existing signature directly to `/api/gift_code`; `/api/player` and CAPTCHA are no longer part of the flow. Profiles therefore require both Character ID and Server/Region before auto claim can be enabled.

The previous daily 00:00 UTC source check could discover codes many hours late. Observed additions around 08:00 and 12:00 UTC show there is no single midnight release time, so hourly source checks provide timely discovery without repeatedly submitting claims.

## Validation

- rebased feature branch `mvn package`: 112 tests passed; desktop package succeeded
- current `local/staging` `mvn test`: 151 tests passed
- feature-to-staging follow-up patch IDs match exactly
- exact captured official request signature is covered by a regression test

## Risks

The hourly scheduler and request pacing still need live confirmation after the user-controlled staging restart. The staging package reached the runtime dependency copy step but could not replace a JAR locked by the running bot; no bot process was stopped. The equivalent feature-worktree package completed successfully.
