### PR TITLE
fix(telegram): restore queue controls and log downloads

### DIFF
--- a/fg-engine/src/main/java/dev/frostguard/engine/service/TelegramBotService.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/service/TelegramBotService.java
@@ -55,6 +55,8 @@ import java.util.ArrayList;
  */
 public class TelegramBotService implements BotStateListener {
 
+    static final String CURRENT_LOG_PATH = "log/frostguard.log";
+
     private static final Logger logger = LoggerFactory.getLogger(TelegramBotService.class);
     private static final String API_BASE = "https://api.telegram.org/bot";
 
@@ -292,7 +294,7 @@ public class TelegramBotService implements BotStateListener {
                 + "`/screenshot`  — Capture & send emulator screen\n"
                 + "`/queue`       — Task queue (schedule / remove / run)\n"
                 + "`/stats`       — Bot activity statistics per profile\n"
-                + "`/logs`        — Download log files (bot.log / CleanBot.log)\n"
+                + "`/logs`        — Download the Frostguard log\n"
                 + "`/profiles`    — View & toggle profiles on/off\n"
                 + "\n"
                 + "❓ *Help*\n"
@@ -744,6 +746,9 @@ public class TelegramBotService implements BotStateListener {
     private List<TaskEntry> buildTaskEntries(long profileId, TaskQueue queue) {
         List<TaskEntry> list = new ArrayList<>();
         for (TpDailyTaskEnum task : TpDailyTaskEnum.values()) {
+            if (!isStandardQueueTask(task)) {
+                continue;
+            }
             TaskStateData state = TaskManagementService.shared().lookupTaskState(profileId, task.getId());
             boolean scheduled = (queue != null) && queue.isTaskQueued(task);
             boolean executing = (state != null) && state.isExecuting();
@@ -763,6 +768,10 @@ public class TelegramBotService implements BotStateListener {
             return a.taskEnum.getName().compareTo(b.taskEnum.getName());
         });
         return list;
+    }
+
+    static boolean isStandardQueueTask(TpDailyTaskEnum task) {
+        return task != TpDailyTaskEnum.CUSTOM_TASK;
     }
 
     // ── Callback handling ─────────────────────────────────────────────────────
@@ -842,17 +851,8 @@ public class TelegramBotService implements BotStateListener {
                     handleProfileToggleCallback(callbackId, chatId, messageId, Long.parseLong(parts[1]));
                 }
                 case "log_dl" -> {
-                    if (parts.length < 2) {
-                        answerCallbackQuery(callbackId, "");
-                        return;
-                    }
                     answerCallbackQuery(callbackId, "📥 Downloading...");
-                    String type = parts[1];
-                    String path = "log/bot.log";
-                    if ("clean".equals(type)) {
-                        path = "log/CleanBot.log";
-                    }
-                    sendDocument(chatId, path);
+                    sendDocument(chatId, CURRENT_LOG_PATH);
                 }
                 default -> answerCallbackQuery(callbackId, "");
             }
@@ -1199,8 +1199,9 @@ public class TelegramBotService implements BotStateListener {
         ArrayNode kb = objectMapper.createArrayNode();
         ArrayNode row = objectMapper.createArrayNode();
 
-        row.add(objectMapper.createObjectNode().put("text", "📄 bot.log").put("callback_data", "log_dl:bot"));
-        row.add(objectMapper.createObjectNode().put("text", "🧹 CleanBot.log").put("callback_data", "log_dl:clean"));
+        row.add(objectMapper.createObjectNode()
+                .put("text", "📄 frostguard.log")
+                .put("callback_data", "log_dl"));
         kb.add(row);
 
         ObjectNode markup = objectMapper.createObjectNode();
@@ -1401,4 +1402,3 @@ public class TelegramBotService implements BotStateListener {
         }
     }
 }
-

--- a/fg-engine/src/test/java/dev/frostguard/engine/service/TelegramBotServiceTest.java
+++ b/fg-engine/src/test/java/dev/frostguard/engine/service/TelegramBotServiceTest.java
@@ -1,0 +1,22 @@
+package dev.frostguard.engine.service;
+
+import dev.frostguard.api.configs.TpDailyTaskEnum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TelegramBotServiceTest {
+
+    @Test
+    void standardQueueExcludesCustomTaskPlaceholder() {
+        assertFalse(TelegramBotService.isStandardQueueTask(TpDailyTaskEnum.CUSTOM_TASK));
+        assertTrue(TelegramBotService.isStandardQueueTask(TpDailyTaskEnum.INITIALIZE));
+    }
+
+    @Test
+    void logDownloadUsesConfiguredFrostguardLogName() {
+        assertEquals("log/frostguard.log", TelegramBotService.CURRENT_LOG_PATH);
+    }
+}

--- a/fg-watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
+++ b/fg-watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
@@ -531,7 +531,7 @@ public class TelegramWatcher {
               + "`/screenshot`  — Capture & send emulator screen\n"
               + "`/queue`       — Task queue (schedule / remove / run)\n"
               + "`/stats`       — Bot activity statistics per profile\n"
-              + "`/logs`        — Download log files (bot.log / CleanBot.log)\n"
+              + "`/logs`        — Download the Frostguard log\n"
               + "`/profiles`    — View & toggle profiles on/off\n\n"
               + "❓ *Help*\n"
               + "`/help`        — Show this message\n"
@@ -625,4 +625,3 @@ public class TelegramWatcher {
         return props;
     }
 }
-


### PR DESCRIPTION
## Summary

- exclude the `CUSTOM_TASK` placeholder from the standard Telegram queue controls
- download the configured `log/frostguard.log` file instead of the obsolete `bot.log` and `CleanBot.log` paths
- update the Telegram help text and add focused regression coverage

### Impact

The Telegram queue renders again, while custom tasks remain managed through their existing dedicated flow. The log center now exposes the actual current Frostguard log.

## Why

`/queue` iterated every `TpDailyTaskEnum` value and tried to create a normal task prototype for `CUSTOM_TASK`. Custom tasks intentionally use a separate keyed creation path, so the normal registry returned no mapping and the entire queue page failed.

The log menu still referenced legacy filenames that the current Logback configuration no longer creates, causing both download buttons to report `file not found`.

## Validation

- live-confirmed `/queue` and `/logs` on Bot 1 and Bot 2
- `mvn -pl fg-app,fg-watcher -am package -DskipTests=false`
- 48 engine tests and 11 task tests passed
- shaded watcher and desktop bundle built successfully

## Risks

None known.
