### PR TITLE
fix(bear): stop disabled rally joins

### DIFF
--- a/fg-tasks/src/main/java/dev/frostguard/tasks/combat/BearTrapRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/combat/BearTrapRoutine.java
@@ -725,7 +725,10 @@ private void handleJoinRallies2() {
         if (!joinRally || sharedEmulator) {
             if (sharedEmulator) {
                 logInfo(routineLogBearTrapLine("Skipping rally joining because this profile shares an emulator with another account."));
+            } else {
+                logDebug(routineLogBearTrapLine("Skipping rally joining because joining is disabled."));
             }
+            return;
         }
 
         try {


### PR DESCRIPTION
## What changed

- stop Bear Trap rally joining immediately when joining is disabled
- stop Bear Trap rally joining for profiles that share an emulator
- log the disabled-join decision at debug level

## Root cause

`handleJoinRallies2()` detected both skip conditions but only logged them. Because the method did not return, it continued into march inspection and the rally join flow.

## Impact

The Bear Trap routine now respects the `Enable Join Rally` setting and the existing shared-emulator safety rule.

## Verification

- inspected the resulting one-file diff
- `git diff --check`
- confirmed the identical patch on `local/staging`, `local/ready`, and `deploy/bot2`
- no build or process start was run per operator request
