### PR TITLE
build(runtime): require Java 21 and authorize native access

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@
 
 | Requirement | Version | Download |
 |:-----------:|:-------:|:--------:|
-| ![Java](https://img.shields.io/badge/Java_JDK-ED8B00?style=flat-square&logo=openjdk&logoColor=white) | `17` or newer | **[Adoptium Temurin](https://adoptium.net/)** |
+| ![Java](https://img.shields.io/badge/Java_JDK-ED8B00?style=flat-square&logo=openjdk&logoColor=white) | `21` | **[Adoptium Temurin](https://adoptium.net/)** |
 | ![Maven](https://img.shields.io/badge/Apache_Maven-C71A36?style=flat-square&logo=apache-maven&logoColor=white) | `3.8+` | **[Download Maven](https://maven.apache.org/install.html)** |
 
 </div>
@@ -228,7 +228,7 @@
 3. Under **System variables**, select `Path` and click **Edit**
 4. Add the `bin` directories of your Java and Maven installations:
    ```
-   C:\Program Files\Eclipse Adoptium\jdk-17\bin
+   C:\Program Files\Eclipse Adoptium\jdk-21\bin
    C:\apache-maven-3.9.9\bin
    ```
 5. Click **OK** and restart your terminal
@@ -529,4 +529,3 @@ Any contributions you make are **greatly appreciated**.
 </div>
 
 <!-- SEO Keywords: Whiteout Survival Automation, Frostguard, Whiteout Survival Macro, Whiteout Survival Auto Script, Open Source Automation, Auto Join Rallies, Whiteout Survival PC Bot, Auto Farm, Whiteout Survival Helper, Multi Account Bot -->
-

--- a/fg-app/pom.xml
+++ b/fg-app/pom.xml
@@ -146,6 +146,7 @@
 							<Built-By>${user.name}</Built-By>
 							<Build-Jdk>${java.version}</Build-Jdk>
 							<Build-Time>${maven.build.timestamp}</Build-Time>
+							<Enable-Native-Access>ALL-UNNAMED</Enable-Native-Access>
 						</manifestEntries>
 					</archive>
 				</configuration>


### PR DESCRIPTION
## Summary

- document Java 21 as the required build and runtime version
- update the Windows JDK path example to Java 21
- add `Enable-Native-Access: ALL-UNNAMED` to the executable desktop JAR manifest

## Why

The project already compiles and runs against a Java 21 baseline, while the README still advertised Java 17 or newer. Running the classpath distribution on JDK 24+ also reports restricted native-access warnings when SQLite loads its native library. Frostguard intentionally uses native SQLite and OpenCV code, so the executable JAR should declare that requirement explicitly.

## Validation

- installed Temurin JDK 21.0.11+10 and confirmed both `java` and `javac`
- `mvn -pl fg-app -am package -DskipTests -Dmaven.jar.forceCreation=true` completed with Maven running on Java 21
- packaged manifest confirms `Build-Jdk-Spec: 21`, `Build-Jdk: 21`, and `Enable-Native-Access: ALL-UNNAMED`
- isolated Java 21 startup completed through JavaFX and OpenCV initialization with neither the SQLite `System.load` warning nor the JavaFX renderer `Unsafe` warning
- isolated Java 25 startup confirmed the manifest also removes the SQLite `System.load` warning on JDK 24+

## Risks

JavaFX still reports its classpath/unnamed-module warning, as expected. No module-path migration is included in this PR; that broader packaging decision is tracked separately in #55.
