### PR TITLE
feat(ci): build temporary Windows bundles from unmerged pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,18 +210,28 @@
 
 ### ⚡ Prefer a ready-made build?
 
-A Windows desktop bundle is built automatically every night and after every pull
-request, so you can test the latest code without installing Java or Maven.
+A Windows desktop bundle is built automatically every night, so you can test the
+latest code without installing Java or Maven. No GitHub account is needed:
 
-1. Open the **[Actions tab](../../actions/workflows/daily-windows-bundle.yml)**
-2. Click the most recent green **Daily Windows Bundle** run
-3. Download the **`frostguard-windows-desktop-bundle-<version>`** artifact
-4. Extract it anywhere and run `frostguard-<version>.jar`
+**[⬇ Download the nightly bundle](../../releases/download/nightly/frostguard-windows-desktop-bundle.zip)**
+
+Extract it anywhere and run `java -jar frostguard-*.jar` (Java 21+). Every bundle
+is verified in CI — structure, manifest classpath and a real launch smoke test —
+before that link is updated, and the same message is posted to Discord.
+
+> [!TIP]
+> Need a build of a change that is still an **open pull request**? Comment
+> `/build-pr 47 48` on any issue or pull request and a temporary bundle is built
+> from it — stacked pull requests included. See
+> **[docs/PR_TEST_BUILDS.md](docs/PR_TEST_BUILDS.md)**, which also covers the
+> one-time installation step a maintainer performs first.
 
 > [!IMPORTANT]
-> GitHub requires you to be **signed in** to download workflow artifacts, and
-> they are retained for **14 days**. Every bundle is verified in CI (structure,
-> classpath, and a real launch smoke test) before it is published.
+> `nightly` is replaced by every build and is not a stable release. The
+> per-run artifact under the
+> **[Actions tab](../../actions/workflows/daily-windows-bundle.yml)** is still
+> available for 14 days, but downloading an artifact requires being signed in to
+> GitHub.
 
 <br/>
 
@@ -303,6 +313,18 @@ Linux or macOS. See **[`ci/README.md`](ci/README.md)** for details.
 mvn clean install -Djavafx.platform=win
 python3 ci/verify_bundle.py fg-app/target/frostguard-*-desktop-bundle.zip
 ci/smoke_test_bundle.sh fg-app/target/frostguard-*-desktop-bundle.zip
+```
+
+The CI tooling has its own fast self-tests (no network, no build required):
+
+```sh
+python3 ci/test_verify_bundle.py
+python3 ci/test_discord_notify.py
+python3 ci/test_pr_build_plan.py
+python3 ci/test_pr_build_combine.py
+python3 ci/test_pr_build_notify.py
+python3 ci/test_pr_build_command.py
+python3 ci/test_pr_build_cleanup.py
 ```
 
 <br/>

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,11 +1,41 @@
 # Continuous Integration
 
-Frostguard builds on GitHub Actions from
-[`.github/workflows/daily-windows-bundle.yml`](../.github/workflows/daily-windows-bundle.yml).
-No manual activation step is needed — the workflow is live as soon as it lands on
-`main`, and the first scheduled run happens at the next 03:17 UTC.
+Three workflows:
 
-## When it runs
+| Workflow | Purpose |
+|---|---|
+| `daily-windows-bundle.yml` | the nightly Windows bundle from `main`, published as the rolling `nightly` prerelease |
+| `pr-test-build.yml` | temporary bundles built from **unmerged** pull requests, on request |
+| `pr-test-build-cleanup.yml` | expiry of those temporary builds |
+
+## Installing the workflows
+
+All three currently live in [`workflows/`](workflows) instead of
+`.github/workflows/`, because GitHub rejects a push that touches
+`.github/workflows/` unless the pushing credential holds the `workflows`
+permission — which the automation that opened this change does not have. Files in
+`ci/workflows/` are inert: Actions never reads them.
+
+A repository owner installs them once, from a normal clone:
+
+```sh
+bash ci/install_workflows.sh            # dry run, lists what would move
+bash ci/install_workflows.sh --apply    # git mv into .github/workflows/
+git commit -m "ci(actions): install pull request test build workflows"
+git push
+```
+
+`daily-windows-bundle.yml` replaces the existing nightly workflow; the only
+changes are the extracted LFS check and the new test step. The script is
+idempotent — after the move `ci/workflows/` no longer exists and a second run
+does nothing.
+
+Once installed, the nightly needs no further activation; the first scheduled run
+happens at the next 03:17 UTC. The PR test build is documented for testers in
+[`docs/PR_TEST_BUILDS.md`](../docs/PR_TEST_BUILDS.md); the notes below cover the
+implementation.
+
+## When the nightly runs
 
 | Trigger | Purpose |
 |---|---|
@@ -121,6 +151,62 @@ Test the payload without posting anything:
 python3 ci/test_discord_notify.py     # 21 self-tests, no network
 python3 ci/discord_notify.py --status success --version 2.1.0 \
   --download-url https://example.com/bundle.zip --dry-run
+```
+
+## Unmerged pull request test builds
+
+`/build-pr 47 48 49 65`, typed as a comment on any issue or pull request (or run
+from the Actions tab), produces a temporary Windows bundle built from those pull
+requests. Tester-facing documentation is in
+[`docs/PR_TEST_BUILDS.md`](../docs/PR_TEST_BUILDS.md). The parts worth knowing
+when changing the code:
+
+| Script | Responsibility |
+|---|---|
+| [`pr_build_command.py`](pr_build_command.py) | parse the command, authorize the requester, enforce the cooldown |
+| [`pr_build_plan.py`](pr_build_plan.py) | reject unbuildable pull requests, pin head commits, drop contained stack entries, derive the merge order, render the plan and the release notes |
+| [`pr_build_combine.py`](pr_build_combine.py) | merge the pinned commits on a throwaway branch, report conflicts, optionally propose a both-sides resolution |
+| [`pr_build_notify.py`](pr_build_notify.py) | the Discord message for plan, conflict, success and failure |
+| [`pr_build_cleanup.py`](pr_build_cleanup.py) | retire `pr-test-*` prereleases by age or when every included pull request is closed |
+| [`verify_lfs_assets.sh`](verify_lfs_assets.sh) | the Git LFS materialisation guard, shared by both build workflows |
+| [`install_workflows.sh`](install_workflows.sh) | move the staged workflow files into `.github/workflows/`, once |
+
+Design decisions that are easy to undo by accident:
+
+- **The build job references no secret.** It compiles unreviewed code, including
+  its `pom.xml` plugins. Adding `secrets.*` to that job — or widening its
+  `permissions` beyond `contents: read` — would hand the webhook and a write
+  token to whatever a pull request wants to execute. The publish job is where
+  credentials belong, and it runs only default-branch code.
+- **Commits are pinned, then re-verified.** `pr_build_plan.py verify` runs again
+  after the ~30 minute build. A pull request that was closed, merged or
+  force-pushed in the meantime stops the publication instead of producing a
+  download whose notes are wrong.
+- **Conflicts never pick a side.** `--ours`/`--theirs` would silently drop half a
+  pull request. The only automatic resolution offered is `--union`, which keeps
+  both sides, writes the diff out for review, and is refused outright for binary
+  and delete/modify conflicts.
+- **Nothing is pushed.** `pr_build_combine.py` raises if a `git push` ever
+  appears in its arguments, and the combined commit only exists in the build
+  job's workspace. The published tag points at the base commit — a new ref, not a
+  moved branch.
+- **The build key is the identity of a build.** It hashes the base commit and the
+  ordered head commits, which is what makes reuse safe: a different order or a
+  single new commit yields a different key, tag and asset name.
+- **The release notes carry a hidden marker** (`<!-- frostguard-pr-test … -->`)
+  listing the included pull requests. The cleanup reads it back, which is why no
+  state has to be stored anywhere else — and why the notes must not be edited by
+  hand.
+
+Run the whole tool suite in about two seconds:
+
+```sh
+python3 ci/test_pr_build_plan.py       # 41 tests
+python3 ci/test_pr_build_combine.py    # 13 tests, real throwaway repositories
+python3 ci/test_pr_build_notify.py     # 18 tests
+python3 ci/test_pr_build_command.py    # 23 tests
+python3 ci/test_pr_build_cleanup.py    # 13 tests
+node tools/discord-build-command/test-worker.mjs   # optional Discord endpoint
 ```
 
 ## Why two verification layers

--- a/ci/install_workflows.sh
+++ b/ci/install_workflows.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Move the staged workflow files in ci/workflows/ into .github/workflows/.
+#
+# Why this script exists
+# ----------------------
+# The pull request that introduced the unmerged test build feature could not
+# place these files in .github/workflows/ directly: the token used to push it
+# is not allowed to create or update workflow files. The files are therefore
+# parked in ci/workflows/ where they are inert, and a repository owner runs
+# this script once to put them in the place GitHub Actions reads.
+#
+# Usage
+# -----
+#   bash ci/install_workflows.sh            # show what would move
+#   bash ci/install_workflows.sh --apply    # move the files and stage the change
+#
+# After --apply, review "git status", commit, and push with an account that may
+# update workflows (a normal personal push is enough).
+
+set -euo pipefail
+
+SOURCE_DIR="ci/workflows"
+TARGET_DIR=".github/workflows"
+APPLY=0
+
+for argument in "$@"; do
+    case "$argument" in
+        --apply)
+            APPLY=1
+            ;;
+        -h | --help)
+            sed -n '2,/^$/p' "$0" | sed 's/^#\{1,\} \{0,1\}//;s/^#$//'
+            exit 0
+            ;;
+        *)
+            echo "unknown option: $argument" >&2
+            echo "run with --help for usage" >&2
+            exit 2
+            ;;
+    esac
+done
+
+repository_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$repository_root" ]; then
+    echo "run this from inside the repository" >&2
+    exit 1
+fi
+cd "$repository_root"
+
+if [ ! -d "$SOURCE_DIR" ]; then
+    echo "nothing to install: $SOURCE_DIR does not exist"
+    echo "the workflows are most likely already in $TARGET_DIR"
+    exit 0
+fi
+
+shopt -s nullglob
+staged_files=("$SOURCE_DIR"/*.yml)
+shopt -u nullglob
+
+if [ "${#staged_files[@]}" -eq 0 ]; then
+    echo "nothing to install: no .yml files in $SOURCE_DIR"
+    exit 0
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+    echo "Would install ${#staged_files[@]} workflow file(s) into $TARGET_DIR:"
+    for file in "${staged_files[@]}"; do
+        name="$(basename "$file")"
+        if [ -e "$TARGET_DIR/$name" ]; then
+            echo "  $name  (replaces the existing file)"
+        else
+            echo "  $name  (new file)"
+        fi
+    done
+    echo
+    echo "Re-run with --apply to perform the move."
+    exit 0
+fi
+
+mkdir -p "$TARGET_DIR"
+
+for file in "${staged_files[@]}"; do
+    name="$(basename "$file")"
+    if [ -e "$TARGET_DIR/$name" ]; then
+        git rm --quiet --force "$TARGET_DIR/$name" >/dev/null 2>&1 || rm -f "$TARGET_DIR/$name"
+    fi
+    # "git rm" deletes the directory too once it holds no tracked files.
+    mkdir -p "$TARGET_DIR"
+    if git ls-files --error-unmatch "$file" >/dev/null 2>&1; then
+        git mv "$file" "$TARGET_DIR/$name"
+    else
+        mv "$file" "$TARGET_DIR/$name"
+        git add "$TARGET_DIR/$name"
+    fi
+    echo "installed $TARGET_DIR/$name"
+done
+
+rmdir "$SOURCE_DIR" 2>/dev/null || true
+
+cat <<'DONE'
+
+Done. Next steps:
+  1. git status                 review the move
+  2. git commit -m "ci(actions): install pull request test build workflows"
+  3. git push
+  4. Open the Actions tab and confirm "Unmerged pull request test build" and
+     "Unmerged pull request test build cleanup" are listed.
+DONE

--- a/ci/pr_build_cleanup.py
+++ b/ci/pr_build_cleanup.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Expire the temporary prereleases created for unmerged PR test builds.
+
+A test build is only useful while the pull requests it contains are still open
+and still at the commits that were built. Left alone, the ``pr-test-*`` tags
+would accumulate forever and testers would keep finding stale downloads through
+search engines, which is how an unreviewed build ends up being treated as a
+release.
+
+Two rules retire a build:
+
+1. **Age.** Anything older than the TTL goes, because the base branch has moved
+   on and the build no longer represents any reviewable state.
+2. **All pull requests finished.** Once every included PR is closed or merged,
+   the build has no audience left, whatever its age.
+
+Releases whose tag does not start with ``pr-test-`` are never touched, so a real
+tagged release or the rolling ``nightly`` tag cannot be deleted by a bug here.
+
+Usage:
+    pr_build_cleanup.py --repository owner/name [--ttl-days 7] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# The marker is written into the release notes by the planner, so both ends of
+# that contract live in one module and cannot drift apart.
+from pr_build_plan import (  # noqa: E402
+    DEFAULT_API_BASE,
+    DEFAULT_TTL_DAYS,
+    MARKER_PATTERN,
+    TAG_PREFIX,
+    marker_block,
+    parse_marker,
+)
+
+
+def parse_timestamp(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat((value or "").replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def decide(
+    releases: list[dict],
+    pull_state,
+    now: datetime,
+    ttl_days: int = DEFAULT_TTL_DAYS,
+) -> list[tuple[dict, str]]:
+    """Pick the releases to delete. ``pull_state(number)`` returns open/closed.
+
+    Kept free of I/O so the retirement rules can be tested exhaustively.
+    """
+    doomed: list[tuple[dict, str]] = []
+    cutoff = now - timedelta(days=ttl_days)
+    for release in releases:
+        tag = release.get("tag_name") or ""
+        if not tag.startswith(TAG_PREFIX):
+            continue
+
+        created = parse_timestamp(
+            release.get("created_at") or release.get("published_at") or ""
+        )
+        if created is not None and created < cutoff:
+            age = (now - created).days
+            doomed.append((release, f"{age} days old (TTL is {ttl_days} days)"))
+            continue
+
+        prs = parse_marker(release.get("body") or "").get("prs") or []
+        if not prs:
+            # No marker means the notes were edited or the release predates the
+            # marker. Age is then the only safe criterion, so leave it alone.
+            continue
+        states = {number: pull_state(int(number)) for number in prs}
+        if all(state and state != "open" for state in states.values()):
+            doomed.append(
+                (
+                    release,
+                    "every included pull request is closed or merged ("
+                    + ", ".join(f"#{n} {s}" for n, s in sorted(states.items()))
+                    + ")",
+                )
+            )
+    return doomed
+
+
+class ReleaseApi:
+    """The release and pull-request calls the cleanup needs, over plain REST."""
+
+    def __init__(
+        self,
+        repository: str,
+        token: str,
+        api_base: str = DEFAULT_API_BASE,
+        timeout: float = 30.0,
+    ) -> None:
+        self.repository = repository
+        self.token = token
+        self.api_base = api_base.rstrip("/")
+        self.timeout = timeout
+
+    def _request(self, method: str, path: str) -> tuple[int, object]:
+        request = urllib.request.Request(
+            f"{self.api_base}{path}",
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "frostguard-ci/1.0 (+https://github.com/Shederator/wosbot)",
+                **({"Authorization": f"Bearer {self.token}"} if self.token else {}),
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                raw = response.read().decode("utf-8") or "null"
+                return response.status, json.loads(raw)
+        except urllib.error.HTTPError as error:
+            return error.code, None
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            print(f"::warning::{method} {path} failed: {error}")
+            return 0, None
+
+    def releases(self) -> list[dict]:
+        found: list[dict] = []
+        for page in range(1, 11):  # 1000 releases is far more than plausible
+            status, body = self._request(
+                "GET", f"/repos/{self.repository}/releases?per_page=100&page={page}"
+            )
+            if status != 200 or not isinstance(body, list) or not body:
+                break
+            found.extend(body)
+            if len(body) < 100:
+                break
+        return found
+
+    def pull_state(self, number: int) -> str:
+        status, body = self._request(
+            "GET", f"/repos/{self.repository}/pulls/{number}"
+        )
+        if status != 200 or not isinstance(body, dict):
+            # An unreadable PR must not be treated as finished: that would let a
+            # transient API error delete a build testers are still using.
+            return "open"
+        if body.get("merged"):
+            return "merged"
+        return body.get("state") or "open"
+
+    def delete_release(self, release: dict) -> bool:
+        status, _ = self._request(
+            "DELETE", f"/repos/{self.repository}/releases/{release['id']}"
+        )
+        if status not in (204, 404):
+            print(
+                f"::warning::Could not delete release {release.get('tag_name')} "
+                f"(HTTP {status})."
+            )
+            return False
+        tag = release.get("tag_name") or ""
+        tag_status, _ = self._request(
+            "DELETE", f"/repos/{self.repository}/git/refs/tags/{tag}"
+        )
+        if tag_status not in (204, 404, 422):
+            print(f"::warning::Release {tag} is gone but its tag remains.")
+        return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--ttl-days", type=int, default=DEFAULT_TTL_DAYS)
+    parser.add_argument("--api-base", default=DEFAULT_API_BASE)
+    parser.add_argument("--token-env", default="GITHUB_TOKEN")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="list what would be deleted without deleting anything",
+    )
+    args = parser.parse_args(argv)
+
+    token = os.environ.get(args.token_env, "")
+    if not token:
+        print(f"::error::{args.token_env} is empty; cannot talk to the API.")
+        return 1
+
+    api = ReleaseApi(args.repository, token, api_base=args.api_base)
+    releases = api.releases()
+    candidates = [
+        release
+        for release in releases
+        if (release.get("tag_name") or "").startswith(TAG_PREFIX)
+    ]
+    doomed = decide(
+        candidates, api.pull_state, datetime.now(timezone.utc), args.ttl_days
+    )
+
+    lines = [
+        "### Unmerged test build cleanup",
+        "",
+        f"- temporary test releases found: {len(candidates)}",
+        f"- retired in this run: {len(doomed)}"
+        + (" (dry run)" if args.dry_run else ""),
+        "",
+    ]
+    for release, reason in doomed:
+        tag = release.get("tag_name")
+        lines.append(f"- `{tag}` — {reason}")
+        if args.dry_run:
+            print(f"Would delete {tag}: {reason}")
+            continue
+        if api.delete_release(release):
+            print(f"Deleted {tag}: {reason}")
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+    print(
+        f"Checked {len(candidates)} temporary test release(s); "
+        f"{len(doomed)} retired."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/pr_build_combine.py
+++ b/ci/pr_build_combine.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Combine pinned pull-request commits in a disposable test workspace.
+
+What this script must never do is as important as what it does:
+
+* It never touches ``main`` and never touches a PR branch. The combination
+  happens on a throwaway local branch (``pr-test/<build key>``) that is only
+  ever created inside the checkout of one CI job and is never pushed.
+* It never resolves a conflict by picking ``--ours`` or ``--theirs``. Silently
+  discarding one side of a conflict produces a build that behaves like neither
+  pull request, and the tester has no way to notice.
+
+Conflicts therefore stop the run by default. The requester gets the exact list
+of conflicting files. Optionally (``--resolution union``) the script prepares a
+*proposal* that keeps both sides of every text conflict, writes the resulting
+diff out for review, and — because a union merge can produce code that compiles
+but is nonsense — labels the outcome as a proposal in the report. Binary
+conflicts are never resolved automatically: there is no meaningful union of two
+PNGs or two DLLs.
+
+Usage:
+    pr_build_combine.py --plan plan.json --report combine-report.json \\
+        [--resolution stop|union] [--proposal-diff proposal.diff] [--repo .]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+# A conflicted file has up to three staged blobs: 1 = merge base, 2 = ours,
+# 3 = theirs. A missing stage means the file was added or deleted on that side.
+STAGE_BASE, STAGE_OURS, STAGE_THEIRS = 1, 2, 3
+
+
+class GitError(RuntimeError):
+    pass
+
+
+class Git:
+    """Thin wrapper that fails loudly and keeps the workspace read-auditable."""
+
+    def __init__(self, repo: str = ".") -> None:
+        self.repo = repo
+
+    def run(self, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+        if "push" in args:
+            # Belt and braces: this script has no business writing to a remote,
+            # and a future edit that adds a push should fail here immediately.
+            raise GitError("pr_build_combine.py must never push")
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if check and completed.returncode != 0:
+            raise GitError(
+                f"git {' '.join(args)} failed with {completed.returncode}: "
+                f"{completed.stderr.strip() or completed.stdout.strip()}"
+            )
+        return completed
+
+    def out(self, *args: str) -> str:
+        return self.run(*args).stdout.strip()
+
+    def unmerged_paths(self) -> list[str]:
+        listing = self.run("diff", "--name-only", "--diff-filter=U", "-z").stdout
+        return [path for path in listing.split("\0") if path]
+
+    def stage_blob(self, stage: int, path: str) -> bytes | None:
+        completed = subprocess.run(
+            ["git", "show", f":{stage}:{path}"],
+            cwd=self.repo,
+            capture_output=True,
+            check=False,
+        )
+        return completed.stdout if completed.returncode == 0 else None
+
+    def is_lfs_tracked(self, path: str) -> bool:
+        value = self.run("check-attr", "filter", "--", path, check=False).stdout
+        return value.strip().endswith(": lfs")
+
+
+def looks_binary(blob: bytes | None) -> bool:
+    """A NUL byte in the first 8 KiB is git's own heuristic for "binary"."""
+    if blob is None:
+        return False
+    return b"\0" in blob[:8192]
+
+
+def describe_conflict(git: Git, path: str) -> dict:
+    """Collect enough about one conflicted file to explain it in a message."""
+    base = git.stage_blob(STAGE_BASE, path)
+    ours = git.stage_blob(STAGE_OURS, path)
+    theirs = git.stage_blob(STAGE_THEIRS, path)
+
+    if ours is None or theirs is None:
+        # One side deleted or renamed the file while the other changed it. There
+        # is no text merge for that; a human has to decide.
+        kind = "delete/modify"
+    elif looks_binary(base) or looks_binary(ours) or looks_binary(theirs):
+        kind = "binary"
+    elif git.is_lfs_tracked(path):
+        kind = "binary"
+    else:
+        kind = "text"
+
+    return {
+        "path": path,
+        "kind": kind,
+        "resolvable_by_union": kind == "text",
+    }
+
+
+def union_resolve(git: Git, path: str) -> bool:
+    """Rewrite one text conflict so that both sides survive.
+
+    ``git merge-file --union`` keeps every line from both sides instead of
+    choosing one, which is the only automatic resolution that cannot silently
+    drop a pull request's change. It can still produce duplicated statements, so
+    the caller must show the diff and ask before building it.
+    """
+    base = git.stage_blob(STAGE_BASE, path) or b""
+    ours = git.stage_blob(STAGE_OURS, path)
+    theirs = git.stage_blob(STAGE_THEIRS, path)
+    if ours is None or theirs is None:
+        return False
+
+    root = git.out("rev-parse", "--show-toplevel")
+    scratch = os.path.join(root, ".git", "pr-test-union")
+    os.makedirs(scratch, exist_ok=True)
+    names = {}
+    for label, blob in (("base", base), ("ours", ours), ("theirs", theirs)):
+        names[label] = os.path.join(scratch, f"{label}.blob")
+        with open(names[label], "wb") as handle:
+            handle.write(blob)
+
+    merged = subprocess.run(
+        [
+            "git",
+            "merge-file",
+            "--union",
+            "-p",
+            "-L",
+            "combined so far",
+            "-L",
+            "merge base",
+            "-L",
+            f"incoming ({path})",
+            names["ours"],
+            names["base"],
+            names["theirs"],
+        ],
+        cwd=git.repo,
+        capture_output=True,
+        check=False,
+    )
+    # --union never leaves markers behind, so a non-zero exit means the inputs
+    # could not be merged at all rather than "there were conflicts".
+    if merged.returncode != 0 and not merged.stdout:
+        return False
+
+    target = os.path.join(root, path)
+    os.makedirs(os.path.dirname(target) or root, exist_ok=True)
+    with open(target, "wb") as handle:
+        handle.write(merged.stdout)
+    git.run("add", "--", path)
+    return True
+
+
+def combine(
+    git: Git,
+    plan: dict,
+    resolution: str = "stop",
+    proposal_diff: str = "",
+) -> dict:
+    """Merge every planned head onto a disposable branch. Returns the report."""
+    order = plan.get("order") or []
+    pulls = plan.get("pull_requests") or {}
+    base_sha = plan.get("base_sha") or ""
+    branch = f"pr-test/{plan.get('build_key', 'workspace')}"
+
+    report: dict = {
+        "status": "clean",
+        "branch": branch,
+        "base_sha": base_sha,
+        "merges": [],
+        "conflicts": [],
+        "resolution": resolution,
+        "resolved_paths": [],
+        "head_sha": "",
+    }
+
+    if not order:
+        report["status"] = "empty"
+        return report
+
+    # A detached, freshly created branch means the merge cannot possibly move
+    # main or any PR branch, even if a later step misbehaves.
+    git.run("checkout", "--force", "-B", branch, base_sha)
+
+    for number in order:
+        facts = pulls.get(str(number), {})
+        sha = facts.get("head_sha") or ""
+        title = facts.get("title") or ""
+        if not sha:
+            report["status"] = "error"
+            report["error"] = f"#{number} has no pinned commit in the plan"
+            return report
+
+        message = f"test merge: PR #{number} {title}".strip()
+        merged = git.run(
+            "merge",
+            "--no-ff",
+            "--no-edit",
+            "-m",
+            message,
+            sha,
+            check=False,
+        )
+        if merged.returncode == 0:
+            report["merges"].append(
+                {"number": number, "sha": sha, "status": "merged"}
+            )
+            continue
+
+        conflicts = [describe_conflict(git, path) for path in git.unmerged_paths()]
+        if not conflicts:
+            # Merge failed for a reason other than a content conflict, e.g. a
+            # local modification or an unrelated-history refusal.
+            git.run("merge", "--abort", check=False)
+            report["status"] = "error"
+            report["error"] = (
+                f"merging #{number} ({sha[:7]}) failed without a content "
+                f"conflict: {merged.stderr.strip()[:400]}"
+            )
+            return report
+
+        report["conflicts"].append(
+            {"number": number, "sha": sha, "files": conflicts}
+        )
+
+        unresolvable = [item for item in conflicts if not item["resolvable_by_union"]]
+        if resolution != "union" or unresolvable:
+            git.run("merge", "--abort", check=False)
+            report["status"] = "conflict"
+            return report
+
+        for item in conflicts:
+            if not union_resolve(git, item["path"]):
+                git.run("merge", "--abort", check=False)
+                report["status"] = "conflict"
+                return report
+            report["resolved_paths"].append(item["path"])
+
+        ours_before = git.out("rev-parse", "HEAD")
+        git.run(
+            "commit",
+            "--no-verify",
+            "-m",
+            f"{message} (union resolution proposal)",
+        )
+        report["merges"].append(
+            {
+                "number": number,
+                "sha": sha,
+                "status": "merged with union resolution",
+                "conflicting_files": [item["path"] for item in conflicts],
+            }
+        )
+        if proposal_diff:
+            # Show what the proposal changed relative to the combination as it
+            # stood before this merge. That is the diff a reviewer needs in
+            # order to accept or reject the automatic resolution.
+            diff = git.run(
+                "diff",
+                f"{ours_before}..HEAD",
+                "--",
+                *[item["path"] for item in conflicts],
+                check=False,
+            ).stdout
+            with open(proposal_diff, "a", encoding="utf-8") as handle:
+                handle.write(f"# union resolution proposal for PR #{number}\n")
+                handle.write(diff)
+                handle.write("\n")
+        report["status"] = "resolved"
+
+    report["head_sha"] = git.out("rev-parse", "HEAD")
+    report["commits"] = len(
+        git.run("rev-list", f"{base_sha}..HEAD").stdout.split()
+    )
+    return report
+
+
+def render_conflict_report(report: dict, plan: dict) -> str:
+    """Explain a stopped merge in a way a non-git-expert can act on."""
+    lines = ["### The pull requests cannot be combined", ""]
+    for entry in report.get("conflicts") or []:
+        number = entry["number"]
+        facts = (plan.get("pull_requests") or {}).get(str(number), {})
+        lines.append(
+            f"Merging [#{number}]({facts.get('url', '')}) "
+            f"(`{entry['sha'][:7]}`) conflicts in:"
+        )
+        lines.append("")
+        for item in entry["files"]:
+            note = {
+                "text": "text conflict",
+                "binary": "binary file — needs a manual choice",
+                "delete/modify": "changed on one side, removed on the other",
+            }.get(item["kind"], item["kind"])
+            lines.append(f"- `{item['path']}` — {note}")
+        lines.append("")
+
+    resolvable = all(
+        item["resolvable_by_union"]
+        for entry in report.get("conflicts") or []
+        for item in entry["files"]
+    )
+    if resolvable and report.get("conflicts"):
+        lines.append(
+            "Every conflict is a text conflict, so a resolution that keeps "
+            "**both** sides can be attempted. Re-request the build with "
+            "conflict resolution set to `union`; the proposed diff is posted "
+            "for review before anything is published."
+        )
+    else:
+        lines.append(
+            "At least one conflict cannot be resolved automatically, so the "
+            "authors have to rebase or a maintainer has to combine the changes "
+            "by hand. Nothing was changed in the repository."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", required=True)
+    parser.add_argument("--report", default="combine-report.json")
+    parser.add_argument("--markdown", default="", help="write the summary here")
+    parser.add_argument("--proposal-diff", default="")
+    parser.add_argument(
+        "--resolution",
+        default="stop",
+        choices=("stop", "union"),
+        help="stop on conflict, or propose a both-sides union resolution",
+    )
+    parser.add_argument("--repo", default=".")
+    args = parser.parse_args(argv)
+
+    with open(args.plan, encoding="utf-8") as handle:
+        plan = json.load(handle)
+
+    git = Git(args.repo)
+    try:
+        report = combine(git, plan, args.resolution, args.proposal_diff)
+    except GitError as error:
+        report = {"status": "error", "error": str(error), "conflicts": []}
+
+    with open(args.report, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2, sort_keys=True)
+
+    markdown = ""
+    if report["status"] in {"conflict", "error"}:
+        markdown = render_conflict_report(report, plan)
+        if report.get("error"):
+            markdown += f"\n`{report['error']}`\n"
+    elif report["status"] == "resolved":
+        markdown = (
+            "### Conflicts were resolved with a union proposal\n\n"
+            "The following files kept **both** sides of the conflict:\n\n"
+            + "".join(f"- `{path}`\n" for path in report["resolved_paths"])
+            + "\nReview the attached `proposal.diff` before trusting the "
+            "resulting build.\n"
+        )
+    if args.markdown and markdown:
+        with open(args.markdown, "w", encoding="utf-8") as handle:
+            handle.write(markdown)
+    if markdown:
+        print(markdown)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary and markdown:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(markdown)
+
+    if report["status"] in {"conflict", "error", "empty"}:
+        print(f"::error::Combining the pull requests failed ({report['status']}).")
+        return 1
+    print(
+        f"Combined {len(report['merges'])} pull request(s) onto "
+        f"{report['base_sha'][:7]} as {report['head_sha'][:7]}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/pr_build_command.py
+++ b/ci/pr_build_command.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Parse and authorize a ``/build-pr`` request written as a GitHub comment.
+
+A Discord webhook can only *send* messages, so the command itself has to arrive
+somewhere GitHub can already see it. A comment on any issue or pull request is
+that place: it needs no extra hosting, no bot token and no third-party service,
+and the workflow file that reacts to it is always the trusted copy from the
+default branch.
+
+Accepted syntax (everything after the command name is free-form):
+
+    /build-pr 47 48 49 65          plan only, nothing is built yet
+    /build-pr 47 48 49 65 confirm  actually build and publish
+    /build-pr 47 48 union confirm  allow a both-sides union resolution
+    /build-pr 47 48 order=48,47    override the derived merge order
+    /build-pr help                 print the usage back into the thread
+
+Three separate guards keep this from becoming a build-farm faucet:
+
+* the commenter must have write access, or be listed in an explicit allowlist;
+* the plan step never builds unless ``confirm`` is present;
+* a cooldown limits how many builds one person can start per hour.
+
+Usage:
+    pr_build_command.py parse --body-file comment.txt
+    pr_build_command.py authorize --permission write --actor octocat
+    pr_build_command.py cooldown --runs runs.json --actor octocat
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+COMMAND = "/build-pr"
+
+# Permission levels GitHub reports for a collaborator. "write" and above may
+# start builds; "read" and "none" may not, because a build consumes the
+# repository's Actions minutes and publishes a public download.
+WRITE_PERMISSIONS = {"admin", "maintain", "write"}
+
+# Author associations that are accepted without an extra API call.
+TRUSTED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+
+DEFAULT_COOLDOWN_MINUTES = 60
+DEFAULT_MAX_RUNS_PER_WINDOW = 3
+
+USAGE = f"""**Unmerged PR test builds**
+
+```
+{COMMAND} 47 48 49 65          show the merge plan (nothing is built)
+{COMMAND} 47 48 49 65 confirm  build it and publish a temporary download
+{COMMAND} 47 48 union confirm  allow a resolution that keeps both sides
+{COMMAND} 47 48 order=48,47    override the merge order
+{COMMAND} help                 this message
+```
+
+The plan is always shown first: it lists the pinned commits, drops pull requests
+that are already contained in a later one, and explains anything it rejected.
+Add `confirm` once the plan looks right. Downloads are temporary and labelled as
+unmerged test builds.
+"""
+
+
+@dataclass
+class Command:
+    is_command: bool = False
+    help: bool = False
+    prs: str = ""
+    confirm: bool = False
+    resolution: str = "stop"
+    order: str = ""
+    unknown: list[str] = field(default_factory=list)
+
+
+def parse_command(body: str) -> Command:
+    """Read the first ``/build-pr`` line of a comment.
+
+    Only a line that *starts* with the command counts, so quoting somebody
+    else's command in a reply cannot trigger a second build.
+    """
+    for raw_line in (body or "").splitlines():
+        line = raw_line.strip()
+        if not line.lower().startswith(COMMAND):
+            continue
+        remainder = line[len(COMMAND):].strip()
+        command = Command(is_command=True)
+
+        order_match = re.search(r"order\s*=\s*([0-9,\s#]+)", remainder, re.I)
+        if order_match:
+            command.order = order_match.group(1).strip()
+            remainder = remainder.replace(order_match.group(0), " ")
+
+        words: list[str] = []
+        for token in re.split(r"[\s,]+", remainder):
+            if not token:
+                continue
+            lowered = token.lower()
+            if lowered in {"help", "-h", "--help", "?"}:
+                command.help = True
+            elif lowered in {"confirm", "--confirm", "yes", "build"}:
+                command.confirm = True
+            elif lowered in {"union", "--union", "resolve"}:
+                command.resolution = "union"
+            elif lowered in {"stop", "--stop"}:
+                command.resolution = "stop"
+            elif re.fullmatch(r"#?\d+", token):
+                words.append(token)
+            else:
+                command.unknown.append(token)
+        command.prs = " ".join(words)
+        if not command.prs and not command.help:
+            command.help = True
+        return command
+    return Command()
+
+
+def is_authorized(
+    permission: str,
+    association: str = "",
+    actor: str = "",
+    allowlist: str = "",
+) -> tuple[bool, str]:
+    """Decide whether ``actor`` may spend runner time on a test build."""
+    allowed = {
+        name.strip().lower()
+        for name in re.split(r"[\s,]+", allowlist or "")
+        if name.strip()
+    }
+    if actor and actor.lower() in allowed:
+        return True, f"@{actor} is on the test-build allowlist"
+    if (permission or "").lower() in WRITE_PERMISSIONS:
+        return True, f"@{actor or 'requester'} has {permission} access"
+    if (association or "").upper() in TRUSTED_ASSOCIATIONS:
+        return True, f"@{actor or 'requester'} is a repository {association.lower()}"
+    return False, (
+        "Only people with write access to this repository (or names on the "
+        "`PR_TEST_BUILD_ALLOWLIST` variable) can start a test build. Ask a "
+        "maintainer to run it for you."
+    )
+
+
+def cooldown_exceeded(
+    runs: list[dict],
+    actor: str,
+    now: datetime,
+    minutes: int = DEFAULT_COOLDOWN_MINUTES,
+    max_runs: int = DEFAULT_MAX_RUNS_PER_WINDOW,
+) -> tuple[bool, str]:
+    """Count this actor's recent builds, so a typo cannot flood the queue.
+
+    ``runs`` is the ``workflow_runs`` array from the REST API. Only runs that
+    actually built something count: a plan-only run costs a minute and should
+    not use up somebody's quota.
+    """
+    window_start = now - timedelta(minutes=minutes)
+    recent = 0
+    for run in runs:
+        if (run.get("actor") or {}).get("login", "").lower() != (actor or "").lower():
+            continue
+        started = run.get("run_started_at") or run.get("created_at") or ""
+        try:
+            when = datetime.fromisoformat(started.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if when >= window_start:
+            recent += 1
+    if recent >= max_runs:
+        return True, (
+            f"@{actor} already started {recent} test builds in the last "
+            f"{minutes} minutes (limit {max_runs}). Wait for those to finish "
+            "before requesting another one."
+        )
+    return False, ""
+
+
+def write_output(pairs: dict[str, str]) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        for key, value in pairs.items():
+            print(f"{key}={value}")
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in pairs.items():
+            if "\n" in value:
+                handle.write(f"{key}<<__FG_EOF__\n{value}\n__FG_EOF__\n")
+            else:
+                handle.write(f"{key}={value}\n")
+
+
+def command_parse(args: argparse.Namespace) -> int:
+    if args.body_file:
+        with open(args.body_file, encoding="utf-8") as handle:
+            body = handle.read()
+    else:
+        body = args.body
+    command = parse_command(body)
+    write_output(
+        {
+            "is_command": "true" if command.is_command else "false",
+            "help": "true" if command.help else "false",
+            "prs": command.prs,
+            "confirm": "true" if command.confirm else "false",
+            "resolution": command.resolution,
+            "order": command.order,
+            "unknown": " ".join(command.unknown),
+            "usage": USAGE,
+        }
+    )
+    if command.unknown:
+        print(
+            "::warning::Ignored tokens that are not pull request numbers: "
+            + ", ".join(command.unknown)
+        )
+    return 0
+
+
+def command_authorize(args: argparse.Namespace) -> int:
+    allowed, reason = is_authorized(
+        args.permission, args.association, args.actor, args.allowlist
+    )
+    write_output(
+        {"authorized": "true" if allowed else "false", "reason": reason}
+    )
+    print(reason)
+    return 0
+
+
+def command_cooldown(args: argparse.Namespace) -> int:
+    try:
+        with open(args.runs, encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        # Not being able to read the history must not block a legitimate build.
+        print(f"::warning::Could not read the run history ({error}); skipping "
+              "the cooldown check.")
+        write_output({"blocked": "false", "reason": ""})
+        return 0
+    runs = payload.get("workflow_runs") if isinstance(payload, dict) else payload
+    blocked, reason = cooldown_exceeded(
+        runs or [],
+        args.actor,
+        datetime.now(timezone.utc),
+        args.minutes,
+        args.max_runs,
+    )
+    write_output({"blocked": "true" if blocked else "false", "reason": reason})
+    if blocked:
+        print(f"::warning::{reason}")
+    return 0
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parse_cmd = subparsers.add_parser("parse")
+    parse_cmd.add_argument("--body", default="")
+    parse_cmd.add_argument("--body-file", default="")
+    parse_cmd.set_defaults(func=command_parse)
+
+    auth = subparsers.add_parser("authorize")
+    auth.add_argument("--permission", default="")
+    auth.add_argument("--association", default="")
+    auth.add_argument("--actor", default="")
+    auth.add_argument("--allowlist", default="")
+    auth.set_defaults(func=command_authorize)
+
+    cooldown = subparsers.add_parser("cooldown")
+    cooldown.add_argument("--runs", required=True)
+    cooldown.add_argument("--actor", default="")
+    cooldown.add_argument("--minutes", type=int, default=DEFAULT_COOLDOWN_MINUTES)
+    cooldown.add_argument(
+        "--max-runs", type=int, default=DEFAULT_MAX_RUNS_PER_WINDOW
+    )
+    cooldown.set_defaults(func=command_cooldown)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/pr_build_notify.py
+++ b/ci/pr_build_notify.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Post the status of an unmerged PR test build to a Discord webhook.
+
+The nightly notifier in ``discord_notify.py`` answers "is main healthy". This
+one answers a different question: "what exactly is in the build I am about to
+install, and is it safe to trust it?" Every message therefore carries the pull
+request numbers, titles and the **pinned** head commits, and every download is
+labelled as an unmerged test build so nobody mistakes it for a release.
+
+Delivery, retrying, redaction and the "never let @everyone in a title ping the
+channel" rule are shared with the nightly notifier instead of being reimplemented
+here.
+
+Usage:
+    DISCORD_PR_BUILD_WEBHOOK_URL=... ci/pr_build_notify.py --status success \\
+        --plan plan.json --download-url https://... --run-url https://...
+    ci/pr_build_notify.py --status plan --plan plan.json --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from discord_notify import (  # noqa: E402  (deliberate: shared helpers)
+    CONTENT_LIMIT,
+    EMBED_DESCRIPTION_LIMIT,
+    EMBED_FIELD_NAME_LIMIT,
+    EMBED_FIELD_VALUE_LIMIT,
+    EMBED_FOOTER_LIMIT,
+    EMBED_TITLE_LIMIT,
+    human_size,
+    lenient_int,
+    post,
+    truncate,
+)
+from datetime import datetime, timezone  # noqa: E402
+
+STATUS_STYLE = {
+    # A plan is not a result: it is a request for confirmation before ~30
+    # minutes of runner time is spent, so it gets its own neutral colour.
+    "plan": (0x3498DB, "Test build planned"),
+    "success": (0x2ECC71, "Unmerged test build ready"),
+    "conflict": (0xE67E22, "Pull requests could not be combined"),
+    "failure": (0xE74C3C, "Test build failed"),
+    "rejected": (0x95A5A6, "Request rejected"),
+    "reused": (0x2ECC71, "Existing test build reused"),
+}
+
+WEBHOOK_ENV_DEFAULT = "DISCORD_PR_BUILD_WEBHOOK_URL"
+WEBHOOK_ENV_FALLBACK = "DISCORD_NIGHTLY_WEBHOOK_URL"
+
+WARNING = (
+    "⚠️ **Unmerged test build.** It contains code that has not been reviewed "
+    "or merged. Use a test profile, not your main account data."
+)
+
+
+def load_plan(path: str) -> dict:
+    if not path:
+        return {}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"::warning::Could not read the plan {path!r}: {error}")
+        return {}
+
+
+def pr_lines(plan: dict, limit: int = 10) -> list[str]:
+    """One line per included pull request: number, title, author, pinned SHA."""
+    lines: list[str] = []
+    order = plan.get("order") or []
+    pulls = plan.get("pull_requests") or {}
+    for number in order[:limit]:
+        facts = pulls.get(str(number), {})
+        title = truncate(facts.get("title") or "", 110)
+        sha = (facts.get("head_sha") or "")[:7]
+        url = facts.get("url") or ""
+        head = f"[#{number}]({url})" if url else f"#{number}"
+        author = facts.get("author") or "unknown"
+        lines.append(f"{head} `{sha}` {title} — @{author}")
+    if len(order) > limit:
+        lines.append(f"…and {len(order) - limit} more")
+    return lines
+
+
+def rejection_lines(plan: dict) -> list[str]:
+    lines = [
+        f"#{item['number']}: {item['reason']}"
+        for item in plan.get("rejected") or []
+    ]
+    lines += [
+        f"#{item['number']} already contained in #{item['contained_in']}"
+        for item in plan.get("contained") or []
+    ]
+    if plan.get("invalid_tokens"):
+        lines.append(
+            "Not pull request numbers: "
+            + ", ".join(f"`{token}`" for token in plan["invalid_tokens"])
+        )
+    if plan.get("duplicates_removed"):
+        lines.append(
+            "Duplicates removed: "
+            + ", ".join(f"#{number}" for number in plan["duplicates_removed"])
+        )
+    return lines
+
+
+def conflict_lines(report: dict, limit: int = 12) -> list[str]:
+    lines: list[str] = []
+    shown = 0
+    for entry in report.get("conflicts") or []:
+        lines.append(f"**#{entry['number']}** (`{entry['sha'][:7]}`)")
+        for item in entry.get("files") or []:
+            if shown >= limit:
+                lines.append("…more files omitted")
+                return lines
+            suffix = "" if item.get("kind") == "text" else f" ({item['kind']})"
+            lines.append(f"`{item['path']}`{suffix}")
+            shown += 1
+    return lines
+
+
+def build_payload(args: argparse.Namespace) -> dict:
+    plan = load_plan(args.plan)
+    report = load_plan(args.report)
+    color, headline = STATUS_STYLE.get(args.status, STATUS_STYLE["failure"])
+
+    numbers = plan.get("order") or []
+    label = ", ".join(f"#{number}" for number in numbers) or "no pull request"
+    title = f"{headline} — {label}"
+
+    fields: list[dict] = []
+
+    def add_field(name: str, value: str, inline: bool = False) -> None:
+        value = truncate(value, EMBED_FIELD_VALUE_LIMIT)
+        if value:
+            fields.append(
+                {
+                    "name": truncate(name, EMBED_FIELD_NAME_LIMIT),
+                    "value": value,
+                    "inline": inline,
+                }
+            )
+
+    if numbers:
+        add_field("Included pull requests", "\n".join(pr_lines(plan)))
+    rejected = rejection_lines(plan)
+    if rejected:
+        add_field("Not included", "\n".join(rejected))
+    if args.status == "conflict":
+        add_field("Conflicting files", "\n".join(conflict_lines(report)))
+
+    base_sha = (plan.get("base_sha") or "")[:7]
+    if base_sha:
+        add_field("Base", f"`{plan.get('base_ref', 'main')}` at `{base_sha}`", True)
+    if plan.get("build_key"):
+        add_field("Build key", f"`{plan['build_key']}`", True)
+    if args.bundle_bytes > 0:
+        add_field("Download size", human_size(args.bundle_bytes), True)
+    if args.test_count > 0:
+        add_field("JUnit tests", f"{args.test_count} passed", True)
+    if args.requester:
+        add_field("Requested by", args.requester, True)
+    if args.expires:
+        add_field("Expires", args.expires, True)
+
+    description: list[str] = []
+    if args.status in {"success", "reused"}:
+        if args.download_url and not args.download_url.startswith("http"):
+            print(
+                "::warning::Ignoring a download URL that is not absolute: "
+                f"{args.download_url!r}"
+            )
+            args.download_url = ""
+        if args.download_url:
+            description.append(
+                f"**[⬇ Download the test build]({args.download_url})**"
+            )
+            description.append(
+                "Unzip anywhere, then run `java -jar frostguard-*.jar` "
+                "(Java 21+ required)."
+            )
+        description.append(WARNING)
+    elif args.status == "plan":
+        description.append(
+            "This is the merge plan only — **nothing has been built yet.**"
+        )
+        if args.confirm_hint:
+            description.append(args.confirm_hint)
+    elif args.status == "conflict":
+        description.append(
+            "Git cannot combine these pull requests. Nothing in the "
+            "repository was changed and no build was published."
+        )
+    elif args.status == "rejected":
+        description.append(args.reason or "The request was not accepted.")
+    else:
+        description.append(
+            f"{headline}. The pull request branches were not modified."
+        )
+
+    if args.run_url and args.status != "plan":
+        description.append(f"[Workflow log]({args.run_url})")
+    elif args.run_url:
+        description.append(f"[Workflow run]({args.run_url})")
+
+    embed = {
+        "title": truncate(title, EMBED_TITLE_LIMIT),
+        "color": color,
+        "description": truncate("\n\n".join(description), EMBED_DESCRIPTION_LIMIT),
+        "fields": fields,
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    if args.run_url:
+        embed["url"] = args.run_url
+
+    footer_parts = [part for part in (args.repository, args.thread_url) if part]
+    if args.run_number:
+        footer_parts.append(f"run #{args.run_number}")
+    footer = " • ".join(footer_parts)
+    if footer:
+        embed["footer"] = {"text": truncate(footer, EMBED_FOOTER_LIMIT)}
+
+    payload = {
+        "username": args.username,
+        "embeds": [embed],
+        # Structural, not cosmetic: a PR title containing @everyone must not be
+        # able to ping the channel.
+        "allowed_mentions": {"parse": []},
+    }
+    # The bare link stays tappable in the mobile client and in the notification
+    # preview, where an embed link is easy to miss.
+    if args.status in {"success", "reused"} and args.download_url:
+        payload["content"] = truncate(args.download_url, CONTENT_LIMIT)
+    return payload
+
+
+def resolve_webhook(primary_env: str, fallback_env: str) -> tuple[str, str]:
+    """Prefer a dedicated test-build webhook, fall back to the nightly one.
+
+    A separate channel for unreviewed builds is the safer setup, but requiring
+    it would mean the feature does nothing on a server that already has the
+    nightly webhook configured.
+    """
+    value = os.environ.get(primary_env, "").strip()
+    if value:
+        return value, primary_env
+    return os.environ.get(fallback_env, "").strip(), fallback_env
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--status", required=True, choices=sorted(STATUS_STYLE))
+    parser.add_argument("--plan", default="", help="plan JSON from pr_build_plan.py")
+    parser.add_argument("--report", default="", help="combine report JSON")
+    parser.add_argument("--download-url", default="")
+    parser.add_argument("--run-url", default="")
+    parser.add_argument("--run-number", default="")
+    parser.add_argument("--repository", default="")
+    parser.add_argument("--requester", default="")
+    parser.add_argument("--thread-url", default="")
+    parser.add_argument("--reason", default="")
+    parser.add_argument("--expires", default="")
+    parser.add_argument("--confirm-hint", default="")
+    parser.add_argument("--bundle-bytes", type=lenient_int, default=0)
+    parser.add_argument("--test-count", type=lenient_int, default=0)
+    parser.add_argument("--username", default="Frostguard Test Builds")
+    parser.add_argument("--webhook-env", default=WEBHOOK_ENV_DEFAULT)
+    parser.add_argument("--webhook-env-fallback", default=WEBHOOK_ENV_FALLBACK)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(args)
+
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    webhook, source = resolve_webhook(args.webhook_env, args.webhook_env_fallback)
+    if not webhook:
+        print(
+            f"::warning::Neither {args.webhook_env} nor "
+            f"{args.webhook_env_fallback} is set; no Discord message was sent."
+        )
+        return 0
+    if not re.match(
+        r"^https://(canary\.|ptb\.)?discord(app)?\.com/api/webhooks/", webhook
+    ):
+        print(
+            f"::error::{source} does not look like a Discord webhook URL "
+            "(expected https://discord.com/api/webhooks/<id>/<token>)."
+        )
+        return 1
+
+    post(
+        webhook,
+        json.dumps(payload).encode("utf-8"),
+        "application/json",
+        args.timeout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/pr_build_plan.py
+++ b/ci/pr_build_plan.py
@@ -1,0 +1,868 @@
+#!/usr/bin/env python3
+"""Plan a combined Windows test build for one or more open pull requests.
+
+A tester asks for a build with a list of PR numbers, for example
+``/build-pr 47 48 49 65``. Turning that wish into something safe to build takes
+more than a ``git merge``:
+
+* A closed or merged PR must be rejected with a reason, not silently skipped.
+* Every head commit is **pinned** here. Once a build is planned, a later push to
+  a PR branch must not be able to change what gets built and published.
+* Stacked PRs overlap. If #48's head already contains #47's head, merging both
+  is redundant and merging them in the wrong order can conflict for no reason,
+  so contained entries are dropped and the rest is ordered base-to-tip.
+* Nothing in here writes to the repository. The planner only reads the API and
+  the local object database.
+
+The module is deliberately split into pure functions plus two thin adapters
+(:class:`GitHubClient`, :class:`GitCommands`) so the whole decision logic can be
+unit-tested without a network or a real repository — see
+``ci/test_pr_build_plan.py``.
+
+Usage:
+    pr_build_plan.py plan  --repository owner/name --request "47 48,49" \\
+        --base-ref main --output plan.json --markdown plan.md
+    pr_build_plan.py verify --repository owner/name --plan plan.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import heapq
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+DEFAULT_API_BASE = "https://api.github.com"
+
+# A single request may combine at most this many pull requests. The ceiling is a
+# flood guard, not a technical limit: every extra PR adds a full ~30 minute
+# Windows build to the queue, and a merge plan nobody can review is not useful.
+MAX_PULL_REQUESTS = 10
+
+# Length of the hex digest that identifies a build. Long enough that two
+# different PR sets cannot collide in practice, short enough for a release tag.
+BUILD_KEY_LENGTH = 12
+
+TAG_PREFIX = "pr-test-"
+
+# The publisher embeds this marker in the release notes, and the cleanup reads it
+# back. Keeping the bookkeeping inside the release itself means no extra state
+# has to be stored anywhere, and an HTML comment is invisible to testers.
+MARKER_PATTERN = re.compile(r"<!--\s*frostguard-pr-test\s*(\{.*?\})\s*-->", re.S)
+
+DEFAULT_TTL_DAYS = 7
+
+
+@dataclass
+class PullRequestFacts:
+    """The pinned facts about one pull request, as read once from the API."""
+
+    number: int
+    title: str = ""
+    state: str = ""
+    merged: bool = False
+    draft: bool = False
+    head_sha: str = ""
+    head_ref: str = ""
+    head_repo: str = ""
+    base_ref: str = ""
+    author: str = ""
+    url: str = ""
+    updated_at: str = ""
+    error: str = ""
+
+    @property
+    def short_sha(self) -> str:
+        return self.head_sha[:7]
+
+
+@dataclass
+class Rejection:
+    number: int
+    reason: str
+
+
+@dataclass
+class Containment:
+    number: int
+    contained_in: int
+    reason: str
+
+
+@dataclass
+class PlanResult:
+    order: list[int] = field(default_factory=list)
+    rejected: list[Rejection] = field(default_factory=list)
+    contained: list[Containment] = field(default_factory=list)
+    problems: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+def parse_pr_request(text: str) -> tuple[list[int], list[str], list[int]]:
+    """Split a free-form request into PR numbers, junk tokens and duplicates.
+
+    Testers type ``47 48,49``, ``#47, #48`` or ``47/48``. Only decimal numbers
+    are accepted; everything else is reported back so the requester learns what
+    was ignored instead of silently getting a different build.
+
+    Returns ``(numbers, invalid_tokens, duplicates_removed)`` with the first
+    occurrence order preserved.
+    """
+    tokens = [token for token in re.split(r"[^0-9A-Za-z#_-]+", text or "") if token]
+
+    numbers: list[int] = []
+    invalid: list[str] = []
+    duplicates: list[int] = []
+    for token in tokens:
+        # "#47" and "047" are both unambiguous ways of writing 47; anything
+        # else (a word, a URL fragment, a range like "47-49") is not a PR
+        # number and is reported instead of guessed at.
+        candidate = token.lstrip("#")
+        if not candidate.isdigit():
+            invalid.append(token)
+            continue
+        value = int(candidate)
+        if value <= 0:
+            invalid.append(token)
+            continue
+        if value in numbers:
+            duplicates.append(value)
+            continue
+        numbers.append(value)
+    return numbers, invalid, duplicates
+
+
+def parse_order_override(text: str, allowed: list[int]) -> tuple[list[int], list[str]]:
+    """Parse an explicit base-to-tip order, keeping only known PR numbers."""
+    numbers, invalid, _ = parse_pr_request(text)
+    problems: list[str] = []
+    if invalid:
+        problems.append(
+            "Ignored unparseable tokens in the order override: "
+            + ", ".join(sorted(set(invalid)))
+        )
+    unknown = [number for number in numbers if number not in allowed]
+    if unknown:
+        problems.append(
+            "The order override lists pull requests that are not part of the "
+            "plan: " + ", ".join(f"#{number}" for number in unknown)
+        )
+    kept = [number for number in numbers if number in allowed]
+    missing = [number for number in allowed if number not in kept]
+    return kept + missing, problems
+
+
+def classify(facts: PullRequestFacts) -> str:
+    """Return an empty string when the PR is buildable, else the reason why not."""
+    if facts.error:
+        return facts.error
+    if facts.merged:
+        return "already merged into the base branch"
+    if facts.state != "open":
+        return f"not open (state: {facts.state or 'unknown'})"
+    if not re.fullmatch(r"[0-9a-f]{40}", facts.head_sha or ""):
+        return "the API returned no usable head commit"
+    return ""
+
+
+def select_and_order(
+    requested: list[int],
+    facts: dict[int, PullRequestFacts],
+    is_ancestor,
+    commit_time,
+    repository: str = "",
+    order_override: str = "",
+) -> PlanResult:
+    """Reject unbuildable PRs, drop contained ones and order the rest.
+
+    ``is_ancestor(a, b)`` must report whether commit ``a`` is an ancestor of
+    commit ``b``; ``commit_time(sha)`` returns a sortable committer timestamp.
+    Both are injected so this function stays free of subprocess calls.
+    """
+    result = PlanResult()
+
+    kept: list[int] = []
+    for number in requested:
+        entry = facts.get(number) or PullRequestFacts(number=number, error="not found")
+        reason = classify(entry)
+        if reason:
+            result.rejected.append(Rejection(number=number, reason=reason))
+            continue
+        if entry.draft:
+            result.notes.append(
+                f"#{number} is a draft pull request; its code is included anyway."
+            )
+        kept.append(number)
+
+    # --- containment -------------------------------------------------------
+    # A stacked PR's head commit already contains its ancestors' commits, so
+    # merging the ancestor as well is pure risk: it either no-ops or, after a
+    # rebase, resurrects an older version of the same change.
+    dropped: set[int] = set()
+    for outer in kept:
+        for inner in kept:
+            if outer == inner or outer in dropped or inner in dropped:
+                continue
+            outer_sha = facts[outer].head_sha
+            inner_sha = facts[inner].head_sha
+            if outer_sha == inner_sha:
+                # Two PRs pointing at the same commit: keep the lower number so
+                # the choice is stable across re-planning.
+                loser, winner = max(outer, inner), min(outer, inner)
+                if loser not in dropped:
+                    dropped.add(loser)
+                    result.contained.append(
+                        Containment(
+                            number=loser,
+                            contained_in=winner,
+                            reason="identical head commit",
+                        )
+                    )
+                continue
+            if is_ancestor(inner_sha, outer_sha):
+                dropped.add(inner)
+                result.contained.append(
+                    Containment(
+                        number=inner,
+                        contained_in=outer,
+                        reason=(
+                            f"{inner_sha[:7]} is an ancestor of "
+                            f"{outer_sha[:7]}"
+                        ),
+                    )
+                )
+
+    remaining = [number for number in kept if number not in dropped]
+    if not remaining:
+        return result
+
+    # --- ordering ----------------------------------------------------------
+    # Two independent signals put a stack in base-to-tip order:
+    #   1. A PR whose base branch is another requested PR's head branch must be
+    #      merged after it (only possible for same-repository PRs, since a fork
+    #      cannot target another fork's branch).
+    #   2. Otherwise older head commits go first, which keeps the merge sequence
+    #      close to the order the work was actually written in.
+    dependencies: dict[int, set[int]] = {number: set() for number in remaining}
+    for earlier in remaining:
+        for later in remaining:
+            if earlier == later:
+                continue
+            same_repo = (
+                not repository
+                or facts[earlier].head_repo.lower() == repository.lower()
+            )
+            if (
+                same_repo
+                and facts[earlier].head_ref
+                and facts[later].base_ref == facts[earlier].head_ref
+            ):
+                dependencies[later].add(earlier)
+
+    times: dict[int, int] = {}
+    for number in remaining:
+        try:
+            times[number] = int(commit_time(facts[number].head_sha))
+        except (TypeError, ValueError):
+            times[number] = 0
+
+    ready = [(times[n], n) for n in remaining if not dependencies[n]]
+    heapq.heapify(ready)
+    ordered: list[int] = []
+    pending = {number: set(deps) for number, deps in dependencies.items()}
+    while ready:
+        _, number = heapq.heappop(ready)
+        ordered.append(number)
+        for other, deps in pending.items():
+            if number in deps:
+                deps.discard(number)
+                if not deps and other not in ordered:
+                    heapq.heappush(ready, (times[other], other))
+
+    if len(ordered) != len(remaining):
+        # A cycle can only come from contradictory base branches. Falling back
+        # to the requested order keeps the build possible; the note explains it.
+        leftovers = [number for number in remaining if number not in ordered]
+        result.problems.append(
+            "Could not derive a stack order for "
+            + ", ".join(f"#{number}" for number in leftovers)
+            + " (their base branches form a cycle); using the requested order."
+        )
+        ordered = list(remaining)
+
+    if order_override:
+        override, problems = parse_order_override(order_override, ordered)
+        result.notes.extend(problems)
+        result.notes.append(
+            "Merge order was overridden by the requester: "
+            + " → ".join(f"#{number}" for number in override)
+        )
+        ordered = override
+
+    result.order = ordered
+    return result
+
+
+def compute_build_key(base_sha: str, ordered_shas: list[str]) -> str:
+    """Derive a stable identifier from the exact commits that will be merged.
+
+    The same PR set at the same commits, on the same base, yields the same key,
+    which is what makes "reuse the existing build instead of burning another 30
+    minutes of runner time" possible. Any push to any included PR changes it.
+    """
+    digest = hashlib.sha256()
+    digest.update(f"{base_sha}\n".encode())
+    for sha in ordered_shas:
+        digest.update(f"{sha}\n".encode())
+    return digest.hexdigest()[:BUILD_KEY_LENGTH]
+
+
+class GitHubClient:
+    """The few REST calls the planner needs, with a readable failure mode."""
+
+    def __init__(
+        self,
+        repository: str,
+        token: str = "",
+        api_base: str = DEFAULT_API_BASE,
+        timeout: float = 30.0,
+    ) -> None:
+        self.repository = repository
+        self.token = token
+        self.api_base = api_base.rstrip("/")
+        self.timeout = timeout
+
+    def _get(self, path: str) -> tuple[int, dict]:
+        request = urllib.request.Request(
+            f"{self.api_base}{path}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "frostguard-ci/1.0 (+https://github.com/Shederator/wosbot)",
+                **({"Authorization": f"Bearer {self.token}"} if self.token else {}),
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                return response.status, json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            body = ""
+            try:
+                body = error.read().decode("utf-8", "replace")[:200]
+            except OSError:
+                pass
+            return error.code, {"message": body}
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            return 0, {"message": str(error)}
+
+    def pull(self, number: int) -> PullRequestFacts:
+        status, body = self._get(f"/repos/{self.repository}/pulls/{number}")
+        if status == 404:
+            return PullRequestFacts(
+                number=number,
+                error="no such pull request in this repository",
+            )
+        if status != 200:
+            return PullRequestFacts(
+                number=number,
+                error=f"the GitHub API returned HTTP {status or 'no response'}",
+            )
+        head = body.get("head") or {}
+        head_repo = (head.get("repo") or {}).get("full_name") or ""
+        return PullRequestFacts(
+            number=number,
+            title=body.get("title") or "",
+            state=body.get("state") or "",
+            merged=bool(body.get("merged")),
+            draft=bool(body.get("draft")),
+            head_sha=head.get("sha") or "",
+            head_ref=head.get("ref") or "",
+            head_repo=head_repo,
+            base_ref=(body.get("base") or {}).get("ref") or "",
+            author=(body.get("user") or {}).get("login") or "",
+            url=body.get("html_url") or "",
+            updated_at=body.get("updated_at") or "",
+        )
+
+
+class GitCommands:
+    """Local read-only git queries. Nothing here writes a ref or pushes."""
+
+    def __init__(self, cwd: str = ".") -> None:
+        self.cwd = cwd
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def fetch_pull_head(self, number: int, remote: str = "origin") -> str:
+        """Fetch ``refs/pull/<n>/head`` and return the SHA it resolved to.
+
+        Fetching the base repository's PR ref works for forks too, and it is the
+        only way to pin a fork's commit without trusting the fork's remote.
+        """
+        completed = self._run(
+            "fetch",
+            "--no-tags",
+            "--quiet",
+            remote,
+            f"+refs/pull/{number}/head:refs/pr-test/{number}",
+        )
+        if completed.returncode != 0:
+            return ""
+        return self.rev_parse(f"refs/pr-test/{number}")
+
+    def rev_parse(self, ref: str) -> str:
+        completed = self._run("rev-parse", "--verify", f"{ref}^{{commit}}")
+        return completed.stdout.strip() if completed.returncode == 0 else ""
+
+    def is_ancestor(self, maybe_ancestor: str, descendant: str) -> bool:
+        if not maybe_ancestor or not descendant:
+            return False
+        return self._run(
+            "merge-base", "--is-ancestor", maybe_ancestor, descendant
+        ).returncode == 0
+
+    def commit_time(self, sha: str) -> int:
+        completed = self._run("show", "-s", "--format=%ct", sha)
+        try:
+            return int(completed.stdout.strip())
+        except ValueError:
+            return 0
+
+
+def plan_to_dict(
+    repository: str,
+    request_text: str,
+    requested: list[int],
+    invalid: list[str],
+    duplicates: list[int],
+    facts: dict[int, PullRequestFacts],
+    result: PlanResult,
+    base_ref: str,
+    base_sha: str,
+    requester: str = "",
+    conflict_resolution: str = "stop",
+) -> dict:
+    ordered_shas = [facts[number].head_sha for number in result.order]
+    key = compute_build_key(base_sha, ordered_shas)
+    return {
+        "version": 1,
+        "repository": repository,
+        "request": request_text,
+        "requester": requester,
+        "created_at": datetime.now(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "base_ref": base_ref,
+        "base_sha": base_sha,
+        "conflict_resolution": conflict_resolution,
+        "requested": requested,
+        "invalid_tokens": sorted(set(invalid)),
+        "duplicates_removed": sorted(set(duplicates)),
+        "rejected": [vars(item) for item in result.rejected],
+        "contained": [vars(item) for item in result.contained],
+        "problems": result.problems,
+        "notes": result.notes,
+        "order": result.order,
+        "pull_requests": {
+            str(number): vars(facts[number])
+            for number in result.order
+        },
+        "build_key": key,
+        "tag": f"{TAG_PREFIX}{key}",
+        "asset_name": asset_name(result.order),
+    }
+
+
+def asset_name(order: list[int]) -> str:
+    """A download filename that says what it is before anyone opens it.
+
+    The name is derived only from the PR numbers, so re-requesting the same set
+    produces the same URL and an already-posted link keeps working.
+    """
+    numbers = "-".join(str(number) for number in order) or "none"
+    return f"frostguard-unmerged-test-build-pr-{numbers}.zip"
+
+
+def render_markdown(plan: dict) -> str:
+    """Render the merge plan a human has to approve before resources are spent."""
+    lines: list[str] = []
+    order = plan.get("order") or []
+    lines.append("### Unmerged PR test build — merge plan")
+    lines.append("")
+    if order:
+        lines.append(
+            f"Base: `{plan.get('base_ref', 'main')}` at "
+            f"`{(plan.get('base_sha') or '')[:7]}` — "
+            f"merged in this order:"
+        )
+        lines.append("")
+        lines.append("| # | Pull request | Author | Pinned commit |")
+        lines.append("|---|---|---|---|")
+        for position, number in enumerate(order, start=1):
+            facts = (plan.get("pull_requests") or {}).get(str(number), {})
+            title = (facts.get("title") or "").replace("|", "\\|")
+            lines.append(
+                f"| {position} | [#{number}]({facts.get('url', '')}) {title} "
+                f"| @{facts.get('author', 'unknown')} "
+                f"| `{(facts.get('head_sha') or '')[:7]}` |"
+            )
+        lines.append("")
+        lines.append(f"Build key: `{plan.get('build_key', '')}`")
+    else:
+        lines.append("Nothing buildable was requested.")
+    lines.append("")
+
+    if plan.get("rejected"):
+        lines.append("**Rejected**")
+        for item in plan["rejected"]:
+            lines.append(f"- #{item['number']}: {item['reason']}")
+        lines.append("")
+    if plan.get("contained"):
+        lines.append("**Already contained in a later head (dropped)**")
+        for item in plan["contained"]:
+            lines.append(
+                f"- #{item['number']} is contained in #{item['contained_in']} "
+                f"({item['reason']})"
+            )
+        lines.append("")
+    if plan.get("duplicates_removed"):
+        lines.append(
+            "**Duplicates removed:** "
+            + ", ".join(f"#{number}" for number in plan["duplicates_removed"])
+        )
+        lines.append("")
+    if plan.get("invalid_tokens"):
+        lines.append(
+            "**Ignored, not a PR number:** "
+            + ", ".join(f"`{token}`" for token in plan["invalid_tokens"])
+        )
+        lines.append("")
+    for problem in plan.get("problems") or []:
+        lines.append(f"> [!WARNING]\n> {problem}")
+        lines.append("")
+    for note in plan.get("notes") or []:
+        lines.append(f"- {note}")
+    if plan.get("notes"):
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def marker_block(prs: list[int], build_key: str, base_sha: str) -> str:
+    """Render the machine-readable marker embedded in the release notes."""
+    payload = json.dumps(
+        {"prs": list(prs), "key": build_key, "base": base_sha},
+        sort_keys=True,
+    )
+    return f"<!-- frostguard-pr-test {payload} -->"
+
+
+def parse_marker(body: str) -> dict:
+    match = MARKER_PATTERN.search(body or "")
+    if not match:
+        return {}
+    try:
+        return json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return {}
+
+
+def render_notes(plan: dict, ttl_days: int = DEFAULT_TTL_DAYS) -> str:
+    """Write the release body for a temporary, unmerged test build.
+
+    The warning comes first and is unmissable. Somebody will find this release
+    through a search engine months from now with no idea what ``pr-test-`` means,
+    and the page has to tell them not to run it on their real account data.
+    """
+    base_sha = plan.get("base_sha") or ""
+    lines = [
+        "> [!CAUTION]",
+        "> **Unmerged test build.** This bundle contains pull request code that",
+        "> has not been reviewed or merged, and it is not a release. Use a test",
+        "> profile, not your main account data.",
+        "",
+        f"Built by combining these pull requests onto `{plan.get('base_ref', 'main')}` "
+        f"at `{base_sha[:7]}`, in this order:",
+        "",
+    ]
+    for position, number in enumerate(plan.get("order") or [], start=1):
+        facts = (plan.get("pull_requests") or {}).get(str(number), {})
+        lines.append(
+            f"{position}. #{number} {facts.get('title', '')} "
+            f"(`{(facts.get('head_sha') or '')[:7]}`, @{facts.get('author', 'unknown')})"
+        )
+    lines += [
+        "",
+        "**Install:** unzip anywhere, then run `java -jar frostguard-*.jar` "
+        "(Java 21+ required).",
+        "",
+        "Verified: bundle structure, manifest classpath and launch smoke test.",
+        "",
+        f"This prerelease is deleted automatically after {ttl_days} days, or as "
+        "soon as every included pull request is closed or merged.",
+        "",
+        marker_block(
+            plan.get("order") or [], plan.get("build_key", ""), base_sha
+        ),
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def verify_plan(plan: dict, client: GitHubClient) -> list[str]:
+    """Re-check, right before publishing, that the plan still describes reality.
+
+    Between planning and publishing there is a full Windows build. A PR can be
+    closed, merged or force-pushed in that window, and publishing a download
+    that claims to contain a commit it does not is exactly the confusion this
+    check exists to prevent.
+    """
+    problems: list[str] = []
+    for number in plan.get("order") or []:
+        pinned = (plan.get("pull_requests") or {}).get(str(number), {})
+        current = client.pull(int(number))
+        reason = classify(current)
+        if reason:
+            problems.append(f"#{number} is no longer buildable: {reason}")
+            continue
+        if current.head_sha != pinned.get("head_sha"):
+            problems.append(
+                f"#{number} moved from {str(pinned.get('head_sha'))[:7]} to "
+                f"{current.short_sha} while the build was running."
+            )
+    return problems
+
+
+def write_github_output(pairs: dict[str, str]) -> None:
+    """Publish step outputs, tolerating a local run with no Actions context."""
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        for key, value in pairs.items():
+            print(f"{key}={value}")
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in pairs.items():
+            if "\n" in value:
+                handle.write(f"{key}<<__FG_EOF__\n{value}\n__FG_EOF__\n")
+            else:
+                handle.write(f"{key}={value}\n")
+
+
+def command_plan(args: argparse.Namespace) -> int:
+    requested, invalid, duplicates = parse_pr_request(args.request)
+    if not requested:
+        print(
+            "::error::No pull request number was given. Expected something "
+            'like "47 48 49".'
+        )
+        return 1
+    if len(requested) > MAX_PULL_REQUESTS:
+        print(
+            f"::error::{len(requested)} pull requests were requested; at most "
+            f"{MAX_PULL_REQUESTS} may be combined in one test build."
+        )
+        return 1
+
+    client = GitHubClient(
+        args.repository,
+        token=os.environ.get(args.token_env, ""),
+        api_base=args.api_base,
+    )
+    git = GitCommands()
+
+    facts: dict[int, PullRequestFacts] = {}
+    for number in requested:
+        entry = client.pull(number)
+        if not classify(entry):
+            # Pin the commit locally as well. If the ref cannot be fetched the
+            # build could never reproduce this plan, so treat it as a rejection
+            # here rather than as a mysterious failure 30 minutes later.
+            fetched = git.fetch_pull_head(number, remote=args.remote)
+            if not fetched:
+                entry.error = (
+                    "its head commit could not be fetched from "
+                    f"refs/pull/{number}/head"
+                )
+            elif fetched != entry.head_sha:
+                entry.error = (
+                    f"its head moved while planning ({entry.short_sha} → "
+                    f"{fetched[:7]}); request the build again"
+                )
+        facts[number] = entry
+
+    base_sha = git.rev_parse(args.base_sha or f"{args.remote}/{args.base_ref}")
+    if not base_sha:
+        base_sha = git.rev_parse("HEAD")
+    if not base_sha:
+        print("::error::Could not resolve the base commit to build on top of.")
+        return 1
+
+    result = select_and_order(
+        requested,
+        facts,
+        is_ancestor=git.is_ancestor,
+        commit_time=git.commit_time,
+        repository=args.repository,
+        order_override=args.order,
+    )
+    plan = plan_to_dict(
+        repository=args.repository,
+        request_text=args.request,
+        requested=requested,
+        invalid=invalid,
+        duplicates=duplicates,
+        facts=facts,
+        result=result,
+        base_ref=args.base_ref,
+        base_sha=base_sha,
+        requester=args.requester,
+        conflict_resolution=args.conflict_resolution,
+    )
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as handle:
+            json.dump(plan, handle, indent=2, sort_keys=True)
+    markdown = render_markdown(plan)
+    if args.markdown:
+        with open(args.markdown, "w", encoding="utf-8") as handle:
+            handle.write(markdown)
+    print(markdown)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(markdown)
+
+    write_github_output(
+        {
+            "buildable": "true" if plan["order"] else "false",
+            "build_key": plan["build_key"],
+            "tag": plan["tag"],
+            "asset_name": plan["asset_name"],
+            "pr_list": ",".join(str(number) for number in plan["order"]),
+        }
+    )
+
+    if not plan["order"]:
+        print(
+            "::error::None of the requested pull requests can be built. "
+            "See the plan above for the reason per pull request."
+        )
+        return 1
+    return 0
+
+
+def command_verify(args: argparse.Namespace) -> int:
+    with open(args.plan, encoding="utf-8") as handle:
+        plan = json.load(handle)
+    client = GitHubClient(
+        plan.get("repository") or args.repository,
+        token=os.environ.get(args.token_env, ""),
+        api_base=args.api_base,
+    )
+    problems = verify_plan(plan, client)
+    if problems:
+        for problem in problems:
+            print(f"::error::{problem}")
+        print(
+            "\nThe plan no longer matches the repository, so nothing was "
+            "published. Request the build again to pick up the new commits."
+        )
+        return 1
+    print(
+        "All "
+        f"{len(plan.get('order') or [])} pull requests are still open at the "
+        "pinned commits."
+    )
+    return 0
+
+
+def command_notes(args: argparse.Namespace) -> int:
+    with open(args.plan, encoding="utf-8") as handle:
+        plan = json.load(handle)
+    notes = render_notes(plan, args.ttl_days)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as handle:
+            handle.write(notes)
+    else:
+        print(notes)
+    # The publisher needs these three facts for `gh release create`, and reading
+    # them out of the same file that produced the notes keeps them consistent.
+    write_github_output(
+        {
+            "base_sha": plan.get("base_sha", ""),
+            "tag": plan.get("tag", ""),
+            "asset_name": plan.get("asset_name", ""),
+            "pr_list": ",".join(str(number) for number in plan.get("order") or []),
+        }
+    )
+    return 0
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-base", default=DEFAULT_API_BASE)
+    parser.add_argument(
+        "--token-env",
+        default="GITHUB_TOKEN",
+        help="environment variable holding the API token",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    planner = subparsers.add_parser("plan", help="resolve and order a request")
+    planner.add_argument("--repository", required=True)
+    planner.add_argument("--request", required=True)
+    planner.add_argument("--requester", default="")
+    planner.add_argument("--base-ref", default="main")
+    planner.add_argument("--base-sha", default="")
+    planner.add_argument("--remote", default="origin")
+    planner.add_argument("--order", default="", help="explicit base-to-tip order")
+    planner.add_argument(
+        "--conflict-resolution",
+        default="stop",
+        choices=("stop", "union"),
+        help="what to do when git cannot combine the branches",
+    )
+    planner.add_argument("--output", default="", help="write the plan JSON here")
+    planner.add_argument("--markdown", default="", help="write the summary here")
+    planner.set_defaults(func=command_plan)
+
+    verifier = subparsers.add_parser(
+        "verify", help="re-check a plan against the live repository"
+    )
+    verifier.add_argument("--plan", required=True)
+    verifier.add_argument("--repository", default="")
+    verifier.set_defaults(func=command_verify)
+
+    notes = subparsers.add_parser(
+        "notes", help="render the release body for a planned test build"
+    )
+    notes.add_argument("--plan", required=True)
+    notes.add_argument("--output", default="")
+    notes.add_argument("--ttl-days", type=int, default=DEFAULT_TTL_DAYS)
+    notes.set_defaults(func=command_notes)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/test_pr_build_cleanup.py
+++ b/ci/test_pr_build_cleanup.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Self-tests for ci/pr_build_cleanup.py.
+
+This script deletes releases, so the tests care mostly about what it must *not*
+delete: a real tagged release, the rolling ``nightly`` prerelease, a fresh test
+build, or a build whose pull requests are still open. A cleanup bug that deletes
+too much is far more expensive than one that deletes too little.
+
+Run with:  python3 ci/test_pr_build_cleanup.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pr_build_cleanup as cleanup  # noqa: E402
+
+NOW = datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+
+
+def release(
+    tag: str,
+    days_old: float = 0,
+    prs: list[int] | None = None,
+    identifier: int = 1,
+) -> dict:
+    created = (NOW - timedelta(days=days_old)).isoformat().replace("+00:00", "Z")
+    body = "Unmerged test build.\n"
+    if prs is not None:
+        body += cleanup.marker_block(prs, "abc123", "f" * 40)
+    return {
+        "id": identifier,
+        "tag_name": tag,
+        "created_at": created,
+        "body": body,
+    }
+
+
+def states(mapping: dict[int, str]):
+    return lambda number: mapping.get(number, "open")
+
+
+class MarkerTest(unittest.TestCase):
+
+    def test_the_marker_round_trips(self):
+        body = "notes\n" + cleanup.marker_block([48, 49], "key", "base")
+        parsed = cleanup.parse_marker(body)
+        self.assertEqual([48, 49], parsed["prs"])
+        self.assertEqual("key", parsed["key"])
+
+    def test_a_missing_or_broken_marker_yields_nothing(self):
+        self.assertEqual({}, cleanup.parse_marker("just notes"))
+        self.assertEqual(
+            {}, cleanup.parse_marker("<!-- frostguard-pr-test {not json} -->")
+        )
+
+    def test_the_marker_is_invisible_in_rendered_markdown(self):
+        # It is an HTML comment on purpose: testers should not see bookkeeping.
+        self.assertTrue(cleanup.marker_block([1], "k", "b").startswith("<!--"))
+
+
+class RetirementRuleTest(unittest.TestCase):
+
+    def test_a_fresh_test_build_with_open_pull_requests_is_kept(self):
+        doomed = cleanup.decide(
+            [release("pr-test-abc", days_old=1, prs=[48, 49])],
+            states({}),
+            NOW,
+        )
+        self.assertEqual([], doomed)
+
+    def test_an_expired_test_build_is_retired(self):
+        doomed = cleanup.decide(
+            [release("pr-test-abc", days_old=9, prs=[48])], states({}), NOW
+        )
+        self.assertEqual(1, len(doomed))
+        self.assertIn("TTL", doomed[0][1])
+
+    def test_a_build_whose_pull_requests_all_finished_is_retired(self):
+        doomed = cleanup.decide(
+            [release("pr-test-abc", days_old=1, prs=[48, 49])],
+            states({48: "merged", 49: "closed"}),
+            NOW,
+        )
+        self.assertEqual(1, len(doomed))
+        self.assertIn("closed or merged", doomed[0][1])
+
+    def test_one_still_open_pull_request_keeps_the_build_alive(self):
+        doomed = cleanup.decide(
+            [release("pr-test-abc", days_old=1, prs=[48, 49])],
+            states({48: "merged"}),
+            NOW,
+        )
+        self.assertEqual([], doomed)
+
+    def test_a_real_release_is_never_touched(self):
+        doomed = cleanup.decide(
+            [
+                {"id": 9, "tag_name": "v2.1.0", "created_at": "2020-01-01T00:00:00Z"},
+                {"id": 8, "tag_name": "nightly", "created_at": "2020-01-01T00:00:00Z"},
+            ],
+            states({}),
+            NOW,
+        )
+        self.assertEqual([], doomed)
+
+    def test_a_test_build_without_a_marker_is_only_retired_by_age(self):
+        fresh = release("pr-test-abc", days_old=1)
+        fresh["body"] = "notes without a marker"
+        self.assertEqual([], cleanup.decide([fresh], states({}), NOW))
+
+        old = release("pr-test-def", days_old=30)
+        old["body"] = "notes without a marker"
+        self.assertEqual(1, len(cleanup.decide([old], states({}), NOW)))
+
+    def test_the_ttl_is_configurable(self):
+        candidate = [release("pr-test-abc", days_old=3, prs=[48])]
+        self.assertEqual([], cleanup.decide(candidate, states({}), NOW, ttl_days=7))
+        self.assertEqual(
+            1, len(cleanup.decide(candidate, states({}), NOW, ttl_days=2))
+        )
+
+    def test_an_unreadable_timestamp_does_not_delete_the_release(self):
+        broken = release("pr-test-abc", prs=[48])
+        broken["created_at"] = "not a date"
+        self.assertEqual([], cleanup.decide([broken], states({}), NOW))
+
+
+class ApiSafetyTest(unittest.TestCase):
+
+    def test_an_unreadable_pull_request_counts_as_open(self):
+        # Otherwise a transient API failure would delete builds testers are
+        # still downloading.
+        api = cleanup.ReleaseApi("owner/name", token="x", api_base="http://127.0.0.1:1")
+        self.assertEqual("open", api.pull_state(48))
+
+    def test_only_the_test_prefix_is_considered(self):
+        self.assertTrue("pr-test-abc".startswith(cleanup.TAG_PREFIX))
+        self.assertFalse("nightly".startswith(cleanup.TAG_PREFIX))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ci/test_pr_build_combine.py
+++ b/ci/test_pr_build_combine.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Self-tests for ci/pr_build_combine.py.
+
+These run against real throwaway repositories created with ``git init``, because
+the properties worth guaranteeing are properties of git's behaviour, not of a
+mock: a conflict really stops the run, a union resolution really keeps both
+sides, a binary conflict is really refused, and ``main`` plus every source
+branch really still point at the same commit afterwards.
+
+Run with:  python3 ci/test_pr_build_combine.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pr_build_combine as combiner  # noqa: E402
+
+
+def git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+class Sandbox:
+    """A tiny repository with a `main` branch and per-"pull request" branches."""
+
+    def __init__(self, directory: Path) -> None:
+        self.repo = directory
+        git(self.repo, "init", "--quiet", "--initial-branch", "main")
+        git(self.repo, "config", "user.email", "ci@example.invalid")
+        git(self.repo, "config", "user.name", "Frostguard CI")
+        git(self.repo, "config", "commit.gpgsign", "false")
+        self.write("README.md", "base\n")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "--quiet", "-m", "base")
+        self.base_sha = git(self.repo, "rev-parse", "HEAD")
+
+    def write(self, name: str, content: str | bytes) -> None:
+        path = self.repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            path.write_bytes(content)
+        else:
+            path.write_text(content, encoding="utf-8")
+
+    def branch(self, name: str, files: dict[str, str | bytes]) -> str:
+        git(self.repo, "checkout", "--quiet", "-B", name, self.base_sha)
+        for filename, content in files.items():
+            self.write(filename, content)
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "--quiet", "-m", f"work on {name}")
+        sha = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "checkout", "--quiet", "main")
+        return sha
+
+    def plan(self, entries: list[tuple[int, str]]) -> dict:
+        return {
+            "build_key": "testkey00000",
+            "base_ref": "main",
+            "base_sha": self.base_sha,
+            "order": [number for number, _ in entries],
+            "pull_requests": {
+                str(number): {
+                    "number": number,
+                    "title": f"change {number}",
+                    "head_sha": sha,
+                    "url": f"https://example.invalid/pull/{number}",
+                }
+                for number, sha in entries
+            },
+        }
+
+
+class CombineTestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._temp = tempfile.TemporaryDirectory()
+        self.sandbox = Sandbox(Path(self._temp.name))
+        self.git = combiner.Git(str(self.sandbox.repo))
+
+    def tearDown(self) -> None:
+        self._temp.cleanup()
+
+
+class CleanCombineTest(CombineTestCase):
+
+    def test_independent_pull_requests_merge_cleanly_in_order(self):
+        first = self.sandbox.branch("pr-47", {"a.txt": "from 47\n"})
+        second = self.sandbox.branch("pr-48", {"b.txt": "from 48\n"})
+        plan = self.sandbox.plan([(47, first), (48, second)])
+
+        report = combiner.combine(self.git, plan)
+
+        self.assertEqual("clean", report["status"])
+        self.assertEqual(2, len(report["merges"]))
+        self.assertEqual([], report["conflicts"])
+        # Both changes are present: a merge that quietly dropped one would be
+        # indistinguishable from success without this.
+        self.assertEqual("from 47\n", (self.sandbox.repo / "a.txt").read_text())
+        self.assertEqual("from 48\n", (self.sandbox.repo / "b.txt").read_text())
+
+    def test_combining_never_moves_main_or_a_source_branch(self):
+        first = self.sandbox.branch("pr-47", {"a.txt": "from 47\n"})
+        second = self.sandbox.branch("pr-48", {"b.txt": "from 48\n"})
+        before = {
+            "main": git(self.sandbox.repo, "rev-parse", "main"),
+            "pr-47": git(self.sandbox.repo, "rev-parse", "pr-47"),
+            "pr-48": git(self.sandbox.repo, "rev-parse", "pr-48"),
+        }
+
+        combiner.combine(self.git, self.sandbox.plan([(47, first), (48, second)]))
+
+        for ref, sha in before.items():
+            self.assertEqual(
+                sha,
+                git(self.sandbox.repo, "rev-parse", ref),
+                f"{ref} must not be modified by a test build",
+            )
+
+    def test_work_happens_on_a_disposable_branch_named_after_the_build(self):
+        first = self.sandbox.branch("pr-47", {"a.txt": "from 47\n"})
+        report = combiner.combine(self.git, self.sandbox.plan([(47, first)]))
+        self.assertEqual("pr-test/testkey00000", report["branch"])
+        self.assertEqual(
+            "pr-test/testkey00000",
+            git(self.sandbox.repo, "rev-parse", "--abbrev-ref", "HEAD"),
+        )
+
+    def test_an_empty_plan_is_reported_rather_than_built(self):
+        report = combiner.combine(self.git, self.sandbox.plan([]))
+        self.assertEqual("empty", report["status"])
+
+    def test_pushing_is_refused_structurally(self):
+        with self.assertRaises(combiner.GitError):
+            self.git.run("push", "origin", "main")
+
+
+class ConflictTest(CombineTestCase):
+
+    def conflicting_plan(self) -> dict:
+        first = self.sandbox.branch("pr-47", {"shared.txt": "line from 47\n"})
+        second = self.sandbox.branch("pr-48", {"shared.txt": "line from 48\n"})
+        return self.sandbox.plan([(47, first), (48, second)])
+
+    def test_a_text_conflict_stops_the_run_and_names_the_file(self):
+        report = combiner.combine(self.git, self.conflicting_plan())
+
+        self.assertEqual("conflict", report["status"])
+        self.assertEqual(1, len(report["conflicts"]))
+        self.assertEqual(48, report["conflicts"][0]["number"])
+        self.assertEqual(
+            ["shared.txt"],
+            [item["path"] for item in report["conflicts"][0]["files"]],
+        )
+        self.assertEqual("text", report["conflicts"][0]["files"][0]["kind"])
+
+    def test_a_stopped_conflict_leaves_no_merge_in_progress(self):
+        combiner.combine(self.git, self.conflicting_plan())
+        # MERGE_HEAD surviving would mean the workspace was left mid-merge and
+        # any following step would operate on a half-merged tree.
+        self.assertFalse((self.sandbox.repo / ".git" / "MERGE_HEAD").exists())
+
+    def test_the_conflict_report_never_picks_a_side(self):
+        report = combiner.combine(self.git, self.conflicting_plan())
+        rendered = combiner.render_conflict_report(report, self.conflicting_plan())
+        self.assertIn("shared.txt", rendered)
+        self.assertNotIn("--ours", rendered)
+        self.assertNotIn("--theirs", rendered)
+        self.assertIn("union", rendered)
+
+    def test_union_resolution_keeps_both_sides(self):
+        with tempfile.TemporaryDirectory() as out:
+            diff_path = str(Path(out) / "proposal.diff")
+            report = combiner.combine(
+                self.git,
+                self.conflicting_plan(),
+                resolution="union",
+                proposal_diff=diff_path,
+            )
+            self.assertEqual("resolved", report["status"])
+            self.assertEqual(["shared.txt"], report["resolved_paths"])
+            merged = (self.sandbox.repo / "shared.txt").read_text()
+            self.assertIn("line from 47", merged)
+            self.assertIn("line from 48", merged)
+            self.assertNotIn("<<<<<<<", merged)
+            # The proposal has to be reviewable, so the diff is written out.
+            self.assertIn("shared.txt", Path(diff_path).read_text())
+
+    def test_a_binary_conflict_is_refused_even_in_union_mode(self):
+        first = self.sandbox.branch("pr-47", {"asset.bin": b"\x00\x01from 47"})
+        second = self.sandbox.branch("pr-48", {"asset.bin": b"\x00\x02from 48"})
+        plan = self.sandbox.plan([(47, first), (48, second)])
+
+        report = combiner.combine(self.git, plan, resolution="union")
+
+        self.assertEqual("conflict", report["status"])
+        kinds = [item["kind"] for item in report["conflicts"][0]["files"]]
+        self.assertEqual(["binary"], kinds)
+        self.assertFalse(report["conflicts"][0]["files"][0]["resolvable_by_union"])
+        self.assertIn(
+            "manual",
+            combiner.render_conflict_report(report, plan),
+        )
+
+    def test_a_delete_modify_conflict_is_refused_even_in_union_mode(self):
+        self.sandbox.write("shared.txt", "original\n")
+        git(self.sandbox.repo, "add", "-A")
+        git(self.sandbox.repo, "commit", "--quiet", "-m", "add shared")
+        self.sandbox.base_sha = git(self.sandbox.repo, "rev-parse", "HEAD")
+
+        git(self.sandbox.repo, "checkout", "--quiet", "-B", "pr-47")
+        (self.sandbox.repo / "shared.txt").unlink()
+        git(self.sandbox.repo, "add", "-A")
+        git(self.sandbox.repo, "commit", "--quiet", "-m", "delete shared")
+        first = git(self.sandbox.repo, "rev-parse", "HEAD")
+        git(self.sandbox.repo, "checkout", "--quiet", "main")
+
+        second = self.sandbox.branch("pr-48", {"shared.txt": "changed by 48\n"})
+        plan = self.sandbox.plan([(47, first), (48, second)])
+
+        report = combiner.combine(self.git, plan, resolution="union")
+
+        self.assertEqual("conflict", report["status"])
+        self.assertEqual(
+            "delete/modify", report["conflicts"][0]["files"][0]["kind"]
+        )
+
+
+class HelperTest(unittest.TestCase):
+
+    def test_binary_detection_uses_the_nul_byte_heuristic(self):
+        self.assertTrue(combiner.looks_binary(b"abc\x00def"))
+        self.assertFalse(combiner.looks_binary(b"plain text\n"))
+        self.assertFalse(combiner.looks_binary(None))
+
+    def test_conflict_report_is_json_serialisable(self):
+        json.dumps(
+            {
+                "status": "conflict",
+                "conflicts": [
+                    {
+                        "number": 48,
+                        "sha": "a" * 40,
+                        "files": [
+                            {
+                                "path": "x",
+                                "kind": "text",
+                                "resolvable_by_union": True,
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ci/test_pr_build_command.py
+++ b/ci/test_pr_build_command.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Self-tests for ci/pr_build_command.py.
+
+The command parser and the two guards around it are the whole access-control
+story for test builds: whoever gets past them can spend the repository's Actions
+minutes and publish a public download. So the interesting cases here are the
+hostile and the clumsy ones — a quoted command in a reply, a drive-by comment
+from someone without write access, a typo repeated five times in a row.
+
+Run with:  python3 ci/test_pr_build_command.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pr_build_command as command  # noqa: E402
+
+NOW = datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+
+
+class ParsingTest(unittest.TestCase):
+
+    def test_a_plain_request_is_a_plan_not_a_build(self):
+        result = command.parse_command("/build-pr 47 48 49 65")
+        self.assertTrue(result.is_command)
+        self.assertEqual("47 48 49 65", result.prs)
+        self.assertFalse(result.confirm)
+        self.assertEqual("stop", result.resolution)
+
+    def test_confirm_switches_the_request_into_a_real_build(self):
+        result = command.parse_command("/build-pr 47 48 confirm")
+        self.assertTrue(result.confirm)
+        self.assertEqual("47 48", result.prs)
+
+    def test_union_opts_into_a_both_sides_resolution(self):
+        result = command.parse_command("/build-pr 47 48 union confirm")
+        self.assertEqual("union", result.resolution)
+        self.assertTrue(result.confirm)
+
+    def test_order_override_is_extracted_and_not_treated_as_numbers(self):
+        result = command.parse_command("/build-pr 47 48 49 order=49,47,48 confirm")
+        self.assertEqual("49,47,48", result.order)
+        self.assertEqual("47 48 49", result.prs)
+
+    def test_hash_prefixed_numbers_and_commas_are_accepted(self):
+        result = command.parse_command("/build-pr #47, #48")
+        self.assertEqual("#47 #48", result.prs)
+
+    def test_a_quoted_command_in_a_reply_does_not_trigger_a_build(self):
+        # GitHub reply quoting prefixes lines with "> ". Reacting to those would
+        # make every thread reply start another build.
+        body = "> /build-pr 47 48 confirm\n\nLooks good to me."
+        self.assertFalse(command.parse_command(body).is_command)
+
+    def test_the_command_may_appear_after_a_line_of_prose(self):
+        body = "Please build these:\n/build-pr 47 48 confirm"
+        result = command.parse_command(body)
+        self.assertTrue(result.is_command)
+        self.assertTrue(result.confirm)
+
+    def test_a_comment_without_the_command_is_ignored(self):
+        self.assertFalse(command.parse_command("nice work, thanks!").is_command)
+        self.assertFalse(command.parse_command("").is_command)
+
+    def test_help_is_shown_for_an_empty_or_explicit_help_request(self):
+        self.assertTrue(command.parse_command("/build-pr").help)
+        self.assertTrue(command.parse_command("/build-pr help").help)
+
+    def test_unknown_tokens_are_reported_instead_of_guessed(self):
+        result = command.parse_command("/build-pr 47 latest nightly")
+        self.assertEqual("47", result.prs)
+        self.assertEqual(["latest", "nightly"], result.unknown)
+
+    def test_usage_text_documents_every_accepted_keyword(self):
+        for keyword in ("confirm", "union", "order=", "help"):
+            self.assertIn(keyword, command.USAGE)
+
+
+class AuthorizationTest(unittest.TestCase):
+
+    def test_write_access_is_enough(self):
+        for permission in ("admin", "maintain", "write"):
+            allowed, _ = command.is_authorized(permission, actor="Shederator")
+            self.assertTrue(allowed, permission)
+
+    def test_read_access_is_not_enough(self):
+        allowed, reason = command.is_authorized("read", actor="drive-by")
+        self.assertFalse(allowed)
+        self.assertIn("write access", reason)
+
+    def test_an_explicit_allowlist_can_grant_a_trusted_tester(self):
+        allowed, reason = command.is_authorized(
+            "read", actor="TrustedTester", allowlist="someone, TRUSTEDTESTER"
+        )
+        self.assertTrue(allowed)
+        self.assertIn("allowlist", reason)
+
+    def test_the_author_association_is_accepted_when_the_api_says_nothing(self):
+        allowed, _ = command.is_authorized("", association="OWNER", actor="x")
+        self.assertTrue(allowed)
+        allowed, _ = command.is_authorized(
+            "", association="FIRST_TIME_CONTRIBUTOR", actor="x"
+        )
+        self.assertFalse(allowed)
+
+    def test_an_empty_permission_and_association_is_refused(self):
+        allowed, _ = command.is_authorized("", "", "nobody", "")
+        self.assertFalse(allowed)
+
+
+def run(actor: str, minutes_ago: int) -> dict:
+    return {
+        "actor": {"login": actor},
+        "run_started_at": (NOW - timedelta(minutes=minutes_ago))
+        .isoformat()
+        .replace("+00:00", "Z"),
+    }
+
+
+class CooldownTest(unittest.TestCase):
+
+    def test_a_first_request_is_never_blocked(self):
+        blocked, _ = command.cooldown_exceeded([], "Shederator", NOW)
+        self.assertFalse(blocked)
+
+    def test_a_burst_of_requests_from_one_person_is_blocked(self):
+        runs = [run("Shederator", 5), run("Shederator", 10), run("Shederator", 15)]
+        blocked, reason = command.cooldown_exceeded(runs, "Shederator", NOW)
+        self.assertTrue(blocked)
+        self.assertIn("limit 3", reason)
+
+    def test_old_requests_fall_out_of_the_window(self):
+        runs = [run("Shederator", 90), run("Shederator", 120), run("Shederator", 200)]
+        blocked, _ = command.cooldown_exceeded(runs, "Shederator", NOW)
+        self.assertFalse(blocked)
+
+    def test_other_people_do_not_consume_your_quota(self):
+        runs = [run("CodeLtDave", 1), run("bizulk", 2), run("CodeLtDave", 3)]
+        blocked, _ = command.cooldown_exceeded(runs, "Shederator", NOW)
+        self.assertFalse(blocked)
+
+    def test_a_malformed_timestamp_is_skipped_rather_than_crashing(self):
+        runs = [{"actor": {"login": "Shederator"}, "run_started_at": "nonsense"}]
+        blocked, _ = command.cooldown_exceeded(runs, "Shederator", NOW)
+        self.assertFalse(blocked)
+
+    def test_an_unreadable_history_never_blocks_a_legitimate_build(self):
+        # A failing API call must not become a denial of service on the feature.
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "missing.json"
+            code = command.main(
+                ["cooldown", "--runs", str(path), "--actor", "Shederator"]
+            )
+            self.assertEqual(0, code)
+
+    def test_the_history_file_from_the_api_is_understood(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "runs.json"
+            path.write_text(
+                json.dumps({"workflow_runs": [run("Shederator", 1)]}),
+                encoding="utf-8",
+            )
+            code = command.main(
+                ["cooldown", "--runs", str(path), "--actor", "Shederator"]
+            )
+            self.assertEqual(0, code)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ci/test_pr_build_notify.py
+++ b/ci/test_pr_build_notify.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Self-tests for ci/pr_build_notify.py.
+
+The notification is the only thing most testers will ever read about a test
+build, so the payload has to carry the facts that decide whether installing it is
+a good idea: which pull requests, at which commits, and that the download is
+unmerged and unreviewed. These tests pin that contract, plus Discord's size
+limits and the no-mass-ping rule, without touching the network.
+
+Run with:  python3 ci/test_pr_build_notify.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pr_build_notify as notifier  # noqa: E402
+
+PLAN = {
+    "version": 1,
+    "repository": "Shederator/wosbot",
+    "base_ref": "main",
+    "base_sha": "f" * 40,
+    "build_key": "abc123def456",
+    "tag": "pr-test-abc123def456",
+    "asset_name": "frostguard-unmerged-test-build-pr-48-49.zip",
+    "order": [48, 49],
+    "requested": [47, 48, 49],
+    "invalid_tokens": ["latest"],
+    "duplicates_removed": [49],
+    "rejected": [{"number": 44, "reason": "already merged into the base branch"}],
+    "contained": [
+        {"number": 47, "contained_in": 48, "reason": "1234567 is an ancestor"}
+    ],
+    "problems": [],
+    "notes": [],
+    "pull_requests": {
+        "48": {
+            "number": 48,
+            "title": "fix(deployment): account final costs across march routines",
+            "head_sha": "d0fb22a48f3469d4bfcf09f8fe20745bf3f8c373",
+            "author": "CodeLtDave",
+            "url": "https://github.com/Shederator/wosbot/pull/48",
+        },
+        "49": {
+            "number": 49,
+            "title": "fix(intel): derive availability from typed march state",
+            "head_sha": "8162d39700d72e3afecae7eee1038d202b8cc367",
+            "author": "CodeLtDave",
+            "url": "https://github.com/Shederator/wosbot/pull/49",
+        },
+    },
+}
+
+REPORT = {
+    "status": "conflict",
+    "conflicts": [
+        {
+            "number": 49,
+            "sha": "8162d39700d72e3afecae7eee1038d202b8cc367",
+            "files": [
+                {
+                    "path": "fg-tasks/src/main/java/Intel.java",
+                    "kind": "text",
+                    "resolvable_by_union": True,
+                },
+                {
+                    "path": "fg-vision/src/main/resources/templates/x.png",
+                    "kind": "binary",
+                    "resolvable_by_union": False,
+                },
+            ],
+        }
+    ],
+}
+
+
+class PayloadTestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._temp = tempfile.TemporaryDirectory()
+        directory = Path(self._temp.name)
+        self.plan_path = directory / "plan.json"
+        self.plan_path.write_text(json.dumps(PLAN), encoding="utf-8")
+        self.report_path = directory / "report.json"
+        self.report_path.write_text(json.dumps(REPORT), encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self._temp.cleanup()
+
+    def payload(self, *extra: str) -> dict:
+        args = notifier.parse_args(
+            [
+                "--plan",
+                str(self.plan_path),
+                "--repository",
+                "Shederator/wosbot",
+                "--run-url",
+                "https://github.com/Shederator/wosbot/actions/runs/1",
+                "--run-number",
+                "7",
+                *extra,
+            ]
+        )
+        return notifier.build_payload(args)
+
+    def flat(self, payload: dict) -> str:
+        return json.dumps(payload)
+
+
+class SuccessMessageTest(PayloadTestCase):
+
+    def test_success_carries_the_download_link_as_tappable_content(self):
+        payload = self.payload(
+            "--status",
+            "success",
+            "--download-url",
+            "https://github.com/Shederator/wosbot/releases/download/"
+            "pr-test-abc123def456/frostguard-unmerged-test-build-pr-48-49.zip",
+        )
+        self.assertIn("releases/download/pr-test-", payload["content"])
+
+    def test_success_labels_the_build_as_unmerged_and_unreviewed(self):
+        payload = self.payload(
+            "--status", "success", "--download-url", "https://example.invalid/x.zip"
+        )
+        description = payload["embeds"][0]["description"]
+        self.assertIn("Unmerged test build", description)
+        self.assertIn("not been reviewed", description)
+
+    def test_every_included_pull_request_is_listed_with_its_pinned_commit(self):
+        body = self.flat(self.payload("--status", "success"))
+        self.assertIn("#48", body)
+        self.assertIn("#49", body)
+        self.assertIn("d0fb22a", body)
+        self.assertIn("8162d39", body)
+
+    def test_rejected_and_contained_pull_requests_are_explained(self):
+        body = self.flat(self.payload("--status", "success"))
+        self.assertIn("already merged", body)
+        self.assertIn("#47 already contained in #48", body)
+        self.assertIn("latest", body)
+
+    def test_a_relative_download_url_is_dropped_instead_of_advertised(self):
+        payload = self.payload(
+            "--status", "success", "--download-url", "frostguard.zip"
+        )
+        self.assertNotIn("content", payload)
+
+    def test_expiry_is_advertised_when_known(self):
+        body = self.flat(
+            self.payload("--status", "success", "--expires", "in 7 days")
+        )
+        self.assertIn("in 7 days", body)
+
+
+class PlanMessageTest(PayloadTestCase):
+
+    def test_a_plan_says_clearly_that_nothing_was_built(self):
+        payload = self.payload("--status", "plan")
+        self.assertIn("nothing has been built", payload["embeds"][0]["description"])
+        self.assertNotIn("content", payload)
+
+    def test_the_confirmation_hint_is_passed_through(self):
+        payload = self.payload(
+            "--status", "plan", "--confirm-hint", "Reply `/build-pr 48 49 confirm`"
+        )
+        self.assertIn("confirm", payload["embeds"][0]["description"])
+
+
+class ConflictMessageTest(PayloadTestCase):
+
+    def test_conflicting_files_are_named_with_their_kind(self):
+        payload = self.payload(
+            "--status", "conflict", "--report", str(self.report_path)
+        )
+        body = self.flat(payload)
+        self.assertIn("Intel.java", body)
+        self.assertIn("templates/x.png", body)
+        self.assertIn("binary", body)
+
+    def test_conflict_states_that_nothing_was_changed_or_published(self):
+        payload = self.payload(
+            "--status", "conflict", "--report", str(self.report_path)
+        )
+        description = payload["embeds"][0]["description"]
+        self.assertIn("Nothing in the repository was changed", description)
+
+
+class SafetyTest(PayloadTestCase):
+
+    def test_mass_pings_are_disabled_structurally(self):
+        payload = self.payload("--status", "success")
+        self.assertEqual({"parse": []}, payload["allowed_mentions"])
+
+    def test_a_pull_request_title_cannot_ping_the_channel(self):
+        hostile = dict(PLAN)
+        hostile["pull_requests"] = {
+            "48": {
+                "number": 48,
+                "title": "@everyone install this now",
+                "head_sha": "a" * 40,
+                "author": "attacker",
+                "url": "https://example.invalid/pull/48",
+            }
+        }
+        hostile["order"] = [48]
+        path = Path(self._temp.name) / "hostile.json"
+        path.write_text(json.dumps(hostile), encoding="utf-8")
+        args = notifier.parse_args(["--status", "success", "--plan", str(path)])
+        payload = notifier.build_payload(args)
+        self.assertEqual({"parse": []}, payload["allowed_mentions"])
+
+    def test_every_string_stays_inside_discord_limits(self):
+        long_plan = dict(PLAN)
+        long_plan["pull_requests"] = {
+            str(number): {
+                "number": number,
+                "title": "x" * 400,
+                "head_sha": f"{number:040x}",
+                "author": "y" * 100,
+                "url": "https://example.invalid/pull/1",
+            }
+            for number in range(1, 31)
+        }
+        long_plan["order"] = list(range(1, 31))
+        path = Path(self._temp.name) / "long.json"
+        path.write_text(json.dumps(long_plan), encoding="utf-8")
+        args = notifier.parse_args(["--status", "success", "--plan", str(path)])
+        payload = notifier.build_payload(args)
+        embed = payload["embeds"][0]
+        self.assertLessEqual(len(embed["title"]), notifier.EMBED_TITLE_LIMIT)
+        self.assertLessEqual(
+            len(embed["description"]), notifier.EMBED_DESCRIPTION_LIMIT
+        )
+        for field in embed["fields"]:
+            self.assertLessEqual(len(field["name"]), notifier.EMBED_FIELD_NAME_LIMIT)
+            self.assertLessEqual(
+                len(field["value"]), notifier.EMBED_FIELD_VALUE_LIMIT
+            )
+
+    def test_a_missing_plan_file_does_not_crash_the_notification(self):
+        args = notifier.parse_args(
+            ["--status", "failure", "--plan", "/nonexistent/plan.json"]
+        )
+        payload = notifier.build_payload(args)
+        self.assertIn("failed", payload["embeds"][0]["title"].lower())
+
+
+class WebhookResolutionTest(unittest.TestCase):
+
+    def test_a_dedicated_webhook_wins_over_the_nightly_one(self):
+        import os
+
+        os.environ["FG_TEST_PRIMARY"] = "https://discord.com/api/webhooks/1/a"
+        os.environ["FG_TEST_FALLBACK"] = "https://discord.com/api/webhooks/2/b"
+        try:
+            value, source = notifier.resolve_webhook(
+                "FG_TEST_PRIMARY", "FG_TEST_FALLBACK"
+            )
+            self.assertEqual("https://discord.com/api/webhooks/1/a", value)
+            self.assertEqual("FG_TEST_PRIMARY", source)
+        finally:
+            del os.environ["FG_TEST_PRIMARY"]
+            del os.environ["FG_TEST_FALLBACK"]
+
+    def test_the_nightly_webhook_is_used_when_no_dedicated_one_exists(self):
+        import os
+
+        os.environ.pop("FG_TEST_PRIMARY", None)
+        os.environ["FG_TEST_FALLBACK"] = "https://discord.com/api/webhooks/2/b"
+        try:
+            value, source = notifier.resolve_webhook(
+                "FG_TEST_PRIMARY", "FG_TEST_FALLBACK"
+            )
+            self.assertEqual("https://discord.com/api/webhooks/2/b", value)
+            self.assertEqual("FG_TEST_FALLBACK", source)
+        finally:
+            del os.environ["FG_TEST_FALLBACK"]
+
+    def test_a_non_discord_url_is_rejected_before_anything_is_posted(self):
+        import os
+
+        os.environ["FG_TEST_PRIMARY"] = "https://evil.example/api/webhooks/1/a"
+        try:
+            code = notifier.main(
+                [
+                    "--status",
+                    "success",
+                    "--webhook-env",
+                    "FG_TEST_PRIMARY",
+                    "--webhook-env-fallback",
+                    "FG_TEST_ABSENT",
+                ]
+            )
+            self.assertEqual(1, code)
+        finally:
+            del os.environ["FG_TEST_PRIMARY"]
+
+    def test_no_webhook_at_all_is_a_warning_not_a_failure(self):
+        code = notifier.main(
+            [
+                "--status",
+                "success",
+                "--webhook-env",
+                "FG_TEST_ABSENT_A",
+                "--webhook-env-fallback",
+                "FG_TEST_ABSENT_B",
+            ]
+        )
+        self.assertEqual(0, code)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ci/test_pr_build_plan.py
+++ b/ci/test_pr_build_plan.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Self-tests for ci/pr_build_plan.py.
+
+Every rule that protects a tester lives in this module: rejecting closed pull
+requests, pinning head commits, dropping stack entries that are already
+contained in a later head, and refusing to publish when a branch moved during
+the build. All of them are decisions, not I/O, so they are tested here without a
+network or a repository.
+
+Run with:  python3 ci/test_pr_build_plan.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pr_build_plan as planner  # noqa: E402
+
+
+def facts(number: int, **overrides) -> planner.PullRequestFacts:
+    defaults = {
+        "title": f"change {number}",
+        "state": "open",
+        "head_sha": f"{number:040x}",
+        "head_ref": f"branch-{number}",
+        "head_repo": "CodeLtDave/wosbot",
+        "base_ref": "main",
+        "author": "CodeLtDave",
+        "url": f"https://github.com/Shederator/wosbot/pull/{number}",
+    }
+    defaults.update(overrides)
+    return planner.PullRequestFacts(number=number, **defaults)
+
+
+def no_ancestry(_a: str, _b: str) -> bool:
+    return False
+
+
+def order_of(
+    requested: list[int],
+    entries: dict[int, planner.PullRequestFacts],
+    is_ancestor=no_ancestry,
+    times: dict[int, int] | None = None,
+    **kwargs,
+) -> planner.PlanResult:
+    times = times or {}
+    return planner.select_and_order(
+        requested,
+        entries,
+        is_ancestor=is_ancestor,
+        commit_time=lambda sha: times.get(sha, 0),
+        **kwargs,
+    )
+
+
+class RequestParsingTest(unittest.TestCase):
+
+    def test_accepts_the_separators_people_actually_type(self):
+        numbers, invalid, duplicates = planner.parse_pr_request("47 48,49  #65")
+        self.assertEqual([47, 48, 49, 65], numbers)
+        self.assertEqual([], invalid)
+        self.assertEqual([], duplicates)
+
+    def test_reports_duplicates_instead_of_building_them_twice(self):
+        numbers, _, duplicates = planner.parse_pr_request("47 47 48 47")
+        self.assertEqual([47, 48], numbers)
+        self.assertEqual([47, 47], duplicates)
+
+    def test_reports_tokens_that_are_not_pull_request_numbers(self):
+        numbers, invalid, _ = planner.parse_pr_request("47 latest v2 48")
+        self.assertEqual([47, 48], numbers)
+        self.assertEqual(["latest", "v2"], invalid)
+
+    def test_rejects_zero_and_empty_requests(self):
+        self.assertEqual(([], [], []), planner.parse_pr_request(""))
+        self.assertEqual([], planner.parse_pr_request("0")[0])
+
+
+class ClassificationTest(unittest.TestCase):
+
+    def test_open_pull_request_with_a_head_commit_is_buildable(self):
+        self.assertEqual("", planner.classify(facts(47)))
+
+    def test_merged_and_closed_pull_requests_are_rejected_with_a_reason(self):
+        self.assertIn("merged", planner.classify(facts(47, merged=True, state="closed")))
+        self.assertIn("not open", planner.classify(facts(47, state="closed")))
+
+    def test_missing_or_malformed_head_commit_is_rejected(self):
+        self.assertIn("head commit", planner.classify(facts(47, head_sha="")))
+        self.assertIn("head commit", planner.classify(facts(47, head_sha="nope")))
+
+    def test_api_errors_are_surfaced_verbatim(self):
+        self.assertEqual(
+            "no such pull request in this repository",
+            planner.classify(
+                planner.PullRequestFacts(
+                    number=999, error="no such pull request in this repository"
+                )
+            ),
+        )
+
+
+class SelectionTest(unittest.TestCase):
+
+    def test_closed_pull_requests_are_rejected_but_the_rest_still_builds(self):
+        entries = {47: facts(47), 48: facts(48, state="closed")}
+        result = order_of([47, 48], entries)
+        self.assertEqual([47], result.order)
+        self.assertEqual(1, len(result.rejected))
+        self.assertEqual(48, result.rejected[0].number)
+
+    def test_contained_stack_entry_is_dropped(self):
+        # #47's head is an ancestor of #48's head: merging both is redundant.
+        entries = {47: facts(47), 48: facts(48)}
+
+        def ancestry(a: str, b: str) -> bool:
+            return a == entries[47].head_sha and b == entries[48].head_sha
+
+        result = order_of([47, 48], entries, is_ancestor=ancestry)
+        self.assertEqual([48], result.order)
+        self.assertEqual([47], [item.number for item in result.contained])
+        self.assertEqual(48, result.contained[0].contained_in)
+
+    def test_identical_heads_keep_the_lower_number_deterministically(self):
+        same = "a" * 40
+        entries = {51: facts(51, head_sha=same), 52: facts(52, head_sha=same)}
+        result = order_of([51, 52], entries, is_ancestor=lambda a, b: a == b)
+        self.assertEqual([51], result.order)
+        self.assertEqual([52], [item.number for item in result.contained])
+
+    def test_base_branch_of_a_same_repository_stack_forces_the_order(self):
+        entries = {
+            41: facts(41, head_repo="Shederator/wosbot", head_ref="feat/a"),
+            42: facts(
+                42,
+                head_repo="Shederator/wosbot",
+                head_ref="feat/b",
+                base_ref="feat/a",
+            ),
+        }
+        # Newest first in the request, and #42 has the older commit time: only
+        # the base-branch relation can produce the correct base-to-tip order.
+        result = order_of(
+            [42, 41],
+            entries,
+            times={entries[41].head_sha: 200, entries[42].head_sha: 100},
+            repository="Shederator/wosbot",
+        )
+        self.assertEqual([41, 42], result.order)
+
+    def test_unrelated_pull_requests_are_ordered_oldest_commit_first(self):
+        entries = {47: facts(47), 48: facts(48), 65: facts(65)}
+        result = order_of(
+            [65, 47, 48],
+            entries,
+            times={
+                entries[47].head_sha: 300,
+                entries[48].head_sha: 100,
+                entries[65].head_sha: 200,
+            },
+        )
+        self.assertEqual([48, 65, 47], result.order)
+
+    def test_draft_pull_requests_are_built_but_flagged(self):
+        result = order_of([47], {47: facts(47, draft=True)})
+        self.assertEqual([47], result.order)
+        self.assertTrue(any("draft" in note for note in result.notes))
+
+    def test_order_override_wins_and_is_recorded(self):
+        entries = {47: facts(47), 48: facts(48)}
+        result = order_of([47, 48], entries, order_override="48 47")
+        self.assertEqual([48, 47], result.order)
+        self.assertTrue(any("overridden" in note for note in result.notes))
+
+    def test_order_override_cannot_smuggle_in_unknown_numbers(self):
+        entries = {47: facts(47), 48: facts(48)}
+        result = order_of([47, 48], entries, order_override="48 999")
+        self.assertEqual([48, 47], result.order)
+        self.assertTrue(any("#999" in note for note in result.notes))
+
+    def test_a_request_where_nothing_is_buildable_yields_no_order(self):
+        entries = {47: facts(47, state="closed")}
+        result = order_of([47], entries)
+        self.assertEqual([], result.order)
+
+
+class BuildKeyTest(unittest.TestCase):
+
+    def test_same_commits_produce_the_same_key(self):
+        first = planner.compute_build_key("base", ["a" * 40, "b" * 40])
+        second = planner.compute_build_key("base", ["a" * 40, "b" * 40])
+        self.assertEqual(first, second)
+
+    def test_a_push_to_any_pull_request_changes_the_key(self):
+        first = planner.compute_build_key("base", ["a" * 40, "b" * 40])
+        second = planner.compute_build_key("base", ["a" * 40, "c" * 40])
+        self.assertNotEqual(first, second)
+
+    def test_merge_order_changes_the_key(self):
+        # Order matters for the result of a merge, so it must matter for the
+        # identity of the build as well; otherwise the reuse check would hand
+        # back a bundle that was combined differently.
+        self.assertNotEqual(
+            planner.compute_build_key("base", ["a" * 40, "b" * 40]),
+            planner.compute_build_key("base", ["b" * 40, "a" * 40]),
+        )
+
+    def test_a_new_base_commit_changes_the_key(self):
+        self.assertNotEqual(
+            planner.compute_build_key("base1", ["a" * 40]),
+            planner.compute_build_key("base2", ["a" * 40]),
+        )
+
+    def test_key_is_short_enough_for_a_tag(self):
+        key = planner.compute_build_key("base", ["a" * 40])
+        self.assertEqual(planner.BUILD_KEY_LENGTH, len(key))
+
+
+class PlanDocumentTest(unittest.TestCase):
+
+    def plan(self, **kwargs) -> dict:
+        entries = {47: facts(47), 48: facts(48), 44: facts(44, state="closed")}
+        result = order_of([47, 48, 44], entries)
+        return planner.plan_to_dict(
+            repository="Shederator/wosbot",
+            request_text="47 48 44 44 latest",
+            requested=[47, 48, 44],
+            invalid=["latest"],
+            duplicates=[44],
+            facts=entries,
+            result=result,
+            base_ref="main",
+            base_sha="f" * 40,
+            requester="Shederator",
+            **kwargs,
+        )
+
+    def test_plan_pins_every_head_commit(self):
+        plan = self.plan()
+        self.assertEqual([47, 48], plan["order"])
+        for number in plan["order"]:
+            self.assertEqual(
+                f"{number:040x}", plan["pull_requests"][str(number)]["head_sha"]
+            )
+
+    def test_plan_is_json_serialisable_and_stable(self):
+        json.dumps(self.plan())
+
+    def test_tag_and_asset_name_are_derived_from_the_request(self):
+        plan = self.plan()
+        self.assertTrue(plan["tag"].startswith(planner.TAG_PREFIX))
+        self.assertEqual(
+            "frostguard-unmerged-test-build-pr-47-48.zip", plan["asset_name"]
+        )
+
+    def test_markdown_explains_rejections_duplicates_and_junk(self):
+        markdown = planner.render_markdown(self.plan())
+        self.assertIn("#47", markdown)
+        self.assertIn("Rejected", markdown)
+        self.assertIn("#44", markdown)
+        self.assertIn("Duplicates removed", markdown)
+        self.assertIn("`latest`", markdown)
+
+    def test_markdown_shows_the_pinned_commits(self):
+        markdown = planner.render_markdown(self.plan())
+        self.assertIn(f"{47:040x}"[:7], markdown)
+
+    def test_markdown_survives_a_title_containing_a_table_pipe(self):
+        entries = {47: facts(47, title="fix: a | b")}
+        result = order_of([47], entries)
+        plan = planner.plan_to_dict(
+            repository="Shederator/wosbot",
+            request_text="47",
+            requested=[47],
+            invalid=[],
+            duplicates=[],
+            facts=entries,
+            result=result,
+            base_ref="main",
+            base_sha="f" * 40,
+        )
+        self.assertIn("fix: a \\| b", planner.render_markdown(plan))
+
+
+class FakeClient:
+    def __init__(self, entries: dict[int, planner.PullRequestFacts]) -> None:
+        self.entries = entries
+
+    def pull(self, number: int) -> planner.PullRequestFacts:
+        return self.entries.get(number) or planner.PullRequestFacts(
+            number=number, error="not found"
+        )
+
+
+class VerifyTest(unittest.TestCase):
+
+    def base_plan(self) -> dict:
+        entries = {47: facts(47), 48: facts(48)}
+        result = order_of([47, 48], entries)
+        return planner.plan_to_dict(
+            repository="Shederator/wosbot",
+            request_text="47 48",
+            requested=[47, 48],
+            invalid=[],
+            duplicates=[],
+            facts=entries,
+            result=result,
+            base_ref="main",
+            base_sha="f" * 40,
+        )
+
+    def test_unchanged_pull_requests_verify_clean(self):
+        plan = self.base_plan()
+        client = FakeClient({47: facts(47), 48: facts(48)})
+        self.assertEqual([], planner.verify_plan(plan, client))
+
+    def test_a_force_push_during_the_build_blocks_publishing(self):
+        plan = self.base_plan()
+        client = FakeClient({47: facts(47, head_sha="d" * 40), 48: facts(48)})
+        problems = planner.verify_plan(plan, client)
+        self.assertEqual(1, len(problems))
+        self.assertIn("moved", problems[0])
+
+    def test_a_pull_request_merged_during_the_build_blocks_publishing(self):
+        plan = self.base_plan()
+        client = FakeClient(
+            {47: facts(47), 48: facts(48, state="closed", merged=True)}
+        )
+        problems = planner.verify_plan(plan, client)
+        self.assertEqual(1, len(problems))
+        self.assertIn("#48", problems[0])
+
+
+class ReleaseNotesTest(unittest.TestCase):
+
+    def plan(self) -> dict:
+        entries = {48: facts(48), 49: facts(49)}
+        result = order_of([48, 49], entries)
+        return planner.plan_to_dict(
+            repository="Shederator/wosbot",
+            request_text="48 49",
+            requested=[48, 49],
+            invalid=[],
+            duplicates=[],
+            facts=entries,
+            result=result,
+            base_ref="main",
+            base_sha="f" * 40,
+        )
+
+    def test_the_warning_comes_before_anything_else(self):
+        # Somebody will find this release through a search engine with no idea
+        # what "pr-test-" means; the first thing they read must be the warning.
+        notes = planner.render_notes(self.plan())
+        self.assertTrue(notes.startswith("> [!CAUTION]"))
+        self.assertIn("has not been reviewed or merged", notes)
+        self.assertIn("not a release", notes)
+
+    def test_notes_list_every_pull_request_with_its_pinned_commit(self):
+        notes = planner.render_notes(self.plan())
+        self.assertIn("1. #48", notes)
+        self.assertIn("2. #49", notes)
+        self.assertIn(f"{48:040x}"[:7], notes)
+
+    def test_notes_state_the_install_command_that_actually_exists(self):
+        # The bundle ships no launcher .bat for the app itself, so naming one
+        # would send every tester into a support question.
+        self.assertIn("java -jar frostguard-*.jar", planner.render_notes(self.plan()))
+
+    def test_notes_announce_the_expiry(self):
+        notes = planner.render_notes(self.plan(), ttl_days=3)
+        self.assertIn("after 3 days", notes)
+
+    def test_notes_embed_a_marker_the_cleanup_can_read_back(self):
+        notes = planner.render_notes(self.plan())
+        parsed = planner.parse_marker(notes)
+        self.assertEqual([48, 49], parsed["prs"])
+        self.assertEqual(self.plan()["build_key"], parsed["key"])
+
+    def test_the_marker_round_trips_and_survives_junk(self):
+        block = planner.marker_block([1, 2], "key", "base")
+        self.assertEqual([1, 2], planner.parse_marker(f"notes\n{block}\n")["prs"])
+        self.assertEqual({}, planner.parse_marker("no marker here"))
+        self.assertEqual(
+            {}, planner.parse_marker("<!-- frostguard-pr-test {broken} -->")
+        )
+
+    def test_notes_command_writes_a_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            plan_path = Path(directory) / "plan.json"
+            notes_path = Path(directory) / "notes.md"
+            plan_path.write_text(json.dumps(self.plan()), encoding="utf-8")
+            code = planner.main(
+                [
+                    "notes",
+                    "--plan",
+                    str(plan_path),
+                    "--output",
+                    str(notes_path),
+                    "--ttl-days",
+                    "7",
+                ]
+            )
+            self.assertEqual(0, code)
+            self.assertIn("#48", notes_path.read_text(encoding="utf-8"))
+
+
+class CliTest(unittest.TestCase):
+
+    def test_verify_command_reads_a_plan_file(self):
+        entries = {47: facts(47)}
+        result = order_of([47], entries)
+        plan = planner.plan_to_dict(
+            repository="Shederator/wosbot",
+            request_text="47",
+            requested=[47],
+            invalid=[],
+            duplicates=[],
+            facts=entries,
+            result=result,
+            base_ref="main",
+            base_sha="f" * 40,
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "plan.json"
+            path.write_text(json.dumps(plan), encoding="utf-8")
+            args = planner.parse_args(["verify", "--plan", str(path)])
+            self.assertEqual(str(path), args.plan)
+
+    def test_plan_command_requires_a_repository_and_a_request(self):
+        with self.assertRaises(SystemExit):
+            planner.parse_args(["plan"])
+
+    def test_max_pull_requests_is_a_real_guardrail(self):
+        self.assertGreaterEqual(planner.MAX_PULL_REQUESTS, 2)
+        self.assertLessEqual(planner.MAX_PULL_REQUESTS, 20)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ci/verify_lfs_assets.sh
+++ b/ci/verify_lfs_assets.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Assert that every Git LFS asset in the checkout is a real binary.
+#
+# The Windows OpenCV .dll, adb.exe and the .traineddata OCR models are tracked
+# with Git LFS. If any of them is still a ~130 byte pointer stub the build
+# silently produces a bundle that only fails on a user's machine, so this fails
+# loudly instead.
+#
+# It is a shared script rather than an inline workflow step because two
+# workflows now build the bundle (the nightly one and the unmerged PR test
+# build), and a guard that exists in only one of them is a guard that will be
+# forgotten.
+#
+# Usage: ci/verify_lfs_assets.sh
+set -euo pipefail
+
+git lfs pull
+
+mapfile -t assets < <(git lfs ls-files --name-only)
+
+# An empty list would make every check below vacuously succeed, which is exactly
+# the failure mode this script exists to prevent.
+if [[ "${#assets[@]}" -eq 0 ]]; then
+  echo "::error::git lfs ls-files returned no assets. LFS tracking or the" \
+       "checkout is broken; the bundle would ship pointer stubs."
+  exit 1
+fi
+
+# These are the assets the shipped bundle cannot work without.
+required=(
+  "fg-vision/src/main/resources/native/opencv/opencv_java4110.dll"
+  "tools/adb/adb.exe"
+  "tools/adb/AdbWinApi.dll"
+  "tools/tesseract/eng.traineddata"
+)
+for want in "${required[@]}"; do
+  found=0
+  for asset in "${assets[@]}"; do
+    [[ "${asset}" == "${want}" ]] && found=1 && break
+  done
+  if [[ "${found}" -ne 1 ]]; then
+    echo "::error::Expected LFS-tracked asset is not tracked: ${want}"
+    exit 1
+  fi
+done
+
+failed=0
+for asset in "${assets[@]}"; do
+  [[ -z "${asset}" ]] && continue
+  if [[ ! -f "${asset}" ]]; then
+    echo "::error file=${asset}::LFS asset is missing from the checkout."
+    failed=1
+    continue
+  fi
+  # A pointer stub is a ~130 byte text file starting with this URL.
+  if head -c 45 "${asset}" | grep -q 'git-lfs.github.com/spec'; then
+    echo "::error file=${asset}::LFS asset was not materialised (still a pointer stub)."
+    failed=1
+    continue
+  fi
+  # Every real asset here is far larger than any stub could be.
+  size="$(stat -c%s "${asset}")"
+  if [[ "${size}" -lt 10240 ]]; then
+    echo "::error file=${asset}::LFS asset is implausibly small (${size} bytes)."
+    failed=1
+  fi
+done
+
+if [[ "${failed}" -ne 0 ]]; then
+  exit 1
+fi
+echo "All ${#assets[@]} Git LFS assets were materialised."

--- a/ci/workflows/daily-windows-bundle.yml
+++ b/ci/workflows/daily-windows-bundle.yml
@@ -1,0 +1,334 @@
+name: Daily Windows Bundle
+
+on:
+  push:
+    branches:
+      - "ci/**"
+  pull_request:
+    paths:
+      - "**/pom.xml"
+      - "**/src/**"
+      - "tools/**"
+      - "custom_tasks/**"
+      - "ci/**"
+      - "fg-watcher.bat"
+      - ".gitattributes"
+      - ".github/workflows/*.yml"
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+# `contents: write` is needed to publish the rolling `nightly` release that the
+# Discord message links to. An Actions artifact URL requires a signed-in GitHub
+# account with access to this repository, so it is useless as a "downloadable"
+# link for testers in a Discord channel.
+permissions:
+  contents: write
+
+concurrency:
+  group: daily-windows-bundle-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  # Keeps `mvn` output readable in the Actions log and avoids a 200 MB download
+  # log on a cold cache.
+  MAVEN_ARGS: "-B --no-transfer-progress -Dstyle.color=never"
+
+jobs:
+  build-windows-bundle:
+    name: Build Windows desktop bundle on Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      # Shared with the PR test build workflow: a pointer stub that slips
+      # through here produces a bundle that only fails on a user's machine.
+      - name: Verify Git LFS assets are real binaries
+        run: ci/verify_lfs_assets.sh
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      # The saved-frame vision tests run OCR through tess4j, which binds the host
+      # libtesseract/libleptonica at runtime. OpenCV itself needs no system
+      # package: the openpnp artifact ships the Linux native image.
+      - name: Install Tesseract native libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            tesseract-ocr libtesseract-dev libleptonica-dev
+
+      # Guards the bundle verifier itself. A verification script that cannot fail
+      # would turn a broken release artifact into a green check mark.
+      - name: Test the bundle verifier
+        run: python3 ci/test_verify_bundle.py
+
+      # The notifier runs in a non-blocking step, so a bug in it would show up
+      # as "no message arrived" rather than as a red build. Its own tests run
+      # here, before the 30-minute Maven build, so a broken payload contract
+      # fails in seconds.
+      - name: Test the Discord notifier
+        run: python3 ci/test_discord_notify.py
+
+      # The PR test build tooling lives in the same directory and is guarded on
+      # every pull request that touches `ci/`, so a broken planner, combiner or
+      # cleanup rule is caught here in seconds instead of during a test build.
+      - name: Test the PR test build tooling
+        run: |
+          python3 ci/test_pr_build_plan.py
+          python3 ci/test_pr_build_combine.py
+          python3 ci/test_pr_build_notify.py
+          python3 ci/test_pr_build_command.py
+          python3 ci/test_pr_build_cleanup.py
+
+      - name: Resolve project version
+        id: version
+        run: |
+          set -euo pipefail
+          version="$(mvn ${MAVEN_ARGS} -q help:evaluate \
+            -Dexpression=project.version -DforceStdout)"
+          if [[ -z "${version}" ]]; then
+            echo "::error::Could not resolve the Maven project version."
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "Project version: ${version}"
+
+      # Tests are intentionally NOT skipped. The vision/OCR suites are the ones
+      # most likely to regress, and they run correctly on Linux now that the
+      # OpenCV native image is selected per platform.
+      - name: Build Windows desktop bundle
+        run: mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
+
+      - name: Locate the desktop bundle
+        id: bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          zip_path="$(find fg-app/target -maxdepth 1 -type f \
+            -name '*-desktop-bundle.zip' | sort | tail -n 1)"
+          if [[ -z "${zip_path}" ]]; then
+            echo "::error::No desktop bundle ZIP found under fg-app/target."
+            exit 1
+          fi
+          echo "path=${zip_path}" >> "${GITHUB_OUTPUT}"
+          echo "Bundle: ${zip_path} ($(du -h "${zip_path}" | cut -f1))"
+
+      # Structural verification: the right files, at the right paths, and every
+      # manifest Class-Path entry really present.
+      - name: Verify Windows bundle contents
+        run: python3 ci/verify_bundle.py "${{ steps.bundle.outputs.path }}" --platform win
+
+      # Launch verification: the staged JARs actually link together. Catches the
+      # dropped-dependency class of breakage that a file listing cannot see.
+      - name: Smoke test the desktop bundle
+        run: ci/smoke_test_bundle.sh "${{ steps.bundle.outputs.path }}"
+
+      # Metrics are computed once here and exposed as step outputs so the job
+      # summary and the Discord notification cannot disagree with each other.
+      - name: Collect build metrics
+        id: metrics
+        if: always()
+        shell: bash
+        run: |
+          set -uo pipefail
+          zip_path="${{ steps.bundle.outputs.path }}"
+
+          bundle_name=""
+          bundle_bytes=0
+          jar_count=0
+          if [[ -n "${zip_path}" && -f "${zip_path}" ]]; then
+            bundle_name="$(basename "${zip_path}")"
+            bundle_bytes="$(stat -c%s "${zip_path}")"
+            jar_count="$(unzip -Z1 "${zip_path}" \
+              | grep -Ec '^lib/[^/]+\.jar$' || true)"
+          fi
+
+          # Surefire writes one XML per test class; tests="N" is the per-class
+          # count. `|| true` keeps a zero-report build from tripping pipefail.
+          test_count="$(grep -rhoE 'tests="[0-9]+"' --include='*.xml' \
+            */target/surefire-reports 2>/dev/null \
+            | grep -oE '[0-9]+' \
+            | awk '{total += $1} END {print total+0}' || true)"
+          test_count="${test_count:-0}"
+
+          {
+            echo "bundle_name=${bundle_name}"
+            echo "bundle_bytes=${bundle_bytes}"
+            echo "jar_count=${jar_count:-0}"
+            echo "test_count=${test_count}"
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "### Windows desktop bundle"
+            echo
+            if [[ -n "${bundle_name}" ]]; then
+              echo "- Archive: \`${bundle_name}\`"
+              echo "- Version: \`${{ steps.version.outputs.version }}\`"
+              echo "- Size: $(du -h "${zip_path}" | cut -f1)"
+              echo "- Runtime JARs under \`lib/\`: ${jar_count:-0}"
+              echo "- Verified: structure, manifest classpath, launch smoke test"
+            else
+              echo "- :x: No bundle was produced."
+            fi
+            echo
+            echo "- JUnit tests executed: ${test_count}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload Windows desktop bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: frostguard-windows-desktop-bundle-${{ steps.version.outputs.version }}
+          path: ${{ steps.bundle.outputs.path }}
+          if-no-files-found: error
+          # A ZIP does not recompress usefully; skipping it saves several minutes.
+          compression-level: 0
+          retention-days: 14
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: "**/target/surefire-reports/*.xml"
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # A rolling prerelease gives the Discord message a stable, public,
+      # login-free download URL. Pull requests are excluded on purpose: a PR
+      # from a fork gets a read-only token, and republishing `nightly` from an
+      # unmerged branch would hand testers an unreviewed build.
+      - name: Publish the rolling nightly release
+        id: release
+        if: >-
+          success() &&
+          github.event_name != 'pull_request' &&
+          github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIP_PATH: ${{ steps.bundle.outputs.path }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # The asset is uploaded under a FIXED name, not the versioned one. The
+          # download URL contains the asset filename, so a versioned name would
+          # silently change the link on every version bump and break every
+          # message already posted to the channel.
+          asset="frostguard-windows-desktop-bundle.zip"
+          staged="$(dirname "${ZIP_PATH}")/${asset}"
+          cp "${ZIP_PATH}" "${staged}"
+
+          notes="$(printf '%s\n' \
+            "Automated Windows desktop bundle for Frostguard \`${VERSION}\`." \
+            "" \
+            "Built from \`${GITHUB_SHA}\` on $(date -u '+%Y-%m-%d %H:%M UTC')." \
+            "Verified: bundle structure, manifest classpath and launch smoke test." \
+            "" \
+            "**Install:** unzip anywhere, then run \`java -jar frostguard-*.jar\`" \
+            "(Java 21+ required)." \
+            "" \
+            "This tag is replaced by every nightly build; it is not a stable release.")"
+
+          # Recreate the release from scratch each night. `gh release edit
+          # --target` does NOT move an existing tag, so editing in place would
+          # leave the `nightly` tag pinned to the first commit it was ever cut
+          # from while the notes claimed a newer SHA. --cleanup-tag removes the
+          # tag too, so the recreated one points at this build.
+          if gh release view nightly >/dev/null 2>&1; then
+            gh release delete nightly --yes --cleanup-tag
+          fi
+
+          # Creating the release with the asset in the same call means there is
+          # never a window where the tag exists but the download 404s.
+          gh release create nightly "${staged}" \
+            --title "Nightly build ${VERSION}" \
+            --notes "${notes}" \
+            --prerelease \
+            --target "${GITHUB_SHA}"
+
+          # Read the URL back from the API instead of predicting it. A predicted
+          # URL is exactly how a 404 gets posted to the channel: if the upload
+          # landed under a different name, or not at all, this fails here rather
+          # than in Discord.
+          # `browser_download_url` straight from the REST API is unambiguous,
+          # unlike gh's `url` JSON field which is the API URL for some versions.
+          url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
+            --jq ".assets[] | select(.name == \"${asset}\") | .browser_download_url")"
+          if [[ -z "${url}" ]]; then
+            echo "::error::Asset ${asset} is not attached to the nightly release."
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
+              --jq '.assets[].name'
+            exit 1
+          fi
+
+          # Prove the link actually serves the file before it is advertised.
+          # A release asset redirects to a signed CDN URL, so follow redirects.
+          code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
+            --retry 3 --retry-delay 5 -r 0-1023 "${url}")"
+          if [[ "${code}" != "200" && "${code}" != "206" ]]; then
+            echo "::error::Download URL ${url} returned HTTP ${code}."
+            exit 1
+          fi
+
+          echo "download_url=${url}" >> "${GITHUB_OUTPUT}"
+          echo "Published and verified ${asset} at ${url} (HTTP ${code})"
+
+      # Runs even when the build failed, so a broken nightly is visible in the
+      # channel instead of being silently absent. `continue-on-error` keeps a
+      # Discord outage from turning a good build red.
+      - name: Notify Discord
+        if: always() && github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          # A commit message is attacker-controlled text. Interpolating it
+          # straight into the `run:` block would let `$(...)` or a backtick in a
+          # commit subject execute on the runner, with the webhook secret in
+          # scope. Passing it through the environment keeps it inert data.
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          JOB_STATUS: ${{ job.status }}
+          BUNDLE_NAME: ${{ steps.metrics.outputs.bundle_name }}
+          BUNDLE_BYTES: ${{ steps.metrics.outputs.bundle_bytes }}
+          JAR_COUNT: ${{ steps.metrics.outputs.jar_count }}
+          TEST_COUNT: ${{ steps.metrics.outputs.test_count }}
+          DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # `head_commit` only exists on push events. The nightly is a
+          # `schedule` run, which is precisely the case that matters most, so
+          # read the subject out of the checkout when the payload has none.
+          COMMIT_MESSAGE="${COMMIT_MESSAGE:-}"
+          if [[ -z "${COMMIT_MESSAGE}" ]]; then
+            COMMIT_MESSAGE="$(git log -1 --pretty=%s || true)"
+          fi
+
+          python3 ci/discord_notify.py \
+            --status "${JOB_STATUS,,}" \
+            --version "${VERSION}" \
+            --bundle-name "${BUNDLE_NAME}" \
+            --bundle-bytes "${BUNDLE_BYTES:-0}" \
+            --jar-count "${JAR_COUNT:-0}" \
+            --test-count "${TEST_COUNT:-0}" \
+            --download-url "${DOWNLOAD_URL}" \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --run-number "${GITHUB_RUN_NUMBER}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --branch "${GITHUB_REF_NAME}" \
+            --trigger "${GITHUB_EVENT_NAME}" \
+            --commit "${GITHUB_SHA}" \
+            --commit-message "${COMMIT_MESSAGE}" \
+            --actor "${GITHUB_ACTOR}"

--- a/ci/workflows/pr-test-build-cleanup.yml
+++ b/ci/workflows/pr-test-build-cleanup.yml
@@ -1,0 +1,68 @@
+name: PR Test Build Cleanup
+
+# Retires the temporary `pr-test-*` prereleases created by the PR Test Build
+# workflow. Without this, unreviewed builds would stay downloadable forever and
+# would eventually be found — and trusted — by people who never saw the thread
+# they were built for.
+#
+# A build is retired when it is older than the TTL, or as soon as every pull
+# request it contains is closed or merged. Releases whose tag does not start with
+# `pr-test-` are never touched, so a real release and the rolling `nightly`
+# prerelease are safe from a bug in here.
+
+on:
+  schedule:
+    - cron: "41 4 * * *"
+  workflow_dispatch:
+    inputs:
+      ttl_days:
+        description: "Delete test builds older than this many days"
+        required: false
+        default: "7"
+        type: string
+      dry_run:
+        description: "List what would be deleted without deleting it"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pr-test-build-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Retire expired test builds
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out the default branch
+        uses: actions/checkout@v4
+
+      # The rules decide what gets deleted, so they are unit-tested before they
+      # are given a write-capable token.
+      - name: Test the cleanup rules
+        run: python3 ci/test_pr_build_cleanup.py
+
+      - name: Retire expired test builds
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TTL_DAYS: ${{ inputs.ttl_days || '7' }}
+          # A scheduled run deletes for real; a manual run defaults to a dry run
+          # so the effect can be inspected before it happens.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          extra=()
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            extra+=(--dry-run)
+          fi
+          python3 ci/pr_build_cleanup.py \
+            --repository "${GITHUB_REPOSITORY}" \
+            --ttl-days "${TTL_DAYS}" \
+            "${extra[@]}"

--- a/ci/workflows/pr-test-build.yml
+++ b/ci/workflows/pr-test-build.yml
@@ -1,0 +1,766 @@
+name: PR Test Build
+
+# Builds a temporary Windows bundle from one or more *unmerged* pull requests so
+# testers can try changes before they land, including stacked pull requests.
+#
+# Two ways to start it:
+#   * comment `/build-pr 47 48 49 65` on any issue or pull request;
+#   * Actions tab → this workflow → "Run workflow" with the same list.
+#
+# The first run only plans: it prints the pinned commits and the merge order and
+# stops. Add `confirm` (comment) or tick "Build and publish" (dispatch) to spend
+# runner time. Nothing here ever writes to `main` or to a pull request branch.
+#
+# Job layout, and why it is split this way:
+#
+#   plan     trusted code only, reads the API, decides what may be built
+#   build    checks out and compiles UNTRUSTED pull request code — therefore it
+#            has a read-only token and references no secret at all
+#   publish  trusted code only, holds `contents: write` and the Discord webhook,
+#            and never runs anything that came out of a pull request
+#
+# That split is the whole point: the untrusted step cannot reach the webhook, the
+# release credentials or a write-capable token, no matter what a pull request's
+# `pom.xml` tries to execute.
+
+on:
+  workflow_dispatch:
+    inputs:
+      prs:
+        description: 'Open PR numbers, e.g. "47 48 49 65"'
+        required: true
+        type: string
+      confirm:
+        description: "Build and publish (off = plan only)"
+        required: false
+        default: false
+        type: boolean
+      conflict_resolution:
+        description: "On conflict: stop, or propose keeping both sides"
+        required: false
+        default: stop
+        type: choice
+        options:
+          - stop
+          - union
+      order:
+        description: 'Optional merge order override, e.g. "48,47,49"'
+        required: false
+        default: ""
+        type: string
+  issue_comment:
+    types: [created]
+
+# Read-only by default. Only the publishing job widens this, and it never runs
+# pull request code.
+permissions:
+  contents: read
+
+# One test build at a time. Combined with the per-requester cooldown in the plan
+# job, this keeps an accidental burst of comments from occupying every runner.
+concurrency:
+  group: pr-test-build
+  cancel-in-progress: false
+
+env:
+  MAVEN_ARGS: "-B --no-transfer-progress -Dstyle.color=never"
+  # How long a published test build stays downloadable. The cleanup workflow
+  # enforces it; the number is repeated in the messages so testers know.
+  TEST_BUILD_TTL_DAYS: "7"
+
+jobs:
+  plan:
+    name: Validate and plan
+    # `issue_comment` fires for every comment in the repository, so filter here
+    # rather than spending a runner on unrelated conversation.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.comment != null &&
+       contains(github.event.comment.body, '/build-pr'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+      # Needed to answer in the thread the command was typed in. Both jobs that
+      # comment run trusted code from the default branch only.
+      issues: write
+    outputs:
+      should_build: ${{ steps.decide.outputs.should_build }}
+      reuse_url: ${{ steps.reuse.outputs.download_url }}
+      build_key: ${{ steps.plan.outputs.build_key }}
+      tag: ${{ steps.plan.outputs.tag }}
+      asset_name: ${{ steps.plan.outputs.asset_name }}
+      pr_list: ${{ steps.plan.outputs.pr_list }}
+      resolution: ${{ steps.request.outputs.resolution }}
+      requester: ${{ steps.request.outputs.requester }}
+      thread_number: ${{ steps.request.outputs.thread_number }}
+
+    steps:
+      - name: Check out the default branch
+        uses: actions/checkout@v4
+        with:
+          # No LFS and no pull request code here: this job only reads metadata.
+          fetch-depth: 0
+
+      # A comment body and a dispatch input are both attacker-controlled text.
+      # Neither is ever interpolated into a shell command: the text goes to disk
+      # and the parser reads it, so the only things that reach later steps are
+      # the digits, keywords and order list it recognised. Both entry points go
+      # through the same parser, so they cannot disagree about what a request
+      # means.
+      - name: Read the request
+        id: request
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          DISPATCH_PRS: ${{ inputs.prs }}
+          DISPATCH_CONFIRM: ${{ inputs.confirm }}
+          DISPATCH_RESOLUTION: ${{ inputs.conflict_resolution }}
+          DISPATCH_ORDER: ${{ inputs.order }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          THREAD_NUMBER: ${{ github.event.issue.number }}
+          THREAD_URL: ${{ github.event.comment.html_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "issue_comment" ]]; then
+            printf '%s' "${COMMENT_BODY}" > request.txt
+            {
+              echo "requester=${COMMENT_AUTHOR}"
+              echo "thread_number=${THREAD_NUMBER}"
+              echo "thread_url=${THREAD_URL}"
+            } >> "${GITHUB_OUTPUT}"
+          else
+            # Rebuilt as a command line so the dispatch path is validated by the
+            # very same parser instead of a second, divergent implementation.
+            {
+              printf '/build-pr %s' "${DISPATCH_PRS}"
+              if [[ "${DISPATCH_CONFIRM}" == "true" ]]; then printf ' confirm'; fi
+              if [[ "${DISPATCH_RESOLUTION}" == "union" ]]; then printf ' union'; fi
+              if [[ -n "${DISPATCH_ORDER}" ]]; then
+                printf ' order=%s' "${DISPATCH_ORDER}"
+              fi
+              printf '\n'
+            } > request.txt
+            {
+              echo "requester=${GITHUB_ACTOR}"
+              echo "thread_number="
+              echo "thread_url="
+            } >> "${GITHUB_OUTPUT}"
+          fi
+          python3 ci/pr_build_command.py parse --body-file request.txt
+
+      - name: Post the usage when help was asked for
+        if: steps.request.outputs.help == 'true' && steps.request.outputs.thread_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          USAGE: ${{ steps.request.outputs.usage }}
+        run: |
+          printf '%s' "${USAGE}" > usage.md
+          gh issue comment "${{ steps.request.outputs.thread_number }}" \
+            --body-file usage.md
+
+      - name: Stop after the usage message
+        if: steps.request.outputs.help == 'true'
+        run: |
+          echo "::notice::Usage was requested; nothing to build."
+          echo "SKIP_REST=true" >> "${GITHUB_ENV}"
+
+      # Who may spend the repository's Actions minutes. `author_association`
+      # alone is not enough (it says nothing for an org member with read
+      # access), so the collaborator permission is read from the API.
+      - name: Authorize the requester
+        id: auth
+        if: env.SKIP_REST != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALLOWLIST: ${{ vars.PR_TEST_BUILD_ALLOWLIST }}
+          ASSOCIATION: ${{ github.event.comment.author_association }}
+          REQUESTER: ${{ steps.request.outputs.requester }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          permission="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/collaborators/${REQUESTER}/permission" \
+            --jq '.permission' 2>/dev/null || echo "")"
+          python3 ci/pr_build_command.py authorize \
+            --permission "${permission}" \
+            --association "${ASSOCIATION:-}" \
+            --actor "${REQUESTER}" \
+            --allowlist "${ALLOWLIST:-}"
+
+      - name: Explain a rejected request
+        if: env.SKIP_REST != 'true' && steps.auth.outputs.authorized != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REASON: ${{ steps.auth.outputs.reason }}
+        run: |
+          if [[ -n "${{ steps.request.outputs.thread_number }}" ]]; then
+            printf '%s\n' "${REASON}" > rejected.md
+            gh issue comment "${{ steps.request.outputs.thread_number }}" \
+              --body-file rejected.md
+          fi
+          echo "::error::${REASON}"
+          exit 1
+
+      # Only builds count against the quota; planning is cheap and must stay
+      # usable even when somebody is iterating on a request.
+      - name: Check the cooldown
+        id: cooldown
+        if: env.SKIP_REST != 'true' && steps.request.outputs.confirm == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTER: ${{ steps.request.outputs.requester }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/pr-test-build.yml/runs?per_page=50" \
+            > runs.json 2>/dev/null || echo '{"workflow_runs":[]}' > runs.json
+          python3 ci/pr_build_command.py cooldown \
+            --runs runs.json --actor "${REQUESTER}"
+
+      - name: Resolve, pin and order the pull requests
+        id: plan
+        if: env.SKIP_REST != 'true' && steps.auth.outputs.authorized == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRS: ${{ steps.request.outputs.prs }}
+          REQUESTER: ${{ steps.request.outputs.requester }}
+          ORDER: ${{ steps.request.outputs.order }}
+          RESOLUTION: ${{ steps.request.outputs.resolution }}
+          BASE_REF: ${{ github.event.repository.default_branch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 ci/pr_build_plan.py plan \
+            --repository "${GITHUB_REPOSITORY}" \
+            --request "${PRS}" \
+            --requester "${REQUESTER}" \
+            --order "${ORDER}" \
+            --conflict-resolution "${RESOLUTION}" \
+            --base-ref "${BASE_REF:-main}" \
+            --output plan.json \
+            --markdown plan.md
+
+      # A plan is worthless if the bundle it describes already exists: the same
+      # commits in the same order produce the same build key, so an earlier
+      # download can simply be handed out again.
+      - name: Look for an existing build of exactly these commits
+        id: reuse
+        if: steps.plan.outputs.buildable == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          tag="${{ steps.plan.outputs.tag }}"
+          asset="${{ steps.plan.outputs.asset_name }}"
+          url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
+            --jq ".assets[] | select(.name == \"${asset}\") | .browser_download_url" \
+            2>/dev/null || true)"
+          if [[ -n "${url}" ]]; then
+            echo "download_url=${url}" >> "${GITHUB_OUTPUT}"
+            echo "::notice::Reusing the existing build at ${url}"
+          fi
+
+      - name: Decide whether to build
+        id: decide
+        if: env.SKIP_REST != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          should_build=false
+          if [[ "${{ steps.plan.outputs.buildable }}" == "true" \
+             && "${{ steps.request.outputs.confirm }}" == "true" \
+             && "${{ steps.cooldown.outputs.blocked }}" != "true" \
+             && -z "${{ steps.reuse.outputs.download_url }}" ]]; then
+            should_build=true
+          fi
+          echo "should_build=${should_build}" >> "${GITHUB_OUTPUT}"
+          echo "Build requested: ${{ steps.request.outputs.confirm }}; will build: ${should_build}"
+
+      - name: Publish the plan artifact
+        if: steps.plan.outputs.buildable == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-test-build-plan
+          path: |
+            plan.json
+            plan.md
+          if-no-files-found: error
+          retention-days: 7
+
+      # Everything the requester needs in order to decide, in the thread they
+      # asked in. The Discord message carries the same facts for the channel.
+      - name: Report the plan in the thread
+        if: >-
+          always() && env.SKIP_REST != 'true' &&
+          steps.auth.outputs.authorized == 'true' &&
+          steps.request.outputs.thread_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COOLDOWN_REASON: ${{ steps.cooldown.outputs.reason }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          {
+            if [[ -f plan.md ]]; then cat plan.md; else
+              echo "The request could not be planned. See the workflow log."
+            fi
+            echo
+            if [[ -n "${COOLDOWN_REASON}" ]]; then
+              echo "> [!WARNING]"
+              echo "> ${COOLDOWN_REASON}"
+            elif [[ -n "${{ steps.reuse.outputs.download_url }}" ]]; then
+              echo "A build of exactly these commits already exists:"
+              echo "${{ steps.reuse.outputs.download_url }}"
+              echo
+              echo "It is an **unmerged test build**. Push to any of the pull"
+              echo "requests and a new build will be planned."
+            elif [[ "${{ steps.decide.outputs.should_build }}" == "true" ]]; then
+              echo "Building now — this takes roughly 30 minutes."
+              echo "[Follow the run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
+            else
+              echo "Nothing has been built yet. Reply with:"
+              echo
+              echo '```'
+              echo "/build-pr ${{ steps.plan.outputs.pr_list }} confirm"
+              echo '```'
+              echo
+              echo "to start the build, or add \`order=...\` to change the merge"
+              echo "order. Every download is an unmerged test build and is"
+              echo "deleted after ${TEST_BUILD_TTL_DAYS} days."
+            fi
+          } > thread.md
+          gh issue comment "${{ steps.request.outputs.thread_number }}" \
+            --body-file thread.md
+
+      # A request where everything was rejected is the most confusing outcome to
+      # leave silent: the tester sees no build and no reason. The plan file is
+      # written even then, so the channel gets the explanation too.
+      - name: Report a fully rejected request to Discord
+        if: always() && steps.plan.outcome == 'failure' && hashFiles('plan.json') != ''
+        continue-on-error: true
+        env:
+          DISCORD_PR_BUILD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_BUILD_WEBHOOK_URL }}
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+        run: |
+          python3 ci/pr_build_notify.py \
+            --status rejected \
+            --plan plan.json \
+            --reason "None of the requested pull requests could be built. See the plan for the reason per pull request." \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --run-number "${GITHUB_RUN_NUMBER}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --requester "@${{ steps.request.outputs.requester }}"
+
+      - name: Report the plan to Discord
+        if: always() && env.SKIP_REST != 'true' && steps.plan.outputs.buildable == 'true'
+        continue-on-error: true
+        env:
+          DISCORD_PR_BUILD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_BUILD_WEBHOOK_URL }}
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          if [[ -n "${{ steps.reuse.outputs.download_url }}" ]]; then
+            python3 ci/pr_build_notify.py \
+              --status reused \
+              --plan plan.json \
+              --download-url "${{ steps.reuse.outputs.download_url }}" \
+              --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              --run-number "${GITHUB_RUN_NUMBER}" \
+              --repository "${GITHUB_REPOSITORY}" \
+              --requester "@${{ steps.request.outputs.requester }}" \
+              --expires "after ${TEST_BUILD_TTL_DAYS} days"
+          elif [[ "${{ steps.decide.outputs.should_build }}" != "true" ]]; then
+            python3 ci/pr_build_notify.py \
+              --status plan \
+              --plan plan.json \
+              --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              --run-number "${GITHUB_RUN_NUMBER}" \
+              --repository "${GITHUB_REPOSITORY}" \
+              --requester "@${{ steps.request.outputs.requester }}" \
+              --confirm-hint "Confirm with \`/build-pr ${{ steps.plan.outputs.pr_list }} confirm\` on GitHub."
+          fi
+
+  build:
+    name: Combine and build (untrusted code)
+    needs: plan
+    if: needs.plan.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Deliberately minimal, and deliberately the only permissions this job has.
+    # It compiles code from pull requests, which means it runs `pom.xml` plugins
+    # nobody has reviewed. No secret is referenced anywhere in this job, so none
+    # is available to that code.
+    permissions:
+      contents: read
+    outputs:
+      combine_status: ${{ steps.combine.outputs.status }}
+      bundle_name: ${{ steps.metrics.outputs.bundle_name }}
+      bundle_bytes: ${{ steps.metrics.outputs.bundle_bytes }}
+      test_count: ${{ steps.metrics.outputs.test_count }}
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          # The merge needs real history, not a shallow clone.
+          fetch-depth: 0
+
+      - name: Verify Git LFS assets are real binaries
+        run: ci/verify_lfs_assets.sh
+
+      - name: Download the plan
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-test-build-plan
+
+      # `refs/pull/<n>/head` is fetched from this repository, so a fork's commit
+      # is pinned without ever adding the fork as a remote.
+      - name: Fetch the pinned pull request commits
+        env:
+          PR_LIST: ${{ needs.plan.outputs.pr_list }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra numbers <<< "${PR_LIST}"
+          for number in "${numbers[@]}"; do
+            [[ -z "${number}" ]] && continue
+            git fetch --no-tags origin \
+              "+refs/pull/${number}/head:refs/pr-test/${number}"
+          done
+
+          # The plan pinned a base commit that may no longer be the branch tip
+          # if main moved while the request was being confirmed. Fetch it
+          # explicitly so the combination is reproducible either way.
+          base_sha="$(python3 -c "import json;print(json.load(open('plan.json'))['base_sha'])")"
+          if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "${base_sha}"
+          fi
+
+      - name: Combine the pull requests in a disposable workspace
+        id: combine
+        env:
+          RESOLUTION: ${{ needs.plan.outputs.resolution }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+          python3 ci/pr_build_combine.py \
+            --plan plan.json \
+            --report combine-report.json \
+            --markdown combine-report.md \
+            --proposal-diff proposal.diff \
+            --resolution "${RESOLUTION}"
+          code=$?
+          status="$(python3 -c \
+            "import json;print(json.load(open('combine-report.json')).get('status','unknown'))" \
+            2>/dev/null || echo unknown)"
+          echo "status=${status}" >> "${GITHUB_OUTPUT}"
+          # The step fails on a conflict on purpose, so the publish job never
+          # runs. The report was already written, and the reporting job posts it.
+          exit "${code}"
+
+      # Uploaded even (especially) when the merge failed: the conflict report is
+      # what the requester needs, and the publish job posts it from here.
+      - name: Upload the combine report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-test-build-combine-report
+          path: |
+            combine-report.json
+            combine-report.md
+            proposal.diff
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Install Tesseract native libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            tesseract-ocr libtesseract-dev libleptonica-dev
+
+      - name: Test the bundle verifier
+        run: python3 ci/test_verify_bundle.py
+
+      - name: Build the Windows desktop bundle
+        run: mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
+
+      - name: Locate the desktop bundle
+        id: bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          zip_path="$(find fg-app/target -maxdepth 1 -type f \
+            -name '*-desktop-bundle.zip' | sort | tail -n 1)"
+          if [[ -z "${zip_path}" ]]; then
+            echo "::error::No desktop bundle ZIP found under fg-app/target."
+            exit 1
+          fi
+          echo "path=${zip_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify Windows bundle contents
+        run: python3 ci/verify_bundle.py "${{ steps.bundle.outputs.path }}" --platform win
+
+      - name: Smoke test the desktop bundle
+        run: ci/smoke_test_bundle.sh "${{ steps.bundle.outputs.path }}"
+
+      # The asset is renamed here, in the job that produced it, so the publish
+      # job never has to guess which file it received.
+      - name: Stage the download under its final name
+        id: metrics
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p upload
+          cp "${{ steps.bundle.outputs.path }}" \
+            "upload/${{ needs.plan.outputs.asset_name }}"
+          bytes="$(stat -c%s "upload/${{ needs.plan.outputs.asset_name }}")"
+          tests="$(grep -rhoE 'tests="[0-9]+"' --include='*.xml' \
+            */target/surefire-reports 2>/dev/null \
+            | grep -oE '[0-9]+' | awk '{t += $1} END {print t+0}' || true)"
+          {
+            echo "bundle_name=${{ needs.plan.outputs.asset_name }}"
+            echo "bundle_bytes=${bytes}"
+            echo "test_count=${tests:-0}"
+          } >> "${GITHUB_OUTPUT}"
+          {
+            echo "### Unmerged test build"
+            echo
+            echo "- pull requests: ${{ needs.plan.outputs.pr_list }}"
+            echo "- build key: \`${{ needs.plan.outputs.build_key }}\`"
+            echo "- size: $(du -h "upload/${{ needs.plan.outputs.asset_name }}" | cut -f1)"
+            echo "- JUnit tests executed: ${tests:-0}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload the test bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-test-build-bundle
+          path: upload/${{ needs.plan.outputs.asset_name }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+  publish:
+    name: Publish the temporary test release
+    needs: [plan, build]
+    if: needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # The only job with write access and the only job that sees the webhook. It
+    # runs no pull request code: the checkout is the default branch and the
+    # bundle is treated purely as a file to upload.
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - name: Check out the default branch
+        uses: actions/checkout@v4
+
+      - name: Download the plan
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-test-build-plan
+
+      - name: Download the test bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-test-build-bundle
+          path: upload
+
+      # The build took half an hour. A pull request may have been merged, closed
+      # or force-pushed in that time, and publishing a download that claims to
+      # contain a commit it does not is exactly the confusion to avoid.
+      - name: Re-check that every pull request is still open and unchanged
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 ci/pr_build_plan.py verify --plan plan.json
+
+      # The notes, the tag and the asset name all come out of the plan file, so
+      # the release page cannot describe a different build than the one that was
+      # verified. The renderer is unit-tested; a heredoc in YAML would not be.
+      - name: Render the release notes
+        run: |
+          python3 ci/pr_build_plan.py notes \
+            --plan plan.json --output notes.md \
+            --ttl-days "${TEST_BUILD_TTL_DAYS}"
+        # `notes` writes base_sha, tag, asset_name and pr_list as step outputs,
+        # so the release below cannot describe a different build than the plan.
+        id: notes
+
+      - name: Create the temporary prerelease
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.notes.outputs.tag }}
+          ASSET: ${{ steps.notes.outputs.asset_name }}
+          BASE_SHA: ${{ steps.notes.outputs.base_sha }}
+          PR_LIST: ${{ steps.notes.outputs.pr_list }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # The tag points at the base commit the build was made from. The
+          # combined commit only ever existed in the build job's workspace, and
+          # pushing it would mean writing a branch to this repository — which
+          # this feature must never do. A tag is a new ref, not a moved branch.
+          # Recreate rather than edit: `gh release edit --target` does not move
+          # an existing tag, so editing in place could leave the tag pointing at
+          # a commit the notes do not describe.
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release delete "${TAG}" --yes --cleanup-tag
+          fi
+          gh release create "${TAG}" "upload/${ASSET}" \
+            --title "Unmerged test build — PRs ${PR_LIST}" \
+            --notes-file notes.md \
+            --prerelease \
+            --target "${BASE_SHA}"
+
+          # Read the URL back from the API and actually fetch it: a predicted
+          # URL is how a dead link ends up in the channel.
+          url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            --jq ".assets[] | select(.name == \"${ASSET}\") | .browser_download_url")"
+          if [[ -z "${url}" ]]; then
+            echo "::error::Asset ${ASSET} is not attached to ${TAG}."
+            exit 1
+          fi
+          code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
+            --retry 3 --retry-delay 5 -r 0-1023 "${url}")"
+          if [[ "${code}" != "200" && "${code}" != "206" ]]; then
+            echo "::error::Download URL ${url} returned HTTP ${code}."
+            exit 1
+          fi
+          echo "download_url=${url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Announce the download in the thread
+        if: needs.plan.outputs.thread_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "### Unmerged test build ready"
+            echo
+            echo "${{ steps.release.outputs.download_url }}"
+            echo
+            echo "Pull requests: ${{ needs.plan.outputs.pr_list }} — build key"
+            echo "\`${{ needs.plan.outputs.build_key }}\`."
+            echo
+            echo "> [!CAUTION]"
+            echo "> Unreviewed, unmerged code. Use a test profile. The download"
+            echo "> disappears after ${TEST_BUILD_TTL_DAYS} days."
+          } > announce.md
+          gh issue comment "${{ needs.plan.outputs.thread_number }}" \
+            --body-file announce.md
+
+      - name: Announce the download in Discord
+        continue-on-error: true
+        env:
+          DISCORD_PR_BUILD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_BUILD_WEBHOOK_URL }}
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+        run: |
+          python3 ci/pr_build_notify.py \
+            --status success \
+            --plan plan.json \
+            --download-url "${{ steps.release.outputs.download_url }}" \
+            --bundle-bytes "${{ needs.build.outputs.bundle_bytes }}" \
+            --test-count "${{ needs.build.outputs.test_count }}" \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --run-number "${GITHUB_RUN_NUMBER}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --requester "@${{ needs.plan.outputs.requester }}" \
+            --expires "after ${TEST_BUILD_TTL_DAYS} days"
+
+  report_failure:
+    name: Report a conflict or a failed build
+    needs: [plan, build]
+    if: always() && needs.plan.outputs.should_build == 'true' && needs.build.result != 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Check out the default branch
+        uses: actions/checkout@v4
+
+      - name: Download the plan
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-test-build-plan
+
+      - name: Download the combine report
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-test-build-combine-report
+
+      - name: Classify the failure
+        id: why
+        shell: bash
+        run: |
+          set -uo pipefail
+          status="failure"
+          if [[ -f combine-report.json ]]; then
+            reported="$(python3 -c "import json;print(json.load(open('combine-report.json')).get('status',''))" 2>/dev/null || true)"
+            if [[ "${reported}" == "conflict" || "${reported}" == "error" ]]; then
+              status="conflict"
+            fi
+          fi
+          echo "status=${status}" >> "${GITHUB_OUTPUT}"
+
+      - name: Report in the thread
+        if: needs.plan.outputs.thread_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          {
+            if [[ -f combine-report.md ]]; then
+              cat combine-report.md
+            else
+              echo "### The test build failed"
+              echo
+              echo "The pull requests were combined, but the build or one of"
+              echo "its verification steps failed."
+            fi
+            echo
+            echo "[Workflow log](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+            echo
+            echo "No branch in this repository was changed and nothing was"
+            echo "published."
+          } > failure.md
+          gh issue comment "${{ needs.plan.outputs.thread_number }}" \
+            --body-file failure.md
+
+      - name: Report in Discord
+        continue-on-error: true
+        env:
+          DISCORD_PR_BUILD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_BUILD_WEBHOOK_URL }}
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+        run: |
+          python3 ci/pr_build_notify.py \
+            --status "${{ steps.why.outputs.status }}" \
+            --plan plan.json \
+            --report combine-report.json \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --run-number "${GITHUB_RUN_NUMBER}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --requester "@${{ needs.plan.outputs.requester }}"

--- a/docs/PR_TEST_BUILDS.md
+++ b/docs/PR_TEST_BUILDS.md
@@ -1,0 +1,207 @@
+# Unmerged pull request test builds
+
+Sometimes a fix exists in a pull request but has not been merged yet, and the
+only way to find out whether it actually works is to run it. This is how a
+tester gets a Windows bundle built from one or more **unmerged** pull requests,
+including stacked ones, without anybody handing out repository access and without
+touching `main` or the pull request branches.
+
+> [!CAUTION]
+> Every download produced this way contains code that has not been reviewed or
+> merged. Point it at a test profile, not at your main account data.
+
+> [!IMPORTANT]
+> **One-time installation.** The workflow files arrive parked in
+> [`ci/workflows/`](../ci/workflows) because the pull request that added them was
+> not permitted to write into `.github/workflows/`. Until a repository owner runs
+> the installer below, `/build-pr` does nothing. See
+> [Installing the workflows](#installing-the-workflows).
+
+## Requesting a build
+
+Comment on any issue or pull request in this repository:
+
+```
+/build-pr 47 48 49 65
+```
+
+Nothing is built yet. The workflow replies in the same thread with the **merge
+plan**: which pull requests it accepted, the exact commit it pinned for each one,
+the order it will merge them in, and an explanation for anything it left out.
+Read it, then confirm:
+
+```
+/build-pr 47 48 49 65 confirm
+```
+
+The build takes roughly 30 minutes. When it finishes, the download link is posted
+in the thread and in the Discord channel.
+
+| You type | What happens |
+|---|---|
+| `/build-pr 47 48` | plan only — nothing is built |
+| `/build-pr 47 48 confirm` | build it and publish a temporary download |
+| `/build-pr 47 48 union confirm` | on conflict, propose a resolution that keeps both sides |
+| `/build-pr 47 48 order=48,47` | override the merge order |
+| `/build-pr help` | print the usage into the thread |
+
+Maintainers can do exactly the same from *Actions → PR Test Build → Run
+workflow*, which is useful when there is no thread to comment in.
+
+## What the plan step decides for you
+
+- **Closed, merged or non-existent pull requests are rejected**, each with a
+  reason. A typo does not silently produce a build of something else.
+- **Duplicates are removed** and anything that is not a pull request number is
+  reported back rather than guessed at.
+- **Commits are pinned.** Once a plan exists, a later push to a pull request
+  cannot change what gets built, and a push during the build stops the
+  publication instead of shipping a download whose description is wrong.
+- **Stacked pull requests are collapsed.** If #65's head commit already contains
+  #47, #48 and #49 — which is exactly what a stack looks like — merging the
+  ancestors again is redundant and can conflict for no reason. Only #65 is built,
+  and the plan says so.
+- **The merge order is derived**, base-to-tip: a pull request whose base branch is
+  another requested pull request's head branch goes after it, otherwise older
+  commits go first. Override it with `order=` if you know better.
+- **An identical build is reused.** The same pull requests at the same commits
+  produce the same build key, so you get the existing download instead of waiting
+  another half hour.
+
+## When the pull requests cannot be combined
+
+Git conflicts stop the request. You get the list of conflicting files, each
+labelled as a text conflict, a binary conflict, or a file one side deleted while
+the other changed it. **No side is ever picked automatically** — a build that
+silently dropped half of a pull request would behave like neither pull request,
+and you would have no way to notice.
+
+If every conflict is a text conflict, you can ask for a resolution that keeps
+**both** sides:
+
+```
+/build-pr 47 48 union confirm
+```
+
+The proposed resolution is uploaded as `proposal.diff` on the workflow run and
+listed in the job summary. Keeping both sides can produce code that compiles but
+duplicates work, so treat such a build as a rough experiment, not as evidence
+that the pull requests are compatible. Binary conflicts always need a human.
+
+## What you get
+
+A prerelease tagged `pr-test-<build key>`, marked as a prerelease so it never
+displaces a real release, carrying one asset:
+
+```
+frostguard-unmerged-test-build-pr-<numbers>.zip
+```
+
+Unzip it anywhere and run `java -jar frostguard-*.jar` (Java 21+). The release
+notes list every included pull request with its author and pinned commit.
+
+The bundle went through the same verification as the nightly build: structure,
+manifest classpath, launch smoke test, and the full JUnit suite.
+
+**These downloads expire.** A cleanup job deletes them after 7 days, or as soon
+as every included pull request is closed or merged. Real releases and the rolling
+`nightly` prerelease are never touched.
+
+## Guardrails
+
+- Only people with **write access**, or names listed in the
+  `PR_TEST_BUILD_ALLOWLIST` repository variable, can start a build. Everyone else
+  gets an explanation instead of a build.
+- **Cooldown:** at most 3 builds per person per hour. Planning is free.
+- **One build at a time**, so a burst of comments cannot occupy every runner.
+- At most **10 pull requests** in one request.
+- A quoted `/build-pr` line in a reply does **not** start a second build.
+- `main` and the pull request branches are never modified. The combination lives
+  on a throwaway branch inside one CI job and is never pushed. Publishing creates
+  a tag on the base commit — a new ref, not a moved branch.
+
+## Why untrusted code cannot reach the secrets
+
+Building a pull request means compiling code nobody has reviewed, including its
+`pom.xml` and whatever build plugins it names. The workflow is therefore split
+into three jobs with different privileges:
+
+| Job | Runs | Token | Secrets |
+|---|---|---|---|
+| `plan` | only code from the default branch | read | none |
+| `build` | **untrusted pull request code** | read-only | **none referenced** |
+| `publish` | only code from the default branch | `contents: write` | Discord webhook |
+
+The build job references no secret at all and holds a read-only token, so there
+is nothing for a malicious `pom.xml` to steal — no webhook, no release
+credentials, no write access. The publish job holds those, verifies the pull
+requests are still open at the pinned commits, and treats the bundle purely as a
+file to upload; it never executes anything that came out of a pull request.
+
+## For maintainers
+
+Configuration:
+
+| Where | Name | Purpose |
+|---|---|---|
+| Secret | `DISCORD_PR_BUILD_WEBHOOK_URL` | optional; a separate channel for unreviewed builds. Falls back to `DISCORD_NIGHTLY_WEBHOOK_URL` |
+| Variable | `PR_TEST_BUILD_ALLOWLIST` | optional; GitHub logins that may build without write access |
+
+Workflows (paths after installation):
+
+- `.github/workflows/pr-test-build.yml` — plan, combine, build, publish, report.
+  Staged at [`ci/workflows/pr-test-build.yml`](../ci/workflows/pr-test-build.yml).
+- `.github/workflows/pr-test-build-cleanup.yml` — daily expiry. A manual run
+  defaults to a dry run. Staged at
+  [`ci/workflows/pr-test-build-cleanup.yml`](../ci/workflows/pr-test-build-cleanup.yml).
+- `.github/workflows/daily-windows-bundle.yml` — the existing nightly build, with
+  the duplicated Git LFS check replaced by the shared
+  [`ci/verify_lfs_assets.sh`](../ci/verify_lfs_assets.sh) and a step that runs the
+  new self-tests. Staged at
+  [`ci/workflows/daily-windows-bundle.yml`](../ci/workflows/daily-windows-bundle.yml).
+
+### Installing the workflows
+
+GitHub refuses pushes that add or change files under `.github/workflows/` unless
+the pushing credential carries the `workflows` permission, which the automation
+that opened the pull request does not have. The three files therefore sit in
+`ci/workflows/`, where GitHub Actions ignores them, and a repository owner moves
+them into place once — from a normal clone, with a normal personal push:
+
+```sh
+git checkout main
+git pull
+bash ci/install_workflows.sh            # shows what would move
+bash ci/install_workflows.sh --apply    # moves the files and stages the change
+git commit -m "ci(actions): install pull request test build workflows"
+git push
+```
+
+The script is safe to re-run: once `ci/workflows/` is gone it reports that there
+is nothing left to install. Afterwards the Actions tab lists **Unmerged pull
+request test build** and **Unmerged pull request test build cleanup**, and the
+first `/build-pr` comment will be answered.
+
+Tooling and tests live in [`ci/`](../ci/README.md) and run in seconds:
+
+```sh
+python3 ci/test_pr_build_plan.py
+python3 ci/test_pr_build_combine.py
+python3 ci/test_pr_build_notify.py
+python3 ci/test_pr_build_command.py
+python3 ci/test_pr_build_cleanup.py
+```
+
+Preview a plan or a message locally without touching anything:
+
+```sh
+GITHUB_TOKEN=$(gh auth token) python3 ci/pr_build_plan.py plan \
+  --repository Shederator/wosbot --request "47 48 49 65" \
+  --output plan.json --markdown plan.md
+
+python3 ci/pr_build_notify.py --status plan --plan plan.json --dry-run
+```
+
+Typing the command **inside Discord** needs a registered Discord application, not
+just a webhook; a webhook can only send. That step is optional and documented in
+[`tools/discord-build-command/`](../tools/discord-build-command/README.md).

--- a/tools/discord-build-command/README.md
+++ b/tools/discord-build-command/README.md
@@ -1,0 +1,108 @@
+# Optional: the `/build-pr` slash command in Discord
+
+Everything about unmerged PR test builds already works **without** this
+directory. A maintainer or an allowlisted tester types
+
+```
+/build-pr 47 48 49 65
+```
+
+as a comment on any issue or pull request, and the results — plan, conflicts or
+download link — are posted to the Discord channel through the webhook that is
+already configured. See [`docs/PR_TEST_BUILDS.md`](../../docs/PR_TEST_BUILDS.md).
+
+This directory exists for the one thing a webhook fundamentally cannot do.
+
+## Why a webhook is not enough
+
+A Discord webhook is **outbound only**. It is a URL you POST messages to; it
+never receives anything, has no presence in the server and cannot be typed at.
+Slash commands and buttons are *inbound interactions*, and Discord only delivers
+those to a registered **application**, either over a gateway connection (a
+process that must stay online) or to an **Interactions Endpoint URL** — an HTTPS
+endpoint that must verify a signature and answer within three seconds.
+
+So: keep the webhook for the notifications, and add an application only if you
+want the command itself inside Discord. The application here needs no gateway
+process and no always-on server; it is one Cloudflare Worker on the free plan.
+
+## What it does
+
+```
+/build-pr in Discord
+      │  signature-verified, channel and role checked
+      ▼
+Cloudflare Worker ──► workflow_dispatch on pr-test-build.yml
+      │
+      ▼
+"Planning…" plus a Build it / Cancel button pair
+      │
+GitHub Actions plans, builds and publishes, then the existing webhook posts
+the plan, the conflict report or the download link into the channel
+```
+
+The Worker deliberately does very little: it sanitises the PR list down to
+digits, checks the channel and the caller's roles, and starts exactly one
+workflow. Every real guard — who may build, the cooldown, whether the pull
+requests are open, whether they can be combined — stays in the workflow, where it
+is unit-tested and where a mistake in this file cannot bypass it.
+
+## Setup
+
+**1. Create the application** at <https://discord.com/developers/applications>.
+Copy the **Application ID** and the **Public Key**. Under *Bot*, copy the token
+(needed only once, in step 4).
+
+**2. Create a GitHub token.** A fine-grained personal access token on
+`Shederator/wosbot` with **Actions: Read and write** and nothing else. It can
+start the test-build workflow and do nothing more.
+
+**3. Deploy the Worker:**
+
+```sh
+cd tools/discord-build-command
+npx wrangler secret put DISCORD_PUBLIC_KEY   # paste the public key
+npx wrangler secret put GITHUB_TOKEN         # paste the fine-grained token
+npx wrangler deploy
+```
+
+Restrict who may use it (recommended — right-click a channel or role in Discord
+with developer mode on to copy its ID):
+
+```sh
+npx wrangler secret put ALLOWED_CHANNEL_IDS  # e.g. 123456789012345678
+npx wrangler secret put ALLOWED_ROLE_IDS     # e.g. the "Tester" role ID
+```
+
+**4. Point Discord at the Worker.** In the application's *General Information*
+page, set **Interactions Endpoint URL** to the deployed
+`https://frostguard-build-command.<your-subdomain>.workers.dev` and save.
+Discord immediately sends a signed PING; saving only succeeds if the Worker
+verified it, which is a useful end-to-end check.
+
+**5. Register the command** (once, and after any option change):
+
+```sh
+DISCORD_APPLICATION_ID=... DISCORD_BOT_TOKEN=... DISCORD_GUILD_ID=... \
+  node register-command.mjs
+```
+
+**6. Invite the application** to the server with the `applications.commands`
+scope. It needs no message permissions and no privileged intents.
+
+## Tests
+
+```sh
+node tools/discord-build-command/test-worker.mjs
+```
+
+14 tests, no network: input sanitising (including shell metacharacters and a cap
+on how many pull requests one command may queue), the channel and role
+allowlists, the dispatch payload shape, and that no message can ping the channel.
+
+## Rotating or removing it
+
+Rotate the GitHub token or the public key with `wrangler secret put` — nothing
+else changes. To remove the command entirely, delete the Worker and clear the
+Interactions Endpoint URL; the GitHub comment command keeps working, because it
+never depended on any of this.

--- a/tools/discord-build-command/register-command.mjs
+++ b/tools/discord-build-command/register-command.mjs
@@ -1,0 +1,69 @@
+// Register (or update) the `/build-pr` slash command for one Discord server.
+//
+// Run this once, and again whenever the options below change. Guild-scoped
+// registration is used on purpose: it appears immediately, and the command stays
+// invisible on every other server the application might be added to.
+//
+// Usage:
+//   DISCORD_APPLICATION_ID=... DISCORD_BOT_TOKEN=... DISCORD_GUILD_ID=... \
+//     node tools/discord-build-command/register-command.mjs
+//
+// The bot token is only needed for this one call. The Worker itself never sees
+// it: it authenticates to Discord with the request signature instead.
+
+const { DISCORD_APPLICATION_ID, DISCORD_BOT_TOKEN, DISCORD_GUILD_ID } = process.env;
+
+if (!DISCORD_APPLICATION_ID || !DISCORD_BOT_TOKEN || !DISCORD_GUILD_ID) {
+  console.error(
+    "Set DISCORD_APPLICATION_ID, DISCORD_BOT_TOKEN and DISCORD_GUILD_ID first.",
+  );
+  process.exit(1);
+}
+
+const command = {
+  name: "build-pr",
+  description: "Build a temporary Windows test bundle from open pull requests",
+  // 1 = CHAT_INPUT
+  type: 1,
+  options: [
+    {
+      name: "prs",
+      description: 'Open PR numbers, for example "47 48 49 65"',
+      type: 3, // STRING
+      required: true,
+    },
+    {
+      name: "confirm",
+      description: "Skip the plan and build straight away",
+      type: 5, // BOOLEAN
+      required: false,
+    },
+    {
+      name: "union",
+      description: "On conflict, propose a resolution that keeps both sides",
+      type: 5,
+      required: false,
+    },
+  ],
+};
+
+const url =
+  `https://discord.com/api/v10/applications/${DISCORD_APPLICATION_ID}` +
+  `/guilds/${DISCORD_GUILD_ID}/commands`;
+
+const response = await fetch(url, {
+  method: "POST",
+  headers: {
+    Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify(command),
+});
+
+const body = await response.text();
+if (!response.ok) {
+  console.error(`Discord rejected the registration (HTTP ${response.status}):`);
+  console.error(body);
+  process.exit(1);
+}
+console.log("Registered /build-pr for guild", DISCORD_GUILD_ID);

--- a/tools/discord-build-command/test-worker.mjs
+++ b/tools/discord-build-command/test-worker.mjs
@@ -1,0 +1,124 @@
+// Self-tests for the optional Discord command endpoint.
+//
+// The endpoint holds a GitHub token, so the tests concentrate on the checks that
+// stand between a Discord message and a workflow run: input sanitising, the
+// channel and role allowlists, and the shape of the dispatch payload.
+//
+// Run with:  node tools/discord-build-command/test-worker.mjs
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  acknowledgement,
+  commandOptions,
+  dispatchPayload,
+  isAllowed,
+  parseIdList,
+  parsePrsOption,
+} from "./worker.js";
+
+test("only pull request numbers survive the option parser", () => {
+  assert.deepEqual(parsePrsOption("47 48,49 #65"), [47, 48, 49, 65]);
+  assert.deepEqual(parsePrsOption("47 47 48"), [47, 48]);
+  assert.deepEqual(parsePrsOption(""), []);
+  assert.deepEqual(parsePrsOption(undefined), []);
+});
+
+test("shell metacharacters cannot reach the workflow inputs", () => {
+  // The Worker holds a GitHub token; anything but digits must be dropped here.
+  assert.deepEqual(parsePrsOption("47; rm -rf / && echo 48"), [47, 48]);
+  assert.deepEqual(parsePrsOption("$(whoami)"), []);
+  assert.deepEqual(parsePrsOption("`id`"), []);
+});
+
+test("a request is capped so one command cannot queue endless builds", () => {
+  const many = Array.from({ length: 40 }, (_, index) => index + 1).join(" ");
+  assert.equal(parsePrsOption(many).length, 10);
+});
+
+test("an empty allowlist means the restriction is not configured", () => {
+  const interaction = { channel_id: "1", member: { roles: [] } };
+  assert.equal(isAllowed(interaction, {}).allowed, true);
+});
+
+test("a channel allowlist keeps the command out of other channels", () => {
+  const env = { ALLOWED_CHANNEL_IDS: "111, 222" };
+  assert.equal(isAllowed({ channel_id: "111" }, env).allowed, true);
+  const denied = isAllowed({ channel_id: "999" }, env);
+  assert.equal(denied.allowed, false);
+  assert.match(denied.reason, /channel/);
+});
+
+test("a role allowlist keeps the command away from every other member", () => {
+  const env = { ALLOWED_ROLE_IDS: "role-tester" };
+  assert.equal(
+    isAllowed({ channel_id: "1", member: { roles: ["role-tester"] } }, env).allowed,
+    true,
+  );
+  const denied = isAllowed({ channel_id: "1", member: { roles: ["role-other"] } }, env);
+  assert.equal(denied.allowed, false);
+  assert.match(denied.reason, /tester role/);
+});
+
+test("a member with no roles at all is refused when a role is required", () => {
+  const env = { ALLOWED_ROLE_IDS: "role-tester" };
+  assert.equal(isAllowed({ channel_id: "1" }, env).allowed, false);
+});
+
+test("id lists tolerate the separators people paste", () => {
+  assert.deepEqual(parseIdList(" 1, 2\n3 "), ["1", "2", "3"]);
+  assert.deepEqual(parseIdList(undefined), []);
+});
+
+test("command options are read into a plain request", () => {
+  const interaction = {
+    data: {
+      options: [
+        { name: "prs", value: "47 48" },
+        { name: "confirm", value: true },
+      ],
+    },
+  };
+  assert.deepEqual(commandOptions(interaction), {
+    prs: [47, 48],
+    confirm: true,
+    union: false,
+  });
+});
+
+test("the dispatch payload only ever contains strings", () => {
+  const payload = dispatchPayload({ prs: [47, 48], confirm: true, union: false }, "main");
+  assert.equal(payload.ref, "main");
+  for (const value of Object.values(payload.inputs)) {
+    assert.equal(typeof value, "string");
+  }
+  assert.equal(payload.inputs.prs, "47 48");
+  assert.equal(payload.inputs.confirm, "true");
+  assert.equal(payload.inputs.conflict_resolution, "stop");
+});
+
+test("union mode is passed through", () => {
+  const payload = dispatchPayload({ prs: [47], confirm: true, union: true }, "main");
+  assert.equal(payload.inputs.conflict_resolution, "union");
+});
+
+test("an unconfirmed request offers a Build it button and does not claim to build", () => {
+  const message = acknowledgement({ prs: [47, 48], confirm: false }, "https://example.invalid");
+  assert.match(message.content, /Nothing is built yet/);
+  const ids = message.components[0].components.map((component) => component.custom_id);
+  assert.deepEqual(ids, ["build:47-48", "cancel"]);
+});
+
+test("a confirmed request has no buttons and warns that the build is unmerged", () => {
+  const message = acknowledgement({ prs: [47], confirm: true }, "");
+  assert.equal(message.components, undefined);
+  assert.match(message.content, /unmerged test build/);
+});
+
+test("no message can ping the channel", () => {
+  for (const confirm of [true, false]) {
+    const message = acknowledgement({ prs: [47], confirm }, "");
+    assert.deepEqual(message.allowed_mentions, { parse: [] });
+  }
+});

--- a/tools/discord-build-command/worker.js
+++ b/tools/discord-build-command/worker.js
@@ -1,0 +1,282 @@
+// Discord interactions endpoint for the `/build-pr` command.
+//
+// This is OPTIONAL. The test-build feature works without it: `/build-pr 47 48`
+// typed as a GitHub comment does the same thing, and a Discord *webhook* already
+// delivers the results to the channel. What a webhook cannot do is receive
+// anything — it is outbound only. A slash command with buttons is an inbound
+// interaction, and Discord only delivers those to a registered application, at
+// an HTTPS endpoint that answers within three seconds. This file is that
+// endpoint, small enough to run on a free Cloudflare Worker.
+//
+// It holds a GitHub token, so it never trusts its input:
+//   * every request is Ed25519-verified against the application public key, so
+//     only Discord can invoke it;
+//   * the channel and the caller's roles are checked against an allowlist;
+//   * only digits survive from the PR list, so nothing can be smuggled into the
+//     workflow inputs;
+//   * it can only start ONE workflow (`pr-test-build.yml`) — the token needs no
+//     other permission, and the workflow re-runs its own authorization and
+//     cooldown checks anyway.
+//
+// See README.md in this directory for the deployment steps.
+
+const INTERACTION_PING = 1;
+const INTERACTION_COMMAND = 2;
+const INTERACTION_COMPONENT = 3;
+
+const REPLY = 4;
+const REPLY_EPHEMERAL_FLAG = 64;
+
+/** Extract at most 10 pull request numbers, discarding everything else. */
+export function parsePrsOption(raw) {
+  const numbers = [];
+  for (const token of String(raw ?? "").split(/[^0-9]+/)) {
+    if (!token) continue;
+    const value = Number.parseInt(token, 10);
+    if (!Number.isSafeInteger(value) || value <= 0) continue;
+    if (!numbers.includes(value)) numbers.push(value);
+  }
+  return numbers.slice(0, 10);
+}
+
+/** Parse a space or comma separated allowlist from an environment variable. */
+export function parseIdList(raw) {
+  return String(raw ?? "")
+    .split(/[\s,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Decide whether an interaction may start a build.
+ *
+ * An empty channel list means "any channel"; an empty role list means "anyone
+ * who can see the channel". Both are explicit opt-outs, so a misconfigured
+ * deployment fails closed only where the operator asked it to.
+ */
+export function isAllowed(interaction, env) {
+  const channels = parseIdList(env.ALLOWED_CHANNEL_IDS);
+  if (channels.length > 0 && !channels.includes(interaction.channel_id)) {
+    return { allowed: false, reason: "This command only works in the test-build channel." };
+  }
+  const roles = parseIdList(env.ALLOWED_ROLE_IDS);
+  if (roles.length === 0) return { allowed: true, reason: "" };
+
+  const held = interaction.member?.roles ?? [];
+  if (held.some((role) => roles.includes(role))) return { allowed: true, reason: "" };
+  return {
+    allowed: false,
+    reason: "You need the tester role to request a build. Ask a moderator for it.",
+  };
+}
+
+/** Read the options of a slash command into a plain object. */
+export function commandOptions(interaction) {
+  const options = interaction.data?.options ?? [];
+  const value = (name) => options.find((option) => option.name === name)?.value;
+  return {
+    prs: parsePrsOption(value("prs")),
+    confirm: Boolean(value("confirm")),
+    union: Boolean(value("union")),
+  };
+}
+
+/** Build the `workflow_dispatch` body. Inputs must all be strings. */
+export function dispatchPayload({ prs, confirm, union }, ref) {
+  return {
+    ref: ref || "main",
+    inputs: {
+      prs: prs.join(" "),
+      confirm: confirm ? "true" : "false",
+      conflict_resolution: union ? "union" : "stop",
+      order: "",
+    },
+  };
+}
+
+/** The message posted back into the channel while the workflow starts up. */
+export function acknowledgement({ prs, confirm }, runsUrl) {
+  const list = prs.map((number) => `#${number}`).join(", ");
+  const lines = confirm
+    ? [
+        `Building an **unmerged test build** of ${list}.`,
+        "The merge plan, the pinned commits and the download link are posted here when it finishes (roughly 30 minutes).",
+      ]
+    : [
+        `Planning a test build of ${list}. **Nothing is built yet.**`,
+        "The plan lists the pinned commits and drops pull requests that are already contained in a later one. Press **Build it** once it looks right.",
+      ];
+  if (runsUrl) lines.push(`[Workflow runs](${runsUrl})`);
+
+  const message = {
+    content: lines.join("\n"),
+    allowed_mentions: { parse: [] },
+  };
+  if (!confirm && prs.length > 0) {
+    message.components = [
+      {
+        type: 1,
+        components: [
+          {
+            type: 2,
+            style: 3,
+            label: "Build it",
+            custom_id: `build:${prs.join("-")}`,
+          },
+          {
+            type: 2,
+            style: 2,
+            label: "Cancel",
+            custom_id: "cancel",
+          },
+        ],
+      },
+    ];
+  }
+  return message;
+}
+
+function reply(message, ephemeral = false) {
+  const data = { ...message };
+  if (ephemeral) data.flags = REPLY_EPHEMERAL_FLAG;
+  return Response.json({ type: REPLY, data });
+}
+
+function hexToBytes(hex) {
+  const clean = String(hex ?? "").trim();
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(clean.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Verify Discord's Ed25519 request signature.
+ *
+ * Without this anybody who learns the endpoint URL could start builds, so a
+ * failure here is a 401 and nothing else happens.
+ */
+export async function verifySignature(request, body, publicKey) {
+  const signature = request.headers.get("X-Signature-Ed25519");
+  const timestamp = request.headers.get("X-Signature-Timestamp");
+  if (!signature || !timestamp || !publicKey) return false;
+  try {
+    const key = await crypto.subtle.importKey(
+      "raw",
+      hexToBytes(publicKey),
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+    return await crypto.subtle.verify(
+      { name: "Ed25519" },
+      key,
+      hexToBytes(signature),
+      new TextEncoder().encode(timestamp + body),
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function startWorkflow(env, payload) {
+  const response = await fetch(
+    `https://api.github.com/repos/${env.GITHUB_REPOSITORY}` +
+      "/actions/workflows/pr-test-build.yml/dispatches",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "frostguard-build-command/1.0",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+  );
+  // 204 is the documented success status; anything else is reported to the user
+  // rather than swallowed, so a rotated token does not look like a hung build.
+  return { ok: response.status === 204, status: response.status };
+}
+
+export default {
+  async fetch(request, env) {
+    if (request.method !== "POST") {
+      return new Response("This endpoint only accepts Discord interactions.", {
+        status: 405,
+      });
+    }
+
+    const body = await request.text();
+    if (!(await verifySignature(request, body, env.DISCORD_PUBLIC_KEY))) {
+      return new Response("invalid request signature", { status: 401 });
+    }
+
+    let interaction;
+    try {
+      interaction = JSON.parse(body);
+    } catch {
+      return new Response("malformed payload", { status: 400 });
+    }
+
+    if (interaction.type === INTERACTION_PING) {
+      return Response.json({ type: INTERACTION_PING });
+    }
+
+    const runsUrl =
+      `https://github.com/${env.GITHUB_REPOSITORY}/actions/workflows/pr-test-build.yml`;
+
+    if (interaction.type === INTERACTION_COMPONENT) {
+      const customId = interaction.data?.custom_id ?? "";
+      if (customId === "cancel") {
+        return reply({ content: "Cancelled. Nothing was built." }, true);
+      }
+      if (!customId.startsWith("build:")) {
+        return reply({ content: "Unknown button." }, true);
+      }
+      const gate = isAllowed(interaction, env);
+      if (!gate.allowed) return reply({ content: gate.reason }, true);
+
+      const request_ = { prs: parsePrsOption(customId.slice("build:".length)), confirm: true, union: false };
+      const result = await startWorkflow(env, dispatchPayload(request_, env.GITHUB_REF));
+      if (!result.ok) {
+        return reply(
+          { content: `Could not start the build (GitHub returned ${result.status}).` },
+          true,
+        );
+      }
+      return reply(acknowledgement(request_, runsUrl));
+    }
+
+    if (interaction.type === INTERACTION_COMMAND) {
+      if (interaction.data?.name !== "build-pr") {
+        return reply({ content: "Unknown command." }, true);
+      }
+      const gate = isAllowed(interaction, env);
+      if (!gate.allowed) return reply({ content: gate.reason }, true);
+
+      const options = commandOptions(interaction);
+      if (options.prs.length === 0) {
+        return reply(
+          {
+            content:
+              "Give me at least one open pull request number, for example `/build-pr prs: 47 48 49 65`.",
+          },
+          true,
+        );
+      }
+      const result = await startWorkflow(env, dispatchPayload(options, env.GITHUB_REF));
+      if (!result.ok) {
+        return reply(
+          { content: `Could not start the workflow (GitHub returned ${result.status}).` },
+          true,
+        );
+      }
+      return reply(acknowledgement(options, runsUrl));
+    }
+
+    return new Response("unsupported interaction type", { status: 400 });
+  },
+};

--- a/tools/discord-build-command/wrangler.toml
+++ b/tools/discord-build-command/wrangler.toml
@@ -1,0 +1,19 @@
+name = "frostguard-build-command"
+main = "worker.js"
+compatibility_date = "2025-01-01"
+
+# Public configuration. Neither of these is a credential: the repository is
+# public, and the ref is only the branch the workflow is dispatched from.
+[vars]
+GITHUB_REPOSITORY = "Shederator/wosbot"
+GITHUB_REF = "main"
+
+# Optional guardrails. Leave a value empty to disable that restriction.
+#   ALLOWED_CHANNEL_IDS  the command only answers in these channels
+#   ALLOWED_ROLE_IDS     only members holding one of these roles may build
+# Set them the same way as the vars above, or with `wrangler secret put` if you
+# would rather keep the IDs out of the repository.
+#
+# The two real secrets are set once, interactively, and never committed:
+#   wrangler secret put DISCORD_PUBLIC_KEY
+#   wrangler secret put GITHUB_TOKEN


### PR DESCRIPTION
Closes #68.

## What this adds

A tester can comment this on any issue or pull request:

```
/build-pr 47 48 49 65
```

Nothing is built yet — the workflow replies in the thread with a **merge plan**:
which pull requests it accepted, the exact commit it pinned for each, the order
it will merge them in, and a reason for everything it left out. Adding `confirm`
runs the build and publishes a temporary, public, clearly labelled Windows
bundle.

| Comment | Effect |
|---|---|
| `/build-pr 47 48` | plan only, nothing is built |
| `/build-pr 47 48 confirm` | build and publish a temporary download |
| `/build-pr 47 48 union confirm` | on conflict, propose a both-sides resolution and show its diff |
| `/build-pr 47 48 order=48,47` | override the merge order |
| `/build-pr help` | usage into the thread |

Tester documentation: **[`docs/PR_TEST_BUILDS.md`](docs/PR_TEST_BUILDS.md)**.

## One-time step before it works

The three workflow files are staged in **`ci/workflows/`**, not
`.github/workflows/`, because a push that touches `.github/workflows/` is
rejected unless the pushing credential carries the `workflows` permission. Files
in `ci/workflows/` are inert — Actions never reads them.

After merging, install them in one step from a normal clone:

```sh
bash ci/install_workflows.sh            # dry run, shows what would move
bash ci/install_workflows.sh --apply    # git mv into .github/workflows/
git commit -m "ci(actions): install pull request test build workflows"
git push
```

## How the acceptance criteria are met

| Requirement from #68 | Where |
|---|---|
| Numbers only, junk reported, not silently ignored | `pr_build_plan.parse_pr_request` |
| Every pull request must be open, with a reason otherwise | `pr_build_plan.classify` |
| Head commits pinned so a later push cannot change a running build | `GitHubClient.pull` + re-verified in `publish` |
| Stacked pull requests detected, contained ones dropped | `merge-base --is-ancestor` in `select_and_order` |
| Safe base-to-tip order, overridable | `select_and_order`, `order=` |
| Plan shown, confirmation required before spending build time | `plan` job, `confirm` keyword |
| Combined only in a disposable workspace, `main` and PR branches untouched | `pr_build_combine.combine`, throwaway branch, never pushed |
| Conflicts reported per file, never silently resolved | `describe_conflict`, `render_conflict_report` |
| Both-sides resolution proposed with a diff, binary always manual | `union_resolve`, `looks_binary` |
| Untrusted code gets no write access and no secrets | `build` job: `contents: read`, zero secrets referenced |
| Temporary prerelease, separate from `nightly`, labelled and itemised | `pr-test-<key>` prerelease, `render_notes` |
| Temporary builds expire | `pr-test-build-cleanup.yml` + `pr_build_cleanup.decide` |
| Role restriction, dedupe, re-check before publish, reuse, cooldown, concurrency | `pr_build_command.py`, reuse lookup, `concurrency` group |

### Secret isolation

| Job | Runs | Token | Secrets referenced |
|---|---|---|---|
| `plan` | default-branch code | read | GitHub token, Discord webhook |
| `build` | **unreviewed pull request code** | `contents: read` | **none** |
| `publish` | default-branch code | `contents: write` | GitHub token, Discord webhook |

The build job compiles a `pom.xml` nobody reviewed, so it holds nothing worth
stealing. Publishing treats the produced bundle purely as a file to upload.

## Also fixed

- The Git LFS materialisation guard existed as inline prose in one workflow only.
  It is now `ci/verify_lfs_assets.sh`, shared by both build workflows.
- The README told testers to download the Actions artifact, which requires being
  signed in to GitHub. It now links the public release asset.
- The nightly workflow's pull request filter ignored changes to the workflow
  files themselves.

## Optional

`tools/discord-build-command/` is a small interactions endpoint that exposes the
same command as a real Discord slash command, for the case where typing it in
Discord is preferred over commenting on GitHub. A webhook alone cannot do this —
webhooks are outbound only. Nothing else in this change depends on it.

## Testing

108 new tests, all local and fast, wired into the nightly workflow:

```sh
python3 ci/test_pr_build_plan.py       # 41
python3 ci/test_pr_build_combine.py    # 13, real throwaway repositories
python3 ci/test_pr_build_notify.py     # 18
python3 ci/test_pr_build_command.py    # 23
python3 ci/test_pr_build_cleanup.py    # 13
node tools/discord-build-command/test-worker.mjs   # 14
```

Beyond the unit tests, the planner and combiner were exercised against this
repository's live data:

- The example from the issue, `47 48,49 #65 47 latest 999`, rejects #999 as
  nonexistent, removes the duplicate #47, reports `latest` as junk, and drops
  47 → 48 → 49 as already contained in #65, leaving only #65 to build.
- A clean combination of #63 and #51 merged without conflict.
- #42 with #41 produced a twelve-file conflict report plus the union suggestion,
  with `main` and both pull request branches verified unmoved afterwards.
