### PR TITLE
ci: publish the nightly Windows bundle to Discord with a working download link

### DIFF
--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -18,8 +18,12 @@ on:
     - cron: "17 3 * * *"
   workflow_dispatch:
 
+# `contents: write` is needed to publish the rolling `nightly` release that the
+# Discord message links to. An Actions artifact URL requires a signed-in GitHub
+# account with access to this repository, so it is useless as a "downloadable"
+# link for testers in a Discord channel.
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: daily-windows-bundle-${{ github.ref }}
@@ -128,6 +132,13 @@ jobs:
       - name: Test the bundle verifier
         run: python3 ci/test_verify_bundle.py
 
+      # The notifier runs in a non-blocking step, so a bug in it would show up
+      # as "no message arrived" rather than as a red build. Its own tests run
+      # here, before the 30-minute Maven build, so a broken payload contract
+      # fails in seconds.
+      - name: Test the Discord notifier
+        run: python3 ci/test_discord_notify.py
+
       - name: Resolve project version
         id: version
         run: |
@@ -171,31 +182,55 @@ jobs:
       - name: Smoke test the desktop bundle
         run: ci/smoke_test_bundle.sh "${{ steps.bundle.outputs.path }}"
 
-      - name: Summarise the build
+      # Metrics are computed once here and exposed as step outputs so the job
+      # summary and the Discord notification cannot disagree with each other.
+      - name: Collect build metrics
+        id: metrics
         if: always()
         shell: bash
         run: |
-          set -euo pipefail
+          set -uo pipefail
           zip_path="${{ steps.bundle.outputs.path }}"
+
+          bundle_name=""
+          bundle_bytes=0
+          jar_count=0
+          if [[ -n "${zip_path}" && -f "${zip_path}" ]]; then
+            bundle_name="$(basename "${zip_path}")"
+            bundle_bytes="$(stat -c%s "${zip_path}")"
+            jar_count="$(unzip -Z1 "${zip_path}" \
+              | grep -Ec '^lib/[^/]+\.jar$' || true)"
+          fi
+
+          # Surefire writes one XML per test class; tests="N" is the per-class
+          # count. `|| true` keeps a zero-report build from tripping pipefail.
+          test_count="$(grep -rhoE 'tests="[0-9]+"' --include='*.xml' \
+            */target/surefire-reports 2>/dev/null \
+            | grep -oE '[0-9]+' \
+            | awk '{total += $1} END {print total+0}' || true)"
+          test_count="${test_count:-0}"
+
+          {
+            echo "bundle_name=${bundle_name}"
+            echo "bundle_bytes=${bundle_bytes}"
+            echo "jar_count=${jar_count:-0}"
+            echo "test_count=${test_count}"
+          } >> "${GITHUB_OUTPUT}"
+
           {
             echo "### Windows desktop bundle"
             echo
-            if [[ -n "${zip_path}" && -f "${zip_path}" ]]; then
-              echo "- Archive: \`$(basename "${zip_path}")\`"
+            if [[ -n "${bundle_name}" ]]; then
+              echo "- Archive: \`${bundle_name}\`"
               echo "- Version: \`${{ steps.version.outputs.version }}\`"
               echo "- Size: $(du -h "${zip_path}" | cut -f1)"
-              echo "- Runtime JARs under \`lib/\`: $(unzip -Z1 "${zip_path}" \
-                | grep -Ec '^lib/[^/]+\.jar$' || true)"
+              echo "- Runtime JARs under \`lib/\`: ${jar_count:-0}"
               echo "- Verified: structure, manifest classpath, launch smoke test"
             else
               echo "- :x: No bundle was produced."
             fi
             echo
-            echo "Tests run:"
-            grep -rhoE 'tests="[0-9]+"' --include='*.xml' \
-              */target/surefire-reports 2>/dev/null \
-              | grep -oE '[0-9]+' \
-              | awk '{total += $1} END {print "- JUnit tests executed: " total+0}'
+            echo "- JUnit tests executed: ${test_count}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload Windows desktop bundle
@@ -216,3 +251,133 @@ jobs:
           path: "**/target/surefire-reports/*.xml"
           if-no-files-found: ignore
           retention-days: 7
+
+      # A rolling prerelease gives the Discord message a stable, public,
+      # login-free download URL. Pull requests are excluded on purpose: a PR
+      # from a fork gets a read-only token, and republishing `nightly` from an
+      # unmerged branch would hand testers an unreviewed build.
+      - name: Publish the rolling nightly release
+        id: release
+        if: >-
+          success() &&
+          github.event_name != 'pull_request' &&
+          github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIP_PATH: ${{ steps.bundle.outputs.path }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # The asset is uploaded under a FIXED name, not the versioned one. The
+          # download URL contains the asset filename, so a versioned name would
+          # silently change the link on every version bump and break every
+          # message already posted to the channel.
+          asset="frostguard-windows-desktop-bundle.zip"
+          staged="$(dirname "${ZIP_PATH}")/${asset}"
+          cp "${ZIP_PATH}" "${staged}"
+
+          notes="$(printf '%s\n' \
+            "Automated Windows desktop bundle for Frostguard \`${VERSION}\`." \
+            "" \
+            "Built from \`${GITHUB_SHA}\` on $(date -u '+%Y-%m-%d %H:%M UTC')." \
+            "Verified: bundle structure, manifest classpath and launch smoke test." \
+            "" \
+            "**Install:** unzip anywhere, then run \`java -jar frostguard-*.jar\`" \
+            "(Java 21+ required)." \
+            "" \
+            "This tag is replaced by every nightly build; it is not a stable release.")"
+
+          # Recreate the release from scratch each night. `gh release edit
+          # --target` does NOT move an existing tag, so editing in place would
+          # leave the `nightly` tag pinned to the first commit it was ever cut
+          # from while the notes claimed a newer SHA. --cleanup-tag removes the
+          # tag too, so the recreated one points at this build.
+          if gh release view nightly >/dev/null 2>&1; then
+            gh release delete nightly --yes --cleanup-tag
+          fi
+
+          # Creating the release with the asset in the same call means there is
+          # never a window where the tag exists but the download 404s.
+          gh release create nightly "${staged}" \
+            --title "Nightly build ${VERSION}" \
+            --notes "${notes}" \
+            --prerelease \
+            --target "${GITHUB_SHA}"
+
+          # Read the URL back from the API instead of predicting it. A predicted
+          # URL is exactly how a 404 gets posted to the channel: if the upload
+          # landed under a different name, or not at all, this fails here rather
+          # than in Discord.
+          # `browser_download_url` straight from the REST API is unambiguous,
+          # unlike gh's `url` JSON field which is the API URL for some versions.
+          url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
+            --jq ".assets[] | select(.name == \"${asset}\") | .browser_download_url")"
+          if [[ -z "${url}" ]]; then
+            echo "::error::Asset ${asset} is not attached to the nightly release."
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
+              --jq '.assets[].name'
+            exit 1
+          fi
+
+          # Prove the link actually serves the file before it is advertised.
+          # A release asset redirects to a signed CDN URL, so follow redirects.
+          code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
+            --retry 3 --retry-delay 5 -r 0-1023 "${url}")"
+          if [[ "${code}" != "200" && "${code}" != "206" ]]; then
+            echo "::error::Download URL ${url} returned HTTP ${code}."
+            exit 1
+          fi
+
+          echo "download_url=${url}" >> "${GITHUB_OUTPUT}"
+          echo "Published and verified ${asset} at ${url} (HTTP ${code})"
+
+      # Runs even when the build failed, so a broken nightly is visible in the
+      # channel instead of being silently absent. `continue-on-error` keeps a
+      # Discord outage from turning a good build red.
+      - name: Notify Discord
+        if: always() && github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          # A commit message is attacker-controlled text. Interpolating it
+          # straight into the `run:` block would let `$(...)` or a backtick in a
+          # commit subject execute on the runner, with the webhook secret in
+          # scope. Passing it through the environment keeps it inert data.
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          JOB_STATUS: ${{ job.status }}
+          BUNDLE_NAME: ${{ steps.metrics.outputs.bundle_name }}
+          BUNDLE_BYTES: ${{ steps.metrics.outputs.bundle_bytes }}
+          JAR_COUNT: ${{ steps.metrics.outputs.jar_count }}
+          TEST_COUNT: ${{ steps.metrics.outputs.test_count }}
+          DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # `head_commit` only exists on push events. The nightly is a
+          # `schedule` run, which is precisely the case that matters most, so
+          # read the subject out of the checkout when the payload has none.
+          COMMIT_MESSAGE="${COMMIT_MESSAGE:-}"
+          if [[ -z "${COMMIT_MESSAGE}" ]]; then
+            COMMIT_MESSAGE="$(git log -1 --pretty=%s || true)"
+          fi
+
+          python3 ci/discord_notify.py \
+            --status "${JOB_STATUS,,}" \
+            --version "${VERSION}" \
+            --bundle-name "${BUNDLE_NAME}" \
+            --bundle-bytes "${BUNDLE_BYTES:-0}" \
+            --jar-count "${JAR_COUNT:-0}" \
+            --test-count "${TEST_COUNT:-0}" \
+            --download-url "${DOWNLOAD_URL}" \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --run-number "${GITHUB_RUN_NUMBER}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --branch "${GITHUB_REF_NAME}" \
+            --trigger "${GITHUB_EVENT_NAME}" \
+            --commit "${GITHUB_SHA}" \
+            --commit-message "${COMMIT_MESSAGE}" \
+            --actor "${GITHUB_ACTOR}"

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ Thumbs.db
 *.bak
 *.swp
 *~
+
+# Python bytecode from the CI helper scripts
+ci/__pycache__/

--- a/ci/README.md
+++ b/ci/README.md
@@ -9,7 +9,7 @@ No manual activation step is needed — the workflow is live as soon as it lands
 
 | Trigger | Purpose |
 |---|---|
-| `schedule` (03:17 UTC daily) | Publishes a nightly Windows bundle for testers |
+| `schedule` (03:17 UTC daily) | Publishes a nightly Windows bundle for testers, updates the `nightly` release and posts it to Discord |
 | `pull_request` | Guards `pom.xml`, `src/`, `tools/`, `custom_tasks/`, `ci/`, `fg-watcher.bat` and `.gitattributes` |
 | `push` to `ci/**` | Lets CI changes be iterated on a branch |
 | `workflow_dispatch` | On-demand build from the Actions tab |
@@ -42,6 +42,86 @@ No manual activation step is needed — the workflow is live as soon as it lands
    `Class-Path`, and boots the shaded Telegram watcher for real.
 8. Uploads the bundle (version-tagged, no re-compression) and the Surefire
    reports, and writes a job summary with size, JAR count and test count.
+9. Republishes the rolling **`nightly` prerelease** with the bundle attached, so
+   there is a public download URL that needs no GitHub login.
+10. Posts a **Discord notification** with that download link.
+
+## Discord notifications
+
+[`discord_notify.py`](discord_notify.py) posts one message per non-PR run to the
+webhook in the `DISCORD_NIGHTLY_WEBHOOK_URL` repository secret.
+
+### Why a release and not the Actions artifact
+
+An artifact download URL only resolves for a signed-in GitHub account with read
+access to the repository, so it is useless as a "downloadable link" in a Discord
+channel. The bundle is also ~220 MB, far above the 8 MiB a webhook may upload.
+The workflow therefore republishes the rolling `nightly` tag on every `main`
+build and links its asset at this permanent URL:
+
+```
+https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip
+```
+
+Three details keep that link from going stale or 404ing:
+
+- **The asset name carries no version.** A download URL contains the asset
+  filename, so uploading `frostguard-2.1.0-desktop-bundle.zip` would change the
+  link at the next version bump and break every message already in the channel.
+  The versioned ZIP is copied to a fixed name before upload; the version is
+  still reported in the release title, notes and Discord card.
+- **The release is deleted and recreated** (`--cleanup-tag`) rather than edited.
+  `gh release edit --target` does not move an existing tag, so editing in place
+  would leave `nightly` pinned to the first commit it was ever cut from while
+  the notes advertised a newer SHA.
+- **The URL is read back from the API** (`browser_download_url`) and then
+  actually fetched, instead of being predicted from the filename. A predicted
+  URL is precisely how a dead link reaches the channel. If the asset is missing
+  or does not serve a 200/206, the step fails before anything is posted.
+
+The tag is marked *prerelease*, so it never displaces a real tagged release as
+"Latest".
+
+### Setting the secret
+
+*Settings → Secrets and variables → Actions → New repository secret*
+
+| Field | Value |
+|---|---|
+| Name | `DISCORD_NIGHTLY_WEBHOOK_URL` |
+| Secret | the full `https://discord.com/api/webhooks/<id>/<token>` URL |
+
+To rotate it, edit the same secret — nothing else has to change. If the secret is
+absent the notify step logs a warning and the build still passes; a channel
+notification is not worth failing a good artifact over.
+
+### Behaviour worth knowing
+
+- **Failures notify too.** The step is `if: always()`, so a broken nightly shows
+  up as a red card instead of being silently absent — the failure mode a
+  success-only notifier hides.
+- **Pull requests never notify.** A PR from a fork gets a read-only token that
+  cannot read secrets, and republishing `nightly` from unmerged code would hand
+  testers an unreviewed build.
+- **`continue-on-error: true`** keeps a Discord outage from turning a good build
+  red. Delivery is retried on 429 (honouring `Retry-After`) and on 5xx.
+- **No mass pings.** `allowed_mentions: {parse: []}` is set structurally, so an
+  `@everyone` in a commit subject cannot ping the channel.
+- **The commit message is passed through the environment**, never interpolated
+  into the `run:` block, so `$(...)` in a commit subject cannot execute on the
+  runner while the webhook secret is in scope.
+- **The webhook is never printed.** Errors are redacted before logging, since
+  Actions logs are public on a public repository.
+- **A malformed download URL is dropped.** If the release step was skipped, the
+  card falls back to the run link rather than advertising a broken download.
+
+Test the payload without posting anything:
+
+```sh
+python3 ci/test_discord_notify.py     # 21 self-tests, no network
+python3 ci/discord_notify.py --status success --version 2.1.0 \
+  --download-url https://example.com/bundle.zip --dry-run
+```
 
 ## Why two verification layers
 
@@ -77,6 +157,7 @@ substitution really took effect in both directions.
   ```sh
   mvn clean install -Djavafx.platform=win
   python3 ci/test_verify_bundle.py
+  python3 ci/test_discord_notify.py
   python3 ci/verify_bundle.py fg-app/target/frostguard-*-desktop-bundle.zip
   ci/smoke_test_bundle.sh fg-app/target/frostguard-*-desktop-bundle.zip
   ```

--- a/ci/discord_notify.py
+++ b/ci/discord_notify.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Post a Frostguard build notification to a Discord webhook.
+
+The nightly bundle is ~220 MB, far above Discord's per-message upload ceiling,
+and a GitHub Actions artifact link only works for signed-in users with access to
+the repository. So the message this script posts carries the **public release
+asset URL** as plain message content (tappable on mobile, no login required)
+plus an embed with the facts a tester needs before downloading: version, size,
+staged runtime JAR count, executed test count, trigger, branch and commit.
+
+The webhook URL is read from the environment rather than argv, because anything
+passed on a command line shows up in the process list and in `set -x` traces.
+Nothing in this script ever prints the webhook: Discord webhook URLs are
+bearer credentials, and a leaked one lets anyone post to the channel.
+
+Usage:
+    DISCORD_NIGHTLY_WEBHOOK_URL=... ci/discord_notify.py --status success ...
+    ci/discord_notify.py --status success --dry-run   # print payload, post nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+from datetime import datetime, timezone
+
+# Discord's documented limits. Exceeding any of them makes the whole request
+# fail with a 400, so every user-controlled string is truncated to fit.
+CONTENT_LIMIT = 2000
+EMBED_TITLE_LIMIT = 256
+EMBED_DESCRIPTION_LIMIT = 4096
+EMBED_FIELD_NAME_LIMIT = 256
+EMBED_FIELD_VALUE_LIMIT = 1024
+EMBED_FOOTER_LIMIT = 2048
+
+# Webhooks on a non-boosted guild may upload at most 8 MiB. Attaching is opt-in
+# and falls back to a link when the file is larger, because a failed upload
+# would otherwise swallow the notification entirely.
+ATTACHMENT_LIMIT_BYTES = 8 * 1024 * 1024
+
+STATUS_STYLE = {
+    "success": (0x2ECC71, "Build succeeded"),
+    "failure": (0xE74C3C, "Build failed"),
+    "cancelled": (0x95A5A6, "Build cancelled"),
+    "skipped": (0x95A5A6, "Build skipped"),
+}
+
+MAX_ATTEMPTS = 5
+
+
+def lenient_int(value: str) -> int:
+    """Parse an integer that may arrive empty from an unset step output."""
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return 0
+
+
+def human_size(num_bytes: int) -> str:
+    """Format a byte count the way a release page would."""
+    if num_bytes <= 0:
+        return "unknown"
+    size = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} GB"
+
+
+def truncate(text: str, limit: int) -> str:
+    """Cut `text` to `limit` characters, marking that it was cut."""
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def first_line(text: str) -> str:
+    """A commit subject is the first line; the body is noise in a notification."""
+    return (text or "").strip().splitlines()[0].strip() if (text or "").strip() else ""
+
+
+def redact(text: str) -> str:
+    """Strip anything that looks like a webhook token out of diagnostics."""
+    return re.sub(
+        r"(https?://[^\s]*?/webhooks/)\d+/[\w-]+",
+        r"\1<redacted>",
+        text or "",
+    )
+
+
+def build_payload(args: argparse.Namespace) -> dict:
+    color, headline = STATUS_STYLE.get(args.status, STATUS_STYLE["failure"])
+
+    version = args.version or "unknown"
+    title = (
+        f"Frostguard {version} — Windows desktop bundle"
+        if args.status == "success"
+        else f"Frostguard {version} — {headline.lower()}"
+    )
+
+    fields: list[dict] = []
+
+    def add_field(name: str, value: str, inline: bool = True) -> None:
+        value = truncate(value, EMBED_FIELD_VALUE_LIMIT)
+        if value:
+            fields.append(
+                {
+                    "name": truncate(name, EMBED_FIELD_NAME_LIMIT),
+                    "value": value,
+                    "inline": inline,
+                }
+            )
+
+    add_field("Version", f"`{version}`")
+    if args.bundle_bytes > 0:
+        add_field("Download size", human_size(args.bundle_bytes))
+    if args.jar_count > 0:
+        add_field("Runtime JARs", str(args.jar_count))
+    if args.test_count > 0:
+        add_field("JUnit tests", f"{args.test_count} passed")
+    if args.trigger:
+        add_field("Trigger", f"`{args.trigger}`")
+    if args.branch:
+        add_field("Branch", f"`{args.branch}`")
+
+    if args.commit:
+        short = args.commit[:7]
+        subject = first_line(args.commit_message)
+        commit_url = (
+            f"https://github.com/{args.repository}/commit/{args.commit}"
+            if args.repository
+            else ""
+        )
+        link = f"[`{short}`]({commit_url})" if commit_url else f"`{short}`"
+        if subject:
+            link += f" {truncate(subject, 200)}"
+        add_field("Commit", link, inline=False)
+
+    description_parts: list[str] = []
+    if args.status == "success":
+        if args.download_url and not args.download_url.startswith("http"):
+            # A half-populated URL means the release step was skipped or failed.
+            # Advertising it would post a dead link, which is worse than no link.
+            print(
+                "::warning::Ignoring a download URL that is not absolute: "
+                f"{args.download_url!r}"
+            )
+            args.download_url = ""
+        if args.download_url:
+            description_parts.append(
+                f"**[⬇ Download {args.bundle_name or 'the bundle'}]"
+                f"({args.download_url})**"
+            )
+            # The assembly ships no launcher .bat for the app itself (only
+            # fg-watcher.bat), so `java -jar` is the real entry point. Naming a
+            # script that is not in the ZIP would send every tester into a
+            # support question.
+            description_parts.append(
+                "Verified: bundle structure, manifest classpath and launch "
+                "smoke test. Unzip anywhere, then run "
+                "`java -jar frostguard-*.jar` (Java 21+ required)."
+            )
+        elif args.run_url:
+            description_parts.append(
+                f"Build passed. The artifact is attached to "
+                f"[the workflow run]({args.run_url}) "
+                "(a GitHub login with repository access is required)."
+            )
+    else:
+        description_parts.append(
+            f"{headline}. See [the workflow log]({args.run_url}) for the failing "
+            "step." if args.run_url else f"{headline}."
+        )
+
+    embed = {
+        "title": truncate(title, EMBED_TITLE_LIMIT),
+        "color": color,
+        "description": truncate("\n\n".join(description_parts), EMBED_DESCRIPTION_LIMIT),
+        "fields": fields,
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    if args.run_url:
+        embed["url"] = args.run_url
+
+    footer = args.repository or ""
+    if args.run_number:
+        footer = f"{footer} • run #{args.run_number}".strip(" •")
+    if args.actor:
+        footer = f"{footer} • {args.actor}".strip(" •")
+    if footer:
+        embed["footer"] = {"text": truncate(footer, EMBED_FOOTER_LIMIT)}
+
+    # The bare URL as message content stays tappable in the mobile client and in
+    # notification previews, where embed links are easy to miss.
+    content = ""
+    if args.status == "success" and args.download_url:
+        content = truncate(args.download_url, CONTENT_LIMIT)
+
+    payload = {
+        "username": args.username,
+        "embeds": [embed],
+        # Never let a commit subject containing @everyone ping the channel.
+        "allowed_mentions": {"parse": []},
+    }
+    if content:
+        payload["content"] = content
+    return payload
+
+
+def encode_multipart(payload: dict, file_path: str) -> tuple[bytes, str]:
+    """Build a multipart/form-data body carrying `payload_json` plus one file."""
+    boundary = f"----frostguard{uuid.uuid4().hex}"
+    name = os.path.basename(file_path)
+    with open(file_path, "rb") as handle:
+        blob = handle.read()
+
+    parts: list[bytes] = []
+    parts.append(f"--{boundary}\r\n".encode())
+    parts.append(b'Content-Disposition: form-data; name="payload_json"\r\n')
+    parts.append(b"Content-Type: application/json\r\n\r\n")
+    parts.append(json.dumps(payload).encode("utf-8") + b"\r\n")
+    parts.append(f"--{boundary}\r\n".encode())
+    parts.append(
+        f'Content-Disposition: form-data; name="files[0]"; filename="{name}"\r\n'
+        .encode()
+    )
+    parts.append(b"Content-Type: application/octet-stream\r\n\r\n")
+    parts.append(blob + b"\r\n")
+    parts.append(f"--{boundary}--\r\n".encode())
+    return b"".join(parts), f"multipart/form-data; boundary={boundary}"
+
+
+def retry_after_seconds(error: urllib.error.HTTPError, body: str) -> float:
+    """Honour Discord's rate-limit hint instead of guessing."""
+    header = error.headers.get("Retry-After") if error.headers else None
+    if header:
+        try:
+            return min(60.0, max(1.0, float(header)))
+        except ValueError:
+            pass
+    try:
+        return min(60.0, max(1.0, float(json.loads(body).get("retry_after", 5))))
+    except (ValueError, AttributeError, TypeError):
+        return 5.0
+
+
+def post(webhook: str, body: bytes, content_type: str, timeout: float) -> None:
+    """POST with retries for rate limits and transient server errors."""
+    last_error = "no attempt was made"
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        request = urllib.request.Request(
+            webhook,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": content_type,
+                "User-Agent": "frostguard-ci/1.0 (+https://github.com/Shederator/wosbot)",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                print(f"Discord accepted the notification (HTTP {response.status}).")
+                return
+        except urllib.error.HTTPError as error:
+            detail = ""
+            try:
+                detail = error.read().decode("utf-8", "replace")
+            except OSError:
+                pass
+            last_error = f"HTTP {error.code}: {redact(detail)[:500]}"
+            if error.code == 429:
+                delay = retry_after_seconds(error, detail)
+                print(f"Rate limited by Discord; retrying in {delay:.1f}s.")
+                time.sleep(delay)
+                continue
+            if 500 <= error.code < 600:
+                delay = min(30.0, 2.0**attempt)
+                print(f"Discord returned {error.code}; retrying in {delay:.0f}s.")
+                time.sleep(delay)
+                continue
+            # 400/401/404 are permanent: a malformed payload, or a webhook that
+            # was rotated or deleted. Retrying cannot help.
+            break
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            last_error = f"network error: {redact(str(error))}"
+            delay = min(30.0, 2.0**attempt)
+            print(f"{last_error}; retrying in {delay:.0f}s.")
+            time.sleep(delay)
+
+    raise SystemExit(
+        f"::error::Could not deliver the Discord notification ({last_error}). "
+        "Check that the DISCORD_NIGHTLY_WEBHOOK_URL secret still points at a "
+        "live webhook."
+    )
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--status",
+        required=True,
+        choices=sorted(STATUS_STYLE),
+        help="outcome of the build job",
+    )
+    parser.add_argument("--version", default="")
+    parser.add_argument("--bundle-name", default="")
+    # A skipped or failed upstream step yields an empty string from
+    # `steps.*.outputs.*`, which int() would reject and take the whole
+    # notification down with it. Treat unparseable counts as "not measured".
+    parser.add_argument("--bundle-bytes", type=lenient_int, default=0)
+    parser.add_argument("--jar-count", type=lenient_int, default=0)
+    parser.add_argument("--test-count", type=lenient_int, default=0)
+    parser.add_argument("--download-url", default="")
+    parser.add_argument("--run-url", default="")
+    parser.add_argument("--run-number", default="")
+    parser.add_argument("--repository", default="")
+    parser.add_argument("--branch", default="")
+    parser.add_argument(
+        "--trigger",
+        default="",
+        help="the event that started the run (schedule, workflow_dispatch, ...)",
+    )
+    parser.add_argument("--commit", default="")
+    parser.add_argument("--commit-message", default="")
+    parser.add_argument("--actor", default="")
+    parser.add_argument("--username", default="Frostguard Builds")
+    parser.add_argument(
+        "--attach",
+        default="",
+        help="upload this file with the message when it is small enough",
+    )
+    parser.add_argument(
+        "--webhook-env",
+        default="DISCORD_NIGHTLY_WEBHOOK_URL",
+        help="environment variable holding the webhook URL",
+    )
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the payload instead of posting it",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(args)
+
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    webhook = os.environ.get(args.webhook_env, "").strip()
+    if not webhook:
+        # A missing secret is a configuration gap, not a build failure, but it
+        # must be loud: a silent skip looks exactly like a working pipeline.
+        print(
+            f"::warning::{args.webhook_env} is empty; no Discord notification "
+            "was sent."
+        )
+        return 0
+    if not re.match(r"^https://(canary\.|ptb\.)?discord(app)?\.com/api/webhooks/", webhook):
+        print(
+            f"::error::{args.webhook_env} does not look like a Discord webhook "
+            "URL (expected https://discord.com/api/webhooks/<id>/<token>)."
+        )
+        return 1
+
+    body: bytes
+    content_type: str
+    if args.attach and os.path.isfile(args.attach):
+        size = os.path.getsize(args.attach)
+        if size <= ATTACHMENT_LIMIT_BYTES:
+            body, content_type = encode_multipart(payload, args.attach)
+        else:
+            print(
+                f"::notice::{os.path.basename(args.attach)} is "
+                f"{human_size(size)}, over Discord's {human_size(ATTACHMENT_LIMIT_BYTES)} "
+                "webhook upload limit; posting the download link instead."
+            )
+            body = json.dumps(payload).encode("utf-8")
+            content_type = "application/json"
+    else:
+        body = json.dumps(payload).encode("utf-8")
+        content_type = "application/json"
+
+    post(webhook, body, content_type, args.timeout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/test_discord_notify.py
+++ b/ci/test_discord_notify.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Self-tests for ci/discord_notify.py.
+
+The notifier runs once per nightly build, in a step that is deliberately
+non-blocking. That means a bug in it produces either no message at all or a
+message Discord rejects with a 400 — both of which look like "the pipeline is
+fine" from the Actions tab. These tests pin the payload contract (Discord's
+documented limits, no mass pings, no leaked webhook token) without touching the
+network.
+
+Run with:  python3 ci/test_discord_notify.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import discord_notify  # noqa: E402
+
+WEBHOOK = "https://discord.com/api/webhooks/123456789/abcdefTOKEN-value_x"
+
+BASE_ARGS = [
+    "--status", "success",
+    "--version", "2.1.0",
+    "--bundle-name", "frostguard-2.1.0-desktop-bundle.zip",
+    "--bundle-bytes", str(231 * 1024 * 1024),
+    "--jar-count", "76",
+    "--test-count", "412",
+    "--download-url",
+    "https://github.com/Shederator/wosbot/releases/download/nightly/"
+    "frostguard-2.1.0-desktop-bundle.zip",
+    "--run-url", "https://github.com/Shederator/wosbot/actions/runs/1",
+    "--run-number", "42",
+    "--repository", "Shederator/wosbot",
+    "--branch", "main",
+    "--commit", "b962083c0ffee1234567890abcdefabcdefabcde",
+    "--commit-message", "fix(intel): claim final rewards\n\nbody line ignored",
+    "--actor", "Shederator",
+]
+
+
+def payload(extra: list[str] | None = None) -> dict:
+    args = discord_notify.parse_args(BASE_ARGS + (extra or []))
+    return discord_notify.build_payload(args)
+
+
+class PayloadTest(unittest.TestCase):
+
+    def test_success_payload_carries_the_download_link_as_content(self):
+        # The bare URL in `content` is what stays tappable in the mobile client
+        # and in the notification preview; embed links are easy to miss there.
+        result = payload()
+        self.assertIn("releases/download/nightly", result["content"])
+
+    def test_success_embed_is_green_and_names_the_version(self):
+        embed = payload()["embeds"][0]
+        self.assertEqual(0x2ECC71, embed["color"])
+        self.assertIn("2.1.0", embed["title"])
+
+    def test_failure_payload_is_red_and_links_the_log_not_a_download(self):
+        result = payload(["--status", "failure"])
+        embed = result["embeds"][0]
+        self.assertEqual(0xE74C3C, embed["color"])
+        self.assertNotIn("content", result)
+        self.assertIn("workflow log", embed["description"])
+
+    def test_never_pings_the_channel(self):
+        # A commit subject is attacker-influencable via a PR branch, so mentions
+        # must be disabled structurally rather than by sanitising the text.
+        result = payload(["--commit-message", "@everyone please test this"])
+        self.assertEqual({"parse": []}, result["allowed_mentions"])
+
+    def test_uses_only_the_commit_subject(self):
+        fields = payload()["embeds"][0]["fields"]
+        commit = next(f for f in fields if f["name"] == "Commit")
+        self.assertIn("fix(intel): claim final rewards", commit["value"])
+        self.assertNotIn("body line ignored", commit["value"])
+
+    def test_reports_size_in_human_units(self):
+        fields = payload()["embeds"][0]["fields"]
+        size = next(f for f in fields if f["name"] == "Download size")
+        self.assertEqual("231.0 MB", size["value"])
+
+    def test_omits_metrics_that_were_not_measured(self):
+        # A zero test count means the summary grep found nothing, not that zero
+        # tests passed. Printing "0 passed" would be a lie in a release notice.
+        result = payload(["--test-count", "0", "--jar-count", "0"])
+        names = {f["name"] for f in result["embeds"][0]["fields"]}
+        self.assertNotIn("JUnit tests", names)
+        self.assertNotIn("Runtime JARs", names)
+
+    def test_respects_every_discord_length_limit(self):
+        long = "x" * 6000
+        result = payload([
+            "--commit-message", long,
+            "--version", long,
+            "--repository", long,
+        ])
+        embed = result["embeds"][0]
+        self.assertLessEqual(len(result.get("content", "")), discord_notify.CONTENT_LIMIT)
+        self.assertLessEqual(len(embed["title"]), discord_notify.EMBED_TITLE_LIMIT)
+        self.assertLessEqual(
+            len(embed["description"]), discord_notify.EMBED_DESCRIPTION_LIMIT
+        )
+        self.assertLessEqual(
+            len(embed["footer"]["text"]), discord_notify.EMBED_FOOTER_LIMIT
+        )
+        for field in embed["fields"]:
+            self.assertLessEqual(len(field["name"]), discord_notify.EMBED_FIELD_NAME_LIMIT)
+            self.assertLessEqual(
+                len(field["value"]), discord_notify.EMBED_FIELD_VALUE_LIMIT
+            )
+
+    def test_embed_stays_within_the_ten_field_ceiling_of_a_readable_card(self):
+        self.assertLessEqual(len(payload()["embeds"][0]["fields"]), 10)
+
+    def test_payload_is_json_serialisable(self):
+        json.dumps(payload())
+
+    def test_survives_empty_step_outputs(self):
+        # When the build fails early, every `steps.*.outputs.*` interpolates to
+        # an empty string. int("") would crash and lose the failure notice.
+        result = payload([
+            "--status", "failure",
+            "--bundle-bytes", "",
+            "--jar-count", "",
+            "--test-count", "",
+            "--version", "",
+            "--download-url", "",
+        ])
+        self.assertEqual(0xE74C3C, result["embeds"][0]["color"])
+        self.assertIn("unknown", result["embeds"][0]["title"])
+
+    def test_ignores_a_malformed_download_url(self):
+        # A dead link posted to the channel is worse than no link: testers click
+        # it, get a 404 and report the release as broken.
+        result = payload(["--download-url", "frostguard.zip"])
+        self.assertNotIn("content", result)
+        self.assertIn("workflow run", result["embeds"][0]["description"])
+
+    def test_success_without_a_release_falls_back_to_the_run_link(self):
+        # Branch builds skip the release publish, so there is no public URL.
+        result = payload(["--download-url", ""])
+        self.assertNotIn("content", result)
+        self.assertIn("workflow run", result["embeds"][0]["description"])
+
+
+class WebhookHandlingTest(unittest.TestCase):
+
+    def test_missing_secret_warns_but_does_not_fail_the_build(self):
+        # A build that produced a good artifact must not be marked failed just
+        # because the channel notification could not be addressed.
+        code = discord_notify.main(BASE_ARGS + ["--webhook-env", "FG_ABSENT_VAR"])
+        self.assertEqual(0, code)
+
+    def test_rejects_a_secret_that_is_not_a_discord_webhook(self):
+        import os
+        os.environ["FG_TEST_WEBHOOK"] = "https://example.com/not-a-webhook"
+        try:
+            code = discord_notify.main(
+                BASE_ARGS + ["--webhook-env", "FG_TEST_WEBHOOK"]
+            )
+        finally:
+            del os.environ["FG_TEST_WEBHOOK"]
+        self.assertEqual(1, code)
+
+    def test_redacts_the_webhook_token_from_diagnostics(self):
+        # Actions logs are public on a public repository; a leaked webhook lets
+        # anyone post to the Discord channel.
+        message = discord_notify.redact(f"POST {WEBHOOK} failed")
+        self.assertNotIn("abcdefTOKEN-value_x", message)
+        self.assertIn("<redacted>", message)
+
+    def test_honours_the_rate_limit_hint_from_the_response_body(self):
+        error = urllib.error.HTTPError(WEBHOOK, 429, "Too Many Requests", {}, None)
+        delay = discord_notify.retry_after_seconds(error, '{"retry_after": 3.5}')
+        self.assertEqual(3.5, delay)
+
+    def test_clamps_an_absurd_rate_limit_hint(self):
+        error = urllib.error.HTTPError(WEBHOOK, 429, "Too Many Requests", {}, None)
+        self.assertEqual(
+            60.0, discord_notify.retry_after_seconds(error, '{"retry_after": 99999}')
+        )
+
+
+class AttachmentTest(unittest.TestCase):
+
+    def test_small_file_is_uploaded_as_multipart(self):
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as handle:
+            handle.write(b"small payload")
+        body, content_type = discord_notify.encode_multipart(payload(), handle.name)
+        self.assertTrue(content_type.startswith("multipart/form-data; boundary="))
+        self.assertIn(b'name="payload_json"', body)
+        self.assertIn(b'name="files[0]"', body)
+        self.assertIn(b"small payload", body)
+
+    def test_the_upload_ceiling_is_below_discords_webhook_limit(self):
+        # A ~220 MB bundle must never be attempted as an attachment: the failed
+        # upload would swallow the notification entirely.
+        self.assertLessEqual(discord_notify.ATTACHMENT_LIMIT_BYTES, 8 * 1024 * 1024)
+
+
+class LenientIntTest(unittest.TestCase):
+
+    def test_parses_numbers_and_absorbs_junk(self):
+        self.assertEqual(76, discord_notify.lenient_int("76"))
+        self.assertEqual(76, discord_notify.lenient_int(" 76 "))
+        self.assertEqual(0, discord_notify.lenient_int(""))
+        self.assertEqual(0, discord_notify.lenient_int("not-a-number"))
+        self.assertEqual(0, discord_notify.lenient_int(None))
+
+
+class HumanSizeTest(unittest.TestCase):
+
+    def test_formats_common_magnitudes(self):
+        self.assertEqual("unknown", discord_notify.human_size(0))
+        self.assertEqual("512 B", discord_notify.human_size(512))
+        self.assertEqual("1.0 KB", discord_notify.human_size(1024))
+        self.assertEqual("1.0 MB", discord_notify.human_size(1024 * 1024))
+        self.assertEqual("2.0 GB", discord_notify.human_size(2 * 1024**3))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/fg-engine/src/test/java/dev/frostguard/engine/helper/AllianceChampionshipTabPatternEvidenceTest.java
+++ b/fg-engine/src/test/java/dev/frostguard/engine/helper/AllianceChampionshipTabPatternEvidenceTest.java
@@ -20,7 +20,13 @@ class AllianceChampionshipTabPatternEvidenceTest {
     @BeforeAll
     static void loadOpenCv() throws IOException {
         try {
-            OpenCvPatternLocator.extractAndLoadNative("/native/opencv/opencv_java4110.dll");
+            // Must be loadNativeLibrary(), not extractAndLoadNative(...dll):
+            // the bundled DLL is a Windows image, so naming it directly makes
+            // this test fail with UnsatisfiedLinkError on the Linux CI runner
+            // and takes the whole nightly bundle down with it. This selects the
+            // native image for the host platform, exactly like every sibling
+            // frame test does.
+            OpenCvPatternLocator.loadNativeLibrary();
         } catch (UnsatisfiedLinkError ignored) {
             // The app and other tests may already have loaded the native library in this JVM.
         }

--- a/fg-engine/src/test/java/dev/frostguard/engine/helper/OpenCvNativeLoadingTest.java
+++ b/fg-engine/src/test/java/dev/frostguard/engine/helper/OpenCvNativeLoadingTest.java
@@ -88,6 +88,65 @@ class OpenCvNativeLoadingTest {
     }
 
     /**
+     * No test may bind OpenCV by naming the bundled Windows DLL directly.
+     *
+     * <p>{@code extractAndLoadNative("/native/opencv/opencv_java4110.dll")} works
+     * on a Windows developer machine and fails with {@link UnsatisfiedLinkError}
+     * on the Linux CI runner, so a test written that way passes review, passes
+     * locally, and then breaks the nightly Windows bundle for everyone. Two
+     * saved-frame tests had drifted into exactly that shape.</p>
+     *
+     * <p>Scanning the sources keeps the rule enforced for tests that do not exist
+     * yet, which a per-test assertion cannot do.</p>
+     */
+    @Test
+    void noTestBindsOpenCvByNamingTheWindowsDllDirectly() throws Exception {
+        // Walk up from the module directory to the repository root so this works
+        // regardless of which module Surefire is running.
+        java.nio.file.Path root = java.nio.file.Path.of("").toAbsolutePath();
+        while (root != null && !java.nio.file.Files.isDirectory(root.resolve("fg-engine"))) {
+            root = root.getParent();
+        }
+        assertNotNull(root, "Could not locate the repository root from the working directory");
+
+        java.util.List<String> offenders = new java.util.ArrayList<>();
+        for (String module : java.util.List.of(
+                "fg-api", "fg-data", "fg-vision", "fg-engine", "fg-tasks",
+                "fg-watcher", "fg-app")) {
+            java.nio.file.Path tests = root.resolve(module).resolve("src/test/java");
+            if (!java.nio.file.Files.isDirectory(tests)) {
+                continue;
+            }
+            try (var paths = java.nio.file.Files.walk(tests)) {
+                for (java.nio.file.Path file : paths
+                        .filter(p -> p.toString().endsWith(".java"))
+                        .toList()) {
+                    String source = java.nio.file.Files.readString(file);
+                    // Ignore the mention inside this guard's own documentation.
+                    if (file.getFileName().toString().equals("OpenCvNativeLoadingTest.java")) {
+                        continue;
+                    }
+                    for (String line : source.split("\n")) {
+                        String code = line.trim();
+                        if (code.startsWith("//") || code.startsWith("*")) {
+                            continue;
+                        }
+                        if (code.contains("extractAndLoadNative")) {
+                            offenders.add(root.relativize(file).toString());
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        assertTrue(offenders.isEmpty(),
+                "These tests bind the Windows-only OpenCV DLL directly and will fail "
+                        + "on non-Windows CI runners. Call "
+                        + "OpenCvPatternLocator.loadNativeLibrary() instead: " + offenders);
+    }
+
+    /**
      * Callers treat a successful return as "OpenCV is usable". If no native image
      * could be bound the method must throw rather than return quietly, otherwise
      * the failure would surface much later as a confusing {@link UnsatisfiedLinkError}

--- a/fg-tasks/src/test/java/dev/frostguard/tasks/city/TrainingTierPatternEvidenceTest.java
+++ b/fg-tasks/src/test/java/dev/frostguard/tasks/city/TrainingTierPatternEvidenceTest.java
@@ -23,7 +23,13 @@ class TrainingTierPatternEvidenceTest {
     @BeforeAll
     static void loadOpenCv() throws IOException {
         try {
-            OpenCvPatternLocator.extractAndLoadNative("/native/opencv/opencv_java4110.dll");
+            // Must be loadNativeLibrary(), not extractAndLoadNative(...dll):
+            // the bundled DLL is a Windows image, so naming it directly makes
+            // this test fail with UnsatisfiedLinkError on the Linux CI runner
+            // and takes the whole nightly bundle down with it. This selects the
+            // native image for the host platform, exactly like every sibling
+            // frame test does.
+            OpenCvPatternLocator.loadNativeLibrary();
         } catch (UnsatisfiedLinkError ignored) {
             // The app and other tests may already have loaded the native library in this JVM.
         }


### PR DESCRIPTION
## Summary

The nightly Windows bundle was only reachable as a GitHub Actions artifact, which requires a signed-in GitHub account with access to this repository. Testers in the Discord channel had no way to get a build.

Every run on `main` now republishes a rolling `nightly` prerelease with the bundle attached, and posts its **public, login-free** download URL to the webhook held in the `DISCORD_NIGHTLY_WEBHOOK_URL` secret.

Permanent link:

```
https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip
```

## Why not attach the ZIP to the message

The bundle is ~220 MB. A Discord webhook may upload at most 8 MiB, so the file itself can never be attached; the notifier falls back to a link automatically and only attaches when a file is genuinely small enough.

## Getting the download link right

This is the part that quietly 404s if done naively, so each guard is deliberate:

- **Fixed asset name.** A download URL embeds the asset filename. Uploading `frostguard-2.1.0-desktop-bundle.zip` would change the link at the next version bump and break every message already posted to the channel. The versioned ZIP is copied to `frostguard-windows-desktop-bundle.zip` before upload; the version still appears in the release title, notes and the Discord card.
- **Delete and recreate, not edit.** `gh release edit --target` does *not* move an existing tag. Editing in place would leave `nightly` pinned to the first commit it was ever cut from while the notes advertised a newer SHA. `--cleanup-tag` removes the tag so the recreated one points at the current build.
- **Asset attached at creation time**, in a single call, so there is never a window where the tag exists but the download 404s.
- **The URL is read back from the API** (`browser_download_url`) and then actually fetched before being advertised. Predicting the URL from a filename is exactly how a dead link reaches the channel; now a missing or unservable asset fails the step instead. The notifier independently drops any non-absolute URL and falls back to the run link.

## Notification behaviour

- **Failures notify too** (`if: always()`), so a broken nightly shows as a red card rather than being silently absent — the failure mode a success-only notifier hides.
- **Pull requests never publish or notify.** A fork PR token cannot read secrets, and republishing `nightly` from unmerged code would hand testers an unreviewed build.
- `continue-on-error: true` keeps a Discord outage from turning a good build red. Delivery retries on 429 (honouring `Retry-After`) and on 5xx.
- **No mass pings.** `allowed_mentions: {parse: []}` is structural, so `@everyone` in a commit subject cannot ping the channel.
- **No shell injection.** The commit message is passed through the environment, never interpolated into `run:`, so `$(...)` in a commit subject cannot execute on the runner while the webhook secret is in scope.
- **The webhook is never logged.** Diagnostics are redacted, since Actions logs are public on a public repository.
- A missing secret warns and passes rather than failing a good build.

## Also fixed

- The job summary and the Discord card now derive from one shared metrics step, so they cannot disagree.
- The install hint is `java -jar frostguard-*.jar`. The assembly ships no launcher `.bat` for the app itself (only `fg-watcher.bat`), so the obvious `frostguard.bat` instruction would have sent every tester into a support question.

## Tests

- `ci/test_discord_notify.py` — 22 self-tests, no network. Covers Discord's length limits, mention suppression, token redaction, rate-limit handling, the malformed-URL fallback, and empty step outputs from an early build failure. These run *before* the 30-minute Maven build so a broken payload fails in seconds. The suite caught two real bugs during development (a missing argument definition and an `int("")` crash on the failure path).
- `ci/test_verify_bundle.py` — 14 existing tests, still green.

Verified against this repository: both success and failure payloads returned **HTTP 204** from the live webhook, the release publishes, the URL resolves via the API, and an **anonymous request with no GitHub token downloads it (HTTP 200)**.
