### PR TITLE
fix(stamina): correct item top-up accounting and retries

### DIFF
--- a/fg-engine/src/main/java/dev/frostguard/engine/helper/StaminaHelper.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/helper/StaminaHelper.java
@@ -19,8 +19,6 @@ import java.time.LocalDateTime;
 // availability gating, item top-ups, and travel time parsing.
 public class StaminaHelper {
 
-    private static final int STAMINA_ITEM_VALUE = 10;
-
     @FunctionalInterface
     public interface RescheduleCallback {
         void reschedule(LocalDateTime time);
@@ -36,6 +34,7 @@ public class StaminaHelper {
     private final MarchHelper marchSupport;
     private final String accountLabel;
     private final LoggingService centralLog;
+    private final StaminaItemTopUpFlow itemTopUpFlow;
 
     public StaminaHelper(EmulatorController emuManager, String emulatorNumber,
                          ResilientOcrExecutor<Integer> integerHelper,
@@ -51,6 +50,11 @@ public class StaminaHelper {
         this.marchSupport = marchHelper;
         this.accountLabel = profile.getName();
         this.centralLog = LoggingService.obtain();
+        this.itemTopUpFlow = new StaminaItemTopUpFlow(observed -> {
+            int tracked = persistence.getCurrentStamina(accountKey);
+            persistence.setStamina(accountKey, observed);
+            emitInfo("Obtain-more dialog: synchronized tracked stamina " + tracked + " -> " + observed);
+        });
     }
 
     // Opens avatar screen, reads stamina via OCR, persists, then navigates back.
@@ -142,12 +146,12 @@ public class StaminaHelper {
 
     /**
      * Uses Chief Stamina items until the profile holds at least {@code targetStamina}, opening the
-     * Obtain-more dialog from the profile stamina bar. Anything unexpected leaves the dialog and
-     * reports failure, so the caller can fall back to waiting for regeneration.
+     * Obtain-more dialog from the profile stamina bar. The structured result distinguishes a
+     * confirmed item shortage from transient OCR or UI failures so callers can schedule safely.
      *
      * @param itemReserve number of items never to spend
      */
-    public boolean topUpFromProfile(int targetStamina, int itemReserve) {
+    public StaminaTopUpResult topUpFromProfile(int targetStamina, int itemReserve) {
         device.touchArea(deviceSlot, CommonGameAreas.PROFILE_AVATAR.topLeft(),
                 CommonGameAreas.PROFILE_AVATAR.bottomRight(), 1, 200);
         pause(800);
@@ -155,61 +159,79 @@ public class StaminaHelper {
                 CommonGameAreas.STAMINA_BUTTON.bottomRight(), 1, 200);
         pause(1000);
 
-        boolean toppedUp = useItemsInOpenDialog(targetStamina, itemReserve);
+        StaminaTopUpResult result = useItemsInOpenDialog(targetStamina, itemReserve);
         device.pressBack(deviceSlot);
         pause(500);
         device.pressBack(deviceSlot);
         pause(500);
-        return toppedUp;
+        return result;
     }
 
     /** Same, but for the dialog the game opens itself when a red deploy cost is pressed. */
-    public boolean refillFromOpenDialog(int targetStamina, int itemReserve) {
-        boolean toppedUp = useItemsInOpenDialog(targetStamina, itemReserve);
+    public StaminaTopUpResult refillFromOpenDialog(int targetStamina, int itemReserve) {
+        StaminaTopUpResult result = useItemsInOpenDialog(targetStamina, itemReserve);
         emitInfo("Closing obtain-more dialog");
         device.touchPoint(deviceSlot, CommonGameAreas.STAMINA_DIALOG_CLOSE);
         pause(800);
-        return toppedUp;
+        return result;
     }
 
-    private boolean useItemsInOpenDialog(int targetStamina, int itemReserve) {
+    private StaminaTopUpResult useItemsInOpenDialog(int targetStamina, int itemReserve) {
         var useButton = device.locatePattern(deviceSlot, dev.frostguard.api.configs.TemplatesEnum.STAMINA_ITEM_USE_BUTTON,
                 CommonGameAreas.STAMINA_DIALOG_USE_BUTTON.topLeft(),
                 CommonGameAreas.STAMINA_DIALOG_USE_BUTTON.bottomRight(), 85);
         if (!useButton.isFound()) {
             emitWarn("Chief Stamina Use button not found in the obtain-more dialog");
-            return false;
+            return StaminaTopUpResult.uiNotFound();
         }
 
-        Integer current = readDialogNumber(CommonGameAreas.STAMINA_DIALOG_CURRENT,
-                CommonOCRSettings.STAMINA_FRACTION_SETTINGS, "current stamina");
-        Integer itemCount = readDialogNumber(CommonGameAreas.STAMINA_DIALOG_ITEM_COUNT,
-                CommonOCRSettings.SPENT_STAMINA_SETTINGS, "chief stamina item count");
-        if (current == null || itemCount == null) {
-            emitWarn("Could not read stamina or item count from the obtain-more dialog");
-            return false;
+        StaminaTopUpResult result = itemTopUpFlow.topUp(new StaminaItemTopUpFlow.Dialog() {
+            @Override
+            public Integer readCurrentStamina() {
+                return readDialogNumber(CommonGameAreas.STAMINA_DIALOG_CURRENT,
+                        CommonOCRSettings.STAMINA_FRACTION_SETTINGS, "current stamina");
+            }
+
+            @Override
+            public Integer readItemCount() {
+                return readDialogNumber(CommonGameAreas.STAMINA_DIALOG_ITEM_COUNT,
+                        CommonOCRSettings.SPENT_STAMINA_SETTINGS, "chief stamina item count");
+            }
+
+            @Override
+            public boolean useItem() {
+                var currentUseButton = device.locatePattern(
+                        deviceSlot,
+                        dev.frostguard.api.configs.TemplatesEnum.STAMINA_ITEM_USE_BUTTON,
+                        CommonGameAreas.STAMINA_DIALOG_USE_BUTTON.topLeft(),
+                        CommonGameAreas.STAMINA_DIALOG_USE_BUTTON.bottomRight(),
+                        85);
+                if (!currentUseButton.isFound()) {
+                    emitWarn("Chief Stamina Use button disappeared during top-up");
+                    return false;
+                }
+                device.touchPoint(deviceSlot, currentUseButton.getPoint());
+                pause(600);
+                return true;
+            }
+        }, targetStamina, itemReserve);
+        logTopUpResult(result, targetStamina, itemReserve);
+        return result;
+    }
+
+    private void logTopUpResult(StaminaTopUpResult result, int targetStamina, int itemReserve) {
+        String evidence = "status=" + result.status()
+                + " observed=" + result.observedStamina()
+                + " target=" + targetStamina
+                + " itemCount=" + result.itemCount()
+                + " reserve=" + itemReserve
+                + " needed=" + result.itemsNeeded()
+                + " final=" + result.finalStamina();
+        if (result.successful()) {
+            emitInfo("Stamina top-up result: " + evidence);
+        } else {
+            emitWarn("Stamina top-up result: " + evidence);
         }
-
-        int deficit = targetStamina - current;
-        if (deficit <= 0) return true;
-
-        int itemsNeeded = (deficit + STAMINA_ITEM_VALUE - 1) / STAMINA_ITEM_VALUE;
-        int usableItems = Math.max(0, itemCount - itemReserve);
-        emitInfo("Stamina top-up: current=" + current + " target=" + targetStamina
-                + " itemCount=" + itemCount + " reserve=" + itemReserve + " needed=" + itemsNeeded);
-
-        if (usableItems < itemsNeeded) {
-            emitWarn("Need " + itemsNeeded + " Chief Stamina item(s), only " + usableItems
-                    + " usable after reserve " + itemReserve);
-            return false;
-        }
-
-        for (int used = 0; used < itemsNeeded; used++) {
-            device.touchPoint(deviceSlot, useButton.getPoint());
-            pause(600);
-        }
-        addStamina(itemsNeeded * STAMINA_ITEM_VALUE);
-        return true;
     }
 
     private Integer readDialogNumber(dev.frostguard.api.domain.AreaData area,

--- a/fg-engine/src/main/java/dev/frostguard/engine/helper/StaminaItemTopUpFlow.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/helper/StaminaItemTopUpFlow.java
@@ -1,0 +1,78 @@
+package dev.frostguard.engine.helper;
+
+import java.util.function.IntConsumer;
+
+final class StaminaItemTopUpFlow {
+
+    static final int STAMINA_PER_ITEM = 10;
+
+    interface Dialog {
+        Integer readCurrentStamina();
+        Integer readItemCount();
+        boolean useItem();
+    }
+
+    private final IntConsumer synchronizeStamina;
+
+    StaminaItemTopUpFlow(IntConsumer synchronizeStamina) {
+        this.synchronizeStamina = synchronizeStamina;
+    }
+
+    StaminaTopUpResult topUp(Dialog dialog, int targetStamina, int itemReserve) {
+        if (targetStamina < 0 || itemReserve < 0) {
+            throw new IllegalArgumentException("Stamina target and item reserve must not be negative");
+        }
+
+        Integer current = dialog.readCurrentStamina();
+        if (current == null) {
+            return new StaminaTopUpResult(
+                    StaminaTopUpResult.Status.READ_FAILED, null, null, 0, null);
+        }
+        synchronizeStamina.accept(current);
+
+        int deficit = targetStamina - current;
+        if (deficit <= 0) {
+            return new StaminaTopUpResult(
+                    StaminaTopUpResult.Status.ALREADY_SUFFICIENT, current, null, 0, current);
+        }
+
+        int itemsNeeded = (deficit + STAMINA_PER_ITEM - 1) / STAMINA_PER_ITEM;
+        Integer itemCount = null;
+        // With no reserve, the count provides no safety value and can be dangerously plausible
+        // when OCR crops leading digits (for example, 110 as 0). The dialog adapter verifies the
+        // Use button before every click and the final stamina read proves whether the top-up worked.
+        if (itemReserve > 0) {
+            itemCount = dialog.readItemCount();
+            if (itemCount == null) {
+                return new StaminaTopUpResult(
+                        StaminaTopUpResult.Status.READ_FAILED, current, null, itemsNeeded, null);
+            }
+
+            int usableItems = Math.max(0, itemCount - itemReserve);
+            if (usableItems < itemsNeeded) {
+                return new StaminaTopUpResult(
+                        StaminaTopUpResult.Status.INSUFFICIENT_ITEMS,
+                        current, itemCount, itemsNeeded, current);
+            }
+        }
+
+        for (int used = 0; used < itemsNeeded; used++) {
+            if (!dialog.useItem()) {
+                break;
+            }
+        }
+
+        Integer finalStamina = dialog.readCurrentStamina();
+        if (finalStamina == null) {
+            return new StaminaTopUpResult(
+                    StaminaTopUpResult.Status.TOP_UP_NOT_CONFIRMED,
+                    current, itemCount, itemsNeeded, null);
+        }
+        synchronizeStamina.accept(finalStamina);
+
+        StaminaTopUpResult.Status status = finalStamina >= targetStamina
+                ? StaminaTopUpResult.Status.TOPPED_UP
+                : StaminaTopUpResult.Status.TOP_UP_NOT_CONFIRMED;
+        return new StaminaTopUpResult(status, current, itemCount, itemsNeeded, finalStamina);
+    }
+}

--- a/fg-engine/src/main/java/dev/frostguard/engine/helper/StaminaTopUpResult.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/helper/StaminaTopUpResult.java
@@ -1,0 +1,31 @@
+package dev.frostguard.engine.helper;
+
+/** Evidence-backed outcome of one Chief Stamina top-up attempt. */
+public record StaminaTopUpResult(
+        Status status,
+        Integer observedStamina,
+        Integer itemCount,
+        int itemsNeeded,
+        Integer finalStamina) {
+
+    public enum Status {
+        TOPPED_UP,
+        ALREADY_SUFFICIENT,
+        INSUFFICIENT_ITEMS,
+        READ_FAILED,
+        UI_NOT_FOUND,
+        TOP_UP_NOT_CONFIRMED
+    }
+
+    public boolean successful() {
+        return status == Status.TOPPED_UP || status == Status.ALREADY_SUFFICIENT;
+    }
+
+    public boolean confirmedItemShortage() {
+        return status == Status.INSUFFICIENT_ITEMS;
+    }
+
+    public static StaminaTopUpResult uiNotFound() {
+        return new StaminaTopUpResult(Status.UI_NOT_FOUND, null, null, 0, null);
+    }
+}

--- a/fg-engine/src/test/java/dev/frostguard/engine/helper/StaminaItemTopUpFlowTest.java
+++ b/fg-engine/src/test/java/dev/frostguard/engine/helper/StaminaItemTopUpFlowTest.java
@@ -1,0 +1,139 @@
+package dev.frostguard.engine.helper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class StaminaItemTopUpFlowTest {
+
+    @Test
+    void synchronizesObservedAndVerifiedFinalStamina() {
+        List<Integer> synchronizedLevels = new ArrayList<>();
+        FakeDialog dialog = new FakeDialog(155, 67, 147);
+
+        StaminaTopUpResult result = new StaminaItemTopUpFlow(synchronizedLevels::add)
+                .topUp(dialog, 145, 0);
+
+        assertEquals(StaminaTopUpResult.Status.TOPPED_UP, result.status());
+        assertEquals(8, result.itemsNeeded());
+        assertEquals(8, dialog.itemsUsed);
+        assertEquals(List.of(67, 147), synchronizedLevels);
+        assertEquals(147, result.finalStamina());
+    }
+
+    @Test
+    void unreadableItemCountKeepsAuthoritativeStaminaAndDoesNotClick() {
+        List<Integer> synchronizedLevels = new ArrayList<>();
+        FakeDialog dialog = new FakeDialog(null, 67);
+
+        StaminaTopUpResult result = new StaminaItemTopUpFlow(synchronizedLevels::add)
+                .topUp(dialog, 145, 1);
+
+        assertEquals(StaminaTopUpResult.Status.READ_FAILED, result.status());
+        assertEquals(8, result.itemsNeeded());
+        assertEquals(0, dialog.itemsUsed);
+        assertEquals(List.of(67), synchronizedLevels);
+    }
+
+    @Test
+    void zeroReserveCanTopUpWithoutReadableItemCount() {
+        List<Integer> synchronizedLevels = new ArrayList<>();
+        FakeDialog dialog = new FakeDialog(null, 67, 147);
+
+        StaminaTopUpResult result = new StaminaItemTopUpFlow(synchronizedLevels::add)
+                .topUp(dialog, 145, 0);
+
+        assertEquals(StaminaTopUpResult.Status.TOPPED_UP, result.status());
+        assertEquals(8, dialog.itemsUsed);
+        assertEquals(List.of(67, 147), synchronizedLevels);
+    }
+
+    @Test
+    void zeroReserveIgnoresPlausibleZeroFromTruncatedItemCount() {
+        List<Integer> synchronizedLevels = new ArrayList<>();
+        FakeDialog dialog = new FakeDialog(0, 126, 146);
+
+        StaminaTopUpResult result = new StaminaItemTopUpFlow(synchronizedLevels::add)
+                .topUp(dialog, 145, 0);
+
+        assertEquals(StaminaTopUpResult.Status.TOPPED_UP, result.status());
+        assertEquals(2, dialog.itemsUsed);
+        assertEquals(0, dialog.itemCountReads);
+        assertEquals(List.of(126, 146), synchronizedLevels);
+        assertNull(result.itemCount());
+    }
+
+    @Test
+    void confirmedShortageHonorsItemReserve() {
+        FakeDialog dialog = new FakeDialog(155, 67);
+
+        StaminaTopUpResult result = new StaminaItemTopUpFlow(level -> {})
+                .topUp(dialog, 145, 150);
+
+        assertEquals(StaminaTopUpResult.Status.INSUFFICIENT_ITEMS, result.status());
+        assertEquals(8, result.itemsNeeded());
+        assertEquals(0, dialog.itemsUsed);
+    }
+
+    @Test
+    void missingFinalReadNeverCreditsItemsOptimistically() {
+        List<Integer> synchronizedLevels = new ArrayList<>();
+        FakeDialog dialog = new FakeDialog(155, 67, null);
+
+        StaminaTopUpResult result = new StaminaItemTopUpFlow(synchronizedLevels::add)
+                .topUp(dialog, 145, 0);
+
+        assertEquals(StaminaTopUpResult.Status.TOP_UP_NOT_CONFIRMED, result.status());
+        assertEquals(8, dialog.itemsUsed);
+        assertEquals(List.of(67), synchronizedLevels);
+        assertNull(result.finalStamina());
+    }
+
+    @Test
+    void finalReadBelowTargetIsSynchronizedButNotAccepted() {
+        List<Integer> synchronizedLevels = new ArrayList<>();
+        FakeDialog dialog = new FakeDialog(155, 67, 137);
+
+        StaminaTopUpResult result = new StaminaItemTopUpFlow(synchronizedLevels::add)
+                .topUp(dialog, 145, 0);
+
+        assertEquals(StaminaTopUpResult.Status.TOP_UP_NOT_CONFIRMED, result.status());
+        assertEquals(List.of(67, 137), synchronizedLevels);
+        assertEquals(137, result.finalStamina());
+    }
+
+    private static final class FakeDialog implements StaminaItemTopUpFlow.Dialog {
+        private final List<Integer> staminaReads;
+        private final Integer itemCount;
+        private int readIndex;
+        private int itemCountReads;
+        private int itemsUsed;
+
+        private FakeDialog(Integer itemCount, Integer... staminaReads) {
+            this.staminaReads = Arrays.asList(staminaReads);
+            this.itemCount = itemCount;
+        }
+
+        @Override
+        public Integer readCurrentStamina() {
+            return staminaReads.get(readIndex++);
+        }
+
+        @Override
+        public Integer readItemCount() {
+            itemCountReads++;
+            return itemCount;
+        }
+
+        @Override
+        public boolean useItem() {
+            itemsUsed++;
+            return true;
+        }
+    }
+}

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarStaminaTopUpPolicy.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarStaminaTopUpPolicy.java
@@ -1,0 +1,24 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.engine.helper.StaminaTopUpResult;
+
+final class PolarStaminaTopUpPolicy {
+
+    enum Decision {
+        CONTINUE,
+        RETRY_SOON,
+        WAIT_FOR_REGENERATION
+    }
+
+    private PolarStaminaTopUpPolicy() {}
+
+    static Decision decide(StaminaTopUpResult result) {
+        if (result.successful()) {
+            return Decision.CONTINUE;
+        }
+        if (result.confirmedItemShortage()) {
+            return Decision.WAIT_FOR_REGENERATION;
+        }
+        return Decision.RETRY_SOON;
+    }
+}

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarTerrorHuntingRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarTerrorHuntingRoutine.java
@@ -10,6 +10,7 @@ import dev.frostguard.api.domain.PointData;
 import dev.frostguard.data.entity.DailyTask;
 import dev.frostguard.data.repository.DailyTaskRepository;
 import dev.frostguard.engine.helper.MarchSlotAvailabilityEstimator;
+import dev.frostguard.engine.helper.StaminaTopUpResult;
 import dev.frostguard.engine.nav.CommonGameAreas;
 import dev.frostguard.engine.nav.CommonOCRSettings;
 import dev.frostguard.engine.nav.SearchConfigConstants;
@@ -63,6 +64,7 @@ private static final MarchSlotAvailabilityEstimator.Settings MARCH_SLOT_ESTIMATE
 private static final int TARGET_TAKEN_MAX_RETRIES = 3;
 private static final int TARGET_TAKEN_RETRY_MINUTES = 1;
 private static final int RALLY_FAILURE_RETRY_MINUTES = 5;
+private static final int STAMINA_TOP_UP_RETRY_MINUTES = 5;
 // Holds the march slot when the travel time could not be read.
 private static final int UNKNOWN_TRAVEL_HOLD_MINUTES = 10;
 
@@ -111,6 +113,7 @@ private enum RallyLaunchOutcome {
         MARCH_QUEUE_FULL,
         NO_TROOPS_AVAILABLE,
         STAMINA_ITEMS_DISABLED,
+        STAMINA_ITEMS_INSUFFICIENT,
         STAMINA_REFILL_FAILED
     }
 
@@ -225,6 +228,13 @@ private record RallyLaunchResult(RallyLaunchOutcome outcome, String detail) {
             if (result.outcome() == RallyLaunchOutcome.MARCH_QUEUE_FULL) {
                 logInfo(routineLogPolarTerrorHuntingLine("March queue popup detected after Rally. Waiting for a march slot to return."));
                 reschedule(LocalDateTime.now().plusMinutes(UNKNOWN_MARCH_RETRY_MINUTES));
+                return;
+            }
+
+            if (result.outcome() == RallyLaunchOutcome.STAMINA_ITEMS_INSUFFICIENT) {
+                logInfo(routineLogPolarTerrorHuntingLine(
+                        "Confirmed usable stamina items cannot fund the rally; waiting for regeneration."));
+                rescheduleForStaminaRegen();
                 return;
             }
 
@@ -372,9 +382,13 @@ private RallyLaunchResult launchSingleRallyFlow(int polarLevel, boolean useFlag,
             tapPoint(deploy.getPoint());
             sleepTask(1000);
 
-            if (!staminaHelper.refillFromOpenDialog(rallyStaminaCost, staminaItemReserve)) {
-                return fail(RallyLaunchOutcome.STAMINA_REFILL_FAILED,
-                        "Could not refill stamina from the obtain-more dialog");
+            StaminaTopUpResult refill = staminaHelper.refillFromOpenDialog(
+                    rallyStaminaCost, staminaItemReserve);
+            if (!refill.successful()) {
+                RallyLaunchOutcome outcome = refill.confirmedItemShortage()
+                        ? RallyLaunchOutcome.STAMINA_ITEMS_INSUFFICIENT
+                        : RallyLaunchOutcome.STAMINA_REFILL_FAILED;
+                return fail(outcome, "Stamina refill ended with " + refill.status());
             }
 
             deploy = templateSearchHelper.locatePattern(
@@ -499,6 +513,14 @@ private void rescheduleForStaminaRegen() {
         reschedule(retryAt);
     }
 
+private void rescheduleForStaminaTopUpRetry(StaminaTopUpResult result) {
+        LocalDateTime retryAt = LocalDateTime.now().plusMinutes(STAMINA_TOP_UP_RETRY_MINUTES);
+        logWarning(routineLogPolarTerrorHuntingLine(String.format(
+                "Stamina gate: top-up ended with %s; retrying UI/OCR in %d min at %s",
+                result.status(), STAMINA_TOP_UP_RETRY_MINUTES, GameTimeUtils.formatCountdown(retryAt))));
+        reschedule(retryAt);
+    }
+
 // Cheap in-memory guard before any navigation: when items cannot bridge the gap, opening the march
 // panel only to discover the rally is unaffordable wastes a wake-up and a profile switch.
 private boolean staminaCouldSupportRally() {
@@ -522,8 +544,18 @@ private boolean ensureStaminaForRally() {
                 "Stamina gate: current=%d required=%d (reserve %d + rally %d) useItems=%s",
                 current, required, minStaminaLevel, MAX_POLAR_RALLY_STAMINA_COST, useStaminaItems)));
 
-        if (useStaminaItems && staminaHelper.topUpFromProfile(required, staminaItemReserve))
-            return true;
+        if (useStaminaItems) {
+            StaminaTopUpResult result = staminaHelper.topUpFromProfile(required, staminaItemReserve);
+            switch (PolarStaminaTopUpPolicy.decide(result)) {
+                case CONTINUE:
+                    return true;
+                case RETRY_SOON:
+                    rescheduleForStaminaTopUpRetry(result);
+                    return false;
+                case WAIT_FOR_REGENERATION:
+                    break;
+            }
+        }
 
         rescheduleForStaminaRegen();
         return false;

--- a/fg-tasks/src/test/java/dev/frostguard/tasks/combat/PolarStaminaTopUpPolicyTest.java
+++ b/fg-tasks/src/test/java/dev/frostguard/tasks/combat/PolarStaminaTopUpPolicyTest.java
@@ -1,0 +1,36 @@
+package dev.frostguard.tasks.combat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.frostguard.engine.helper.StaminaTopUpResult;
+import org.junit.jupiter.api.Test;
+
+class PolarStaminaTopUpPolicyTest {
+
+    @Test
+    void successfulTopUpContinuesRally() {
+        var result = new StaminaTopUpResult(
+                StaminaTopUpResult.Status.TOPPED_UP, 67, null, 8, 147);
+
+        assertEquals(PolarStaminaTopUpPolicy.Decision.CONTINUE,
+                PolarStaminaTopUpPolicy.decide(result));
+    }
+
+    @Test
+    void unreadableDialogRetriesSoonInsteadOfWaitingForRegeneration() {
+        var result = new StaminaTopUpResult(
+                StaminaTopUpResult.Status.READ_FAILED, 67, null, 8, null);
+
+        assertEquals(PolarStaminaTopUpPolicy.Decision.RETRY_SOON,
+                PolarStaminaTopUpPolicy.decide(result));
+    }
+
+    @Test
+    void confirmedItemShortageWaitsForRegeneration() {
+        var result = new StaminaTopUpResult(
+                StaminaTopUpResult.Status.INSUFFICIENT_ITEMS, 67, 155, 8, 67);
+
+        assertEquals(PolarStaminaTopUpPolicy.Decision.WAIT_FOR_REGENERATION,
+                PolarStaminaTopUpPolicy.decide(result));
+    }
+}


### PR DESCRIPTION
## Summary

- return structured outcomes from Chief Stamina top-up attempts instead of a boolean
- synchronize tracked stamina from the obtain-more dialog before and after item use
- re-find the Use button before every item click and require a final stamina read
- skip item-count OCR entirely when the configured item reserve is zero
- distinguish confirmed item shortage from transient OCR/UI/confirmation failures
- retry transient Polar top-up failures after five minutes instead of scheduling hours of natural regeneration

## Why

The item-count OCR region could crop leading digits while still returning a plausible number. Live logs showed the count degrade from `120` through `18`, `6`, `4`, and `12` to `0`, while the real sequence was approximately `120`, `118`, `116`, `114`, `112`, and `110`.

Because `0` looked like a valid read, Polar treated it as confirmed item exhaustion and scheduled a 220-minute regeneration wait despite usable items still being available.

When no item reserve is configured, the count provides no safety value. The flow now relies on the Use button and final observed stamina instead. Positive-reserve profiles still require an exact count so the reserve remains protected.

## Validation

- `mvn -pl fg-app -am test -DskipTests=false`
- 67 tests passed: 53 engine and 14 task tests
- regression coverage for `126` stamina plus a false item-count OCR value of `0`, confirming two clicks and final stamina `146`
- live Bot 1 soak after the corrected build:
  - 27 confirmed top-ups
  - 28 successfully started Polar rallies
  - 0 item-count OCR reads with reserve zero
  - 0 `INSUFFICIENT_ITEMS` outcomes
  - one unconfirmed top-up correctly retried after five minutes and recovered on the next attempt

## Risks

Profiles with a positive item reserve still depend on the narrow exact-count OCR region. The zero-reserve path is live-confirmed; the positive-reserve OCR path is unchanged.
