### PR TITLE
fix(buildings): handle repeated resource replenishment

### DIFF
--- a/fg-tasks/src/main/java/dev/frostguard/tasks/city/RepeatedResourceReplenishmentFlow.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/city/RepeatedResourceReplenishmentFlow.java
@@ -1,0 +1,61 @@
+package dev.frostguard.tasks.city;
+
+import dev.frostguard.api.domain.PointData;
+
+final class RepeatedResourceReplenishmentFlow {
+
+    enum Outcome {
+        READY,
+        REPLENISH_BUTTON_MISSING,
+        LIMIT_REACHED
+    }
+
+    record Result(Outcome outcome, int replenishedResources) {
+
+        boolean ready() {
+            return outcome == Outcome.READY;
+        }
+    }
+
+    interface Ui {
+
+        PointData findReplenishAll();
+
+        PointData findObtain();
+
+        void openObtain(PointData point);
+
+        void replenishAndConfirm(PointData point);
+    }
+
+    private RepeatedResourceReplenishmentFlow() {
+    }
+
+    static Result run(Ui ui, int maxReplenishments) {
+        int replenishedResources = 0;
+
+        while (replenishedResources < maxReplenishments) {
+            PointData replenishAll = ui.findReplenishAll();
+            if (replenishAll == null) {
+                PointData obtain = ui.findObtain();
+                if (obtain == null) {
+                    return new Result(Outcome.READY, replenishedResources);
+                }
+
+                ui.openObtain(obtain);
+                replenishAll = ui.findReplenishAll();
+                if (replenishAll == null) {
+                    return new Result(Outcome.REPLENISH_BUTTON_MISSING, replenishedResources);
+                }
+            }
+
+            ui.replenishAndConfirm(replenishAll);
+            replenishedResources++;
+        }
+
+        if (ui.findReplenishAll() != null || ui.findObtain() != null) {
+            return new Result(Outcome.LIMIT_REACHED, replenishedResources);
+        }
+        return new Result(Outcome.READY, replenishedResources);
+    }
+}

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/city/UpgradeBuildingsRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/city/UpgradeBuildingsRoutine.java
@@ -2,6 +2,7 @@ package dev.frostguard.tasks.city;
 
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.*;
+import dev.frostguard.engine.helper.TemplateSearchHelper.SearchConfig;
 import dev.frostguard.engine.nav.SearchConfigConstants;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
@@ -25,6 +26,7 @@ import static dev.frostguard.api.configs.TemplatesEnum.BUILDING_BUTTON_UPGRADE;
 import static dev.frostguard.api.configs.TemplatesEnum.BUILDING_SURVIVOR_BUTTON_UPGRADE;
 import static dev.frostguard.api.configs.TemplatesEnum.GAME_HOME_SHORTCUTS_HELP_REQUEST4;
 import static dev.frostguard.api.configs.TemplatesEnum.GAME_HOME_SHORTCUTS_OBTAIN;
+import static dev.frostguard.api.configs.TemplatesEnum.REPLENISH_ALL_BUTTON;
 import static dev.frostguard.engine.nav.ButtonConstants.*;
 import static dev.frostguard.engine.nav.LeftMenuTextSettings.*;
 
@@ -47,6 +49,17 @@ private static final int COMPLETION_SETTLE_SECONDS = 2;
 private static final int MAX_RECOMMENDED_BUILDING_ATTEMPTS = 2;
 
 private static final int TEMPLATE_TAP_RADIUS = 8;
+
+private static final int MAX_RESOURCE_REPLENISHMENTS = 4;
+
+private static final PointData REPLENISH_CONFIRM_POINT = new PointData(511, 1056);
+
+private static final SearchConfig REPLENISH_BUTTON_RECHECK = SearchConfig.builder()
+        .withMaxAttempts(2)
+        .withDelay(300)
+        .withThreshold(90)
+        .withCoordinates(new PointData(180, 1070), new PointData(535, 1195))
+        .build();
 
 private final List<AreaData> queues = new ArrayList<>(Arrays.asList(QUEUE_AREA_1_VALUE, QUEUE_AREA_2_VALUE));
 
@@ -200,22 +213,54 @@ private String routineLogUpgradeBuildingsLine(String note) {
         return "UpgradeBuildingsRoutine | " + note;
     }
 
-private void refillResourcesIfNeededFlow() {
-        ImageSearchResultData result;
-        while ((result = templateSearchHelper.locatePattern(GAME_HOME_SHORTCUTS_OBTAIN,
-                SearchConfigConstants.DEFAULT_SINGLE)).isFound()) {
-            logInfo(routineLogUpgradeBuildingsLine("Refilling resources for the upgrade..."));
-            tapRandomPoint(result.getPoint(), result.getPoint());
-            sleepTask(500);
+private boolean refillResourcesIfNeededFlow() {
+        var result = RepeatedResourceReplenishmentFlow.run(
+                new RepeatedResourceReplenishmentFlow.Ui() {
+                    @Override
+                    public PointData findReplenishAll() {
+                        return foundPoint(templateSearchHelper.locatePattern(
+                                REPLENISH_ALL_BUTTON, REPLENISH_BUTTON_RECHECK));
+                    }
 
+                    @Override
+                    public PointData findObtain() {
+                        return foundPoint(templateSearchHelper.locatePattern(
+                                GAME_HOME_SHORTCUTS_OBTAIN, SearchConfigConstants.DEFAULT_SINGLE));
+                    }
 
-            tapPoint(new PointData(358, 1135));
-            sleepTask(300);
+                    @Override
+                    public void openObtain(PointData point) {
+                        tapPoint(point);
+                        sleepTask(500);
+                    }
 
+                    @Override
+                    public void replenishAndConfirm(PointData point) {
+                        logInfo(routineLogUpgradeBuildingsLine("Refilling one missing resource for the upgrade..."));
+                        tapPoint(point);
+                        sleepTask(300);
+                        tapPoint(REPLENISH_CONFIRM_POINT);
+                        sleepTask(1000);
+                    }
+                },
+                MAX_RESOURCE_REPLENISHMENTS);
 
-            tapPoint(new PointData(511, 1056));
-            sleepTask(1000);
+        if (result.ready()) {
+            if (result.replenishedResources() > 0) {
+                logInfo(routineLogUpgradeBuildingsLine(
+                        "Replenished " + result.replenishedResources() + " missing resource(s)."));
+            }
+            return true;
         }
+
+        logWarning(routineLogUpgradeBuildingsLine(
+                "Resource replenishment did not finish (" + result.outcome()
+                        + "). Skipping the building confirmation."));
+        return false;
+    }
+
+private PointData foundPoint(ImageSearchResultData result) {
+        return result != null && result.isFound() ? result.getPoint() : null;
     }
 
 private void handleSurvivorBuilding() {
@@ -238,7 +283,9 @@ private void handleSurvivorBuilding() {
         tapRandomPoint(survivorUpgrade.getPoint(), survivorUpgrade.getPoint(), 1, 1000);
 
 
-        refillResourcesIfNeededFlow();
+        if (!refillResourcesIfNeededFlow()) {
+            return;
+        }
 
 
         tapRandomPoint(new PointData(450, 1190), new PointData(600, 1230), 1, 1000);
@@ -583,7 +630,9 @@ private void startBuildingAction(String actionName, PointData buttonTopLeft, Poi
         sleepTask(1000);
 
 
-        refillResourcesIfNeededFlow();
+        if (!refillResourcesIfNeededFlow()) {
+            return;
+        }
 
 
         tapRandomPoint(BUILDING_CONFIRM_BUTTON_AREA_VALUE.topLeft(), BUILDING_CONFIRM_BUTTON_AREA_VALUE.bottomRight());

--- a/fg-tasks/src/test/java/dev/frostguard/tasks/city/RepeatedResourceReplenishmentFlowTest.java
+++ b/fg-tasks/src/test/java/dev/frostguard/tasks/city/RepeatedResourceReplenishmentFlowTest.java
@@ -1,0 +1,112 @@
+package dev.frostguard.tasks.city;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.frostguard.api.domain.PointData;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import org.junit.jupiter.api.Test;
+
+class RepeatedResourceReplenishmentFlowTest {
+
+    private static final PointData BUTTON = new PointData(350, 1135);
+
+    @Test
+    void handlesReplenishAllDialogsChainedDirectlyForEachResource() {
+        ScriptedUi ui = new ScriptedUi(
+                states(State.REPLENISH, State.REPLENISH, State.REPLENISH, State.REPLENISH, State.READY));
+
+        var result = RepeatedResourceReplenishmentFlow.run(ui, 4);
+
+        assertTrue(result.ready());
+        assertEquals(4, result.replenishedResources());
+        assertEquals(4, ui.confirmations);
+    }
+
+    @Test
+    void handlesLegacyReturnToBuildingDetailsBetweenResources() {
+        ScriptedUi ui = new ScriptedUi(states(
+                State.OBTAIN, State.REPLENISH,
+                State.OBTAIN, State.REPLENISH,
+                State.READY));
+
+        var result = RepeatedResourceReplenishmentFlow.run(ui, 4);
+
+        assertTrue(result.ready());
+        assertEquals(2, result.replenishedResources());
+        assertEquals(2, ui.obtainScreensOpened);
+        assertEquals(2, ui.confirmations);
+    }
+
+    @Test
+    void refusesToContinueWhenObtainDoesNotOpenReplenishAll() {
+        ScriptedUi ui = new ScriptedUi(states(State.OBTAIN, State.READY));
+
+        var result = RepeatedResourceReplenishmentFlow.run(ui, 4);
+
+        assertEquals(RepeatedResourceReplenishmentFlow.Outcome.REPLENISH_BUTTON_MISSING, result.outcome());
+        assertEquals(0, ui.confirmations);
+    }
+
+    @Test
+    void stopsInsteadOfLoopingForeverWhenResourceDialogRemains() {
+        ScriptedUi ui = new ScriptedUi(states(
+                State.REPLENISH, State.REPLENISH, State.REPLENISH, State.REPLENISH, State.REPLENISH));
+
+        var result = RepeatedResourceReplenishmentFlow.run(ui, 4);
+
+        assertEquals(RepeatedResourceReplenishmentFlow.Outcome.LIMIT_REACHED, result.outcome());
+        assertEquals(4, ui.confirmations);
+    }
+
+    private static Queue<State> states(State... states) {
+        return new ArrayDeque<>(Arrays.asList(states));
+    }
+
+    private enum State {
+        REPLENISH,
+        OBTAIN,
+        READY
+    }
+
+    private static final class ScriptedUi implements RepeatedResourceReplenishmentFlow.Ui {
+
+        private final Queue<State> states;
+        private State current;
+        private int obtainScreensOpened;
+        private int confirmations;
+
+        private ScriptedUi(Queue<State> states) {
+            this.states = states;
+            current = states.remove();
+        }
+
+        @Override
+        public PointData findReplenishAll() {
+            return current == State.REPLENISH ? BUTTON : null;
+        }
+
+        @Override
+        public PointData findObtain() {
+            return current == State.OBTAIN ? BUTTON : null;
+        }
+
+        @Override
+        public void openObtain(PointData point) {
+            obtainScreensOpened++;
+            advance();
+        }
+
+        @Override
+        public void replenishAndConfirm(PointData point) {
+            confirmations++;
+            advance();
+        }
+
+        private void advance() {
+            current = states.isEmpty() ? State.READY : states.remove();
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- handle directly chained `Replenish All` dialogs for each missing building resource
- retain the legacy path where the UI returns to another `Obtain` button
- stop safely when the dialog flow cannot make progress or reaches its iteration limit
- add focused coverage for chained dialogs, legacy returns, missing actions, and the safety limit

## Why

A building upgrade can request several missing resources one after another without returning to the building detail screen. The previous flow expected another `Obtain` button after each replenishment and could press the building confirmation while a resource dialog was still open.

## Verification

- `mvn -pl fg-tasks -am test -DskipTests=false` — 57 tests passed
- focused repeated-replenishment flow tests passed
- operator-confirmed live emulator test on 2026-07-20