### PR TITLE
fix(build): ignore module-local OpenCV caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ dependency-reduced-pom.xml
 *.class
 
 # Runtime-extracted native libraries (regenerated on launch from the classpath)
-/lib/opencv/
+**/lib/opencv/
 
 # ── Logs ──
 *.log


### PR DESCRIPTION
## Summary

- ignore runtime-extracted OpenCV native-library caches in nested Maven module working directories
- keep the canonical bundled native resource and Git LFS configuration unchanged

## Why

The OpenCV loader extracts its bundled native library to `lib/opencv/` relative to the current working directory. The existing root-anchored `/lib/opencv/` rule covers application launches from the repository root but not module-scoped test runs, which can create `fg-engine/lib/opencv/opencv_java4110.dll` and expose the 51.7 MB cache as an untracked Git LFS change.

## Validation

- `git diff --check`
- `git check-ignore -v --no-index -- fg-engine/lib/opencv/opencv_java4110.dll` resolves to `.gitignore:13:**/lib/opencv/`

## Risks

No runtime behavior changes. The PR remains a draft for maintainer review of the broader ignore scope.
