### PR TITLE
fix(polar): stabilize special reward scan

### DIFF
--- a/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
+++ b/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
@@ -152,7 +152,7 @@ public enum ConfigurationKeyEnum {
     POLAR_TERROR_MARCH_5_FLAG_STRING            ("No Flag", String.class,        ConfigCategory.EVENTS),
     POLAR_TERROR_MARCH_6_FLAG_STRING            ("No Flag", String.class,        ConfigCategory.EVENTS),
     POLAR_TERROR_MARCHES_INT                    ("1",       Integer.class,       ConfigCategory.EVENTS),
-    POLAR_TERROR_MODE_STRING                    ("Limited (10)", String.class,   ConfigCategory.EVENTS),
+    POLAR_TERROR_MODE_STRING                    (PolarTerrorMode.SPECIAL_REWARDS.getDisplayName(), String.class, ConfigCategory.EVENTS),
     POLAR_TERROR_USE_STAMINA_ITEMS_BOOL         ("false",   Boolean.class,       ConfigCategory.EVENTS),
     POLAR_TERROR_STAMINA_ITEM_RESERVE_INT       ("0",       Integer.class,       ConfigCategory.EVENTS),
     RALLY_ENABLED_BOOL                          ("false",   Boolean.class,       ConfigCategory.EVENTS),

--- a/fg-api/src/main/java/dev/frostguard/api/configs/PolarTerrorMode.java
+++ b/fg-api/src/main/java/dev/frostguard/api/configs/PolarTerrorMode.java
@@ -1,0 +1,29 @@
+package dev.frostguard.api.configs;
+
+public enum PolarTerrorMode {
+    SPECIAL_REWARDS("Special Rewards (10)"),
+    UNLIMITED("Unlimited");
+
+    private static final String LEGACY_LIMITED_VALUE = "Limited (10)";
+
+    private final String displayName;
+
+    PolarTerrorMode(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public static PolarTerrorMode fromStoredValue(String value) {
+        if (SPECIAL_REWARDS.displayName.equals(value) || LEGACY_LIMITED_VALUE.equals(value)) {
+            return SPECIAL_REWARDS;
+        }
+        return UNLIMITED;
+    }
+
+    public static boolean isLegacyValue(String value) {
+        return LEGACY_LIMITED_VALUE.equals(value);
+    }
+}

--- a/fg-app/src/main/java/dev/frostguard/app/panel/combat/PolarTerrorLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/combat/PolarTerrorLayoutController.java
@@ -2,6 +2,8 @@ package dev.frostguard.app.panel.combat;
 
 import dev.frostguard.app.shared.AbstractProfileController;
 import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.configs.PolarTerrorMode;
+import dev.frostguard.app.panel.profile.ProfileAux;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
@@ -139,7 +141,9 @@ public class PolarTerrorLayoutController extends AbstractProfileController {
         for (int i = 1; i <= MAX_POLAR_TERROR_LEVEL; i++) {
             comboBoxPolarTerrorLevel.getItems().addAll(i);
         }
-        comboBoxPolarTerrorMode.getItems().addAll("Limited (10)", "Unlimited");
+        comboBoxPolarTerrorMode.getItems().addAll(
+                PolarTerrorMode.SPECIAL_REWARDS.getDisplayName(),
+                PolarTerrorMode.UNLIMITED.getDisplayName());
 
         // Manual Rally Join combos
         @SuppressWarnings("unchecked")
@@ -211,6 +215,23 @@ public class PolarTerrorLayoutController extends AbstractProfileController {
         updatePolarTerrorMarchFlagsVisibility(1);
         textFieldPolarStaminaItemReserve.disableProperty().bind(checkBoxPolarUseStaminaItems.selectedProperty().not());
         comboBoxPolarTerrorLevel.disableProperty().bind(checkBoxPolarHighestLevel.selectedProperty());
+    }
+
+    @Override
+    public void onProfileLoad(ProfileAux profile) {
+        super.onProfileLoad(profile);
+
+        String storedMode = profile.getConfiguration(ConfigurationKeyEnum.POLAR_TERROR_MODE_STRING);
+        if (!PolarTerrorMode.isLegacyValue(storedMode)) {
+            return;
+        }
+
+        isLoadingProfile = true;
+        try {
+            comboBoxPolarTerrorMode.setValue(PolarTerrorMode.SPECIAL_REWARDS.getDisplayName());
+        } finally {
+            isLoadingProfile = false;
+        }
     }
 
     private void updateMarchFlagsVisibility(Integer marches) {

--- a/fg-app/src/main/resources/layout/PolarTerrorLayout.fxml
+++ b/fg-app/src/main/resources/layout/PolarTerrorLayout.fxml
@@ -105,7 +105,7 @@
                             </HBox>
 
                             <Label styleClass="task-card-note"
-                                   text="Note: When using a flag or when limited mode is active, rallies will be called one by one."
+                                   text="Note: When using a flag or Special Rewards mode, rallies will be called one by one."
                                    wrapText="true" />
                         </VBox>
                     </Tab>

--- a/fg-engine/src/main/java/dev/frostguard/engine/nav/CommonGameAreas.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/nav/CommonGameAreas.java
@@ -105,6 +105,10 @@ public final class CommonGameAreas {
     // Polar Terror search panel: the level number sits in the pill right of the slider, not on the
     // slider bar itself.
     public static final AreaData POLAR_LEVEL_DISPLAY = region(565, 1030, 665, 1078);
+    public static final AreaData POLAR_SEARCH_BUTTON = region(301, 1200, 412, 1229);
+    // A newly revealed section heading enters this strip before more reward rows are swiped into view.
+    public static final AreaData POLAR_SPECIAL_REWARDS_HEADER = region(35, 1090, 685, 1185);
+    public static final PointData POLAR_REWARD_DETAILS_CLOSE = point(665, 195);
 
     // ── stamina "Obtain more" dialog ─────────────────────────────────
     //

--- a/fg-engine/src/main/java/dev/frostguard/engine/nav/CommonOCRSettings.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/nav/CommonOCRSettings.java
@@ -37,6 +37,11 @@ public final class CommonOCRSettings {
                     .setTextColor(new Color(66, 84, 108))
                     .build();
 
+    // special rewards heading: "Special Rewards (8 left)" in white on a blue section bar
+    public static final TesseractSettingsData POLAR_SPECIAL_REWARDS_SETTINGS =
+            buildLstmConfig("SpecialRewardsleft0123456789() ", true,
+                    255, 255, 255, PageAnalysis.SINGLE_LINE);
+
     // extraction pattern for pulling first integer from noisy OCR text
     public static final Pattern NUMBER_PATTERN = Pattern.compile(".*?(\\d+).*");
 

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarSpecialRewardsScanner.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarSpecialRewardsScanner.java
@@ -1,0 +1,44 @@
+package dev.frostguard.tasks.combat;
+
+import java.util.function.LongConsumer;
+import java.util.function.Supplier;
+
+final class PolarSpecialRewardsScanner {
+
+    enum Result {
+        AVAILABLE,
+        EXHAUSTED,
+        NOT_FOUND
+    }
+
+    static final int MAX_SWIPES = 5;
+    static final long SWIPE_SETTLE_MILLIS = 1000;
+
+    private PolarSpecialRewardsScanner() {
+    }
+
+    static Result scan(Supplier<Integer> visibleRewardsCount,
+                       Runnable swipeToNextPosition,
+                       LongConsumer waitForAnimation) {
+        Result result = classify(visibleRewardsCount.get());
+        if (result != Result.NOT_FOUND) {
+            return result;
+        }
+        for (int swipe = 0; swipe < MAX_SWIPES; swipe++) {
+            swipeToNextPosition.run();
+            waitForAnimation.accept(SWIPE_SETTLE_MILLIS);
+            result = classify(visibleRewardsCount.get());
+            if (result != Result.NOT_FOUND) {
+                return result;
+            }
+        }
+        return Result.NOT_FOUND;
+    }
+
+    private static Result classify(Integer rewardsCount) {
+        if (rewardsCount == null) {
+            return Result.NOT_FOUND;
+        }
+        return rewardsCount == 0 ? Result.EXHAUSTED : Result.AVAILABLE;
+    }
+}

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarTerrorHuntingRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/combat/PolarTerrorHuntingRoutine.java
@@ -1,6 +1,7 @@
 package dev.frostguard.tasks.combat;
 
 import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.configs.PolarTerrorMode;
 import dev.frostguard.api.configs.TemplatesEnum;
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
@@ -101,9 +102,10 @@ public PolarTerrorHuntingRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTa
         super(profile, tpTask);
     }
 
-private enum RallyLaunchOutcome {
+    private enum RallyLaunchOutcome {
         SUCCESS,
         SEARCH_FAILED,
+        NO_SPECIAL_REWARDS,
         RALLY_BUTTON_MISSING,
         HOLD_RALLY_MISSING,
         FLAG_NOT_AVAILABLE,
@@ -115,6 +117,12 @@ private enum RallyLaunchOutcome {
         STAMINA_ITEMS_DISABLED,
         STAMINA_ITEMS_INSUFFICIENT,
         STAMINA_REFILL_FAILED
+    }
+
+    private enum SpecialRewardsStatus {
+        AVAILABLE,
+        EXHAUSTED,
+        READ_FAILED
     }
 
 private record RallyLaunchResult(RallyLaunchOutcome outcome, String detail) {
@@ -150,15 +158,13 @@ private record RallyLaunchResult(RallyLaunchOutcome outcome, String detail) {
         logInfo(routineLogPolarTerrorHuntingLine(String.format(
                 "Configuration: level=%s mode=%s marches=%d staminaReserve=%d useStaminaItems=%s itemReserve=%d",
                 huntHighestLevel ? "highest available" : Integer.toString(polarTerrorLevel),
-                limitedHunting ? "Limited (10)" : "Unlimited",
+                limitedHunting
+                        ? PolarTerrorMode.SPECIAL_REWARDS.getDisplayName()
+                        : PolarTerrorMode.UNLIMITED.getDisplayName(),
                 maxMarches,
                 minStaminaLevel,
                 useStaminaItems,
                 staminaItemReserve)));
-
-        if (limitedHunting && !polarsRemainingFlow(polarTerrorLevel)) {
-            return;
-        }
 
         int deployedCount = resolveActiveDeploymentsCount(profile.getId());
 
@@ -175,10 +181,6 @@ private record RallyLaunchResult(RallyLaunchOutcome outcome, String detail) {
                         deployedCount,
                         GameTimeUtils.formatCountdown(retryAt))));
                 reschedule(retryAt);
-                return;
-            }
-
-            if (limitedHunting && !polarsRemainingFlow(polarTerrorLevel)) {
                 return;
             }
 
@@ -204,7 +206,8 @@ private record RallyLaunchResult(RallyLaunchOutcome outcome, String detail) {
             logInfo(routineLogPolarTerrorHuntingLine("Launching rally " + (deployedCount + 1) + " of " + maxMarches +
                     (useFlag ? " with flag #" + currentFlagNumber : " (Equalize fallback)")));
 
-            RallyLaunchResult result = launchSingleRallyFlow(polarTerrorLevel, useFlag, currentFlagNumber);
+            RallyLaunchResult result = launchSingleRallyFlow(
+                    polarTerrorLevel, useFlag, currentFlagNumber, limitedHunting);
 
             // Cancelling costs no stamina and the search hands out a different creature, so the
             // cheapest answer to a contested target is to look again right away.
@@ -214,7 +217,14 @@ private record RallyLaunchResult(RallyLaunchOutcome outcome, String detail) {
                         "Target was taken by another player; searching for a different polar terror (retry %d/%d)",
                         attempt, TARGET_TAKEN_MAX_RETRIES)));
                 sleepTask(1000);
-                result = launchSingleRallyFlow(polarTerrorLevel, useFlag, currentFlagNumber);
+                result = launchSingleRallyFlow(polarTerrorLevel, useFlag, currentFlagNumber, false);
+            }
+
+            if (result.outcome() == RallyLaunchOutcome.NO_SPECIAL_REWARDS) {
+                logInfo(routineLogPolarTerrorHuntingLine(
+                        "Zero special rewards left. Planning next run after daily reset."));
+                reschedule(GameTimeUtils.dailyResetTime().plusMinutes(30));
+                return;
             }
 
             if (result.outcome() == RallyLaunchOutcome.TARGET_ALREADY_TAKEN) {
@@ -321,7 +331,8 @@ private static void registerDeploymentFlow(long profileId, LocalDateTime returnT
                 .add(returnTime);
     }
 
-private RallyLaunchResult launchSingleRallyFlow(int polarLevel, boolean useFlag, int flagNumber) {
+private RallyLaunchResult launchSingleRallyFlow(int polarLevel, boolean useFlag, int flagNumber,
+                                                boolean checkSpecialRewards) {
         navigationHelper.ensureCorrectScreenLocation(getRequiredStartLocation());
 
         logInfo(routineLogPolarTerrorHuntingLine(String.format("Opening Polar Terror search: level=%s",
@@ -329,6 +340,24 @@ private RallyLaunchResult launchSingleRallyFlow(int polarLevel, boolean useFlag,
         if (!openUpPolarsMenu(polarLevel)) {
             logError(routineLogPolarTerrorHuntingLine("Could not open polars menu."));
             return fail(RallyLaunchOutcome.SEARCH_FAILED, "Polar tab/search result was not verified");
+        }
+
+        if (checkSpecialRewards) {
+            SpecialRewardsStatus rewardsStatus = inspectSpecialRewards();
+            if (rewardsStatus == SpecialRewardsStatus.EXHAUSTED) {
+                return fail(RallyLaunchOutcome.NO_SPECIAL_REWARDS,
+                        "The reward details show zero special rewards left");
+            }
+            if (rewardsStatus == SpecialRewardsStatus.READ_FAILED) {
+                return fail(RallyLaunchOutcome.SEARCH_FAILED,
+                        "Special rewards could not be checked from the Polar Terror result");
+            }
+            logInfo(routineLogPolarTerrorHuntingLine(
+                    "Special rewards remain; searching from the retained Polar Terror panel."));
+            tapRandomPoint(
+                    CommonGameAreas.POLAR_SEARCH_BUTTON.topLeft(),
+                    CommonGameAreas.POLAR_SEARCH_BUTTON.bottomRight());
+            sleepTask(1500);
         }
 
         logInfo(routineLogPolarTerrorHuntingLine("Opening rally dialog"));
@@ -566,7 +595,7 @@ private void hydrateConfiguration() {
         this.polarTerrorLevel = configuredLevel != null ? configuredLevel : MIN_POLAR_LEVEL;
 
         String mode = profile.getConfig(ConfigurationKeyEnum.POLAR_TERROR_MODE_STRING, String.class);
-        this.limitedHunting = "Limited (10)".equals(mode);
+        this.limitedHunting = PolarTerrorMode.fromStoredValue(mode) == PolarTerrorMode.SPECIAL_REWARDS;
 
         Integer configuredMarches = profile.getConfig(ConfigurationKeyEnum.POLAR_TERROR_MARCHES_INT, Integer.class);
         this.maxMarches = configuredMarches != null ? configuredMarches : 1;
@@ -601,42 +630,56 @@ private void hydrateConfiguration() {
         }
     }
 
-private boolean polarsRemainingFlow(int polarLevel) {
-        if (!openUpPolarsMenu(polarLevel)) {
-            return false;
-        }
-
+private SpecialRewardsStatus inspectSpecialRewards() {
         ImageSearchResultData magnifyingGlass = templateSearchHelper.locatePattern(
                 TemplatesEnum.POLAR_TERROR_TAB_MAGNIFYING_GLASS_ICON,
                 SearchConfigConstants.SINGLE_WITH_RETRIES);
         sleepTask(500);
 
         if (!magnifyingGlass.isFound()) {
-            return false;
+            return SpecialRewardsStatus.READ_FAILED;
         }
 
         tapPoint(magnifyingGlass.getPoint());
         sleepTask(2000);
 
-        ImageSearchResultData specialRewardsCompleted = templateSearchHelper.locatePattern(
+        PolarSpecialRewardsScanner.Result result = PolarSpecialRewardsScanner.scan(
+                this::readVisibleSpecialRewardsCount,
+                () -> swipe(new PointData(363, 1088), new PointData(363, 1030)),
+                this::sleepTask);
+        tapPoint(CommonGameAreas.POLAR_REWARD_DETAILS_CLOSE);
+        sleepTask(500);
+        return switch (result) {
+            case AVAILABLE -> SpecialRewardsStatus.AVAILABLE;
+            case EXHAUSTED -> SpecialRewardsStatus.EXHAUSTED;
+            case NOT_FOUND -> SpecialRewardsStatus.READ_FAILED;
+        };
+    }
+
+private Integer readVisibleSpecialRewardsCount() {
+        if (templateSearchHelper.locatePattern(
                 TemplatesEnum.POLAR_TERROR_TAB_SPECIAL_REWARDS,
-                SearchConfigConstants.QUICK_SEARCH);
-        for (int i = 0; i < 5 && !specialRewardsCompleted.isFound(); i++) {
-            specialRewardsCompleted = templateSearchHelper.locatePattern(
-                    TemplatesEnum.POLAR_TERROR_TAB_SPECIAL_REWARDS,
-                    SearchConfigConstants.QUICK_SEARCH);
-            if (specialRewardsCompleted.isFound()) {
-                logWarning(routineLogPolarTerrorHuntingLine("Zero special rewards left, meaning there's no hunts left for today. Planning next run task for reset"));
-                reschedule(GameTimeUtils.dailyResetTime().plusMinutes(30));
-                return false;
-            }
-            swipe(new PointData(363, 1088), new PointData(363, 1030));
-            sleepTask(300);
+                SearchConfigConstants.QUICK_SEARCH).isFound()) {
+            logInfo(routineLogPolarTerrorHuntingLine("Special rewards counter: 0 left"));
+            return 0;
         }
 
-        pressBack();
-        sleepTask(500);
-        return true;
+        Integer count = integerHelper.attemptRecognition(
+                CommonGameAreas.POLAR_SPECIAL_REWARDS_HEADER,
+                1,
+                0L,
+                CommonOCRSettings.POLAR_SPECIAL_REWARDS_SETTINGS,
+                text -> text != null && text.toLowerCase().matches(
+                        ".*special\\s*rewards\\s*\\(?\\s*\\d+\\s*left.*"),
+                text -> {
+                    String countText = text.toLowerCase().replaceFirst(
+                            ".*special\\s*rewards\\s*\\(?\\s*(\\d+)\\s*left.*", "$1");
+                    return Integer.parseInt(countText);
+                });
+        if (count != null) {
+            logInfo(routineLogPolarTerrorHuntingLine("Special rewards counter: " + count + " left"));
+        }
+        return count;
     }
 
 private boolean openUpPolarsMenu(int polarLevel) {
@@ -691,7 +734,9 @@ private boolean openUpPolarsMenu(int polarLevel) {
             }
         }
 
-        tapRandomPoint(new PointData(301, 1200), new PointData(412, 1229));
+        tapRandomPoint(
+                CommonGameAreas.POLAR_SEARCH_BUTTON.topLeft(),
+                CommonGameAreas.POLAR_SEARCH_BUTTON.bottomRight());
         sleepTask(1500);
         return true;
     }

--- a/fg-tasks/src/test/java/dev/frostguard/tasks/combat/PolarSpecialRewardsScannerTest.java
+++ b/fg-tasks/src/test/java/dev/frostguard/tasks/combat/PolarSpecialRewardsScannerTest.java
@@ -1,0 +1,63 @@
+package dev.frostguard.tasks.combat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class PolarSpecialRewardsScannerTest {
+
+    @Test
+    void waitsForSwipeAnimationBeforeScanningNextPosition() {
+        List<String> actions = new ArrayList<>();
+        AtomicInteger scans = new AtomicInteger();
+
+        PolarSpecialRewardsScanner.Result result = PolarSpecialRewardsScanner.scan(
+                () -> {
+                    actions.add("scan");
+                    return scans.incrementAndGet() == 3 ? 0 : null;
+                },
+                () -> actions.add("swipe"),
+                delay -> actions.add("wait:" + delay));
+
+        assertEquals(PolarSpecialRewardsScanner.Result.EXHAUSTED, result);
+        assertEquals(List.of(
+                "scan", "swipe", "wait:1000",
+                "scan", "swipe", "wait:1000",
+                "scan"), actions);
+    }
+
+    @Test
+    void scansOnceBeforeSwipingAndAgainAfterEverySwipe() {
+        List<Long> waits = new ArrayList<>();
+        AtomicInteger scans = new AtomicInteger();
+        AtomicInteger swipes = new AtomicInteger();
+
+        PolarSpecialRewardsScanner.Result result = PolarSpecialRewardsScanner.scan(
+                () -> {
+                    scans.incrementAndGet();
+                    return null;
+                },
+                swipes::incrementAndGet,
+                waits::add);
+
+        assertEquals(PolarSpecialRewardsScanner.Result.NOT_FOUND, result);
+        assertEquals(PolarSpecialRewardsScanner.MAX_SWIPES + 1, scans.get());
+        assertEquals(PolarSpecialRewardsScanner.MAX_SWIPES, swipes.get());
+        assertEquals(List.of(1000L, 1000L, 1000L, 1000L, 1000L), waits);
+    }
+
+    @Test
+    void stopsWithoutSwipingWhenPositiveRewardCountIsVisible() {
+        AtomicInteger swipes = new AtomicInteger();
+
+        PolarSpecialRewardsScanner.Result result = PolarSpecialRewardsScanner.scan(
+                () -> 8,
+                swipes::incrementAndGet,
+                ignored -> { });
+
+        assertEquals(PolarSpecialRewardsScanner.Result.AVAILABLE, result);
+        assertEquals(0, swipes.get());
+    }
+}

--- a/fg-tasks/src/test/java/dev/frostguard/tasks/combat/PolarTerrorModeTest.java
+++ b/fg-tasks/src/test/java/dev/frostguard/tasks/combat/PolarTerrorModeTest.java
@@ -1,0 +1,27 @@
+package dev.frostguard.tasks.combat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.frostguard.api.configs.PolarTerrorMode;
+import org.junit.jupiter.api.Test;
+
+class PolarTerrorModeTest {
+
+    @Test
+    void readsLegacyLimitedModeAsSpecialRewardsMode() {
+        assertEquals(PolarTerrorMode.SPECIAL_REWARDS,
+                PolarTerrorMode.fromStoredValue("Limited (10)"));
+    }
+
+    @Test
+    void keepsUnlimitedModeUnlimited() {
+        assertEquals(PolarTerrorMode.UNLIMITED,
+                PolarTerrorMode.fromStoredValue("Unlimited"));
+    }
+
+    @Test
+    void keepsUnknownStoredValuesBackwardCompatible() {
+        assertEquals(PolarTerrorMode.UNLIMITED,
+                PolarTerrorMode.fromStoredValue("unknown"));
+    }
+}


### PR DESCRIPTION
Closes #61.

## What changed

- scan Reward Details once before swiping and after every bounded swipe
- wait for the scroll animation to settle and stop immediately when `Special Rewards (N left)` is visible
- keep the exact `0 left` template as the authoritative exhausted-state check
- close Reward Details with its `X`, then reuse the retained Polar search panel instead of reopening and configuring the complete search flow
- expose the limited mode as `Special Rewards (10)` while retaining compatibility with stored `Limited (10)` profiles

## Why

The old flow only searched for the exact `Special Rewards (0 left)` template. A positive counter was therefore indistinguishable from an unreadable screen and always consumed every scan position. Reward checking was also performed separately from rally targeting, causing repeated full Polar searches. Finally, closing Reward Details returns to the configured search panel rather than preserving the selected target, so attempting to open the rally dialog immediately could not find the Rally button.

## Validation

- `mvn -pl fg-tasks -am test` — 70 engine tests and 35 task tests passed
- `mvn package` — full reactor package and desktop bundle passed
- saved 720x1280 game frame — OCR read `Special Rewards (8 left)` exactly
- live Special Rewards run — detected `8 left` after two swipes, reused the retained search panel, found the Rally button on the first attempt, and successfully deployed the rally

## Remaining risk

The positive-reward path is live-confirmed. The exact `0 left` path retains the existing template matcher and automated scan behavior, but was not separately exercised with a live exhausted account during this change.
