### PR TITLE
fix(scheduler): restore stamina waits across restarts

### DIFF
--- a/fg-api/src/main/java/dev/frostguard/api/domain/DailyTaskStatusData.java
+++ b/fg-api/src/main/java/dev/frostguard/api/domain/DailyTaskStatusData.java
@@ -15,6 +15,9 @@ public class DailyTaskStatusData {
     private boolean activated;
     private LocalDateTime scheduledAt;
     private LocalDateTime lastCompletion;
+    private Integer staminaMinimumRequired;
+    private Integer staminaRegenerationTarget;
+    private LocalDateTime staminaEarliestRunnableAt;
 
     /* ── primary construction via factory ── */
 
@@ -33,7 +36,11 @@ public class DailyTaskStatusData {
 
     /** Immutable-style copy with updated schedule. */
     public DailyTaskStatusData withUpdatedSchedule(LocalDateTime nextRun) {
-        return create(boundProfileId, taskTypeCode, customLabel, activated, nextRun, lastCompletion);
+        DailyTaskStatusData copy = create(boundProfileId, taskTypeCode, customLabel, activated, nextRun, lastCompletion);
+        copy.staminaMinimumRequired = staminaMinimumRequired;
+        copy.staminaRegenerationTarget = staminaRegenerationTarget;
+        copy.staminaEarliestRunnableAt = staminaEarliestRunnableAt;
+        return copy;
     }
 
     /* ── no-arg for frameworks ── */
@@ -41,12 +48,16 @@ public class DailyTaskStatusData {
 
     /** Constructor used by Hibernate HQL projections. */
     public DailyTaskStatusData(Long profileId, int typeCode, LocalDateTime lastRun,
-                               LocalDateTime nextRun, String label) {
+                               LocalDateTime nextRun, String label, Integer minimumRequired,
+                               Integer regenerationTarget, LocalDateTime earliestRunnableAt) {
         this.boundProfileId = profileId;
         this.taskTypeCode = typeCode;
         this.lastCompletion = lastRun;
         this.scheduledAt = nextRun;
         this.customLabel = label;
+        this.staminaMinimumRequired = minimumRequired;
+        this.staminaRegenerationTarget = regenerationTarget;
+        this.staminaEarliestRunnableAt = earliestRunnableAt;
         this.activated = true;
     }
 
@@ -75,6 +86,21 @@ public class DailyTaskStatusData {
 
     public LocalDateTime getLastCompletion()            { return lastCompletion; }
     public void setLastCompletion(LocalDateTime ts)     { this.lastCompletion = ts; }
+
+    public Integer getStaminaMinimumRequired()          { return staminaMinimumRequired; }
+    public void setStaminaMinimumRequired(Integer value) { this.staminaMinimumRequired = value; }
+
+    public Integer getStaminaRegenerationTarget()       { return staminaRegenerationTarget; }
+    public void setStaminaRegenerationTarget(Integer value) { this.staminaRegenerationTarget = value; }
+
+    public LocalDateTime getStaminaEarliestRunnableAt() { return staminaEarliestRunnableAt; }
+    public void setStaminaEarliestRunnableAt(LocalDateTime value) { this.staminaEarliestRunnableAt = value; }
+
+    public boolean hasStaminaDeferral() {
+        return staminaMinimumRequired != null
+            && staminaRegenerationTarget != null
+            && staminaEarliestRunnableAt != null;
+    }
 
     /* ── legacy delegates ── */
 

--- a/fg-data/src/main/java/dev/frostguard/data/entity/DailyTask.java
+++ b/fg-data/src/main/java/dev/frostguard/data/entity/DailyTask.java
@@ -56,6 +56,15 @@ public class DailyTask {
 	@Column(name = "custom_task_name", nullable = true)
 	private String customTaskLabel;
 
+	@Column(name = "stamina_minimum_required")
+	private Integer staminaMinimumRequired;
+
+	@Column(name = "stamina_regeneration_target")
+	private Integer staminaRegenerationTarget;
+
+	@Column(name = "stamina_earliest_runnable_at")
+	private LocalDateTime staminaEarliestRunnableAt;
+
 	public DailyTask() {}
 
 	public static DailyTask scheduled(Profile owner, DailyTaskTemplate routine,
@@ -109,6 +118,21 @@ public class DailyTask {
 
 	public String getCustomTaskLabel() { return customTaskLabel; }
 	public void setCustomTaskLabel(String label) { this.customTaskLabel = label; }
+
+	public Integer getStaminaMinimumRequired() { return staminaMinimumRequired; }
+	public void setStaminaMinimumRequired(Integer value) { this.staminaMinimumRequired = value; }
+
+	public Integer getStaminaRegenerationTarget() { return staminaRegenerationTarget; }
+	public void setStaminaRegenerationTarget(Integer value) { this.staminaRegenerationTarget = value; }
+
+	public LocalDateTime getStaminaEarliestRunnableAt() { return staminaEarliestRunnableAt; }
+	public void setStaminaEarliestRunnableAt(LocalDateTime value) { this.staminaEarliestRunnableAt = value; }
+
+	public void clearStaminaDeferral() {
+		staminaMinimumRequired = null;
+		staminaRegenerationTarget = null;
+		staminaEarliestRunnableAt = null;
+	}
 
 	// Compatibility delegates for downstream callers
 	public DailyTaskTemplate getDefinition() { return routine; }

--- a/fg-data/src/main/java/dev/frostguard/data/repository/DailyTaskRepository.java
+++ b/fg-data/src/main/java/dev/frostguard/data/repository/DailyTaskRepository.java
@@ -65,7 +65,8 @@ public class DailyTaskRepository {
 		if (profileId == null) return Collections.emptyList();
 		return store.executeQuery(
 			"SELECT new dev.frostguard.api.domain.DailyTaskStatusData(" +
-				"d.owner.id, d.routine.id, d.completedAt, d.nextRunAt, d.customTaskLabel" +
+				"d.owner.id, d.routine.id, d.completedAt, d.nextRunAt, d.customTaskLabel, " +
+				"d.staminaMinimumRequired, d.staminaRegenerationTarget, d.staminaEarliestRunnableAt" +
 			") FROM DailyTask d WHERE d.owner.id = :profileId",
 			DailyTaskStatusData.class,
 			Map.of("profileId", profileId));

--- a/fg-engine/src/main/java/dev/frostguard/engine/helper/StaminaHelper.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/helper/StaminaHelper.java
@@ -5,6 +5,7 @@ import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.engine.emulator.EmulatorController;
 import dev.frostguard.engine.nav.CommonGameAreas;
 import dev.frostguard.engine.nav.CommonOCRSettings;
+import dev.frostguard.engine.schedule.StaminaWaitScheduler;
 import dev.frostguard.engine.service.LoggingService;
 import dev.frostguard.engine.service.StaminaService;
 import dev.frostguard.vision.convert.GameTimeUtils;
@@ -18,11 +19,6 @@ import java.time.LocalDateTime;
 // Orchestrates stamina tracking: OCR reads, regen delay computation,
 // availability gating, item top-ups, and travel time parsing.
 public class StaminaHelper {
-
-    @FunctionalInterface
-    public interface RescheduleCallback {
-        void reschedule(LocalDateTime time);
-    }
 
     private final EmulatorController device;
     private final String deviceSlot;
@@ -271,41 +267,41 @@ public class StaminaHelper {
 
     // Computes minutes needed for stamina to regenerate from current to target.
     public int staminaRegenerationTime(int current, int target) {
-        if (current >= target) return 0;
-        int deficit = target - current;
-        int waitMinutes = deficit * 5;
-        emitDebug(deficit + " points deficit → " + waitMinutes + " min wait");
+        int waitMinutes = Math.toIntExact(StaminaService.minutesToRegenerate(current, target));
+        if (waitMinutes > 0) {
+            emitDebug((target - current) + " points deficit → " + waitMinutes + " min wait");
+        }
         return waitMinutes;
     }
 
     // Validates stamina and optionally march slots; reschedules on failure.
     // If verifyMarches is true, also checks march availability.
     public boolean checkStaminaAndMarchesOrReschedule(
-            int min, int refresh, RescheduleCallback cb) {
-        return verifyReadiness(min, refresh, cb, true);
+            int min, int refresh, StaminaWaitScheduler scheduler) {
+        return verifyReadiness(min, refresh, scheduler, true);
     }
 
     public boolean checkStaminaOrReschedule(
-            int min, int refresh, RescheduleCallback cb) {
-        return verifyReadiness(min, refresh, cb, false);
+            int min, int refresh, StaminaWaitScheduler scheduler) {
+        return verifyReadiness(min, refresh, scheduler, false);
     }
 
     private boolean verifyReadiness(int min, int refresh,
-                                    RescheduleCallback cb, boolean verifyMarches) {
+                                    StaminaWaitScheduler scheduler, boolean verifyMarches) {
         int level = persistence.getCurrentStamina(accountKey);
         emitInfo("Stamina check: " + level);
 
         if (level < min) {
             int regenMinutes = staminaRegenerationTime(level, refresh);
             LocalDateTime retry = LocalDateTime.now().plusMinutes(regenMinutes);
-            cb.reschedule(retry);
-                emitWarn("Insufficient (" + level + "/" + min + ") - retry " +
+            scheduler.deferForStamina(min, refresh, retry);
+            emitWarn("Insufficient (" + level + "/" + min + ") - retry " +
                     GameTimeUtils.formatCountdown(retry));
             return false;
         }
 
         if (verifyMarches && !marchSupport.checkMarchesAvailable()) {
-            cb.reschedule(LocalDateTime.now().plusMinutes(1));
+            scheduler.reschedule(LocalDateTime.now().plusMinutes(1));
             emitWarn("No march slots - retry in 1 min");
             return false;
         }

--- a/fg-engine/src/main/java/dev/frostguard/engine/listener/StaminaChangeListener.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/listener/StaminaChangeListener.java
@@ -7,6 +7,13 @@ public interface StaminaChangeListener {
     // The energy level for accountId was updated.
     void onEnergyLevelChanged(Long accountId, int currentStamina);
 
+    // An authoritative absolute read was applied, for example during startup OCR.
+    default void onStaminaSynchronized(Long accountId, int currentStamina) {}
+
+    // An explicit positive addition was applied, unlike an OCR correction,
+    // deduction, or passive regeneration tick.
+    default void onStaminaAdded(Long accountId, int amount, int currentStamina) {}
+
     // Called before the tracker sweeps all accounts for regeneration.
     default void onRegenerationSweepStarting() {}
 

--- a/fg-engine/src/main/java/dev/frostguard/engine/schedule/DelayedTask.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/schedule/DelayedTask.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 // Foundation class for all game automation tasks. Provides scheduling
 // primitives, profile lifecycle, helper wiring, screen-state validation,
 // emulator shortcuts, and cooperative preemption/injection.
-public abstract class DelayedTask implements Runnable, Delayed {
+public abstract class DelayedTask implements Runnable, Delayed, StaminaWaitScheduler {
 
     // ── core fields ─────────────────────────────────────────────────
     protected volatile boolean recurring = true;
@@ -54,6 +54,7 @@ public abstract class DelayedTask implements Runnable, Delayed {
     private Integer customPriority = null;
     private int repeatIntervalMinutes = 0;
     private String customTaskIdentifier;
+    private volatile StaminaDeferral staminaDeferral;
 
     // ── services ────────────────────────────────────────────────────
     protected EmulatorController emuManager = EmulatorController.getInstance();
@@ -163,6 +164,7 @@ public abstract class DelayedTask implements Runnable, Delayed {
 
     @Override
     public void run() {
+        staminaDeferral = null;
         refreshProfileFromDb();
         boolean switchedProfileOnEmulator = markAndDetectProfileSwitchFlow();
         if (switchedProfileOnEmulator) {
@@ -453,6 +455,28 @@ public abstract class DelayedTask implements Runnable, Delayed {
 
     public void clearSchedule() {
         scheduledTime = null;
+    }
+
+    @Override
+    public void deferForStamina(
+            int minimumRequired,
+            int regenerationTarget,
+            LocalDateTime retryAt,
+            LocalDateTime earliestRunnableAt) {
+        staminaDeferral = new StaminaDeferral(minimumRequired, regenerationTarget, earliestRunnableAt);
+        reschedule(retryAt);
+    }
+
+    public StaminaDeferral getStaminaDeferral() {
+        return staminaDeferral;
+    }
+
+    public void restoreStaminaDeferral(StaminaDeferral deferral) {
+        staminaDeferral = deferral;
+    }
+
+    public void clearStaminaDeferral() {
+        staminaDeferral = null;
     }
 
     @Override

--- a/fg-engine/src/main/java/dev/frostguard/engine/schedule/StaminaDeferral.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/schedule/StaminaDeferral.java
@@ -1,0 +1,34 @@
+package dev.frostguard.engine.schedule;
+
+import java.time.LocalDateTime;
+
+import dev.frostguard.engine.service.StaminaService;
+
+/**
+ * Why a task is sleeping on stamina: the minimum that makes it runnable and the
+ * preferred level it chose for a natural-regeneration wake-up.
+ */
+public record StaminaDeferral(
+        int minimumRequired,
+        int regenerationTarget,
+        LocalDateTime earliestRunnableAt) {
+
+    public StaminaDeferral {
+        if (minimumRequired < 0) {
+            throw new IllegalArgumentException("Minimum stamina must not be negative");
+        }
+        if (regenerationTarget < minimumRequired) {
+            throw new IllegalArgumentException("Regeneration target must cover the runnable minimum");
+        }
+        if (earliestRunnableAt == null) {
+            throw new IllegalArgumentException("Earliest runnable time is required");
+        }
+    }
+
+    public LocalDateTime revisedWakeAt(int currentStamina, LocalDateTime now) {
+        LocalDateTime staminaReadyAt = currentStamina >= minimumRequired
+                ? now
+                : now.plusMinutes(StaminaService.minutesToRegenerate(currentStamina, regenerationTarget));
+        return staminaReadyAt.isBefore(earliestRunnableAt) ? earliestRunnableAt : staminaReadyAt;
+    }
+}

--- a/fg-engine/src/main/java/dev/frostguard/engine/schedule/StaminaWaitScheduler.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/schedule/StaminaWaitScheduler.java
@@ -1,0 +1,22 @@
+package dev.frostguard.engine.schedule;
+
+import java.time.LocalDateTime;
+
+/**
+ * Scheduling boundary used by stamina gates without coupling their helper to a
+ * concrete task implementation.
+ */
+public interface StaminaWaitScheduler {
+
+    void reschedule(LocalDateTime retryAt);
+
+    default void deferForStamina(int minimumRequired, int regenerationTarget, LocalDateTime retryAt) {
+        deferForStamina(minimumRequired, regenerationTarget, retryAt, LocalDateTime.now());
+    }
+
+    void deferForStamina(
+            int minimumRequired,
+            int regenerationTarget,
+            LocalDateTime retryAt,
+            LocalDateTime earliestRunnableAt);
+}

--- a/fg-engine/src/main/java/dev/frostguard/engine/schedule/TaskDispatcher.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/schedule/TaskDispatcher.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import dev.frostguard.api.configs.*;
 import dev.frostguard.api.domain.*;
+import dev.frostguard.engine.listener.StaminaChangeListener;
 import dev.frostguard.engine.schedule.preempt.PreemptionListener;
 import dev.frostguard.engine.schedule.preempt.PreemptionRule;
 import dev.frostguard.engine.service.*;
@@ -14,11 +15,11 @@ import org.slf4j.LoggerFactory;
 // Central orchestrator for all per-profile TaskQueue instances.
 // Handles queue creation, ordered startup, global rule registration,
 // and bulk lifecycle controls (pause/resume/stop).
-public class TaskDispatcher implements PreemptionListener {
+public class TaskDispatcher implements PreemptionListener, StaminaChangeListener {
 
     private static final Logger log = LoggerFactory.getLogger(TaskDispatcher.class);
 
-    private final Map<Long, TaskQueue> managedQueues = new HashMap<>();
+    private final Map<Long, TaskQueue> managedQueues = new ConcurrentHashMap<>();
     private final Map<Long, Boolean> pauseFlags = new ConcurrentHashMap<>();
 
     // ── queue registration ──────────────────────────────────────────
@@ -47,11 +48,47 @@ public class TaskDispatcher implements PreemptionListener {
         }
     }
 
+    @Override
+    public void onEnergyLevelChanged(Long accountId, int currentStamina) {
+        // Scheduling reacts only to explicit additions, not OCR corrections or passive ticks.
+    }
+
+    @Override
+    public void onStaminaSynchronized(Long accountId, int currentStamina) {
+        reconsiderStaminaDeferrals(accountId, currentStamina, "Stamina synchronized");
+    }
+
+    @Override
+    public void onStaminaAdded(Long accountId, int amount, int currentStamina) {
+        reconsiderStaminaDeferrals(accountId, currentStamina, "Stamina +" + amount);
+    }
+
+    private void reconsiderStaminaDeferrals(Long accountId, int currentStamina, String source) {
+        if (accountId == null) {
+            return;
+        }
+        TaskQueue queue = managedQueues.get(accountId);
+        if (queue == null) {
+            return;
+        }
+
+        try {
+            int moved = queue.reconsiderStaminaDeferrals(currentStamina);
+            if (moved > 0) {
+                log.info("{} for profile {} (now {}) advanced {} stamina-blocked task(s)",
+                        source, accountId, currentStamina, moved);
+            }
+        } catch (Exception ex) {
+            log.error("Stamina re-evaluation error [{}]", accountId, ex);
+        }
+    }
+
     // ── start all queues ────────────────────────────────────────────
 
     public void startAll() {
         GlobalMonitorService monitor = GlobalMonitorService.getInstance();
         monitor.registerListener(this);
+        StaminaService.getServices().addStaminaChangeListener(this);
 
         // install global preemption and injection rules
         monitor.registerRule(new dev.frostguard.engine.schedule.preempt.BearTrapPreemptionRule());
@@ -107,6 +144,7 @@ public class TaskDispatcher implements PreemptionListener {
             }
         }
 
+        StaminaService.getServices().removeStaminaChangeListener(this);
         GlobalMonitorService.getInstance().shutdown();
 
         managedQueues.values().forEach(TaskQueue::stop);

--- a/fg-engine/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -152,6 +152,60 @@ public class TaskQueue {
                 .anyMatch(t -> t.getDelay(TimeUnit.SECONDS) < capSec);
     }
 
+    // ---- stamina re-evaluation ---------------------------------------------
+
+    public synchronized int reconsiderStaminaDeferrals(int currentStamina) {
+        int moved = 0;
+        LocalDateTime now = LocalDateTime.now();
+
+        for (DelayedTask task : new ArrayList<>(taskBacklog)) {
+            StaminaDeferral deferral = task.getStaminaDeferral();
+            if (deferral == null) {
+                continue;
+            }
+
+            LocalDateTime revisedWakeAt = deferral.revisedWakeAt(currentStamina, now);
+            if (!revisedWakeAt.isBefore(task.getScheduled())) {
+                continue;
+            }
+
+            LocalDateTime previousWakeAt = task.getScheduled();
+            taskBacklog.remove(task);
+            task.reschedule(revisedWakeAt);
+            taskBacklog.offer(task);
+            recordScheduleAdjustment(task);
+            emitInfoTask(task, String.format(
+                    "External stamina gain: current=%d minimum=%d target=%d floor=%s; wake-up %s -> %s",
+                    currentStamina,
+                    deferral.minimumRequired(),
+                    deferral.regenerationTarget(),
+                    deferral.earliestRunnableAt().format(TS_FMT),
+                    previousWakeAt.format(TS_FMT),
+                    task.getScheduled().format(TS_FMT)));
+            moved++;
+        }
+        return moved;
+    }
+
+    private void recordScheduleAdjustment(DelayedTask task) {
+        Object distinctKey = task.getDistinctKey();
+        String customName = distinctKey == null ? null : distinctKey.toString();
+        TaskStateData state = TaskManagementService.shared().lookupTaskState(
+                profile.getId(), task.getTpDailyTaskId(), customName);
+        if (state == null) {
+            state = new TaskStateData();
+            state.setProfileId(profile.getId());
+            state.setTaskId(task.getTpDailyTaskId());
+            state.setCustomTaskName(customName);
+            state.setScheduled(true);
+            state.setExecuting(false);
+        }
+        state.setNextExecutionTime(task.getScheduled());
+        TaskManagementService.shared().recordTaskState(profile.getId(), state);
+        ScheduleService.obtain().persistScheduleAdjustment(
+                profile, task.getTpTask(), task.getScheduled(), customName, task.getStaminaDeferral());
+    }
+
     // ---- preemption --------------------------------------------------------
 
     public synchronized void preemptActiveTask(PreemptionRule rule) {
@@ -224,6 +278,7 @@ public class TaskQueue {
         if (present != null) {
             taskBacklog.remove(present);
             present.setProfile(profile);
+            present.clearStaminaDeferral();
             present.reschedule(LocalDateTime.now());
             present.setRecurring(recurring);
             taskBacklog.offer(present);
@@ -404,7 +459,8 @@ public class TaskQueue {
         Object k = task.getDistinctKey(); if (k != null) s.setCustomTaskName(k.toString());
         TaskManagementService.shared().recordTaskState(profile.getId(), s);
         if (task.getScheduled() != null) {
-            ScheduleService.obtain().persistDailyCompletion(profile, task.getTpTask(), task.getScheduled(), s.getCustomTaskName());
+            ScheduleService.obtain().persistDailyCompletion(
+                    profile, task.getTpTask(), task.getScheduled(), s.getCustomTaskName(), task.getStaminaDeferral());
         }
     }
 

--- a/fg-engine/src/main/java/dev/frostguard/engine/service/ScheduleService.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/service/ScheduleService.java
@@ -41,6 +41,7 @@ import dev.frostguard.engine.listener.BotStateListener;
 import dev.frostguard.engine.listener.QueueStateListener;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.DelayedTaskRegistry;
+import dev.frostguard.engine.schedule.StaminaDeferral;
 import dev.frostguard.engine.schedule.TaskDispatcher;
 import dev.frostguard.engine.schedule.TaskQueue;
 
@@ -213,16 +214,47 @@ public class ScheduleService {
 
 	public void persistDailyCompletion(AccountDescriptor acct, TpDailyTaskEnum taskType,
 			LocalDateTime nextRun, String customLabel) {
+		persistDailyCompletion(acct, taskType, nextRun, customLabel, null);
+	}
+
+	public void persistDailyCompletion(AccountDescriptor acct, TpDailyTaskEnum taskType,
+			LocalDateTime nextRun, String customLabel, StaminaDeferral staminaDeferral) {
 		if (acct == null || taskType == null) {
 			return;
 		}
-		DailyTask record = dailyTasks.findByAccountIdAndTaskType(acct.getId(), taskType);
+		DailyTask record = findDailyRecord(acct.getId(), taskType, customLabel);
 		if (record == null) {
-			dailyTasks.addDailyTask(newDailyRecord(acct, taskType, nextRun, customLabel));
+			record = newDailyRecord(acct, taskType, nextRun, customLabel);
+			applyStaminaDeferral(record, staminaDeferral);
+			dailyTasks.addDailyTask(record);
 			return;
 		}
 		record.setPreviousRun(LocalDateTime.now());
 		record.setScheduledAt(nextRun);
+		applyStaminaDeferral(record, staminaDeferral);
+		dailyTasks.saveDailyTask(record);
+	}
+
+	public void persistScheduleAdjustment(AccountDescriptor acct, TpDailyTaskEnum taskType,
+			LocalDateTime nextRun, String customLabel) {
+		persistScheduleAdjustment(acct, taskType, nextRun, customLabel, null);
+	}
+
+	public void persistScheduleAdjustment(AccountDescriptor acct, TpDailyTaskEnum taskType,
+			LocalDateTime nextRun, String customLabel, StaminaDeferral staminaDeferral) {
+		if (acct == null || taskType == null) {
+			return;
+		}
+		DailyTask record = findDailyRecord(acct.getId(), taskType, customLabel);
+		if (record == null) {
+			record = newDailyRecord(acct, taskType, nextRun, customLabel);
+			record.setPreviousRun(null);
+			applyStaminaDeferral(record, staminaDeferral);
+			dailyTasks.addDailyTask(record);
+			return;
+		}
+		record.setScheduledAt(nextRun);
+		applyStaminaDeferral(record, staminaDeferral);
 		dailyTasks.saveDailyTask(record);
 	}
 
@@ -335,6 +367,12 @@ public class ScheduleService {
 		} else {
 			task.reschedule(saved.getNextSchedule());
 			task.setLastExecutionTime(saved.getLastExecution());
+			if (saved.hasStaminaDeferral()) {
+				task.restoreStaminaDeferral(new StaminaDeferral(
+						saved.getStaminaMinimumRequired(),
+						saved.getStaminaRegenerationTarget(),
+						saved.getStaminaEarliestRunnableAt()));
+			}
 			state.setLastExecutionTime(saved.getLastExecution());
 			state.setNextExecutionTime(saved.getNextSchedule());
 			log(TpMessageSeverityEnum.INFO, task.getTaskName(), account.getName(),
@@ -471,6 +509,22 @@ public class ScheduleService {
 		record.setPreviousRun(LocalDateTime.now());
 		record.setScheduledAt(nextRun);
 		return record;
+	}
+
+	private DailyTask findDailyRecord(Long accountId, TpDailyTaskEnum taskType, String customLabel) {
+		return customLabel == null
+				? dailyTasks.findByAccountIdAndTaskType(accountId, taskType)
+				: dailyTasks.findByAccountIdTaskTypeAndCustomLabel(accountId, taskType, customLabel);
+	}
+
+	private void applyStaminaDeferral(DailyTask record, StaminaDeferral deferral) {
+		if (deferral == null) {
+			record.clearStaminaDeferral();
+			return;
+		}
+		record.setStaminaMinimumRequired(deferral.minimumRequired());
+		record.setStaminaRegenerationTarget(deferral.regenerationTarget());
+		record.setStaminaEarliestRunnableAt(deferral.earliestRunnableAt());
 	}
 
 	private boolean removeFromQueue(Long accountId, TpDailyTaskEnum taskType, String customLabel) {

--- a/fg-engine/src/main/java/dev/frostguard/engine/service/StaminaService.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/service/StaminaService.java
@@ -102,12 +102,22 @@ public final class StaminaService {
         EnergySlot fresh = new EnergySlot(Math.max(0, stamina), Instant.now());
         slots.put(profileId, fresh);
         broadcastChange(profileId, fresh.level());
+        broadcastSynchronization(profileId, fresh.level());
     }
 
     public void addStamina(Long profileId, int amount) {
         requireId(profileId);
         int updated = applyDelta(profileId, amount);
         broadcastChange(profileId, updated);
+    }
+
+    public void addExternalStamina(Long profileId, int amount) {
+        requireId(profileId);
+        int updated = applyDelta(profileId, amount);
+        broadcastChange(profileId, updated);
+        if (amount > 0) {
+            broadcastAddition(profileId, amount, updated);
+        }
     }
 
     public void subtractStamina(Long profileId, int amount) {
@@ -128,6 +138,13 @@ public final class StaminaService {
         requireId(profileId);
         EnergySlot slot = slots.get(profileId);
         return slot == null || slot.isStale();
+    }
+
+    public static long minutesToRegenerate(int currentStamina, int targetStamina) {
+        if (currentStamina >= targetStamina) {
+            return 0;
+        }
+        return (long) (targetStamina - currentStamina) * TICK_INTERVAL.toMinutes();
     }
 
     // ── Internals ────────────────────────────────────────────────────
@@ -170,6 +187,26 @@ public final class StaminaService {
                 obs.onEnergyLevelChanged(profileId, level);
             } catch (Exception ex) {
                 log.warn("Observer error during energy broadcast", ex);
+            }
+        }
+    }
+
+    private void broadcastAddition(Long profileId, int amount, int level) {
+        for (StaminaChangeListener obs : observers) {
+            try {
+                obs.onStaminaAdded(profileId, amount, level);
+            } catch (Exception ex) {
+                log.warn("Observer error during stamina-addition broadcast", ex);
+            }
+        }
+    }
+
+    private void broadcastSynchronization(Long profileId, int level) {
+        for (StaminaChangeListener obs : observers) {
+            try {
+                obs.onStaminaSynchronized(profileId, level);
+            } catch (Exception ex) {
+                log.warn("Observer error during stamina-synchronization broadcast", ex);
             }
         }
     }

--- a/fg-engine/src/test/java/dev/frostguard/engine/schedule/StaminaDeferralTest.java
+++ b/fg-engine/src/test/java/dev/frostguard/engine/schedule/StaminaDeferralTest.java
@@ -1,0 +1,42 @@
+package dev.frostguard.engine.schedule;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+class StaminaDeferralTest {
+
+    @Test
+    void wakesImmediatelyOnceMinimumIsAvailable() {
+        LocalDateTime now = LocalDateTime.of(2026, 7, 20, 2, 15);
+        StaminaDeferral deferral = new StaminaDeferral(145, 170, now.minusHours(1));
+
+        assertEquals(now, deferral.revisedWakeAt(150, now));
+    }
+
+    @Test
+    void keepsPreferredTargetWhenAdditionDoesNotReachMinimum() {
+        LocalDateTime now = LocalDateTime.of(2026, 7, 20, 2, 15);
+        StaminaDeferral deferral = new StaminaDeferral(145, 170, now.minusHours(1));
+
+        assertEquals(now.plusMinutes(250), deferral.revisedWakeAt(120, now));
+    }
+
+    @Test
+    void rejectsTargetBelowRunnableMinimum() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new StaminaDeferral(145, 140, LocalDateTime.now()));
+    }
+
+    @Test
+    void neverWakesBeforeAnotherBlockingConstraintClears() {
+        LocalDateTime now = LocalDateTime.of(2026, 7, 20, 1, 4);
+        LocalDateTime marchReturns = now.plusMinutes(3);
+        StaminaDeferral deferral = new StaminaDeferral(145, 170, marchReturns);
+
+        assertEquals(marchReturns, deferral.revisedWakeAt(200, now));
+    }
+}

--- a/fg-engine/src/test/java/dev/frostguard/engine/service/DailyTaskStatusDataTest.java
+++ b/fg-engine/src/test/java/dev/frostguard/engine/service/DailyTaskStatusDataTest.java
@@ -1,0 +1,28 @@
+package dev.frostguard.engine.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+
+import dev.frostguard.api.domain.DailyTaskStatusData;
+import org.junit.jupiter.api.Test;
+
+class DailyTaskStatusDataTest {
+
+    @Test
+    void projectedStaminaDeferralSurvivesScheduleCopy() {
+        LocalDateTime lastRun = LocalDateTime.of(2026, 7, 21, 1, 39);
+        LocalDateTime nextRun = LocalDateTime.of(2026, 7, 21, 2, 10);
+        LocalDateTime marchFloor = LocalDateTime.of(2026, 7, 21, 1, 42);
+        DailyTaskStatusData data = new DailyTaskStatusData(
+                2L, 18, lastRun, nextRun, null, 145, 170, marchFloor);
+
+        DailyTaskStatusData copy = data.withUpdatedSchedule(nextRun.plusMinutes(5));
+
+        assertTrue(copy.hasStaminaDeferral());
+        assertEquals(145, copy.getStaminaMinimumRequired());
+        assertEquals(170, copy.getStaminaRegenerationTarget());
+        assertEquals(marchFloor, copy.getStaminaEarliestRunnableAt());
+    }
+}

--- a/fg-engine/src/test/java/dev/frostguard/engine/service/StaminaServiceTest.java
+++ b/fg-engine/src/test/java/dev/frostguard/engine/service/StaminaServiceTest.java
@@ -1,6 +1,10 @@
 package dev.frostguard.engine.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import dev.frostguard.engine.listener.StaminaChangeListener;
 import org.junit.jupiter.api.Test;
 
 class StaminaServiceTest {
@@ -32,5 +36,74 @@ class StaminaServiceTest {
         service.subtractStamina(1003L, 25);
 
         assertEquals(0, service.getCurrentStamina(1003L));
+    }
+
+    @Test
+    void externalPositiveAdditionEmitsDedicatedEventWithoutCapping() {
+        StaminaService service = StaminaService.getServices();
+        AtomicInteger additions = new AtomicInteger();
+        AtomicReference<String> event = new AtomicReference<>();
+        StaminaChangeListener listener = new StaminaChangeListener() {
+            @Override
+            public void onEnergyLevelChanged(Long profileId, int currentStamina) {
+            }
+
+            @Override
+            public void onStaminaAdded(Long profileId, int amount, int currentStamina) {
+                additions.incrementAndGet();
+                event.set(profileId + ":" + amount + ":" + currentStamina);
+            }
+        };
+
+        service.addStaminaChangeListener(listener);
+        try {
+            service.setStamina(1004L, 190);
+            service.addStamina(1004L, 25);
+            service.addExternalStamina(1004L, 10);
+            service.subtractStamina(1004L, 5);
+
+            assertEquals(1, additions.get());
+            assertEquals("1004:10:225", event.get());
+            assertEquals(220, service.getCurrentStamina(1004L));
+        } finally {
+            service.removeStaminaChangeListener(listener);
+        }
+    }
+
+    @Test
+    void absoluteReadEmitsSynchronizationEventOnlyForSet() {
+        StaminaService service = StaminaService.getServices();
+        AtomicInteger synchronizations = new AtomicInteger();
+        AtomicReference<String> event = new AtomicReference<>();
+        StaminaChangeListener listener = new StaminaChangeListener() {
+            @Override
+            public void onEnergyLevelChanged(Long profileId, int currentStamina) {
+            }
+
+            @Override
+            public void onStaminaSynchronized(Long profileId, int currentStamina) {
+                synchronizations.incrementAndGet();
+                event.set(profileId + ":" + currentStamina);
+            }
+        };
+
+        service.addStaminaChangeListener(listener);
+        try {
+            service.setStamina(1005L, 203);
+            service.addStamina(1005L, 1);
+            service.addExternalStamina(1005L, 120);
+            service.subtractStamina(1005L, 9);
+
+            assertEquals(1, synchronizations.get());
+            assertEquals("1005:203", event.get());
+        } finally {
+            service.removeStaminaChangeListener(listener);
+        }
+    }
+
+    @Test
+    void regenerationEstimateUsesFiveMinutesPerPoint() {
+        assertEquals(0, StaminaService.minutesToRegenerate(170, 170));
+        assertEquals(250, StaminaService.minutesToRegenerate(120, 170));
     }
 }

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/combat/BeastSlayRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/combat/BeastSlayRoutine.java
@@ -65,7 +65,7 @@ public class BeastSlayRoutine extends DelayedTask {
 		int minToAct = staminaReserve + STAMINA_COST_PER_ATTACK;
 
 		// Use staminaHelper to check stamina (already read during initialization/validation)
-		if (!staminaHelper.checkStaminaAndMarchesOrReschedule(minToAct, minToAct, this::reschedule)) {
+		if (!staminaHelper.checkStaminaAndMarchesOrReschedule(minToAct, minToAct, this)) {
 			return;
 		}
 

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarTerrorHuntingRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarTerrorHuntingRoutine.java
@@ -267,11 +267,13 @@ private record RallyLaunchResult(RallyLaunchOutcome outcome, String detail) {
             LocalDateTime staminaReadyAt = LocalDateTime.now().plusMinutes(
                     staminaHelper.staminaRegenerationTime(staminaHelper.getCurrentStamina(), refreshStaminaLevel));
             if (staminaReadyAt.isAfter(nextRun)) {
+                LocalDateTime marchReadyAt = nextRun;
                 logInfo(routineLogPolarTerrorHuntingLine(String.format(
                         "Stamina runs out before the march returns; delaying the next run from %s to %s",
                         GameTimeUtils.formatCountdown(nextRun),
                         GameTimeUtils.formatCountdown(staminaReadyAt))));
                 nextRun = staminaReadyAt;
+                deferForStamina(requiredStaminaForRally(), refreshStaminaLevel, nextRun, marchReadyAt);
             }
         }
 
@@ -510,7 +512,7 @@ private void rescheduleForStaminaRegen() {
         logInfo(routineLogPolarTerrorHuntingLine(String.format(
                 "Stamina gate: waiting %d min for regeneration from %d to %d",
                 waitMinutes, current, refreshStaminaLevel)));
-        reschedule(retryAt);
+        deferForStamina(requiredStaminaForRally(), refreshStaminaLevel, retryAt);
     }
 
 private void rescheduleForStaminaTopUpRetry(StaminaTopUpResult result) {

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/dailies/IntelligenceRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/dailies/IntelligenceRoutine.java
@@ -986,9 +986,10 @@ private boolean hasEnoughStaminaFlow() {
 		if (staminaValue < MIN_STAMINA_REQUIRED_FLOOR) {
 			logWarning(routineLogIntelligenceLine("Not enough stamina to process intel. Current stamina: " + staminaValue +
 					". Required: " + MIN_STAMINA_REQUIRED_FLOOR + "."));
-			long minutesToRegen = (long) (MIN_STAMINA_REQUIRED_FLOOR - staminaValue) * 5L;
+			long minutesToRegen = StaminaService.minutesToRegenerate(
+					staminaValue, MIN_STAMINA_REQUIRED_FLOOR);
 			LocalDateTime rescheduleTime = LocalDateTime.now().plusMinutes(minutesToRegen);
-			reschedule(rescheduleTime);
+			deferForStamina(MIN_STAMINA_REQUIRED_FLOOR, MIN_STAMINA_REQUIRED_FLOOR, rescheduleTime);
 			return false;
 		}
 		return true;

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/economy/StorehouseChestRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/economy/StorehouseChestRoutine.java
@@ -386,10 +386,10 @@ public class StorehouseChestRoutine extends DelayedTask {
         sleepTask(4000); // Wait for claim animation
 
         // Update stamina service
-        StaminaService.getServices().addStamina(profile.getId(), BASE_STOREHOUSE_STAMINA);
+        StaminaService.getServices().addExternalStamina(profile.getId(), BASE_STOREHOUSE_STAMINA);
 
         if (agnesStamina != null && agnesStamina > 0) {
-            StaminaService.getServices().addStamina(profile.getId(), agnesStamina);
+            StaminaService.getServices().addExternalStamina(profile.getId(), agnesStamina);
             logInfo(String.format("Claimed %d base stamina + %d from Agnes bonus.",
                     BASE_STOREHOUSE_STAMINA, agnesStamina));
         } else {

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/events/HeroMissionEventRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/events/HeroMissionEventRoutine.java
@@ -64,7 +64,7 @@ public class HeroMissionEventRoutine extends DelayedTask {
         }
 
         // Verify if there's enough stamina to hunt, if not, reschedule the task
-        if (!staminaHelper.checkStaminaAndMarchesOrReschedule(minStaminaLevel, refreshStaminaLevel, this::reschedule))
+        if (!staminaHelper.checkStaminaAndMarchesOrReschedule(minStaminaLevel, refreshStaminaLevel, this))
             return;
 
         int attempt = 0;

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/events/MercenaryEventRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/events/MercenaryEventRoutine.java
@@ -60,7 +60,7 @@ public class MercenaryEventRoutine extends DelayedTask {
         }
 
         // Verify if there's enough stamina to hunt, if not, reschedule the task
-        if (!staminaHelper.checkStaminaAndMarchesOrReschedule(minStaminaLevel, refreshStaminaLevel, this::reschedule))
+        if (!staminaHelper.checkStaminaAndMarchesOrReschedule(minStaminaLevel, refreshStaminaLevel, this))
             return;
 
         int attempt = 0;

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/pets/PetAdventureChestRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/pets/PetAdventureChestRoutine.java
@@ -147,7 +147,7 @@ public class PetAdventureChestRoutine extends DelayedTask {
 		if (!staminaHelper.checkStaminaOrReschedule(
 				MIN_STAMINA_REQUIRED,
 				TARGET_STAMINA_FOR_REFRESH,
-				this::reschedule)) {
+				this)) {
 			return; // Task will be rescheduled by helper
 		}
 

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/pets/PetSkillsRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/pets/PetSkillsRoutine.java
@@ -622,7 +622,7 @@ public class PetSkillsRoutine extends DelayedTask {
             logInfo(String.format("Stamina skill level: %d. Added %d stamina.", level, staminaToAdd));
         }
 
-        StaminaService.getServices().addStamina(profile.getId(), staminaToAdd);
+        StaminaService.getServices().addExternalStamina(profile.getId(), staminaToAdd);
     }
 
     /**


### PR DESCRIPTION
## Summary

- persist the complete stamina deferral for stamina-blocked tasks;
- restore minimum stamina, preferred target, and non-stamina timing floors after restart;
- reconsider restored waits after authoritative OCR, Storehouse claims, and stamina-item gains;
- preserve overfilled stamina and update both live and persisted schedules when a wait moves.

## Why

After a process restart, `daily_task` restored only `next_schedule`. The scheduler no longer knew why the task was waiting, so startup stamina synchronization or later external gains could not advance a now-runnable Polar or Beast task.

## Validation

- rebased onto current `main`; scheduler/StaminaHelper conflicts were resolved while retaining current top-up behavior;
- `mvn -pl fg-tasks -am test` passes on the rebased branch;
- the GitHub Windows desktop-bundle check passes;
- later Bot 1 soak advanced 17 stamina-blocked waits after authoritative OCR or external gains without a scheduler regression;
- Bot 2 preserved overfilled stamina at 323 and deducted confirmed Polar cost from that value.

## Risks

The exact persisted-wait -> process restart -> startup synchronization sequence was not isolated as a live test. The restore path is covered by automated tests, and the available live soak produced no contradictory evidence.