### PR TITLE
fix(gather): retry contested resource nodes

### DIFF
--- a/fg-tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
@@ -312,6 +312,7 @@ public class GatherRoutine extends DelayedTask {
         int deployed = 0;
         int noNode = 0;
         int blocked = 0;
+        int sameTargetBlocked = 0;
         logInfo(String.format("Gather fill: active=%d/%d idleSlots=%d freeSlots=%d pool=%s",
                 currentActive, activeQueues, idleSlotCount, freeSlots, rotationPool));
 
@@ -330,7 +331,7 @@ public class GatherRoutine extends DelayedTask {
 
         if (freeSlots <= 0) {
             saveRotationPool();
-            return new GatherFillResult(0, 0, 0, false);
+            return new GatherFillResult(0, 0, 0, 0, false, 0);
         }
 
         // Shuffle loaded pool for randomness in this run
@@ -379,7 +380,7 @@ public class GatherRoutine extends DelayedTask {
                     if (deployResult == GatherDeployResult.NO_TROOPS_AVAILABLE) {
                         remaining = 0;
                         saveRotationPool();
-                        return new GatherFillResult(deployed, noNode, blocked, true);
+                        return new GatherFillResult(deployed, noNode, blocked, sameTargetBlocked, true, 0);
                     }
                     // Remove failed type from pool to avoid retrying it endlessly
                     rotationPool.remove(type);
@@ -390,6 +391,10 @@ public class GatherRoutine extends DelayedTask {
                     if (deployResult == GatherDeployResult.BLOCKED) {
                         blocked++;
                     }
+                    if (deployResult == GatherDeployResult.SAME_TARGET) {
+                        blocked++;
+                        sameTargetBlocked++;
+                    }
                 }
             }
 
@@ -398,7 +403,7 @@ public class GatherRoutine extends DelayedTask {
         }
 
         saveRotationPool();
-        return new GatherFillResult(deployed, noNode, blocked, false);
+        return new GatherFillResult(deployed, noNode, blocked, sameTargetBlocked, false, remaining);
     }
 
     private void loadRotationPool() {
@@ -682,24 +687,49 @@ public class GatherRoutine extends DelayedTask {
         int minLevel = downgradeLevelOnMissingNode ? 1 : targetLevel;
 
         for (int level = targetLevel; level >= minLevel; level--) {
-            logInfo(String.format("Gather deploy attempt: type=%s level=%d onlyFull=%s", type, level, onlyFullResources));
+            int sameTargetFailures = 0;
+            GatherDeployResult result;
 
-            if (!openSearchMenu()) {
-                return retryLater(GatherDeployResult.BLOCKED);
-            }
-            if (!selectTile(type)) {
-                return retryLater(GatherDeployResult.BLOCKED);
-            }
-            if (!setLevel(level)) {
-                return retryLater(GatherDeployResult.BLOCKED);
-            }
-            setOnlyFullResourcesSearch(onlyFullResources);
-            if (!executeSearch()) {
-                return retryLater(GatherDeployResult.BLOCKED);
-            }
+            do {
+                logInfo(String.format(
+                        "Gather deploy attempt: type=%s level=%d onlyFull=%s nodeAttempt=%d/%d",
+                        type, level, onlyFullResources, sameTargetFailures + 1,
+                        GatherSameTargetRetryPolicy.MAX_NODE_ATTEMPTS));
 
-            GatherDeployResult result = deployMarchAction(type, level);
+                if (!openSearchMenu()) {
+                    return retryLater(GatherDeployResult.BLOCKED);
+                }
+                if (!selectTile(type)) {
+                    return retryLater(GatherDeployResult.BLOCKED);
+                }
+                if (!setLevel(level)) {
+                    return retryLater(GatherDeployResult.BLOCKED);
+                }
+                setOnlyFullResourcesSearch(onlyFullResources);
+                if (!executeSearch()) {
+                    return retryLater(GatherDeployResult.BLOCKED);
+                }
+
+                result = deployMarchAction(type, level);
+                if (result == GatherDeployResult.SAME_TARGET) {
+                    sameTargetFailures++;
+                    if (GatherSameTargetRetryPolicy.shouldSearchAnotherNode(sameTargetFailures)) {
+                        logInfo(String.format(
+                                "Gather target already has an incoming march: type=%s level=%d. Searching another node.",
+                                type, level));
+                        sleepTask(500);
+                    }
+                }
+            } while (result == GatherDeployResult.SAME_TARGET
+                    && GatherSameTargetRetryPolicy.shouldSearchAnotherNode(sameTargetFailures));
+
             if (result == GatherDeployResult.DEPLOYED) {
+                return result;
+            }
+            if (result == GatherDeployResult.SAME_TARGET) {
+                logInfo(String.format(
+                        "Gather target conflict persisted after %d node attempts: type=%s level=%d.",
+                        sameTargetFailures, type, level));
                 return result;
             }
             if (result != GatherDeployResult.NO_NODE_FOUND || level == minLevel) {
@@ -821,11 +851,10 @@ public class GatherRoutine extends DelayedTask {
             return GatherDeployResult.BLOCKED;
         }
 
-        if (templateSearchHelper.locatePattern(TemplatesEnum.TROOPS_ALREADY_MARCHING, SearchConfig.builder().build())
-                .isFound()) {
+        if (deploymentHelper.isSameTargetDialog()) {
             pressBack();
             pressBack();
-            return GatherDeployResult.BLOCKED;
+            return GatherDeployResult.SAME_TARGET;
         }
         return GatherDeployResult.DEPLOYED;
     }
@@ -871,6 +900,23 @@ public class GatherRoutine extends DelayedTask {
     }
 
     private void finalizeReschedule(GatherFillResult fillResult) {
+        if (GatherSameTargetRetryPolicy.requiresCooldown(
+                fillResult.sameTargetBlocked(), fillResult.unfilledSlots())) {
+            LocalDateTime retryAt = LocalDateTime.now()
+                    .plus(GatherSameTargetRetryPolicy.EXHAUSTED_RETRY_DELAY);
+            logInfo(String.format(
+                    "Gather fill finished: deployed=%d noNode=%d blocked=%d noTroops=%s. "
+                            + "Same-target conflicts left %d slot(s) unfilled; retrying node search in %d minutes at %s.",
+                    fillResult.deployed(),
+                    fillResult.noNode(),
+                    fillResult.blocked(),
+                    fillResult.stoppedForNoTroops(),
+                    fillResult.unfilledSlots(),
+                    GatherSameTargetRetryPolicy.EXHAUSTED_RETRY_DELAY.toMinutes(),
+                    GameTimeUtils.formatCountdown(retryAt)));
+            reschedule(retryAt);
+            return;
+        }
         if (earliestReschedule != null) {
             reschedule(earliestReschedule);
             return;
@@ -1163,14 +1209,16 @@ public class GatherRoutine extends DelayedTask {
     private record ActiveGatherMarchCandidate(GatherType type, int queueIndex, LocalDateTime returnTime) {
     }
 
-    private record GatherFillResult(int deployed, int noNode, int blocked, boolean stoppedForNoTroops) {
+    private record GatherFillResult(int deployed, int noNode, int blocked, int sameTargetBlocked,
+                                    boolean stoppedForNoTroops, int unfilledSlots) {
     }
 
     private enum GatherDeployResult {
         DEPLOYED,
         NO_NODE_FOUND,
         NO_TROOPS_AVAILABLE,
-        BLOCKED
+        BLOCKED,
+        SAME_TARGET
     }
 
     private enum RecallReason {

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/economy/GatherSameTargetRetryPolicy.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/economy/GatherSameTargetRetryPolicy.java
@@ -1,0 +1,20 @@
+package dev.frostguard.tasks.economy;
+
+import java.time.Duration;
+
+final class GatherSameTargetRetryPolicy {
+
+    static final int MAX_NODE_ATTEMPTS = 2;
+    static final Duration EXHAUSTED_RETRY_DELAY = Duration.ofMinutes(30);
+
+    private GatherSameTargetRetryPolicy() {
+    }
+
+    static boolean shouldSearchAnotherNode(int failedAttempts) {
+        return failedAttempts < MAX_NODE_ATTEMPTS;
+    }
+
+    static boolean requiresCooldown(int exhaustedConflicts, int unfilledSlots) {
+        return exhaustedConflicts > 0 && unfilledSlots > 0;
+    }
+}

--- a/fg-tasks/src/test/java/dev/frostguard/tasks/economy/GatherSameTargetRetryPolicyTest.java
+++ b/fg-tasks/src/test/java/dev/frostguard/tasks/economy/GatherSameTargetRetryPolicyTest.java
@@ -1,0 +1,25 @@
+package dev.frostguard.tasks.economy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class GatherSameTargetRetryPolicyTest {
+
+    @Test
+    void retriesOneDifferentNodeBeforeStopping() {
+        assertTrue(GatherSameTargetRetryPolicy.shouldSearchAnotherNode(1));
+        assertFalse(GatherSameTargetRetryPolicy.shouldSearchAnotherNode(2));
+    }
+
+    @Test
+    void coolsDownOnlyWhenAConflictLeavesSlotsUnfilled() {
+        assertTrue(GatherSameTargetRetryPolicy.requiresCooldown(1, 1));
+        assertFalse(GatherSameTargetRetryPolicy.requiresCooldown(1, 0));
+        assertFalse(GatherSameTargetRetryPolicy.requiresCooldown(0, 1));
+        assertEquals(Duration.ofMinutes(30), GatherSameTargetRetryPolicy.EXHAUSTED_RETRY_DELAY);
+    }
+}


### PR DESCRIPTION
## Retry contested Gather nodes

### Summary

Gather already recognized the game's "Other Troops are marching toward the same target" dialog, but treated it as a generic blocked deployment.

That left a real march slot idle:

- Gather removed the failed resource type from the current rotation;
- no second node was searched;
- final scheduling used the next active Gather return;
- the log incorrectly reported `All gather slots filled`.

In the observed run, a Meat formation was ready and a physical march slot was idle, but one contested node caused Gather to remain at three active marches for roughly another 1 hour 24 minutes.

### Change

The same-target case is now explicit:

1. Detect the dialog through the shared `DeploymentHelper.isSameTargetDialog()`.
2. Close the dialog and formation screen.
3. Search for another node of the same resource type and level.
4. Retry deployment once.
5. If the second node is also contested and a slot remains unfilled, retry Gather after 30 minutes.

The retry is bounded at two node attempts. Gather does not enter an infinite search loop.

### Scheduling

| Result | Behaviour |
| --- | --- |
| First same-target conflict | Search another node immediately |
| Second same-target conflict | Stop this attempt |
| Slot remains unfilled | Schedule Gather in 30 minutes |
| Another resource fills the slot | Keep normal return-aware scheduling |
| No same-target conflict | Preserve existing behaviour |

This keeps transient destination contention separate from permanent deployment blockers and from real march-slot availability.

### Testing

- `mvn -pl fg-tasks -am test -DskipTests=false` passed with 46 engine tests and 7 task tests.
- Added policy coverage for the two-attempt limit, cooldown conditions, and cooldown duration.
- The final cooldown adjustment from 5 to 30 minutes updated the policy and its assertion; no additional build was run as requested for the integration handoff.
- Live confirmation still needed: first conflict should trigger `nodeAttempt=2/2`; a repeated conflict should schedule the next Gather run 30 minutes later.
