### PR TITLE
fix(training): wake upgrading queues on relevant events

### DIFF
--- a/fg-tasks/src/main/java/dev/frostguard/tasks/city/TrainingRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/city/TrainingRoutine.java
@@ -7,6 +7,7 @@ import dev.frostguard.engine.nav.SearchConfigConstants;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
 import dev.frostguard.engine.service.ConfigService;
+import dev.frostguard.engine.service.TaskManagementService;
 import dev.frostguard.vision.convert.GameTimeUtils;
 import dev.frostguard.vision.convert.RegexNumberParser;
 import dev.frostguard.vision.ocr.ResilientOcrExecutor;
@@ -16,6 +17,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import static dev.frostguard.api.configs.ConfigurationKeyEnum.*;
 import static dev.frostguard.api.configs.TemplatesEnum.*;
 import static dev.frostguard.engine.nav.LeftMenuTextSettings.*;
@@ -1099,14 +1101,55 @@ private boolean manageUpgradingQueues(List<QueueSlot> queues) {
                 .anyMatch(q -> q.status() == QueueMood.UPGRADING);
 
         if (anyUpgrading) {
-            logInfo(routineLogTrainingLine("At least one queue UPGRADING. Planning next run check in " +
-                    UPGRADING_RESCHEDULE_MINUTES_VALUE + " minutes."));
+            LocalDateTime now = LocalDateTime.now();
+            List<LocalDateTime> trainingCompletions = queues.stream()
+                    .filter(q -> q.status() == QueueMood.TRAINING)
+                    .map(QueueSlot::readyAt)
+                    .filter(Objects::nonNull)
+                    .toList();
+            LocalDateTime cityBuildRun = nextCityBuildRun().orElse(null);
+            LocalDateTime constructionCheck = earliestReservationCheck().orElse(null);
+            LocalDateTime nextCheck = selectUpgradingWakeup(
+                    now, trainingCompletions, cityBuildRun, constructionCheck);
 
-            reschedule(LocalDateTime.now().plusMinutes(UPGRADING_RESCHEDULE_MINUTES_VALUE));
+            logInfo(routineLogTrainingLine(
+                    "At least one queue UPGRADING. Planning next run for: "
+                            + nextCheck.format(DATETIME_FORMATTER)
+                            + " (earliest known training/construction event; 10-minute fallback only if unknown)."));
+
+            reschedule(nextCheck);
             return true;
         }
 
         return false;
+    }
+
+private Optional<LocalDateTime> nextCityBuildRun() {
+        if (profile == null || profile.getId() == null) {
+            return Optional.empty();
+        }
+
+        TaskStateData cityBuildState = TaskManagementService.shared().lookupTaskState(
+                profile.getId(), TpDailyTaskEnum.CITY_UPGRADE_FURNACE.getId());
+        if (cityBuildState == null || !cityBuildState.isScheduled()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(cityBuildState.getNextExecutionTime());
+    }
+
+static LocalDateTime selectUpgradingWakeup(
+        LocalDateTime now,
+        Collection<LocalDateTime> trainingCompletions,
+        LocalDateTime cityBuildRun,
+        LocalDateTime constructionCheck) {
+        LocalDateTime fallback = now.plusMinutes(UPGRADING_RESCHEDULE_MINUTES_VALUE);
+        return Stream.concat(
+                        trainingCompletions == null ? Stream.empty() : trainingCompletions.stream(),
+                        Stream.of(cityBuildRun, constructionCheck))
+                .filter(Objects::nonNull)
+                .filter(candidate -> candidate.isAfter(now))
+                .min(LocalDateTime::compareTo)
+                .orElse(fallback);
     }
 
 private List<QueueSlot> filterReadyQueuesFlow(List<QueueSlot> queues) {

--- a/fg-tasks/src/test/java/dev/frostguard/tasks/city/TrainingRoutineSchedulingTest.java
+++ b/fg-tasks/src/test/java/dev/frostguard/tasks/city/TrainingRoutineSchedulingTest.java
@@ -1,0 +1,62 @@
+package dev.frostguard.tasks.city;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TrainingRoutineSchedulingTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 27, 4, 26, 31);
+
+    @Test
+    void upgradingQueueWakesAtEarlierTrainingCompletion() {
+        LocalDateTime trainingCompletion = NOW.plusMinutes(4);
+        LocalDateTime cityBuildRun = NOW.plusMinutes(7);
+
+        LocalDateTime wakeup = TrainingRoutine.selectUpgradingWakeup(
+                NOW, List.of(trainingCompletion), cityBuildRun, null);
+
+        assertEquals(trainingCompletion, wakeup);
+    }
+
+    @Test
+    void upgradingQueueWakesAtEarlierCityBuildRun() {
+        LocalDateTime trainingCompletion = NOW.plusMinutes(8);
+        LocalDateTime cityBuildRun = NOW.plusMinutes(3);
+
+        LocalDateTime wakeup = TrainingRoutine.selectUpgradingWakeup(
+                NOW, List.of(trainingCompletion), cityBuildRun, null);
+
+        assertEquals(cityBuildRun, wakeup);
+    }
+
+    @Test
+    void constructionHandoffCanWakeTrainingBeforeOtherEvents() {
+        LocalDateTime constructionCheck = NOW.plusMinutes(2);
+
+        LocalDateTime wakeup = TrainingRoutine.selectUpgradingWakeup(
+                NOW, List.of(NOW.plusMinutes(6)), NOW.plusMinutes(5), constructionCheck);
+
+        assertEquals(constructionCheck, wakeup);
+    }
+
+    @Test
+    void tenMinuteFallbackIsUsedWhenNoFutureEventIsKnown() {
+        LocalDateTime wakeup = TrainingRoutine.selectUpgradingWakeup(
+                NOW, List.of(NOW.minusMinutes(1)), null, NOW);
+
+        assertEquals(NOW.plusMinutes(10), wakeup);
+    }
+
+    @Test
+    void knownEventAfterTenMinutesAvoidsPeriodicPolling() {
+        LocalDateTime trainingCompletion = NOW.plusMinutes(45);
+
+        LocalDateTime wakeup = TrainingRoutine.selectUpgradingWakeup(
+                NOW, List.of(trainingCompletion), null, null);
+
+        assertEquals(trainingCompletion, wakeup);
+    }
+}


### PR DESCRIPTION
## Summary

- replace the unconditional 10-minute polling cycle for `UPGRADING` training queues
- schedule the next training check at the earliest known troop-training completion, City Upgrade Furnace run, or construction handoff
- retain the 10-minute delay only when no future event is known
- add focused scheduling-policy tests, including the no-periodic-polling case for events more than 10 minutes away

### Impact

Training now sleeps until the first event that can actually change queue availability. Existing behavior remains as a safe fallback when no timing information is available.

## Why

A mixed queue state such as one camp upgrading and another camp training bypassed the existing all-training scheduling path. `manageUpgradingQueues()` then discarded known completion and city-build timings and always scheduled another check ten minutes later.

This caused unnecessary emulator wakeups and could delay handling the next meaningful queue event.

## Validation

- `mvn test`
- 62 tests passed across the reactor (46 engine + 16 task tests)
- focused scheduling and construction tests: 10 passed

## Risks

None known.
