### PR TITLE
feat(ci): combined PR test builds requestable from Discord (/build-pr)

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -161,3 +161,42 @@ substitution really took effect in both directions.
   python3 ci/verify_bundle.py fg-app/target/frostguard-*-desktop-bundle.zip
   ci/smoke_test_bundle.sh fg-app/target/frostguard-*-desktop-bundle.zip
   ```
+
+## Combined PR test builds (`/build-pr`)
+
+Testers can request a temporary Windows bundle that combines one or more
+**open** pull requests — including stacked PRs — without merging anything
+(issue #68). Two entry points exist:
+
+- **Actions tab** → *PR Test Build* → *Run workflow* with `prs: 47,48,49,65`.
+- **Discord** `/build-pr 47 48 49 65` via the Cloudflare Worker in
+  [`discord-bot/`](../discord-bot/README.md), which validates the request,
+  pins head SHAs, shows the plan and asks for confirmation before dispatching
+  the same workflow.
+
+The pipeline is [`pr-test-build.yml`](../setup/github-workflows/pr-test-build.yml)
+(staged under `setup/github-workflows/` until `setup/install-workflows.sh` copies
+it into `.github/workflows/`) with four jobs that enforce a strict trust split:
+
+| Job | Trust | What it does |
+|---|---|---|
+| `plan` | trusted | [`pr_build_plan.py plan`](pr_build_plan.py): rejects closed/merged/non-numeric PRs with reasons, pins every head SHA, drops PRs already contained in another requested head or in `main` (stacked PRs), orders base-to-tip, trial-merges on a detached HEAD and reports conflicting files (binary conflicts flagged). Never executes PR code. |
+| `build` | **untrusted** | `pr_build_plan.py merge` reproduces the planned merge and fails unless the tree is bit-identical to the planned one, then runs the full Maven build. Read-only token, **no secrets**. Its verification is advisory only. |
+| `publish` | trusted | Fresh runner, pristine `main`: re-verifies the bundle with the trusted `verify_bundle.py` + `smoke_test_bundle.sh`, re-checks (`pr_build_plan.py recheck`) that every PR is still open and unchanged, then publishes the `pr-test-<digest>` prerelease. The digest covers base SHA + ordered pinned heads, so identical requests reuse the existing release. |
+| `notify` | trusted | [`pr_test_notify.py`](pr_test_notify.py) posts the outcome to the existing `DISCORD_NIGHTLY_WEBHOOK_URL`: download link (marked **UNMERGED TEST BUILD**), conflict report, rejection reasons, staleness explanation, or failure link. |
+
+No job ever pushes to `main` or a PR branch; the merged tree exists only
+inside the runners. [`pr-test-cleanup.yml`](../setup/github-workflows/pr-test-cleanup.yml)
+deletes each test release after 7 days or once every included PR is closed,
+and never touches `nightly` or real releases.
+
+The Git LFS pointer-stub guard shared with the nightly lives in
+[`check_lfs_assets.sh`](check_lfs_assets.sh).
+
+Run the feature's tests locally:
+
+```sh
+python3 ci/test_pr_build_plan.py     # planner, against real throwaway git repos
+python3 ci/test_pr_test_notify.py    # Discord result messages
+node discord-bot/test_worker.mjs     # worker helpers
+```

--- a/ci/check_lfs_assets.sh
+++ b/ci/check_lfs_assets.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Verify that every Git LFS asset in the checkout is a real binary.
+#
+# The Windows OpenCV .dll, adb.exe and the .traineddata OCR models are all
+# tracked with Git LFS. If any of them is still a pointer stub the build
+# silently produces a bundle that only fails on a user's machine, so fail
+# loudly here instead. Shared by the nightly bundle workflow and the PR test
+# build workflow so the two can never drift apart.
+#
+# Usage: ci/check_lfs_assets.sh [workspace]
+
+set -euo pipefail
+
+workspace="${1:-.}"
+cd "${workspace}"
+
+git lfs pull
+
+mapfile -t assets < <(git lfs ls-files --name-only)
+
+# An empty list would make every check below vacuously succeed, which is
+# exactly the failure mode this script exists to prevent.
+if [[ "${#assets[@]}" -eq 0 ]]; then
+  echo "::error::git lfs ls-files returned no assets. LFS tracking or" \
+       "the checkout is broken; the bundle would ship pointer stubs."
+  exit 1
+fi
+
+# These are the assets the shipped bundle cannot work without.
+required=(
+  "fg-vision/src/main/resources/native/opencv/opencv_java4110.dll"
+  "tools/adb/adb.exe"
+  "tools/adb/AdbWinApi.dll"
+  "tools/tesseract/eng.traineddata"
+)
+for want in "${required[@]}"; do
+  found=0
+  for asset in "${assets[@]}"; do
+    [[ "${asset}" == "${want}" ]] && found=1 && break
+  done
+  if [[ "${found}" -ne 1 ]]; then
+    echo "::error::Expected LFS-tracked asset is not tracked: ${want}"
+    exit 1
+  fi
+done
+
+failed=0
+for asset in "${assets[@]}"; do
+  [[ -z "${asset}" ]] && continue
+  if [[ ! -f "${asset}" ]]; then
+    echo "::error file=${asset}::LFS asset is missing from the checkout."
+    failed=1
+    continue
+  fi
+  # A pointer stub is a ~130 byte text file starting with this URL.
+  if head -c 45 "${asset}" | grep -q 'git-lfs.github.com/spec'; then
+    echo "::error file=${asset}::LFS asset was not materialised (still a pointer stub)."
+    failed=1
+    continue
+  fi
+  # Every real asset here is far larger than any stub could be.
+  size="$(stat -c%s "${asset}")"
+  if [[ "${size}" -lt 10240 ]]; then
+    echo "::error file=${asset}::LFS asset is implausibly small (${size} bytes)."
+    failed=1
+  fi
+done
+
+if [[ "${failed}" -ne 0 ]]; then
+  exit 1
+fi
+echo "All ${#assets[@]} Git LFS assets were materialised."

--- a/ci/pr_build_plan.py
+++ b/ci/pr_build_plan.py
@@ -1,0 +1,743 @@
+#!/usr/bin/env python3
+"""Plan, merge and re-check combined pull-request test builds.
+
+This is the trusted planning half of the `/build-pr` feature (issue #68). It
+never runs code from the requested pull requests: everything here is plain git
+plumbing plus the GitHub REST API, executed from the version of this script
+that lives on the trusted workflow ref.
+
+Sub-commands
+------------
+plan     Validate the requested PR numbers, pin every head SHA, drop PRs whose
+         head is already contained in another requested head (stacked PRs),
+         pick a deterministic base-to-tip order, and trial-merge everything in
+         a disposable detached worktree. Writes a machine-readable plan.json
+         and (optionally) GitHub Actions step outputs. Never touches `main`
+         or any PR branch.
+merge    Reproduce the exact merge described by an existing plan.json in the
+         current workspace and fail loudly unless the resulting tree is
+         bit-identical to the one the plan promised. Used by the untrusted
+         build job so the planner and the builder cannot disagree.
+recheck  Verify that every PR in a plan is still open and still points at the
+         pinned head SHA. Used by the publisher immediately before a release
+         is created, so a force-push between "plan" and "publish" cannot ship
+         code nobody reviewed under the advertised SHAs.
+
+Design rules carried over from the issue:
+- Only numeric PR numbers are accepted; duplicates are deduplicated.
+- Closed and merged PRs are rejected with a per-PR explanation.
+- Conflicts are reported with the conflicting file list. The script never
+  resolves a conflict with `ours`/`theirs`; a conflicted plan is unbuildable.
+- The digest over (base SHA + ordered head SHAs) names the release tag, so an
+  identical request can reuse an existing build instead of rebuilding.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+PLAN_VERSION = 1
+TAG_PREFIX = "pr-test-"
+DIGEST_LENGTH = 12
+
+# More PRs than this in one request is almost certainly a typo, and each extra
+# head multiplies the chance of a conflict wall that helps nobody.
+MAX_PRS_PER_REQUEST = 6
+
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA_PREFIX_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+class PlanError(Exception):
+    """A problem the requester can fix (bad input, closed PR, stale SHA)."""
+
+
+# ---------------------------------------------------------------------------
+# Input parsing
+# ---------------------------------------------------------------------------
+
+def parse_pr_numbers(raw: str) -> tuple[list[int], list[str]]:
+    """Parse '47, 48 49' into deduplicated PR numbers plus per-token errors.
+
+    Order of first appearance is preserved so the requester's intent survives
+    into tie-breaking. Anything that is not a positive integer becomes an
+    error message instead of being silently dropped.
+    """
+    numbers: list[int] = []
+    errors: list[str] = []
+    seen: set[int] = set()
+    for token in re.split(r"[\s,;]+", (raw or "").strip()):
+        if not token:
+            continue
+        # `#47` is how humans write PR numbers; accept it.
+        cleaned = token.lstrip("#")
+        if not cleaned.isdigit():
+            errors.append(f"`{token}` is not a PR number.")
+            continue
+        number = int(cleaned)
+        if number <= 0:
+            errors.append(f"`{token}` is not a valid PR number.")
+            continue
+        if number in seen:
+            continue  # Deduplicate silently; repeating a number is harmless.
+        seen.add(number)
+        numbers.append(number)
+    if not numbers and not errors:
+        errors.append("No PR numbers were given.")
+    if len(numbers) > MAX_PRS_PER_REQUEST:
+        errors.append(
+            f"{len(numbers)} PRs requested; the limit is {MAX_PRS_PER_REQUEST} "
+            "per test build."
+        )
+    return numbers, errors
+
+
+def parse_pinned(raw: str) -> tuple[dict[int, str], list[str]]:
+    """Parse '47:0123abc,48:4567def' into {number: sha_prefix}."""
+    pins: dict[int, str] = {}
+    errors: list[str] = []
+    for token in re.split(r"[\s,;]+", (raw or "").strip()):
+        if not token:
+            continue
+        number_part, sep, sha_part = token.partition(":")
+        if sep != ":" or not sha_part:
+            number_part, sep, sha_part = token.partition("@")
+        sha_part = sha_part.lower()
+        if not number_part.lstrip("#").isdigit() or not SHA_PREFIX_RE.match(sha_part):
+            errors.append(f"`{token}` is not a `<pr>:<sha>` pin.")
+            continue
+        pins[int(number_part.lstrip("#"))] = sha_part
+    return pins, errors
+
+
+# ---------------------------------------------------------------------------
+# GitHub REST API (stdlib only, same policy as ci/discord_notify.py)
+# ---------------------------------------------------------------------------
+
+def github_token() -> str:
+    return (os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or "").strip()
+
+
+def github_api(path: str, token: str) -> dict | list | None:
+    """GET one API path. Returns None on 404, raises PlanError otherwise."""
+    request = urllib.request.Request(
+        f"https://api.github.com{path}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "frostguard-pr-test/1.0 (+https://github.com/Shederator/wosbot)",
+            "X-GitHub-Api-Version": "2022-11-28",
+            **({"Authorization": f"Bearer {token}"} if token else {}),
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise PlanError(f"GitHub API {path} failed with HTTP {error.code}.") from error
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        raise PlanError(f"GitHub API {path} was unreachable: {error}.") from error
+
+
+@dataclass
+class Pull:
+    number: int
+    title: str
+    state: str            # "open" / "closed"
+    merged: bool
+    draft: bool
+    head_sha: str
+    head_ref: str
+    head_owner: str
+    base_ref: str
+    author: str
+
+    @property
+    def is_open(self) -> bool:
+        return self.state == "open"
+
+
+def fetch_pull(repo: str, number: int, token: str) -> Pull | None:
+    data = github_api(f"/repos/{repo}/pulls/{number}", token)
+    if data is None:
+        return None
+    return Pull(
+        number=number,
+        title=str(data.get("title") or ""),
+        state=str(data.get("state") or ""),
+        merged=bool(data.get("merged")),
+        draft=bool(data.get("draft")),
+        head_sha=str((data.get("head") or {}).get("sha") or ""),
+        head_ref=str((data.get("head") or {}).get("ref") or ""),
+        head_owner=str(
+            (((data.get("head") or {}).get("repo") or {}).get("owner") or {}).get("login")
+            or ""
+        ),
+        base_ref=str((data.get("base") or {}).get("ref") or ""),
+        author=str((data.get("user") or {}).get("login") or ""),
+    )
+
+
+def validate_pulls(
+    numbers: list[int],
+    pulls: dict[int, Pull | None],
+    pins: dict[int, str],
+) -> tuple[list[Pull], list[str]]:
+    """Keep only usable PRs; explain every rejection in requester language."""
+    usable: list[Pull] = []
+    errors: list[str] = []
+    for number in numbers:
+        pull = pulls.get(number)
+        if pull is None:
+            errors.append(f"PR #{number} does not exist in this repository.")
+            continue
+        if pull.merged:
+            errors.append(
+                f"PR #{number} is already merged; its changes are in `main`."
+            )
+            continue
+        if not pull.is_open:
+            errors.append(f"PR #{number} is closed and cannot be test-built.")
+            continue
+        if not FULL_SHA_RE.match(pull.head_sha):
+            errors.append(f"PR #{number} has no resolvable head commit.")
+            continue
+        pin = pins.get(number)
+        if pin and not pull.head_sha.startswith(pin):
+            errors.append(
+                f"PR #{number} moved since it was planned: pinned `{pin}` but the "
+                f"branch now points at `{pull.head_sha[:12]}`. Re-run the plan."
+            )
+            continue
+        usable.append(pull)
+    return usable, errors
+
+
+# ---------------------------------------------------------------------------
+# Git plumbing (all read-only against the remote; writes stay in the workspace)
+# ---------------------------------------------------------------------------
+
+def run_git(workspace: str, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", workspace, *args],
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def fetch_pr_heads(workspace: str, pulls: list[Pull]) -> None:
+    """Fetch every pinned head commit into the local object store.
+
+    `pull/N/head` is served by GitHub for every PR regardless of the fork it
+    came from, so this works for fork PRs without any credentials beyond the
+    ones the checkout already has.
+    """
+    refspecs = [f"+refs/pull/{p.number}/head:refs/pr-test/{p.number}" for p in pulls]
+    result = run_git(workspace, "fetch", "--no-tags", "origin", *refspecs, check=False)
+    if result.returncode != 0:
+        raise PlanError(
+            "Could not fetch the PR head commits from origin: "
+            + (result.stderr or result.stdout).strip()[:500]
+        )
+    for pull in pulls:
+        # The pinned SHA must be the commit we actually fetched. If the branch
+        # moved between the API call and the fetch, resolve the pinned SHA
+        # directly; it stays fetchable for a while even after a force-push.
+        have = run_git(workspace, "rev-parse", f"refs/pr-test/{pull.number}").stdout.strip()
+        if have != pull.head_sha:
+            probe = run_git(workspace, "cat-file", "-e", f"{pull.head_sha}^{{commit}}", check=False)
+            if probe.returncode != 0:
+                raise PlanError(
+                    f"PR #{pull.number} was pushed to while planning "
+                    f"(expected `{pull.head_sha[:12]}`, fetched `{have[:12]}`). "
+                    "Please retry."
+                )
+
+
+def is_ancestor(workspace: str, ancestor_sha: str, descendant_sha: str) -> bool:
+    result = run_git(
+        workspace, "merge-base", "--is-ancestor", ancestor_sha, descendant_sha,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise PlanError(
+            f"git merge-base failed for {ancestor_sha[:12]}..{descendant_sha[:12]}: "
+            + (result.stderr or "").strip()[:300]
+        )
+    return result.returncode == 0
+
+
+@dataclass
+class Containment:
+    kept: list[Pull]
+    dropped: list[dict] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+def resolve_containment(workspace: str, base_sha: str, pulls: list[Pull]) -> Containment:
+    """Drop PRs whose head is already reachable from the base or another head.
+
+    For a stack 47 <- 48 <- 49, requesting all three keeps only 49: merging 49
+    brings the other two along, and merging them again would be a no-op that
+    only muddies the report.
+    """
+    result = Containment(kept=[])
+    dropped_numbers: set[int] = set()
+
+    for pull in pulls:
+        if is_ancestor(workspace, pull.head_sha, base_sha):
+            result.dropped.append({"number": pull.number, "contained_in": "base"})
+            result.notes.append(
+                f"PR #{pull.number} is already contained in `main` "
+                f"(head `{pull.head_sha[:12]}`); it was dropped from the plan."
+            )
+            dropped_numbers.add(pull.number)
+
+    candidates = [p for p in pulls if p.number not in dropped_numbers]
+    for pull in candidates:
+        for other in candidates:
+            if other.number == pull.number or other.number in dropped_numbers:
+                continue
+            if pull.head_sha == other.head_sha:
+                # Identical heads: keep the lower PR number deterministically.
+                if pull.number > other.number:
+                    result.dropped.append(
+                        {"number": pull.number, "contained_in": other.number}
+                    )
+                    result.notes.append(
+                        f"PR #{pull.number} points at the same commit as "
+                        f"#{other.number}; it was dropped as a duplicate."
+                    )
+                    dropped_numbers.add(pull.number)
+                    break
+                continue
+            if is_ancestor(workspace, pull.head_sha, other.head_sha):
+                result.dropped.append(
+                    {"number": pull.number, "contained_in": other.number}
+                )
+                result.notes.append(
+                    f"PR #{pull.number} is fully contained in PR #{other.number} "
+                    "(stacked); merging the tip covers it."
+                )
+                dropped_numbers.add(pull.number)
+                break
+
+    result.kept = [p for p in pulls if p.number not in dropped_numbers]
+    return result
+
+
+def order_pulls(kept: list[Pull], explicit_order: list[int] | None) -> list[Pull]:
+    """Deterministic merge order: requester's explicit order, else ascending.
+
+    After containment removal no kept head is an ancestor of another, so any
+    order is *correct*; ascending PR number (oldest work first) is the closest
+    thing to base-to-tip that exists for independent branches and is what a
+    human would predict.
+    """
+    if explicit_order:
+        wanted = {p.number for p in kept}
+        if sorted(explicit_order) != sorted(wanted):
+            raise PlanError(
+                "The explicit order must be a permutation of the kept PRs "
+                f"({', '.join(f'#{n}' for n in sorted(wanted))})."
+            )
+        by_number = {p.number: p for p in kept}
+        return [by_number[n] for n in explicit_order]
+    return sorted(kept, key=lambda p: p.number)
+
+
+def compute_digest(base_sha: str, ordered: list[Pull]) -> str:
+    material = base_sha + "|" + ",".join(f"{p.number}@{p.head_sha}" for p in ordered)
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:DIGEST_LENGTH]
+
+
+# ---------------------------------------------------------------------------
+# Trial merge in a disposable detached worktree
+# ---------------------------------------------------------------------------
+
+def blob_is_binary(workspace: str, blob_sha: str) -> bool:
+    """Git's own heuristic: a NUL byte in the first 8000 bytes means binary."""
+    result = subprocess.run(
+        ["git", "-C", workspace, "cat-file", "blob", blob_sha],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+    return b"\x00" in result.stdout[:8000]
+
+
+def conflict_report(workspace: str) -> list[dict]:
+    """Describe every unmerged path, flagging binary conflicts explicitly.
+
+    Binary detection reads the actual conflicting index stages instead of
+    trusting `diff --numstat`, which reports `0 0` (not `- -`) for unmerged
+    binary paths and would silently misclassify every one of them as text.
+    """
+    stages: dict[str, list[str]] = {}
+    for line in run_git(workspace, "ls-files", "-u").stdout.splitlines():
+        # "<mode> <sha> <stage>\t<path>"
+        meta, _, path = line.partition("\t")
+        parts = meta.split()
+        if len(parts) == 3 and path:
+            stages.setdefault(path, []).append(parts[1])
+    return [
+        {
+            "path": path,
+            "binary": any(blob_is_binary(workspace, sha) for sha in shas),
+        }
+        for path, shas in sorted(stages.items())
+    ]
+
+
+def trial_merge(workspace: str, base_sha: str, ordered: list[Pull]) -> dict:
+    """Merge every head onto a detached HEAD at base_sha, base-to-tip.
+
+    Returns {"ok", "tree_sha", "conflicts": [...]}. On conflict the merge is
+    aborted and the report names the PR that introduced it plus every
+    conflicting file. Nothing here can move a branch: HEAD is detached and no
+    push ever happens.
+    """
+    run_git(workspace, "checkout", "--detach", base_sha)
+    # Merge commits need an identity; use an obviously-synthetic one so the
+    # throwaway commits can never be mistaken for authored work.
+    identity = [
+        "-c", "user.name=Frostguard PR test build",
+        "-c", "user.email=pr-test-build@users.noreply.github.com",
+    ]
+    for pull in ordered:
+        result = subprocess.run(
+            [
+                "git", "-C", workspace, *identity, "merge", "--no-ff", "--no-edit",
+                "-m", f"test-merge: PR #{pull.number} @ {pull.head_sha[:12]}",
+                pull.head_sha,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            conflicts = conflict_report(workspace)
+            run_git(workspace, "merge", "--abort", check=False)
+            if not conflicts:
+                raise PlanError(
+                    f"Merging PR #{pull.number} failed without conflict markers: "
+                    + (result.stderr or result.stdout).strip()[:500]
+                )
+            return {
+                "ok": False,
+                "tree_sha": "",
+                "conflicts": [{"pr": pull.number, "files": conflicts}],
+            }
+    tree_sha = run_git(workspace, "rev-parse", "HEAD^{tree}").stdout.strip()
+    return {"ok": True, "tree_sha": tree_sha, "conflicts": []}
+
+
+# ---------------------------------------------------------------------------
+# Plan document + step outputs
+# ---------------------------------------------------------------------------
+
+def release_tag(digest: str) -> str:
+    return f"{TAG_PREFIX}{digest}"
+
+
+def find_reusable_release(repo: str, tag: str, token: str) -> str:
+    """Return the bundle download URL when this exact plan was already built."""
+    release = github_api(f"/repos/{repo}/releases/tags/{tag}", token)
+    if not isinstance(release, dict):
+        return ""
+    for asset in release.get("assets") or []:
+        name = str(asset.get("name") or "")
+        if name.endswith(".zip"):
+            return str(asset.get("browser_download_url") or "")
+    return ""
+
+
+def write_outputs(path: str, values: dict[str, str]) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            text = str(value)
+            if "\n" in text:
+                handle.write(f"{key}<<PR_TEST_EOF\n{text}\nPR_TEST_EOF\n")
+            else:
+                handle.write(f"{key}={text}\n")
+
+
+def failure_plan(repo: str, base_ref: str, requested_raw: str, errors: list[str]) -> dict:
+    return {
+        "version": PLAN_VERSION,
+        "ok": False,
+        "repository": repo,
+        "base_ref": base_ref,
+        "base_sha": "",
+        "requested": requested_raw,
+        "pulls": [],
+        "dropped": [],
+        "order": [],
+        "digest": "",
+        "tag": "",
+        "merge": {"ok": False, "tree_sha": "", "conflicts": []},
+        "errors": errors,
+        "notes": [],
+        "reuse_url": "",
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def build_plan(args: argparse.Namespace, token: str) -> dict:
+    """Compute the full plan document. Raises PlanError only for infrastructure
+    failures; requester-fixable problems become a failure plan with errors."""
+    numbers, parse_errors = parse_pr_numbers(args.prs)
+    pins, pin_errors = parse_pinned(args.pinned)
+    errors = parse_errors + pin_errors
+    if errors or not numbers:
+        return failure_plan(args.repo, args.base_ref, args.prs, errors)
+
+    pulls_by_number = {n: fetch_pull(args.repo, n, token) for n in numbers}
+    usable, errors = validate_pulls(numbers, pulls_by_number, pins)
+    if errors or not usable:
+        if not errors:
+            errors = ["No usable PRs remain after validation."]
+        return failure_plan(args.repo, args.base_ref, args.prs, errors)
+
+    base_sha = run_git(
+        args.workspace, "rev-parse", f"refs/remotes/origin/{args.base_ref}",
+    ).stdout.strip()
+    if not FULL_SHA_RE.match(base_sha):
+        return failure_plan(
+            args.repo, args.base_ref, args.prs,
+            [f"Could not resolve origin/{args.base_ref} in the workspace."],
+        )
+
+    fetch_pr_heads(args.workspace, usable)
+    containment = resolve_containment(args.workspace, base_sha, usable)
+    if not containment.kept:
+        plan = failure_plan(
+            args.repo, args.base_ref, args.prs,
+            ["Every requested PR is already contained in `main`; there is "
+             "nothing to build."],
+        )
+        plan["notes"] = containment.notes
+        plan["dropped"] = containment.dropped
+        return plan
+
+    explicit = None
+    if args.order:
+        explicit, order_errors = parse_pr_numbers(args.order)
+        if order_errors:
+            return failure_plan(args.repo, args.base_ref, args.prs, order_errors)
+    ordered = order_pulls(containment.kept, explicit)
+
+    digest = compute_digest(base_sha, ordered)
+    tag = release_tag(digest)
+    merge = trial_merge(args.workspace, base_sha, ordered)
+    reuse_url = ""
+    if merge["ok"]:
+        reuse_url = find_reusable_release(args.repo, tag, token)
+
+    return {
+        "version": PLAN_VERSION,
+        "ok": merge["ok"],
+        "repository": args.repo,
+        "base_ref": args.base_ref,
+        "base_sha": base_sha,
+        "requested": args.prs,
+        "pulls": [
+            {
+                "number": p.number,
+                "title": p.title,
+                "head_sha": p.head_sha,
+                "head_ref": p.head_ref,
+                "head_owner": p.head_owner,
+                "author": p.author,
+                "draft": p.draft,
+            }
+            for p in ordered
+        ],
+        "dropped": containment.dropped,
+        "order": [p.number for p in ordered],
+        "digest": digest,
+        "tag": tag,
+        "merge": merge,
+        "errors": [] if merge["ok"] else [
+            "The PRs do not merge cleanly; see the conflict report."
+        ],
+        "notes": containment.notes,
+        "reuse_url": reuse_url,
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    token = github_token()
+    try:
+        plan = build_plan(args, token)
+    except PlanError as error:
+        plan = failure_plan(args.repo, args.base_ref, args.prs, [str(error)])
+
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(plan, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    write_outputs(args.github_output, {
+        "ok": "true" if plan["ok"] else "false",
+        "digest": plan["digest"],
+        "tag": plan["tag"],
+        "base_sha": plan["base_sha"],
+        "reuse_url": plan.get("reuse_url", ""),
+        "order": ",".join(str(n) for n in plan["order"]),
+        "pinned": ",".join(
+            f"{p['number']}:{p['head_sha'][:12]}" for p in plan["pulls"]
+        ),
+    })
+
+    for note in plan.get("notes", []):
+        print(f"::notice::{note}")
+    for error in plan.get("errors", []):
+        print(f"::error::{error}")
+    if plan["ok"]:
+        heads = ", ".join(
+            f"#{p['number']}@{p['head_sha'][:12]}" for p in plan["pulls"]
+        )
+        print(f"Plan {plan['digest']}: merge {heads} onto {plan['base_sha'][:12]}")
+    return 0 if plan["ok"] else 1
+
+
+def cmd_merge(args: argparse.Namespace) -> int:
+    with open(args.plan, encoding="utf-8") as handle:
+        plan = json.load(handle)
+    if not plan.get("ok"):
+        print("::error::The plan is not buildable; refusing to merge.")
+        return 1
+
+    pulls = [
+        Pull(
+            number=int(p["number"]),
+            title=str(p.get("title") or ""),
+            state="open",
+            merged=False,
+            draft=bool(p.get("draft")),
+            head_sha=str(p["head_sha"]),
+            head_ref=str(p.get("head_ref") or ""),
+            head_owner=str(p.get("head_owner") or ""),
+            base_ref=str(plan.get("base_ref") or "main"),
+            author=str(p.get("author") or ""),
+        )
+        for p in plan["pulls"]
+    ]
+    try:
+        fetch_pr_heads(args.workspace, pulls)
+        probe = run_git(
+            args.workspace, "cat-file", "-e", f"{plan['base_sha']}^{{commit}}",
+            check=False,
+        )
+        if probe.returncode != 0:
+            raise PlanError(
+                f"Base commit {plan['base_sha'][:12]} is not in the workspace; "
+                "fetch main history first."
+            )
+        merge = trial_merge(args.workspace, plan["base_sha"], pulls)
+    except PlanError as error:
+        print(f"::error::{error}")
+        return 1
+    if not merge["ok"]:
+        print("::error::The merge conflicted although the plan said it would not. "
+              "A branch probably moved; re-run the plan.")
+        return 1
+    if merge["tree_sha"] != plan["merge"]["tree_sha"]:
+        print(
+            "::error::The merged tree does not match the planned tree "
+            f"({merge['tree_sha'][:12]} != {plan['merge']['tree_sha'][:12]}). "
+            "Refusing to build an unplanned tree."
+        )
+        return 1
+    print(f"Workspace now holds the planned merge (tree {merge['tree_sha'][:12]}).")
+    return 0
+
+
+def cmd_recheck(args: argparse.Namespace) -> int:
+    with open(args.plan, encoding="utf-8") as handle:
+        plan = json.load(handle)
+    token = github_token()
+    problems: list[str] = []
+    for entry in plan.get("pulls", []):
+        number = int(entry["number"])
+        try:
+            pull = fetch_pull(plan["repository"], number, token)
+        except PlanError as error:
+            problems.append(str(error))
+            continue
+        if pull is None:
+            problems.append(f"PR #{number} disappeared.")
+        elif pull.merged:
+            problems.append(f"PR #{number} was merged after planning.")
+        elif not pull.is_open:
+            problems.append(f"PR #{number} was closed after planning.")
+        elif pull.head_sha != entry["head_sha"]:
+            problems.append(
+                f"PR #{number} was pushed to after planning "
+                f"(`{entry['head_sha'][:12]}` -> `{pull.head_sha[:12]}`)."
+            )
+    if problems:
+        for problem in problems:
+            print(f"::error::{problem}")
+        write_outputs(args.github_output, {"fresh": "false",
+                                           "problems": "\n".join(problems)})
+        return 1
+    write_outputs(args.github_output, {"fresh": "true", "problems": ""})
+    print("Every planned PR is still open and unchanged.")
+    return 0
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    plan = sub.add_parser("plan", help="validate, pin, order and trial-merge")
+    plan.add_argument("--prs", required=True, help="e.g. '47,48,49' or '47 48'")
+    plan.add_argument("--pinned", default="", help="e.g. '47:0123abcdef01,48:...'")
+    plan.add_argument("--order", default="", help="explicit merge order override")
+    plan.add_argument("--repo", required=True, help="owner/name")
+    plan.add_argument("--base-ref", default="main")
+    plan.add_argument("--workspace", default=".")
+    plan.add_argument("--output", default="plan.json")
+    plan.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT", ""))
+    plan.set_defaults(func=cmd_plan)
+
+    merge = sub.add_parser("merge", help="reproduce a planned merge exactly")
+    merge.add_argument("--plan", required=True)
+    merge.add_argument("--workspace", default=".")
+    merge.set_defaults(func=cmd_merge)
+
+    recheck = sub.add_parser("recheck", help="verify PRs are still open/unchanged")
+    recheck.add_argument("--plan", required=True)
+    recheck.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT", ""))
+    recheck.set_defaults(func=cmd_recheck)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        return args.func(args)
+    except PlanError as error:
+        print(f"::error::{error}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/pr_test_notify.py
+++ b/ci/pr_test_notify.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Post a combined-PR test build status message to a Discord webhook.
+
+This is the reporting half of the `/build-pr` feature (issue #68). It reads
+the plan.json written by ci/pr_build_plan.py and renders one of four message
+kinds:
+
+- rejected   The request never became a plan (bad numbers, closed/merged PRs).
+- conflict   Git could not combine the PRs; the conflicting files are listed
+             per PR, with binary conflicts flagged. Nothing was auto-resolved.
+- stale      The publisher's re-check found a PR that closed or moved after
+             planning; the build was withheld.
+- success    A verified bundle was published; the message carries the public
+             download link plus every PR number, title and pinned SHA.
+- failure    The build itself failed; links the workflow log.
+
+Every download is explicitly marked as an UNMERGED TEST BUILD so nobody
+mistakes it for a nightly. The webhook URL comes from the environment, never
+argv, for the same process-list reason as ci/discord_notify.py, whose
+delivery machinery (retries, rate limits, redaction) is reused here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from discord_notify import (  # noqa: E402
+    CONTENT_LIMIT,
+    EMBED_DESCRIPTION_LIMIT,
+    EMBED_FIELD_NAME_LIMIT,
+    EMBED_FIELD_VALUE_LIMIT,
+    EMBED_FOOTER_LIMIT,
+    EMBED_TITLE_LIMIT,
+    human_size,
+    lenient_int,
+    post,
+    truncate,
+)
+import re
+
+KIND_STYLE = {
+    "success": (0x2ECC71, "Test build ready"),
+    "conflict": (0xE67E22, "PRs do not merge cleanly"),
+    "rejected": (0xE74C3C, "Request rejected"),
+    "stale": (0xE67E22, "Build withheld — a PR changed"),
+    "failure": (0xE74C3C, "Test build failed"),
+}
+
+TEST_BUILD_WARNING = (
+    "⚠️ **UNMERGED TEST BUILD** — this bundle contains pull-request code that "
+    "has not been reviewed or merged into `main`. Use it only for testing."
+)
+
+# A conflict wall with hundreds of files must not blow Discord's limits;
+# past this many paths the rest is summarised.
+MAX_CONFLICT_FILES_SHOWN = 15
+MAX_LIST_ITEMS = 10
+
+
+def load_plan(path: str) -> dict:
+    if not path or not os.path.isfile(path):
+        return {}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def pr_lines(plan: dict) -> list[str]:
+    """One line per included PR: number, title, pinned SHA, author."""
+    repo = plan.get("repository") or ""
+    lines = []
+    for entry in plan.get("pulls") or []:
+        number = entry.get("number")
+        sha = str(entry.get("head_sha") or "")[:12]
+        title = truncate(str(entry.get("title") or ""), 80)
+        link = (
+            f"[#{number}](https://github.com/{repo}/pull/{number})"
+            if repo else f"#{number}"
+        )
+        lines.append(f"{link} `{sha}` — {title}")
+    return lines
+
+
+def dropped_lines(plan: dict) -> list[str]:
+    lines = []
+    for entry in plan.get("dropped") or []:
+        number = entry.get("number")
+        container = entry.get("contained_in")
+        where = "`main`" if container == "base" else f"#{container}"
+        lines.append(f"#{number} — already contained in {where}, skipped")
+    return lines
+
+
+def conflict_lines(plan: dict) -> list[str]:
+    lines = []
+    for conflict in (plan.get("merge") or {}).get("conflicts") or []:
+        pr = conflict.get("pr")
+        files = conflict.get("files") or []
+        lines.append(f"Merging **#{pr}** conflicted in {len(files)} file(s):")
+        for entry in files[:MAX_CONFLICT_FILES_SHOWN]:
+            marker = " **(binary — needs a manual choice)**" if entry.get("binary") else ""
+            lines.append(f"• `{entry.get('path')}`{marker}")
+        hidden = len(files) - MAX_CONFLICT_FILES_SHOWN
+        if hidden > 0:
+            lines.append(f"• …and {hidden} more")
+    return lines
+
+
+def clamp_list(items: list[str], limit: int = MAX_LIST_ITEMS) -> list[str]:
+    if len(items) <= limit:
+        return items
+    return items[:limit] + [f"…and {len(items) - limit} more"]
+
+
+def build_payload(args: argparse.Namespace, plan: dict) -> dict:
+    color, headline = KIND_STYLE.get(args.kind, KIND_STYLE["failure"])
+    digest = plan.get("digest") or ""
+    requested = str(plan.get("requested") or args.requested or "").strip()
+
+    title = f"/build-pr — {headline}"
+    if digest:
+        title += f" ({digest})"
+
+    fields: list[dict] = []
+
+    def add_field(name: str, value: str, inline: bool = False) -> None:
+        value = truncate(value, EMBED_FIELD_VALUE_LIMIT)
+        if value:
+            fields.append({
+                "name": truncate(name, EMBED_FIELD_NAME_LIMIT),
+                "value": value,
+                "inline": inline,
+            })
+
+    description_parts: list[str] = []
+
+    included = pr_lines(plan)
+    dropped = dropped_lines(plan)
+
+    if args.kind == "success":
+        description_parts.append(TEST_BUILD_WARNING)
+        if args.download_url and args.download_url.startswith("http"):
+            reused = " (reused an earlier identical build)" if args.reused else ""
+            description_parts.append(
+                f"**[⬇ Download the test bundle]({args.download_url})**{reused}"
+            )
+            description_parts.append(
+                "Verified: bundle structure, manifest classpath and launch "
+                "smoke test. Unzip anywhere, then run "
+                "`java -jar frostguard-*.jar` (Java 21+ required)."
+            )
+        if args.expires_utc:
+            description_parts.append(
+                f"This test release expires on **{args.expires_utc}** or when "
+                "every included PR is closed."
+            )
+        if included:
+            add_field("Included PRs (merge order, pinned)", "\n".join(included))
+        base_sha = str(plan.get("base_sha") or "")[:12]
+        if base_sha:
+            add_field("Base", f"`main @ {base_sha}`", inline=True)
+    elif args.kind == "conflict":
+        description_parts.append(
+            "The requested PRs could not be combined automatically. Nothing "
+            "was resolved with `ours`/`theirs` and no branch was modified."
+        )
+        lines = conflict_lines(plan)
+        if lines:
+            add_field("Conflicts", "\n".join(lines))
+        if included:
+            add_field("Attempted merge order", "\n".join(included))
+        description_parts.append(
+            "Rebase the later PR onto the earlier one (or resolve the "
+            "conflict in the PR itself), then request the build again."
+        )
+    elif args.kind == "rejected":
+        errors = clamp_list([str(e) for e in plan.get("errors") or []])
+        if not errors and args.reason:
+            errors = [args.reason]
+        description_parts.append(
+            "The request was not valid, so no build was started."
+        )
+        if errors:
+            add_field("Problems", "\n".join(f"• {e}" for e in errors))
+    elif args.kind == "stale":
+        problems = clamp_list(
+            [line for line in (args.problems or "").splitlines() if line.strip()]
+        )
+        description_parts.append(
+            "Between planning and publishing, at least one PR was closed, "
+            "merged or force-pushed. The finished build was **not** published "
+            "because its pinned SHAs no longer describe the PRs. Request the "
+            "build again to plan against the current heads."
+        )
+        if problems:
+            add_field("What changed", "\n".join(f"• {p}" for p in problems))
+    else:  # failure
+        description_parts.append(
+            f"The build failed. See [the workflow log]({args.run_url}) for "
+            "the failing step." if args.run_url else "The build failed."
+        )
+        if included:
+            add_field("Requested PRs", "\n".join(included))
+
+    if dropped and args.kind in ("success", "conflict"):
+        add_field("Dropped (stacked/contained)", "\n".join(clamp_list(dropped)))
+    if requested and args.kind == "rejected":
+        add_field("You asked for", f"`{truncate(requested, 200)}`", inline=True)
+    if args.requester:
+        add_field("Requested by", truncate(args.requester, 100), inline=True)
+    if args.bundle_bytes > 0 and args.kind == "success":
+        add_field("Download size", human_size(args.bundle_bytes), inline=True)
+
+    embed = {
+        "title": truncate(title, EMBED_TITLE_LIMIT),
+        "color": color,
+        "description": truncate("\n\n".join(description_parts), EMBED_DESCRIPTION_LIMIT),
+        "fields": fields[:10],
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    if args.run_url:
+        embed["url"] = args.run_url
+    footer = "Frostguard PR test builds"
+    if digest:
+        footer += f" • {digest}"
+    embed["footer"] = {"text": truncate(footer, EMBED_FOOTER_LIMIT)}
+
+    payload = {
+        "username": args.username,
+        "embeds": [embed],
+        # A PR title is contributor-controlled text; never let it ping.
+        "allowed_mentions": {"parse": []},
+    }
+    if args.kind == "success" and args.download_url.startswith("http"):
+        payload["content"] = truncate(args.download_url, CONTENT_LIMIT)
+    return payload
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kind", required=True, choices=sorted(KIND_STYLE))
+    parser.add_argument("--plan", default="", help="path to plan.json")
+    parser.add_argument("--download-url", default="")
+    parser.add_argument("--expires-utc", default="")
+    parser.add_argument("--reused", action="store_true",
+                        help="an existing identical build was reused")
+    parser.add_argument("--bundle-bytes", type=lenient_int, default=0)
+    parser.add_argument("--run-url", default="")
+    parser.add_argument("--requester", default="",
+                        help="Discord user who asked for the build")
+    parser.add_argument("--requested", default="",
+                        help="raw PR list as typed, for rejection messages")
+    parser.add_argument("--reason", default="",
+                        help="single-line rejection reason when no plan exists")
+    parser.add_argument("--problems", default="",
+                        help="newline-separated staleness findings")
+    parser.add_argument("--username", default="Frostguard PR Test Builds")
+    parser.add_argument("--webhook-env", default="DISCORD_NIGHTLY_WEBHOOK_URL")
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    plan = load_plan(args.plan)
+    payload = build_payload(args, plan)
+
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    webhook = os.environ.get(args.webhook_env, "").strip()
+    if not webhook:
+        print(f"::warning::{args.webhook_env} is empty; no Discord message sent.")
+        return 0
+    if not re.match(r"^https://(canary\.|ptb\.)?discord(app)?\.com/api/webhooks/", webhook):
+        print(
+            f"::error::{args.webhook_env} does not look like a Discord webhook URL."
+        )
+        return 1
+
+    post(webhook, json.dumps(payload).encode("utf-8"), "application/json",
+         args.timeout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/test_pr_build_plan.py
+++ b/ci/test_pr_build_plan.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Unit tests for ci/pr_build_plan.py.
+
+The git-facing behaviour (containment, ordering, trial merges, conflict
+reporting, plan reproduction) is tested against real throwaway repositories,
+because a mocked `git` would just re-encode the assumptions this suite exists
+to check. The GitHub API is never called: PR metadata is constructed directly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pr_build_plan as plan_mod
+from pr_build_plan import (
+    MAX_PRS_PER_REQUEST,
+    PlanError,
+    Pull,
+    compute_digest,
+    conflict_report,
+    is_ancestor,
+    order_pulls,
+    parse_pinned,
+    parse_pr_numbers,
+    release_tag,
+    resolve_containment,
+    trial_merge,
+    validate_pulls,
+    write_outputs,
+)
+
+
+def git(cwd: str, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", cwd, *args], capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def make_pull(number: int, sha: str, **overrides) -> Pull:
+    defaults = dict(
+        number=number,
+        title=f"PR {number}",
+        state="open",
+        merged=False,
+        draft=False,
+        head_sha=sha,
+        head_ref=f"feature/{number}",
+        head_owner="someone",
+        base_ref="main",
+        author="someone",
+    )
+    defaults.update(overrides)
+    return Pull(**defaults)
+
+
+class ParsePrNumbersTest(unittest.TestCase):
+    def test_accepts_spaces_commas_and_hash_prefixes(self):
+        numbers, errors = parse_pr_numbers("47, 48 #49;65")
+        self.assertEqual(numbers, [47, 48, 49, 65])
+        self.assertEqual(errors, [])
+
+    def test_deduplicates_and_keeps_first_appearance_order(self):
+        numbers, errors = parse_pr_numbers("49 47 49 47 48")
+        self.assertEqual(numbers, [49, 47, 48])
+        self.assertEqual(errors, [])
+
+    def test_rejects_non_numeric_tokens_with_an_explanation(self):
+        numbers, errors = parse_pr_numbers("47 main 48")
+        self.assertEqual(numbers, [47, 48])
+        self.assertEqual(len(errors), 1)
+        self.assertIn("main", errors[0])
+
+    def test_rejects_zero_and_negative_numbers(self):
+        numbers, errors = parse_pr_numbers("0 -3 47")
+        self.assertEqual(numbers, [47])
+        self.assertEqual(len(errors), 2)
+
+    def test_empty_input_is_an_error_not_a_silent_noop(self):
+        numbers, errors = parse_pr_numbers("   ")
+        self.assertEqual(numbers, [])
+        self.assertTrue(errors)
+
+    def test_enforces_the_per_request_ceiling(self):
+        raw = " ".join(str(n) for n in range(1, MAX_PRS_PER_REQUEST + 2))
+        _, errors = parse_pr_numbers(raw)
+        self.assertTrue(any("limit" in e for e in errors))
+
+
+class ParsePinnedTest(unittest.TestCase):
+    def test_parses_colon_and_at_separators(self):
+        pins, errors = parse_pinned("47:0123abcdef0,48@fedcba98765")
+        self.assertEqual(pins, {47: "0123abcdef0", 48: "fedcba98765"})
+        self.assertEqual(errors, [])
+
+    def test_rejects_short_or_non_hex_pins(self):
+        pins, errors = parse_pinned("47:xyz 48:012")
+        self.assertEqual(pins, {})
+        self.assertEqual(len(errors), 2)
+
+
+class ValidatePullsTest(unittest.TestCase):
+    SHA = "a" * 40
+    OTHER = "b" * 40
+
+    def test_merged_and_closed_prs_are_rejected_with_reasons(self):
+        pulls = {
+            1: make_pull(1, self.SHA, merged=True, state="closed"),
+            2: make_pull(2, self.OTHER, state="closed"),
+            3: None,
+            4: make_pull(4, self.SHA),
+        }
+        usable, errors = validate_pulls([1, 2, 3, 4], pulls, {})
+        self.assertEqual([p.number for p in usable], [4])
+        self.assertEqual(len(errors), 3)
+        self.assertIn("merged", errors[0])
+        self.assertIn("closed", errors[1])
+        self.assertIn("does not exist", errors[2])
+
+    def test_a_moved_head_fails_the_pin_check(self):
+        pulls = {5: make_pull(5, self.SHA)}
+        usable, errors = validate_pulls([5], pulls, {5: "b" * 12})
+        self.assertEqual(usable, [])
+        self.assertIn("moved since it was planned", errors[0])
+
+    def test_a_matching_pin_passes(self):
+        pulls = {5: make_pull(5, self.SHA)}
+        usable, errors = validate_pulls([5], pulls, {5: "a" * 12})
+        self.assertEqual([p.number for p in usable], [5])
+        self.assertEqual(errors, [])
+
+
+class GitRepoTestCase(unittest.TestCase):
+    """A tiny real repository with main plus branches for merge tests."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = self._tmp.name
+        git(self.repo, "init", "-q", "-b", "main")
+        git(self.repo, "config", "user.name", "Test")
+        git(self.repo, "config", "user.email", "test@example.invalid")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def commit(self, filename: str, content: str, message: str) -> str:
+        path = os.path.join(self.repo, filename)
+        os.makedirs(os.path.dirname(path) or self.repo, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        git(self.repo, "add", filename)
+        git(self.repo, "commit", "-q", "-m", message)
+        return git(self.repo, "rev-parse", "HEAD")
+
+    def branch_from(self, name: str, start: str) -> None:
+        git(self.repo, "checkout", "-q", "-b", name, start)
+
+
+class ContainmentTest(GitRepoTestCase):
+    def test_stacked_pr_is_dropped_in_favour_of_the_tip(self):
+        base = self.commit("base.txt", "base", "base")
+        self.branch_from("first", base)
+        first = self.commit("a.txt", "a", "first")
+        self.branch_from("second", first)
+        second = self.commit("b.txt", "b", "second")
+
+        result = resolve_containment(
+            self.repo, base,
+            [make_pull(47, first), make_pull(48, second)],
+        )
+        self.assertEqual([p.number for p in result.kept], [48])
+        self.assertEqual(result.dropped, [{"number": 47, "contained_in": 48}])
+        self.assertTrue(any("stacked" in n for n in result.notes))
+
+    def test_pr_already_in_main_is_dropped_against_the_base(self):
+        self.commit("base.txt", "base", "base")
+        self.branch_from("merged-work", "main")
+        merged = self.commit("done.txt", "done", "already merged")
+        git(self.repo, "checkout", "-q", "main")
+        git(self.repo, "merge", "-q", "--no-ff", "--no-edit", "merged-work")
+        base = git(self.repo, "rev-parse", "main")
+
+        result = resolve_containment(self.repo, base, [make_pull(41, merged)])
+        self.assertEqual(result.kept, [])
+        self.assertEqual(result.dropped, [{"number": 41, "contained_in": "base"}])
+
+    def test_identical_heads_keep_the_lower_pr_number(self):
+        base = self.commit("base.txt", "base", "base")
+        self.branch_from("dup", base)
+        head = self.commit("x.txt", "x", "work")
+
+        result = resolve_containment(
+            self.repo, base, [make_pull(50, head), make_pull(51, head)],
+        )
+        self.assertEqual([p.number for p in result.kept], [50])
+        self.assertEqual(result.dropped, [{"number": 51, "contained_in": 50}])
+
+    def test_independent_branches_are_all_kept(self):
+        base = self.commit("base.txt", "base", "base")
+        self.branch_from("one", base)
+        one = self.commit("one.txt", "1", "one")
+        self.branch_from("two", base)
+        two = self.commit("two.txt", "2", "two")
+
+        result = resolve_containment(
+            self.repo, base, [make_pull(1, one), make_pull(2, two)],
+        )
+        self.assertEqual(sorted(p.number for p in result.kept), [1, 2])
+        self.assertEqual(result.dropped, [])
+
+
+class OrderTest(unittest.TestCase):
+    A, B = "a" * 40, "b" * 40
+
+    def test_defaults_to_ascending_pr_number(self):
+        ordered = order_pulls([make_pull(49, self.A), make_pull(47, self.B)], None)
+        self.assertEqual([p.number for p in ordered], [47, 49])
+
+    def test_honours_an_explicit_permutation(self):
+        ordered = order_pulls(
+            [make_pull(47, self.A), make_pull(49, self.B)], [49, 47],
+        )
+        self.assertEqual([p.number for p in ordered], [49, 47])
+
+    def test_rejects_an_order_that_is_not_a_permutation(self):
+        with self.assertRaises(PlanError):
+            order_pulls([make_pull(47, self.A)], [47, 99])
+
+
+class DigestTest(unittest.TestCase):
+    def test_digest_pins_base_heads_and_order(self):
+        base = "c" * 40
+        a, b = make_pull(1, "a" * 40), make_pull(2, "b" * 40)
+        d1 = compute_digest(base, [a, b])
+        self.assertNotEqual(d1, compute_digest(base, [b, a]))
+        self.assertNotEqual(d1, compute_digest("d" * 40, [a, b]))
+        self.assertEqual(d1, compute_digest(base, [a, b]))
+
+    def test_release_tag_is_namespaced_away_from_nightly(self):
+        tag = release_tag("abc123def456")
+        self.assertTrue(tag.startswith("pr-test-"))
+        self.assertNotIn("nightly", tag)
+
+
+class TrialMergeTest(GitRepoTestCase):
+    def test_clean_merge_reports_the_tree_and_no_conflicts(self):
+        base = self.commit("base.txt", "base", "base")
+        self.branch_from("one", base)
+        one = self.commit("one.txt", "1", "one")
+        self.branch_from("two", base)
+        two = self.commit("two.txt", "2", "two")
+
+        result = trial_merge(self.repo, base, [make_pull(1, one), make_pull(2, two)])
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["tree_sha"])
+        self.assertEqual(result["conflicts"], [])
+        # Both files exist in the merged workspace.
+        self.assertTrue(os.path.isfile(os.path.join(self.repo, "one.txt")))
+        self.assertTrue(os.path.isfile(os.path.join(self.repo, "two.txt")))
+
+    def test_merge_never_moves_main_or_the_pr_branches(self):
+        base = self.commit("base.txt", "base", "base")
+        self.branch_from("one", base)
+        one = self.commit("one.txt", "1", "one")
+        trial_merge(self.repo, base, [make_pull(1, one)])
+        self.assertEqual(git(self.repo, "rev-parse", "main"), base)
+        self.assertEqual(git(self.repo, "rev-parse", "one"), one)
+
+    def test_conflict_names_the_pr_and_the_file_and_aborts(self):
+        base = self.commit("shared.txt", "original\n", "base")
+        self.branch_from("left", base)
+        left = self.commit("shared.txt", "left version\n", "left")
+        self.branch_from("right", base)
+        right = self.commit("shared.txt", "right version\n", "right")
+
+        result = trial_merge(
+            self.repo, base, [make_pull(10, left), make_pull(11, right)],
+        )
+        self.assertFalse(result["ok"])
+        self.assertEqual(len(result["conflicts"]), 1)
+        self.assertEqual(result["conflicts"][0]["pr"], 11)
+        files = result["conflicts"][0]["files"]
+        self.assertEqual([f["path"] for f in files], ["shared.txt"])
+        self.assertFalse(files[0]["binary"])
+        # The merge was aborted: the workspace is clean again.
+        self.assertEqual(git(self.repo, "status", "--porcelain"), "")
+
+    def test_binary_conflicts_are_flagged_as_binary(self):
+        path = os.path.join(self.repo, "blob.bin")
+        with open(path, "wb") as handle:
+            handle.write(b"\x00base\x01\x02")
+        git(self.repo, "add", "blob.bin")
+        git(self.repo, "commit", "-q", "-m", "base")
+        base = git(self.repo, "rev-parse", "HEAD")
+
+        self.branch_from("bin-left", base)
+        with open(path, "wb") as handle:
+            handle.write(b"\x00left\x01\x02")
+        git(self.repo, "add", "blob.bin")
+        git(self.repo, "commit", "-q", "-m", "left")
+        left = git(self.repo, "rev-parse", "HEAD")
+
+        self.branch_from("bin-right", base)
+        with open(path, "wb") as handle:
+            handle.write(b"\x00right\x01\x02")
+        git(self.repo, "add", "blob.bin")
+        git(self.repo, "commit", "-q", "-m", "right")
+        right = git(self.repo, "rev-parse", "HEAD")
+
+        result = trial_merge(
+            self.repo, base, [make_pull(20, left), make_pull(21, right)],
+        )
+        self.assertFalse(result["ok"])
+        files = result["conflicts"][0]["files"]
+        self.assertEqual([f["path"] for f in files], ["blob.bin"])
+        self.assertTrue(files[0]["binary"])
+
+    def test_the_same_plan_reproduces_the_same_tree(self):
+        base = self.commit("base.txt", "base", "base")
+        self.branch_from("one", base)
+        one = self.commit("one.txt", "1", "one")
+        first = trial_merge(self.repo, base, [make_pull(1, one)])
+        second = trial_merge(self.repo, base, [make_pull(1, one)])
+        self.assertEqual(first["tree_sha"], second["tree_sha"])
+
+
+class IsAncestorTest(GitRepoTestCase):
+    def test_distinguishes_ancestry_from_unrelated_branches(self):
+        base = self.commit("base.txt", "base", "base")
+        self.branch_from("child", base)
+        child = self.commit("c.txt", "c", "child")
+        self.assertTrue(is_ancestor(self.repo, base, child))
+        self.assertFalse(is_ancestor(self.repo, child, base))
+
+
+class WriteOutputsTest(unittest.TestCase):
+    def test_multiline_values_use_a_heredoc_delimiter(self):
+        with tempfile.NamedTemporaryFile("r", suffix=".txt", delete=False) as handle:
+            path = handle.name
+        try:
+            write_outputs(path, {"a": "one", "b": "line1\nline2"})
+            with open(path, encoding="utf-8") as handle:
+                text = handle.read()
+            self.assertIn("a=one\n", text)
+            self.assertIn("b<<PR_TEST_EOF\nline1\nline2\nPR_TEST_EOF\n", text)
+        finally:
+            os.unlink(path)
+
+    def test_no_path_means_no_write(self):
+        write_outputs("", {"a": "b"})  # must not raise
+
+
+class MergeCommandTest(GitRepoTestCase):
+    """`merge` must refuse anything but the exact planned tree."""
+
+    def _plan_document(self, base: str, pulls: list[Pull], tree_sha: str,
+                       ok: bool = True) -> str:
+        plan = {
+            "version": 1,
+            "ok": ok,
+            "repository": "example/repo",
+            "base_ref": "main",
+            "base_sha": base,
+            "pulls": [
+                {
+                    "number": p.number, "title": p.title, "head_sha": p.head_sha,
+                    "head_ref": p.head_ref, "head_owner": p.head_owner,
+                    "author": p.author, "draft": p.draft,
+                }
+                for p in pulls
+            ],
+            "merge": {"ok": ok, "tree_sha": tree_sha, "conflicts": []},
+        }
+        handle = tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False, encoding="utf-8",
+        )
+        with handle:
+            json.dump(plan, handle)
+        self.addCleanup(os.unlink, handle.name)
+        return handle.name
+
+    def _run_merge(self, plan_path: str) -> int:
+        # fetch_pr_heads needs an origin serving refs/pull/N/head; the local
+        # test repo has none, so point the fetch at pre-created local refs.
+        original = plan_mod.fetch_pr_heads
+        plan_mod.fetch_pr_heads = lambda ws, pulls: None
+        try:
+            return plan_mod.main(["merge", "--plan", plan_path,
+                                  "--workspace", self.repo])
+        finally:
+            plan_mod.fetch_pr_heads = original
+
+    def test_reproduces_a_clean_plan(self):
+        base = self.commit("base.txt", "base", "base")
+        self.branch_from("one", base)
+        one = self.commit("one.txt", "1", "one")
+        planned = trial_merge(self.repo, base, [make_pull(1, one)])
+        plan_path = self._plan_document(base, [make_pull(1, one)],
+                                        planned["tree_sha"])
+        self.assertEqual(self._run_merge(plan_path), 0)
+
+    def test_rejects_a_plan_whose_tree_no_longer_matches(self):
+        base = self.commit("base.txt", "base", "base")
+        self.branch_from("one", base)
+        one = self.commit("one.txt", "1", "one")
+        plan_path = self._plan_document(base, [make_pull(1, one)], "f" * 40)
+        self.assertEqual(self._run_merge(plan_path), 1)
+
+    def test_rejects_an_unbuildable_plan_outright(self):
+        base = self.commit("base.txt", "base", "base")
+        plan_path = self._plan_document(base, [], "", ok=False)
+        self.assertEqual(self._run_merge(plan_path), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ci/test_pr_test_notify.py
+++ b/ci/test_pr_test_notify.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Unit tests for ci/pr_test_notify.py."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pr_test_notify as notify
+from discord_notify import (
+    CONTENT_LIMIT,
+    EMBED_DESCRIPTION_LIMIT,
+    EMBED_FIELD_NAME_LIMIT,
+    EMBED_FIELD_VALUE_LIMIT,
+    EMBED_TITLE_LIMIT,
+)
+
+
+def sample_plan(**overrides) -> dict:
+    plan = {
+        "version": 1,
+        "ok": True,
+        "repository": "Shederator/wosbot",
+        "base_ref": "main",
+        "base_sha": "c0ffee" + "0" * 34,
+        "requested": "47 48 49",
+        "pulls": [
+            {"number": 47, "title": "fix(scheduler): restore stamina waits",
+             "head_sha": "a" * 40, "author": "codeltdave"},
+            {"number": 49, "title": "fix(intel): typed march state",
+             "head_sha": "b" * 40, "author": "codeltdave"},
+        ],
+        "dropped": [{"number": 48, "contained_in": 49}],
+        "order": [47, 49],
+        "digest": "abc123def456",
+        "tag": "pr-test-abc123def456",
+        "merge": {"ok": True, "tree_sha": "d" * 40, "conflicts": []},
+        "errors": [],
+        "notes": [],
+        "reuse_url": "",
+    }
+    plan.update(overrides)
+    return plan
+
+
+def payload_for(kind: str, plan: dict | None, **extra) -> dict:
+    argv = ["--kind", kind, "--dry-run"]
+    for key, value in extra.items():
+        flag = "--" + key.replace("_", "-")
+        if value is True:
+            argv.append(flag)
+        else:
+            argv.extend([flag, str(value)])
+    if plan is not None:
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False, encoding="utf-8",
+        ) as handle:
+            json.dump(plan, handle)
+            path = handle.name
+        argv.extend(["--plan", path])
+    args = notify.parse_args(argv)
+    try:
+        return notify.build_payload(args, notify.load_plan(args.plan))
+    finally:
+        if plan is not None:
+            os.unlink(path)
+
+
+def all_text(payload: dict) -> str:
+    return json.dumps(payload)
+
+
+class SuccessPayloadTest(unittest.TestCase):
+    URL = "https://github.com/Shederator/wosbot/releases/download/pr-test-abc123def456/x.zip"
+
+    def payload(self, **extra) -> dict:
+        defaults = dict(download_url=self.URL, expires_utc="2026-08-07",
+                        bundle_bytes=230000000)
+        defaults.update(extra)
+        return payload_for("success", sample_plan(), **defaults)
+
+    def test_marks_the_download_as_an_unmerged_test_build(self):
+        text = self.payload()["embeds"][0]["description"]
+        self.assertIn("UNMERGED TEST BUILD", text)
+
+    def test_content_carries_the_bare_download_url(self):
+        self.assertEqual(self.payload()["content"], self.URL)
+
+    def test_lists_every_pr_with_number_title_and_pinned_sha(self):
+        text = all_text(self.payload())
+        self.assertIn("#47", text)
+        self.assertIn("#49", text)
+        self.assertIn("a" * 12, text)
+        self.assertIn("b" * 12, text)
+        self.assertIn("restore stamina waits", text)
+
+    def test_explains_the_dropped_stacked_pr(self):
+        text = all_text(self.payload())
+        self.assertIn("#48", text)
+        self.assertIn("already contained in #49", text)
+
+    def test_names_the_expiry(self):
+        self.assertIn("2026-08-07", self.payload()["embeds"][0]["description"])
+
+    def test_flags_a_reused_build(self):
+        text = self.payload(reused=True)["embeds"][0]["description"]
+        self.assertIn("reused", text)
+
+    def test_is_green(self):
+        self.assertEqual(self.payload()["embeds"][0]["color"], 0x2ECC71)
+
+    def test_never_pings_the_channel(self):
+        self.assertEqual(self.payload()["allowed_mentions"], {"parse": []})
+
+
+class ConflictPayloadTest(unittest.TestCase):
+    def plan(self) -> dict:
+        return sample_plan(
+            ok=False,
+            merge={"ok": False, "tree_sha": "", "conflicts": [{
+                "pr": 49,
+                "files": [
+                    {"path": "fg-engine/src/main/java/Foo.java", "binary": False},
+                    {"path": "fg-vision/native/opencv.dll", "binary": True},
+                ],
+            }]},
+            errors=["The PRs do not merge cleanly; see the conflict report."],
+        )
+
+    def test_names_the_conflicting_pr_and_files(self):
+        text = all_text(payload_for("conflict", self.plan()))
+        self.assertIn("#49", text)
+        self.assertIn("Foo.java", text)
+        self.assertIn("opencv.dll", text)
+
+    def test_binary_conflicts_demand_a_manual_choice(self):
+        text = all_text(payload_for("conflict", self.plan()))
+        self.assertIn("binary", text)
+        self.assertIn("manual choice", text)
+
+    def test_says_nothing_was_auto_resolved(self):
+        text = payload_for("conflict", self.plan())["embeds"][0]["description"]
+        self.assertIn("Nothing was resolved", text)
+
+    def test_carries_no_download_content(self):
+        self.assertNotIn("content", payload_for("conflict", self.plan()))
+
+    def test_truncates_an_enormous_conflict_wall(self):
+        files = [{"path": f"module/File{i}.java", "binary": False}
+                 for i in range(200)]
+        plan = sample_plan(
+            ok=False,
+            merge={"ok": False, "tree_sha": "",
+                   "conflicts": [{"pr": 49, "files": files}]},
+        )
+        payload = payload_for("conflict", plan)
+        for field in payload["embeds"][0]["fields"]:
+            self.assertLessEqual(len(field["value"]), EMBED_FIELD_VALUE_LIMIT)
+        self.assertIn("more", all_text(payload))
+
+
+class RejectedPayloadTest(unittest.TestCase):
+    def test_repeats_the_problems_back_to_the_requester(self):
+        plan = {
+            "ok": False,
+            "errors": ["PR #12 is already merged; its changes are in `main`.",
+                       "`banana` is not a PR number."],
+            "requested": "12 banana",
+            "pulls": [], "dropped": [], "merge": {},
+        }
+        text = all_text(payload_for("rejected", plan))
+        self.assertIn("already merged", text)
+        self.assertIn("banana", text)
+
+    def test_works_without_any_plan_file(self):
+        payload = payload_for("rejected", None, reason="Rate limited",
+                              requested="47")
+        self.assertIn("Rate limited", all_text(payload))
+
+    def test_is_red(self):
+        payload = payload_for("rejected", None, reason="x")
+        self.assertEqual(payload["embeds"][0]["color"], 0xE74C3C)
+
+
+class StalePayloadTest(unittest.TestCase):
+    def test_explains_why_publishing_was_withheld(self):
+        payload = payload_for(
+            "stale", sample_plan(),
+            problems="PR #47 was pushed to after planning (`aaa` -> `bbb`).",
+        )
+        text = all_text(payload)
+        self.assertIn("not** published", payload["embeds"][0]["description"])
+        self.assertIn("pushed to after planning", text)
+        self.assertNotIn("content", payload)
+
+
+class FailurePayloadTest(unittest.TestCase):
+    def test_links_the_workflow_log(self):
+        payload = payload_for(
+            "failure", sample_plan(),
+            run_url="https://github.com/Shederator/wosbot/actions/runs/1",
+        )
+        self.assertIn("workflow log", payload["embeds"][0]["description"])
+        self.assertNotIn("content", payload)
+
+
+class LimitsTest(unittest.TestCase):
+    def test_every_discord_length_limit_is_respected(self):
+        plan = sample_plan(
+            pulls=[{"number": n, "title": "T" * 500, "head_sha": "e" * 40,
+                    "author": "x"} for n in range(1, 7)],
+            digest="f" * 100,
+        )
+        payload = payload_for(
+            "success", plan,
+            download_url="https://example.com/" + "z" * 3000,
+            requester="R" * 500,
+        )
+        embed = payload["embeds"][0]
+        self.assertLessEqual(len(embed["title"]), EMBED_TITLE_LIMIT)
+        self.assertLessEqual(len(embed["description"]), EMBED_DESCRIPTION_LIMIT)
+        self.assertLessEqual(len(payload.get("content", "")), CONTENT_LIMIT)
+        self.assertLessEqual(len(embed["fields"]), 10)
+        for field in embed["fields"]:
+            self.assertLessEqual(len(field["name"]), EMBED_FIELD_NAME_LIMIT)
+            self.assertLessEqual(len(field["value"]), EMBED_FIELD_VALUE_LIMIT)
+
+    def test_payload_is_json_serialisable(self):
+        json.dumps(payload_for("success", sample_plan(),
+                               download_url="https://example.com/a.zip"))
+
+
+class MissingPlanTest(unittest.TestCase):
+    def test_a_missing_plan_file_degrades_to_an_empty_plan(self):
+        self.assertEqual(notify.load_plan("/nonexistent/plan.json"), {})
+
+    def test_a_corrupt_plan_file_degrades_to_an_empty_plan(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json",
+                                         delete=False) as handle:
+            handle.write("{not json")
+            path = handle.name
+        try:
+            self.assertEqual(notify.load_plan(path), {})
+        finally:
+            os.unlink(path)
+
+
+class WebhookGuardTest(unittest.TestCase):
+    def test_missing_webhook_warns_but_does_not_fail(self):
+        env_var = "FG_PR_TEST_ABSENT"
+        os.environ.pop(env_var, None)
+        code = notify.main(["--kind", "rejected", "--reason", "x",
+                            "--webhook-env", env_var])
+        self.assertEqual(code, 0)
+
+    def test_non_discord_webhook_is_rejected(self):
+        env_var = "FG_PR_TEST_BAD_HOOK"
+        os.environ[env_var] = "https://example.com/not-a-webhook"
+        try:
+            code = notify.main(["--kind", "rejected", "--reason", "x",
+                                "--webhook-env", env_var])
+        finally:
+            del os.environ[env_var]
+        self.assertEqual(code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -1,0 +1,166 @@
+# `/build-pr` — combined PR test builds from Discord
+
+Lets approved Discord testers request a public Windows test build that
+combines one or more **open** pull requests (including stacked PRs) without
+merging anything, e.g.:
+
+```
+/build-pr prs: 47 48 49 65
+```
+
+This directory contains the Discord half; the build half lives in
+[`setup/github-workflows/pr-test-build.yml`](../setup/github-workflows/pr-test-build.yml)
+(run `bash setup/install-workflows.sh` once to copy the workflows into
+`.github/workflows/` — required because workflow files cannot be pushed by
+tokens without the `workflows` permission).
+The Discord command is optional: the same feature works today from the
+GitHub **Actions tab → PR Test Build → Run workflow** with `prs: 47,48,49,65`.
+
+## How a request flows
+
+```
+/build-pr 47 48 49 65
+   │
+   ▼
+Cloudflare Worker (this directory)
+   • verifies the Discord Ed25519 signature
+   • checks channel + tester role
+   • validates numbers, rejects closed/merged PRs with reasons
+   • pins the exact head SHA of every PR
+   • shows the merge plan with Build / Cancel buttons
+   │  (requester presses Build; cooldown + concurrency checked)
+   ▼
+GitHub Actions: pr-test-build.yml
+   • plan    (trusted)   containment of stacked PRs, order, trial merge,
+                         conflict report — never executes PR code
+   • build   (UNTRUSTED) reproduces the exact planned merge, runs Maven;
+                         read-only token, zero secrets
+   • publish (trusted)   fresh runner re-verifies the bundle, re-checks every
+                         PR is still open and unchanged, publishes the
+                         temporary pr-test-<digest> prerelease
+   • notify  (trusted)   posts the download link / conflict report / failure
+                         to the existing Discord webhook
+   ▼
+pr-test-cleanup.yml deletes the release after 7 days
+or when every included PR is closed.
+```
+
+Key properties:
+
+- **No branch is ever modified.** All merging happens on a detached HEAD in
+  the runner's disposable checkout.
+- **SHAs are pinned twice** (at Discord confirmation and at planning) and
+  re-checked before publishing, so a push mid-build withholds the release
+  instead of shipping unadvertised code.
+- **Conflicts stop the build** and the conflicting files are posted to
+  Discord, binary conflicts flagged as needing a manual choice. Nothing is
+  auto-resolved with `ours`/`theirs`.
+- **Untrusted PR code never sees secrets.** The build job has a read-only
+  token and no `secrets.*`; verification that gates publishing runs from
+  pristine `main` on a fresh runner.
+- **Identical requests reuse the existing build**: the release tag is a
+  digest over the base SHA plus the ordered pinned heads.
+- Every message and release is labelled an **UNMERGED TEST BUILD**.
+
+## Setup (one-time, ~20 minutes)
+
+You need: the Discord server's admin, a Cloudflare account (free tier is
+fine), and repo admin on GitHub.
+
+### 1. Create the Discord application
+
+1. Open <https://discord.com/developers/applications> → **New Application**
+   → name it e.g. `Frostguard Test Builds`.
+2. On **General Information**, note the **Application ID** and the
+   **Public Key**.
+3. On **Bot**, click **Reset Token** and note the **Bot Token** (needed only
+   for command registration, not by the worker).
+4. On **Installation**, pick *Guild Install*; under OAuth2 scopes the bot
+   needs only `applications.commands`. Install it to your server via the
+   generated link.
+
+> A webhook alone is not enough for slash commands: webhooks can only *post*
+> messages. Slash commands need an application with an **interactions
+> endpoint**, which is what this worker provides. Your existing
+> `DISCORD_NIGHTLY_WEBHOOK_URL` webhook is still used — for posting results.
+
+### 2. Create the fine-grained GitHub token for the worker
+
+GitHub → Settings → Developer settings → Fine-grained tokens → Generate:
+
+- Repository access: **only** `Shederator/wosbot`
+- Permissions: **Actions: Read and write** (to dispatch the workflow),
+  **Pull requests: Read**, **Contents: Read**
+- Expiry: your choice; set a reminder to rotate it.
+
+This token cannot push, merge or create releases even if leaked.
+
+### 3. Deploy the worker
+
+```bash
+cd discord-bot
+# Fill DISCORD_APPLICATION_ID (and optionally the channel/role IDs) in
+# wrangler.toml, then:
+npx wrangler deploy
+npx wrangler secret put DISCORD_PUBLIC_KEY   # from step 1.2
+npx wrangler secret put GITHUB_TOKEN         # from step 2
+```
+
+Wrangler prints the worker URL, e.g.
+`https://frostguard-build-pr.<your-subdomain>.workers.dev`.
+
+### 4. Point Discord at the worker
+
+Developer Portal → your application → **General Information** →
+**Interactions Endpoint URL** → paste the worker URL → Save. Discord sends a
+signed PING; if the save succeeds, signature verification works.
+
+### 5. Register the slash command
+
+```bash
+cd discord-bot
+DISCORD_BOT_TOKEN=... DISCORD_APPLICATION_ID=... \
+DISCORD_GUILD_ID=<your server id> node register-command.mjs
+```
+
+With `DISCORD_GUILD_ID` the command appears instantly; without it Discord
+takes up to an hour to propagate it globally.
+
+### 6. Restrict who can use it
+
+Two independent layers; use either or both:
+
+- **Worker config** (`wrangler.toml`): set `ALLOWED_CHANNEL_IDS` and/or
+  `ALLOWED_ROLE_IDS` (enable Developer Mode in Discord, right-click a
+  channel/role → Copy ID), then `npx wrangler deploy` again.
+- **Discord UI**: Server Settings → Integrations → your app → `/build-pr` →
+  limit to specific roles/channels.
+
+### 7. Verify end-to-end
+
+1. In the allowed channel run `/build-pr prs: <an open PR number>`.
+2. Check the plan shows the pinned SHA, press **Build**.
+3. Watch the run under Actions → *PR Test Build*.
+4. The result message (or conflict report) arrives via the existing
+   nightly webhook.
+
+## Configuration reference
+
+| Where | Name | What |
+|---|---|---|
+| `wrangler.toml` | `GITHUB_REPO` | repo whose PRs are built |
+| `wrangler.toml` | `DISCORD_APPLICATION_ID` | application (client) ID |
+| `wrangler.toml` | `ALLOWED_CHANNEL_IDS` | CSV channel allowlist (empty = all) |
+| `wrangler.toml` | `ALLOWED_ROLE_IDS` | CSV role allowlist (empty = all) |
+| `wrangler.toml` | `COOLDOWN_MINUTES` | flood-control gap between builds |
+| worker secret | `DISCORD_PUBLIC_KEY` | interaction signature verification |
+| worker secret | `GITHUB_TOKEN` | fine-grained dispatch-only token |
+| repo secret | `DISCORD_NIGHTLY_WEBHOOK_URL` | already configured; reused for results |
+
+## Tests
+
+```bash
+node discord-bot/test_worker.mjs      # worker helpers
+python3 ci/test_pr_build_plan.py      # planner (real git repos)
+python3 ci/test_pr_test_notify.py     # Discord result messages
+```

--- a/discord-bot/register-command.mjs
+++ b/discord-bot/register-command.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Register (or update) the /build-pr slash command on the Discord application.
+ *
+ * Run once after creating the Discord application, and again whenever the
+ * command definition changes. Registering is idempotent: Discord upserts by
+ * command name.
+ *
+ * Usage:
+ *   DISCORD_BOT_TOKEN=... DISCORD_APPLICATION_ID=... node register-command.mjs
+ *
+ * Optionally register to a single guild for instant availability (global
+ * commands can take up to an hour to propagate):
+ *   DISCORD_GUILD_ID=... node register-command.mjs
+ */
+
+const token = process.env.DISCORD_BOT_TOKEN;
+const applicationId = process.env.DISCORD_APPLICATION_ID;
+const guildId = process.env.DISCORD_GUILD_ID || "";
+
+if (!token || !applicationId) {
+  console.error(
+    "Set DISCORD_BOT_TOKEN and DISCORD_APPLICATION_ID in the environment.",
+  );
+  process.exit(1);
+}
+
+const command = {
+  name: "build-pr",
+  description:
+    "Request a temporary Windows test build combining one or more open PRs",
+  options: [
+    {
+      type: 3, // STRING
+      name: "prs",
+      description: "PR numbers to combine, e.g. 47 48 49 65",
+      required: true,
+    },
+    {
+      type: 3, // STRING
+      name: "order",
+      description: "Optional explicit merge order, e.g. 49 47 (default: ascending)",
+      required: false,
+    },
+  ],
+  // No DMs: the access checks are channel/role based.
+  dm_permission: false,
+};
+
+const url = guildId
+  ? `https://discord.com/api/v10/applications/${applicationId}/guilds/${guildId}/commands`
+  : `https://discord.com/api/v10/applications/${applicationId}/commands`;
+
+const response = await fetch(url, {
+  method: "POST",
+  headers: {
+    Authorization: `Bot ${token}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify(command),
+});
+
+if (!response.ok) {
+  console.error(`Discord returned ${response.status}:`, await response.text());
+  process.exit(1);
+}
+
+const data = await response.json();
+console.log(
+  `Registered /${data.name} (id ${data.id}) ` +
+  (guildId ? `in guild ${guildId}` : "globally (may take up to 1 hour)"),
+);

--- a/discord-bot/test_worker.mjs
+++ b/discord-bot/test_worker.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Tests for the pure helpers of the /build-pr worker.
+ *
+ * Run with: node discord-bot/test_worker.mjs
+ * (No framework: keeps the bot dependency-free, like ci/*.py.)
+ */
+
+import assert from "node:assert/strict";
+import {
+  MAX_PRS,
+  accessError,
+  decodeState,
+  encodeState,
+  hexToBytes,
+  parsePrNumbers,
+} from "./worker.js";
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+// --- parsePrNumbers --------------------------------------------------------
+
+test("accepts spaces, commas and hash prefixes", () => {
+  const { numbers, errors } = parsePrNumbers("47, 48 #49;65");
+  assert.deepEqual(numbers, [47, 48, 49, 65]);
+  assert.deepEqual(errors, []);
+});
+
+test("deduplicates and keeps first-appearance order", () => {
+  const { numbers, errors } = parsePrNumbers("49 47 49 47 48");
+  assert.deepEqual(numbers, [49, 47, 48]);
+  assert.deepEqual(errors, []);
+});
+
+test("rejects non-numeric tokens with an explanation", () => {
+  const { numbers, errors } = parsePrNumbers("47 main 48");
+  assert.deepEqual(numbers, [47, 48]);
+  assert.equal(errors.length, 1);
+  assert.ok(errors[0].includes("main"));
+});
+
+test("empty input is an error, not a silent no-op", () => {
+  const { numbers, errors } = parsePrNumbers("   ");
+  assert.deepEqual(numbers, []);
+  assert.ok(errors.length > 0);
+});
+
+test("enforces the per-request ceiling, matching the planner", () => {
+  const raw = Array.from({ length: MAX_PRS + 1 }, (_, i) => i + 1).join(" ");
+  const { errors } = parsePrNumbers(raw);
+  assert.ok(errors.some((e) => e.includes("limit")));
+});
+
+// --- encodeState / decodeState ---------------------------------------------
+
+test("state survives an encode/decode roundtrip", () => {
+  const state = {
+    pins: [
+      { number: 47, sha: "a".repeat(40) },
+      { number: 49, sha: "b".repeat(40) },
+    ],
+    order: [47, 49],
+    requesterId: "123456789012345678",
+  };
+  const decoded = decodeState(encodeState(state));
+  assert.deepEqual(decoded.order, [47, 49]);
+  assert.equal(decoded.requesterId, "123456789012345678");
+  assert.deepEqual(
+    decoded.pins,
+    [
+      { number: 47, sha: "a".repeat(12) },
+      { number: 49, sha: "b".repeat(12) },
+    ],
+  );
+});
+
+test("a tampered or garbage footer decodes to an unusable state", () => {
+  for (const garbage of ["", "hello", "pins=47@nothex;order=x;req="]) {
+    const decoded = decodeState(garbage);
+    assert.equal(decoded.pins.length, 0);
+  }
+});
+
+test("encoded state stays inside Discord's 2048-char footer limit", () => {
+  const state = {
+    pins: Array.from({ length: MAX_PRS }, (_, i) => ({
+      number: 99999 + i,
+      sha: "f".repeat(40),
+    })),
+    order: Array.from({ length: MAX_PRS }, (_, i) => 99999 + i),
+    requesterId: "9".repeat(20),
+  };
+  assert.ok(encodeState(state).length <= 2048);
+});
+
+// --- hexToBytes -------------------------------------------------------------
+
+test("parses valid hex and rejects everything else", () => {
+  assert.deepEqual(Array.from(hexToBytes("00ff10")), [0, 255, 16]);
+  assert.equal(hexToBytes("xyz"), null);
+  assert.equal(hexToBytes("abc"), null); // odd length
+  assert.equal(hexToBytes(""), null);
+  assert.equal(hexToBytes(null), null);
+});
+
+// --- accessError -------------------------------------------------------------
+
+test("wrong channel is refused when channels are configured", () => {
+  const env = { ALLOWED_CHANNEL_IDS: "111,222", ALLOWED_ROLE_IDS: "" };
+  assert.ok(accessError(env, { channel_id: "333", member: { roles: [] } }));
+  assert.equal(accessError(env, { channel_id: "222", member: { roles: [] } }), "");
+});
+
+test("missing role is refused when roles are configured", () => {
+  const env = { ALLOWED_CHANNEL_IDS: "", ALLOWED_ROLE_IDS: "rrr" };
+  assert.ok(accessError(env, { channel_id: "1", member: { roles: ["other"] } }));
+  assert.equal(accessError(env, { channel_id: "1", member: { roles: ["rrr"] } }), "");
+});
+
+test("no configuration means open access", () => {
+  const env = { ALLOWED_CHANNEL_IDS: "", ALLOWED_ROLE_IDS: "" };
+  assert.equal(accessError(env, { channel_id: "1", member: { roles: [] } }), "");
+});
+
+console.log(`\n${passed} tests passed`);

--- a/discord-bot/worker.js
+++ b/discord-bot/worker.js
@@ -1,0 +1,498 @@
+/**
+ * Frostguard /build-pr Discord command — Cloudflare Worker.
+ *
+ * The Discord half of the combined-PR test build feature (issue #68). This
+ * worker receives Discord interaction webhooks, validates the request, shows
+ * the effective plan (open PRs only, pinned head SHAs, merge order) and asks
+ * the requester to confirm with a Build button before any build resource is
+ * consumed. Confirming dispatches the `pr-test-build.yml` GitHub Actions
+ * workflow, which does the authoritative planning (stacked-PR containment,
+ * trial merge, conflict reporting), building, verification and publishing.
+ *
+ * Trust boundaries:
+ * - This worker holds a fine-grained GitHub token whose ONLY permissions are
+ *   Actions: read/write (to dispatch the workflow) and Pull requests: read,
+ *   on this one repository. It cannot push, merge or create releases.
+ * - The untrusted build job in the workflow never sees this token or the
+ *   Discord credentials; the workflow enforces that separation itself.
+ * - Every interaction is Ed25519-signature-verified against Discord's public
+ *   key, so nobody can forge build requests by POSTing to the worker URL.
+ *
+ * Guardrails:
+ * - Requests are limited to configured channels and roles.
+ * - PR numbers are deduplicated; non-numeric, closed and merged entries are
+ *   rejected with a per-entry explanation.
+ * - Head SHAs are pinned at confirmation time and passed to the workflow,
+ *   which re-verifies them, so a later push cannot change a running build.
+ * - Only the requester can press their own Build/Cancel buttons.
+ * - A cooldown plus a one-build-at-a-time check prevents build floods.
+ */
+
+// ---------------------------------------------------------------------------
+// Small pure helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+export const MAX_PRS = 6; // must match MAX_PRS_PER_REQUEST in ci/pr_build_plan.py
+
+export function parsePrNumbers(raw) {
+  const numbers = [];
+  const errors = [];
+  const seen = new Set();
+  for (const token of String(raw || "").trim().split(/[\s,;]+/)) {
+    if (!token) continue;
+    const cleaned = token.replace(/^#/, "");
+    if (!/^\d+$/.test(cleaned)) {
+      errors.push(`\`${token}\` is not a PR number.`);
+      continue;
+    }
+    const number = parseInt(cleaned, 10);
+    if (number <= 0) {
+      errors.push(`\`${token}\` is not a valid PR number.`);
+      continue;
+    }
+    if (seen.has(number)) continue;
+    seen.add(number);
+    numbers.push(number);
+  }
+  if (numbers.length === 0 && errors.length === 0) {
+    errors.push("No PR numbers were given.");
+  }
+  if (numbers.length > MAX_PRS) {
+    errors.push(`${numbers.length} PRs requested; the limit is ${MAX_PRS} per test build.`);
+  }
+  return { numbers, errors };
+}
+
+/** Encode confirmation state into the embed footer. It survives the
+ * roundtrip to the button click; a button custom_id is capped at 100 chars,
+ * far too small for six pinned SHAs. */
+export function encodeState(state) {
+  const pins = state.pins.map((p) => `${p.number}@${p.sha.slice(0, 12)}`).join(",");
+  return `pins=${pins};order=${state.order.join(",")};req=${state.requesterId}`;
+}
+
+export function decodeState(footerText) {
+  const out = { pins: [], order: [], requesterId: "" };
+  for (const part of String(footerText || "").split(";")) {
+    const [key, value] = part.split("=", 2);
+    if (key === "pins" && value) {
+      for (const entry of value.split(",")) {
+        const [number, sha] = entry.split("@", 2);
+        if (/^\d+$/.test(number) && /^[0-9a-f]{7,40}$/.test(sha || "")) {
+          out.pins.push({ number: parseInt(number, 10), sha });
+        }
+      }
+    } else if (key === "order" && value) {
+      out.order = value.split(",").filter((n) => /^\d+$/.test(n)).map(Number);
+    } else if (key === "req" && value) {
+      out.requesterId = value;
+    }
+  }
+  return out;
+}
+
+export function hexToBytes(hex) {
+  const clean = String(hex || "").trim();
+  if (!/^[0-9a-fA-F]*$/.test(clean) || clean.length % 2 !== 0 || clean.length === 0) {
+    return null;
+  }
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+// ---------------------------------------------------------------------------
+// Discord signature verification
+// ---------------------------------------------------------------------------
+
+async function verifySignature(request, bodyText, publicKeyHex) {
+  const signature = hexToBytes(request.headers.get("X-Signature-Ed25519"));
+  const timestamp = request.headers.get("X-Signature-Timestamp");
+  const publicKey = hexToBytes(publicKeyHex);
+  if (!signature || !timestamp || !publicKey) return false;
+  try {
+    const key = await crypto.subtle.importKey(
+      "raw", publicKey, { name: "Ed25519" }, false, ["verify"],
+    );
+    return await crypto.subtle.verify(
+      "Ed25519", key, signature,
+      new TextEncoder().encode(timestamp + bodyText),
+    );
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API
+// ---------------------------------------------------------------------------
+
+function githubHeaders(env) {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+    "User-Agent": "frostguard-build-pr-bot/1.0 (+https://github.com/Shederator/wosbot)",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function fetchPull(env, number) {
+  const response = await fetch(
+    `https://api.github.com/repos/${env.GITHUB_REPO}/pulls/${number}`,
+    { headers: githubHeaders(env) },
+  );
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`GitHub API returned ${response.status} for PR #${number}`);
+  }
+  return response.json();
+}
+
+/** Returns "" when a build may start, otherwise a human explanation. */
+async function checkCooldownAndConcurrency(env) {
+  const cooldownMinutes = parseInt(env.COOLDOWN_MINUTES || "10", 10);
+  const response = await fetch(
+    `https://api.github.com/repos/${env.GITHUB_REPO}/actions/workflows/pr-test-build.yml/runs?per_page=5`,
+    { headers: githubHeaders(env) },
+  );
+  if (!response.ok) {
+    // Fail closed: if the flood-control check cannot run, neither can a build.
+    return `Could not check running builds (GitHub returned ${response.status}); try again shortly.`;
+  }
+  const data = await response.json();
+  const runs = data.workflow_runs || [];
+  for (const run of runs) {
+    if (run.status === "queued" || run.status === "in_progress") {
+      return `A test build is already ${run.status.replace("_", " ")}: <${run.html_url}>. One combined build runs at a time; please wait for it.`;
+    }
+  }
+  if (runs.length > 0 && cooldownMinutes > 0) {
+    const last = new Date(runs[0].created_at).getTime();
+    const elapsed = (Date.now() - last) / 60000;
+    if (elapsed < cooldownMinutes) {
+      const wait = Math.ceil(cooldownMinutes - elapsed);
+      return `Cooldown: the last test build started ${Math.floor(elapsed)} min ago. Try again in ~${wait} min.`;
+    }
+  }
+  return "";
+}
+
+async function dispatchWorkflow(env, { prs, order, pinned, requester }) {
+  const response = await fetch(
+    `https://api.github.com/repos/${env.GITHUB_REPO}/actions/workflows/pr-test-build.yml/dispatches`,
+    {
+      method: "POST",
+      headers: { ...githubHeaders(env), "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ref: env.GITHUB_DEFAULT_BRANCH || "main",
+        inputs: { prs, order, pinned, requester },
+      }),
+    },
+  );
+  if (response.status !== 204) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(`workflow dispatch failed with ${response.status}: ${detail.slice(0, 200)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Discord responses
+// ---------------------------------------------------------------------------
+
+const InteractionType = { PING: 1, APPLICATION_COMMAND: 2, MESSAGE_COMPONENT: 3 };
+const ResponseType = {
+  PONG: 1,
+  CHANNEL_MESSAGE: 4,
+  DEFERRED_CHANNEL_MESSAGE: 5,
+  UPDATE_MESSAGE: 7,
+};
+const EPHEMERAL = 64;
+
+function json(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function ephemeralReply(content) {
+  return json({
+    type: ResponseType.CHANNEL_MESSAGE,
+    data: { content, flags: EPHEMERAL, allowed_mentions: { parse: [] } },
+  });
+}
+
+async function editOriginal(env, interaction, payload) {
+  await fetch(
+    `https://discord.com/api/v10/webhooks/${env.DISCORD_APPLICATION_ID}/${interaction.token}/messages/@original`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ allowed_mentions: { parse: [] }, ...payload }),
+    },
+  );
+}
+
+function planButtons(disabled = false) {
+  return [{
+    type: 1, // action row
+    components: [
+      { type: 2, style: 3, label: "Build", custom_id: "buildpr:confirm", disabled },
+      { type: 2, style: 4, label: "Cancel", custom_id: "buildpr:cancel", disabled },
+    ],
+  }];
+}
+
+// ---------------------------------------------------------------------------
+// Access control
+// ---------------------------------------------------------------------------
+
+function csv(value) {
+  return String(value || "").split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+export function accessError(env, interaction) {
+  const channels = csv(env.ALLOWED_CHANNEL_IDS);
+  if (channels.length && !channels.includes(String(interaction.channel_id))) {
+    return "`/build-pr` only works in the designated test-build channel.";
+  }
+  const roles = csv(env.ALLOWED_ROLE_IDS);
+  if (roles.length) {
+    const memberRoles = (interaction.member && interaction.member.roles) || [];
+    if (!memberRoles.some((r) => roles.includes(String(r)))) {
+      return "You need the tester role to request test builds. Ask a moderator.";
+    }
+  }
+  return "";
+}
+
+function requesterOf(interaction) {
+  const user = (interaction.member && interaction.member.user) || interaction.user || {};
+  return { id: String(user.id || ""), name: String(user.username || "unknown") };
+}
+
+// ---------------------------------------------------------------------------
+// /build-pr command
+// ---------------------------------------------------------------------------
+
+async function buildPlanPreview(env, interaction) {
+  const options = Object.fromEntries(
+    ((interaction.data && interaction.data.options) || []).map((o) => [o.name, o.value]),
+  );
+  const requester = requesterOf(interaction);
+  const { numbers, errors } = parsePrNumbers(options.prs);
+
+  let orderNumbers = [];
+  if (options.order) {
+    const parsedOrder = parsePrNumbers(options.order);
+    errors.push(...parsedOrder.errors);
+    orderNumbers = parsedOrder.numbers;
+  }
+
+  const pins = [];
+  const lines = [];
+  if (errors.length === 0) {
+    for (const number of numbers) {
+      let pull;
+      try {
+        pull = await fetchPull(env, number);
+      } catch {
+        errors.push(`GitHub was unreachable while checking PR #${number}; try again.`);
+        break;
+      }
+      if (!pull) {
+        errors.push(`PR #${number} does not exist in this repository.`);
+      } else if (pull.merged_at) {
+        errors.push(`PR #${number} is already merged; its changes are in \`main\`.`);
+      } else if (pull.state !== "open") {
+        errors.push(`PR #${number} is closed and cannot be test-built.`);
+      } else {
+        pins.push({ number, sha: pull.head.sha });
+        lines.push(
+          `**[#${number}](https://github.com/${env.GITHUB_REPO}/pull/${number})** ` +
+          `\`${pull.head.sha.slice(0, 12)}\` — ${String(pull.title).slice(0, 80)}`,
+        );
+      }
+    }
+  }
+  if (errors.length === 0 && orderNumbers.length) {
+    const kept = pins.map((p) => p.number);
+    const sameSet = orderNumbers.length === kept.length &&
+      kept.every((n) => orderNumbers.includes(n));
+    if (!sameSet) {
+      errors.push("`order` must list exactly the same PR numbers as `prs`.");
+    }
+  }
+
+  if (errors.length > 0) {
+    await editOriginal(env, interaction, {
+      embeds: [{
+        title: "/build-pr — request rejected",
+        color: 0xe74c3c,
+        description:
+          "Nothing was built.\n\n" + errors.map((e) => `• ${e}`).join("\n"),
+      }],
+    });
+    return;
+  }
+
+  const order = orderNumbers.length
+    ? orderNumbers
+    : pins.map((p) => p.number).sort((a, b) => a - b);
+  const orderedLines = order.map(
+    (n) => lines[pins.findIndex((p) => p.number === n)],
+  );
+
+  await editOriginal(env, interaction, {
+    embeds: [{
+      title: "/build-pr — confirm the merge plan",
+      color: 0x3498db,
+      description: [
+        "The following open PRs will be combined **in this order** on top of",
+        "`main` in a disposable workspace (no branch is modified), then built",
+        "and published as a temporary **unmerged test build**.",
+        "",
+        orderedLines.join("\n"),
+        "",
+        "Head SHAs are **pinned**: pushes after this point will not enter the",
+        "build. Stacked PRs already contained in a later head are dropped",
+        "automatically during planning. If the PRs conflict, the build stops",
+        "and reports the conflicting files here — nothing is auto-resolved.",
+        "",
+        "To use a different order, cancel and re-run `/build-pr` with the",
+        "`order` option.",
+      ].join("\n"),
+      footer: { text: encodeState({ pins, order, requesterId: requester.id }) },
+    }],
+    components: planButtons(),
+  });
+}
+
+async function handleButton(env, interaction) {
+  const customId = String((interaction.data && interaction.data.custom_id) || "");
+  const requester = requesterOf(interaction);
+  const message = interaction.message || {};
+  const embed = (message.embeds && message.embeds[0]) || {};
+  const state = decodeState(embed.footer && embed.footer.text);
+
+  if (!state.requesterId || state.pins.length === 0) {
+    return json({
+      type: ResponseType.UPDATE_MESSAGE,
+      data: {
+        embeds: [{
+          title: "/build-pr — expired",
+          color: 0x95a5a6,
+          description: "This confirmation is no longer valid. Run `/build-pr` again.",
+        }],
+        components: [],
+      },
+    });
+  }
+  if (requester.id !== state.requesterId) {
+    return ephemeralReply("Only the person who requested this plan can confirm or cancel it.");
+  }
+
+  if (customId === "buildpr:cancel") {
+    return json({
+      type: ResponseType.UPDATE_MESSAGE,
+      data: {
+        embeds: [{ ...embed, title: "/build-pr — cancelled", color: 0x95a5a6, footer: undefined }],
+        components: [],
+      },
+    });
+  }
+
+  if (customId !== "buildpr:confirm") {
+    return ephemeralReply("Unknown button.");
+  }
+
+  const throttle = await checkCooldownAndConcurrency(env);
+  if (throttle) {
+    return ephemeralReply(throttle);
+  }
+
+  const pinned = state.pins.map((p) => `${p.number}:${p.sha}`).join(",");
+  try {
+    await dispatchWorkflow(env, {
+      prs: state.order.join(","),
+      order: state.order.join(","),
+      pinned,
+      requester: `${requester.name} (Discord)`,
+    });
+  } catch (error) {
+    return ephemeralReply(`Could not start the build: ${String(error.message).slice(0, 300)}`);
+  }
+
+  return json({
+    type: ResponseType.UPDATE_MESSAGE,
+    data: {
+      embeds: [{
+        title: "/build-pr — build started",
+        color: 0x2ecc71,
+        description: [
+          `Building PRs ${state.order.map((n) => `#${n}`).join(", ")} with pinned heads.`,
+          "",
+          "The result (download link, conflict report or failure) will be",
+          "posted in this channel when the workflow finishes — typically",
+          "30–45 minutes. Progress: " +
+          `<https://github.com/${env.GITHUB_REPO}/actions/workflows/pr-test-build.yml>`,
+        ].join("\n"),
+        footer: undefined,
+      }],
+      components: [],
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export default {
+  async fetch(request, env, ctx) {
+    if (request.method === "GET") {
+      return new Response("frostguard /build-pr interaction endpoint", { status: 200 });
+    }
+    if (request.method !== "POST") {
+      return new Response("method not allowed", { status: 405 });
+    }
+
+    const bodyText = await request.text();
+    const valid = await verifySignature(request, bodyText, env.DISCORD_PUBLIC_KEY);
+    if (!valid) {
+      return new Response("invalid request signature", { status: 401 });
+    }
+
+    let interaction;
+    try {
+      interaction = JSON.parse(bodyText);
+    } catch {
+      return new Response("bad request", { status: 400 });
+    }
+
+    if (interaction.type === InteractionType.PING) {
+      return json({ type: ResponseType.PONG });
+    }
+
+    if (interaction.type === InteractionType.APPLICATION_COMMAND &&
+        interaction.data && interaction.data.name === "build-pr") {
+      const denied = accessError(env, interaction);
+      if (denied) return ephemeralReply(denied);
+      // Validating up to six PRs against GitHub can exceed Discord's 3-second
+      // budget, so defer immediately and edit the reply when the checks land.
+      ctx.waitUntil(buildPlanPreview(env, interaction));
+      return json({ type: ResponseType.DEFERRED_CHANNEL_MESSAGE });
+    }
+
+    if (interaction.type === InteractionType.MESSAGE_COMPONENT &&
+        String((interaction.data || {}).custom_id || "").startsWith("buildpr:")) {
+      const denied = accessError(env, interaction);
+      if (denied) return ephemeralReply(denied);
+      return handleButton(env, interaction);
+    }
+
+    return ephemeralReply("Unsupported interaction.");
+  },
+};

--- a/discord-bot/wrangler.toml
+++ b/discord-bot/wrangler.toml
@@ -17,7 +17,7 @@ GITHUB_REPO = "Shederator/wosbot"
 GITHUB_DEFAULT_BRANCH = "main"
 # Discord application (client) ID from the Developer Portal.
 # Replace after creating the application.
-DISCORD_APPLICATION_ID = "REPLACE_WITH_APPLICATION_ID"
+DISCORD_APPLICATION_ID = "1532693190879215767"
 # Comma-separated Discord channel IDs where /build-pr is allowed.
 # Empty = every channel the command is visible in.
 ALLOWED_CHANNEL_IDS = ""

--- a/discord-bot/wrangler.toml
+++ b/discord-bot/wrangler.toml
@@ -1,0 +1,28 @@
+# Cloudflare Worker config for the /build-pr Discord command.
+#
+# Deploy with:  npx wrangler deploy
+# Secrets (never put these in this file):
+#   npx wrangler secret put DISCORD_PUBLIC_KEY
+#   npx wrangler secret put GITHUB_TOKEN
+#
+# Plain vars below are safe to commit: they are identifiers, not credentials.
+
+name = "frostguard-build-pr"
+main = "worker.js"
+compatibility_date = "2025-01-01"
+
+[vars]
+# The repository whose PRs are built and whose workflow is dispatched.
+GITHUB_REPO = "Shederator/wosbot"
+GITHUB_DEFAULT_BRANCH = "main"
+# Discord application (client) ID from the Developer Portal.
+# Replace after creating the application.
+DISCORD_APPLICATION_ID = "REPLACE_WITH_APPLICATION_ID"
+# Comma-separated Discord channel IDs where /build-pr is allowed.
+# Empty = every channel the command is visible in.
+ALLOWED_CHANNEL_IDS = ""
+# Comma-separated Discord role IDs allowed to request builds.
+# Empty = everyone in the allowed channels.
+ALLOWED_ROLE_IDS = ""
+# Minutes to wait between test builds (flood control).
+COOLDOWN_MINUTES = "10"

--- a/setup/github-workflows/daily-windows-bundle.yml
+++ b/setup/github-workflows/daily-windows-bundle.yml
@@ -1,0 +1,326 @@
+name: Daily Windows Bundle
+
+on:
+  push:
+    branches:
+      - "ci/**"
+  pull_request:
+    paths:
+      - "**/pom.xml"
+      - "**/src/**"
+      - "tools/**"
+      - "custom_tasks/**"
+      - "ci/**"
+      - "fg-watcher.bat"
+      - ".gitattributes"
+      - ".github/workflows/daily-windows-bundle.yml"
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+# `contents: write` is needed to publish the rolling `nightly` release that the
+# Discord message links to. An Actions artifact URL requires a signed-in GitHub
+# account with access to this repository, so it is useless as a "downloadable"
+# link for testers in a Discord channel.
+permissions:
+  contents: write
+
+concurrency:
+  group: daily-windows-bundle-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  # Keeps `mvn` output readable in the Actions log and avoids a 200 MB download
+  # log on a cold cache.
+  MAVEN_ARGS: "-B --no-transfer-progress -Dstyle.color=never"
+
+jobs:
+  build-windows-bundle:
+    name: Build Windows desktop bundle on Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      # The Windows OpenCV .dll, adb.exe and the .traineddata OCR models are all
+      # tracked with Git LFS. If any of them is still a pointer stub the build
+      # silently produces a bundle that only fails on a user's machine, so fail
+      # loudly here instead. The check lives in ci/check_lfs_assets.sh because
+      # the PR test build workflow needs the identical guard.
+      - name: Verify Git LFS assets are real binaries
+        run: ci/check_lfs_assets.sh
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      # The saved-frame vision tests run OCR through tess4j, which binds the host
+      # libtesseract/libleptonica at runtime. OpenCV itself needs no system
+      # package: the openpnp artifact ships the Linux native image.
+      - name: Install Tesseract native libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            tesseract-ocr libtesseract-dev libleptonica-dev
+
+      # Guards the bundle verifier itself. A verification script that cannot fail
+      # would turn a broken release artifact into a green check mark.
+      - name: Test the bundle verifier
+        run: python3 ci/test_verify_bundle.py
+
+      # The notifier runs in a non-blocking step, so a bug in it would show up
+      # as "no message arrived" rather than as a red build. Its own tests run
+      # here, before the 30-minute Maven build, so a broken payload contract
+      # fails in seconds.
+      - name: Test the Discord notifier
+        run: python3 ci/test_discord_notify.py
+
+      - name: Resolve project version
+        id: version
+        run: |
+          set -euo pipefail
+          version="$(mvn ${MAVEN_ARGS} -q help:evaluate \
+            -Dexpression=project.version -DforceStdout)"
+          if [[ -z "${version}" ]]; then
+            echo "::error::Could not resolve the Maven project version."
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "Project version: ${version}"
+
+      # Tests are intentionally NOT skipped. The vision/OCR suites are the ones
+      # most likely to regress, and they run correctly on Linux now that the
+      # OpenCV native image is selected per platform.
+      - name: Build Windows desktop bundle
+        run: mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
+
+      - name: Locate the desktop bundle
+        id: bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          zip_path="$(find fg-app/target -maxdepth 1 -type f \
+            -name '*-desktop-bundle.zip' | sort | tail -n 1)"
+          if [[ -z "${zip_path}" ]]; then
+            echo "::error::No desktop bundle ZIP found under fg-app/target."
+            exit 1
+          fi
+          echo "path=${zip_path}" >> "${GITHUB_OUTPUT}"
+          echo "Bundle: ${zip_path} ($(du -h "${zip_path}" | cut -f1))"
+
+      # Structural verification: the right files, at the right paths, and every
+      # manifest Class-Path entry really present.
+      - name: Verify Windows bundle contents
+        run: python3 ci/verify_bundle.py "${{ steps.bundle.outputs.path }}" --platform win
+
+      # Launch verification: the staged JARs actually link together. Catches the
+      # dropped-dependency class of breakage that a file listing cannot see.
+      - name: Smoke test the desktop bundle
+        run: ci/smoke_test_bundle.sh "${{ steps.bundle.outputs.path }}"
+
+      # Metrics are computed once here and exposed as step outputs so the job
+      # summary and the Discord notification cannot disagree with each other.
+      - name: Collect build metrics
+        id: metrics
+        if: always()
+        shell: bash
+        run: |
+          set -uo pipefail
+          zip_path="${{ steps.bundle.outputs.path }}"
+
+          bundle_name=""
+          bundle_bytes=0
+          jar_count=0
+          if [[ -n "${zip_path}" && -f "${zip_path}" ]]; then
+            bundle_name="$(basename "${zip_path}")"
+            bundle_bytes="$(stat -c%s "${zip_path}")"
+            jar_count="$(unzip -Z1 "${zip_path}" \
+              | grep -Ec '^lib/[^/]+\.jar$' || true)"
+          fi
+
+          # Surefire writes one XML per test class; tests="N" is the per-class
+          # count. `|| true` keeps a zero-report build from tripping pipefail.
+          test_count="$(grep -rhoE 'tests="[0-9]+"' --include='*.xml' \
+            */target/surefire-reports 2>/dev/null \
+            | grep -oE '[0-9]+' \
+            | awk '{total += $1} END {print total+0}' || true)"
+          test_count="${test_count:-0}"
+
+          {
+            echo "bundle_name=${bundle_name}"
+            echo "bundle_bytes=${bundle_bytes}"
+            echo "jar_count=${jar_count:-0}"
+            echo "test_count=${test_count}"
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "### Windows desktop bundle"
+            echo
+            if [[ -n "${bundle_name}" ]]; then
+              echo "- Archive: \`${bundle_name}\`"
+              echo "- Version: \`${{ steps.version.outputs.version }}\`"
+              echo "- Size: $(du -h "${zip_path}" | cut -f1)"
+              echo "- Runtime JARs under \`lib/\`: ${jar_count:-0}"
+              echo "- Verified: structure, manifest classpath, launch smoke test"
+            else
+              echo "- :x: No bundle was produced."
+            fi
+            echo
+            echo "- JUnit tests executed: ${test_count}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload Windows desktop bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: frostguard-windows-desktop-bundle-${{ steps.version.outputs.version }}
+          path: ${{ steps.bundle.outputs.path }}
+          if-no-files-found: error
+          # A ZIP does not recompress usefully; skipping it saves several minutes.
+          compression-level: 0
+          retention-days: 14
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: "**/target/surefire-reports/*.xml"
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # A rolling prerelease gives the Discord message a stable, public,
+      # login-free download URL. Pull requests are excluded on purpose: a PR
+      # from a fork gets a read-only token, and republishing `nightly` from an
+      # unmerged branch would hand testers an unreviewed build.
+      - name: Publish the rolling nightly release
+        id: release
+        if: >-
+          success() &&
+          github.event_name != 'pull_request' &&
+          github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIP_PATH: ${{ steps.bundle.outputs.path }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # The asset is uploaded under a FIXED name, not the versioned one. The
+          # download URL contains the asset filename, so a versioned name would
+          # silently change the link on every version bump and break every
+          # message already posted to the channel.
+          asset="frostguard-windows-desktop-bundle.zip"
+          staged="$(dirname "${ZIP_PATH}")/${asset}"
+          cp "${ZIP_PATH}" "${staged}"
+
+          notes="$(printf '%s\n' \
+            "Automated Windows desktop bundle for Frostguard \`${VERSION}\`." \
+            "" \
+            "Built from \`${GITHUB_SHA}\` on $(date -u '+%Y-%m-%d %H:%M UTC')." \
+            "Verified: bundle structure, manifest classpath and launch smoke test." \
+            "" \
+            "**Install:** unzip anywhere, then run \`java -jar frostguard-*.jar\`" \
+            "(Java 21+ required)." \
+            "" \
+            "This tag is replaced by every nightly build; it is not a stable release.")"
+
+          # Recreate the release from scratch each night. `gh release edit
+          # --target` does NOT move an existing tag, so editing in place would
+          # leave the `nightly` tag pinned to the first commit it was ever cut
+          # from while the notes claimed a newer SHA. --cleanup-tag removes the
+          # tag too, so the recreated one points at this build.
+          if gh release view nightly >/dev/null 2>&1; then
+            gh release delete nightly --yes --cleanup-tag
+          fi
+
+          # Creating the release with the asset in the same call means there is
+          # never a window where the tag exists but the download 404s.
+          gh release create nightly "${staged}" \
+            --title "Nightly build ${VERSION}" \
+            --notes "${notes}" \
+            --prerelease \
+            --target "${GITHUB_SHA}"
+
+          # Read the URL back from the API instead of predicting it. A predicted
+          # URL is exactly how a 404 gets posted to the channel: if the upload
+          # landed under a different name, or not at all, this fails here rather
+          # than in Discord.
+          # `browser_download_url` straight from the REST API is unambiguous,
+          # unlike gh's `url` JSON field which is the API URL for some versions.
+          url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
+            --jq ".assets[] | select(.name == \"${asset}\") | .browser_download_url")"
+          if [[ -z "${url}" ]]; then
+            echo "::error::Asset ${asset} is not attached to the nightly release."
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
+              --jq '.assets[].name'
+            exit 1
+          fi
+
+          # Prove the link actually serves the file before it is advertised.
+          # A release asset redirects to a signed CDN URL, so follow redirects.
+          code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
+            --retry 3 --retry-delay 5 -r 0-1023 "${url}")"
+          if [[ "${code}" != "200" && "${code}" != "206" ]]; then
+            echo "::error::Download URL ${url} returned HTTP ${code}."
+            exit 1
+          fi
+
+          echo "download_url=${url}" >> "${GITHUB_OUTPUT}"
+          echo "Published and verified ${asset} at ${url} (HTTP ${code})"
+
+      # Runs even when the build failed, so a broken nightly is visible in the
+      # channel instead of being silently absent. `continue-on-error` keeps a
+      # Discord outage from turning a good build red.
+      - name: Notify Discord
+        if: always() && github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          # A commit message is attacker-controlled text. Interpolating it
+          # straight into the `run:` block would let `$(...)` or a backtick in a
+          # commit subject execute on the runner, with the webhook secret in
+          # scope. Passing it through the environment keeps it inert data.
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          JOB_STATUS: ${{ job.status }}
+          BUNDLE_NAME: ${{ steps.metrics.outputs.bundle_name }}
+          BUNDLE_BYTES: ${{ steps.metrics.outputs.bundle_bytes }}
+          JAR_COUNT: ${{ steps.metrics.outputs.jar_count }}
+          TEST_COUNT: ${{ steps.metrics.outputs.test_count }}
+          DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # `head_commit` only exists on push events. The nightly is a
+          # `schedule` run, which is precisely the case that matters most, so
+          # read the subject out of the checkout when the payload has none.
+          COMMIT_MESSAGE="${COMMIT_MESSAGE:-}"
+          if [[ -z "${COMMIT_MESSAGE}" ]]; then
+            COMMIT_MESSAGE="$(git log -1 --pretty=%s || true)"
+          fi
+
+          python3 ci/discord_notify.py \
+            --status "${JOB_STATUS,,}" \
+            --version "${VERSION}" \
+            --bundle-name "${BUNDLE_NAME}" \
+            --bundle-bytes "${BUNDLE_BYTES:-0}" \
+            --jar-count "${JAR_COUNT:-0}" \
+            --test-count "${TEST_COUNT:-0}" \
+            --download-url "${DOWNLOAD_URL}" \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --run-number "${GITHUB_RUN_NUMBER}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --branch "${GITHUB_REF_NAME}" \
+            --trigger "${GITHUB_EVENT_NAME}" \
+            --commit "${GITHUB_SHA}" \
+            --commit-message "${COMMIT_MESSAGE}" \
+            --actor "${GITHUB_ACTOR}"

--- a/setup/github-workflows/pr-test-build.yml
+++ b/setup/github-workflows/pr-test-build.yml
@@ -1,0 +1,501 @@
+# Combined PR test builds (issue #68).
+#
+# Testers ask for a Windows bundle that combines one or more open PRs —
+# including stacked PRs — without anything being merged for real. The trigger
+# is workflow_dispatch: a human can run it from the Actions tab, and the
+# Discord /build-pr command dispatches it through the API after the requester
+# confirmed the plan in the channel.
+#
+# Trust model (the whole point of the job split):
+#   plan     trusted   — validates PR numbers, pins head SHAs, drops stacked
+#                        PRs already contained in a later head, orders
+#                        base-to-tip and trial-merges in a detached worktree.
+#                        It performs git merges of PR code but NEVER executes
+#                        any of it.
+#   build    UNTRUSTED — reproduces the exact planned merge and runs Maven on
+#                        it. This job gets no secrets, a read-only token, and
+#                        its results are treated as unverified output.
+#   publish  trusted   — on a fresh runner, re-verifies the bundle with the
+#                        trusted copies of the verifier and smoke test,
+#                        re-checks that every PR is still open and unchanged,
+#                        and only then publishes a clearly-labelled temporary
+#                        prerelease under the pr-test-<digest> tag.
+#   notify   trusted   — posts the outcome (plan rejection, conflict report,
+#                        staleness, failure or the public download link) to
+#                        Discord. Only this job and publish see secrets.
+#
+# Nothing in this workflow pushes to main or to any PR branch: all merging
+# happens on a detached HEAD inside the runner's disposable checkout.
+
+name: PR Test Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      prs:
+        description: "PR numbers to combine, e.g. 47,48,49,65"
+        required: true
+        type: string
+      order:
+        description: "Optional explicit merge order, e.g. 49,47 (default: ascending)"
+        required: false
+        type: string
+        default: ""
+      pinned:
+        description: "Optional pinned SHAs from the Discord confirmation, e.g. 47:0123abcdef01,49:..."
+        required: false
+        type: string
+        default: ""
+      requester:
+        description: "Who asked for this build (shown in the Discord message)"
+        required: false
+        type: string
+        default: ""
+
+# One combined build at a time. Queuing instead of cancelling means a burst of
+# requests degrades to a slow queue, not to lost builds.
+concurrency:
+  group: pr-test-build
+  cancel-in-progress: false
+
+# Default deny; each job asks for exactly what it needs.
+permissions: {}
+
+env:
+  MAVEN_ARGS: "-B --no-transfer-progress -Dstyle.color=never"
+  # How long a temporary test release lives before the cleanup workflow
+  # removes it. Also printed into the release notes and the Discord message.
+  EXPIRY_DAYS: "7"
+
+jobs:
+  plan:
+    name: Validate and plan the combined merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      ok: ${{ steps.plan.outputs.ok }}
+      digest: ${{ steps.plan.outputs.digest }}
+      tag: ${{ steps.plan.outputs.tag }}
+      base_sha: ${{ steps.plan.outputs.base_sha }}
+      reuse_url: ${{ steps.plan.outputs.reuse_url }}
+      order: ${{ steps.plan.outputs.order }}
+    steps:
+      - name: Check out repository (full history for ancestry checks)
+        uses: actions/checkout@v4
+        with:
+          # merge-base ancestry answers are only meaningful with real history.
+          fetch-depth: 0
+          # LFS blobs are irrelevant for planning; pointers merge as text.
+          lfs: false
+
+      # The planner's own tests run first: a broken planner must fail here,
+      # not silently mis-plan a merge.
+      - name: Test the planner and the notifier
+        run: |
+          python3 ci/test_pr_build_plan.py
+          python3 ci/test_pr_test_notify.py
+
+      - name: Plan, pin and trial-merge the requested PRs
+        id: plan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Dispatch inputs are requester-typed text. They are passed through
+          # the environment so a crafted value cannot break out of the shell.
+          INPUT_PRS: ${{ inputs.prs }}
+          INPUT_ORDER: ${{ inputs.order }}
+          INPUT_PINNED: ${{ inputs.pinned }}
+        # `|| true` is NOT used: a rejected or conflicted plan exits 1, but the
+        # plan.json it wrote still reaches the notify job via the artifact, so
+        # the requester gets the explanation instead of a bare red X.
+        continue-on-error: true
+        run: |
+          python3 ci/pr_build_plan.py plan \
+            --prs "${INPUT_PRS}" \
+            --order "${INPUT_ORDER}" \
+            --pinned "${INPUT_PINNED}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base-ref main \
+            --workspace . \
+            --output "${RUNNER_TEMP}/plan.json"
+
+      - name: Upload the plan
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-test-plan
+          path: ${{ runner.temp }}/plan.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Summarise the plan
+        env:
+          PLAN_OK: ${{ steps.plan.outputs.ok }}
+          PLAN_TAG: ${{ steps.plan.outputs.tag }}
+          PLAN_PINNED: ${{ steps.plan.outputs.pinned }}
+          REUSE_URL: ${{ steps.plan.outputs.reuse_url }}
+        run: |
+          {
+            echo "### Combined PR test build plan"
+            echo
+            echo "- Buildable: \`${PLAN_OK:-false}\`"
+            echo "- Tag: \`${PLAN_TAG:-n/a}\`"
+            echo "- Pinned heads: \`${PLAN_PINNED:-n/a}\`"
+            if [[ -n "${REUSE_URL}" ]]; then
+              echo "- Reusing an existing identical build: ${REUSE_URL}"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  build:
+    name: Build the combined bundle (untrusted, no secrets)
+    needs: plan
+    # Skip entirely when the plan failed or an identical build already exists.
+    if: needs.plan.outputs.ok == 'true' && needs.plan.outputs.reuse_url == ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Read-only token, and no `secrets.*` may ever appear in this job: it
+    # executes code from unmerged pull requests (Maven plugins, tests).
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      # Everything under ci/ that runs AFTER the merge must come from main,
+      # not from the merged workspace, or a malicious PR could replace the
+      # verifier with `exit 0`. The copy happens while the workspace is still
+      # pristine main.
+      - name: Stash trusted CI scripts before merging PR code
+        run: |
+          mkdir -p "${RUNNER_TEMP}/trusted-ci"
+          cp -r ci/. "${RUNNER_TEMP}/trusted-ci/"
+
+      - name: Download the plan
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-test-plan
+          path: ${{ runner.temp }}/plan
+
+      # Reproduces the merge and fails unless the resulting tree is
+      # bit-identical to the tree the plan promised, so the planner and the
+      # builder cannot silently diverge.
+      - name: Reproduce the planned merge
+        run: |
+          python3 "${RUNNER_TEMP}/trusted-ci/pr_build_plan.py" merge \
+            --plan "${RUNNER_TEMP}/plan/plan.json" \
+            --workspace .
+
+      # The merged tree may have changed LFS pointers; materialise and verify
+      # them the same way the nightly does.
+      - name: Verify Git LFS assets are real binaries
+        run: bash "${RUNNER_TEMP}/trusted-ci/check_lfs_assets.sh" .
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Install Tesseract native libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            tesseract-ocr libtesseract-dev libleptonica-dev
+
+      # Tests are intentionally NOT skipped: a combined build that fails its
+      # own suite is exactly what the requester needs to know.
+      - name: Build Windows desktop bundle from the merged tree
+        run: mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
+
+      - name: Locate the desktop bundle
+        id: bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          zip_path="$(find fg-app/target -maxdepth 1 -type f \
+            -name '*-desktop-bundle.zip' | sort | tail -n 1)"
+          if [[ -z "${zip_path}" ]]; then
+            echo "::error::No desktop bundle ZIP found under fg-app/target."
+            exit 1
+          fi
+          echo "path=${zip_path}" >> "${GITHUB_OUTPUT}"
+          echo "Bundle: ${zip_path} ($(du -h "${zip_path}" | cut -f1))"
+
+      # Fast feedback only. Untrusted code already ran on this runner, so this
+      # verification is advisory; the publisher re-verifies on a fresh runner
+      # before anything becomes public.
+      - name: Verify bundle contents (advisory)
+        run: |
+          python3 "${RUNNER_TEMP}/trusted-ci/verify_bundle.py" \
+            "${{ steps.bundle.outputs.path }}" --platform win
+
+      - name: Upload the unverified bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-test-bundle
+          path: ${{ steps.bundle.outputs.path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 3
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-test-surefire-reports
+          path: "**/target/surefire-reports/*.xml"
+          if-no-files-found: ignore
+          retention-days: 7
+
+  publish:
+    name: Verify and publish the temporary test release
+    needs: [plan, build]
+    if: needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    outputs:
+      download_url: ${{ steps.release.outputs.download_url }}
+      expires: ${{ steps.release.outputs.expires }}
+      bundle_bytes: ${{ steps.release.outputs.bundle_bytes }}
+      stale: ${{ steps.stale.outputs.stale }}
+      stale_problems: ${{ steps.recheck.outputs.problems }}
+    steps:
+      # Fresh runner, pristine main: the verifier and smoke test used here
+      # cannot have been touched by the PR code.
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Download the plan and the bundle
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/artifacts
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Locate the downloaded bundle
+        id: bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          zip_path="$(find "${RUNNER_TEMP}/artifacts/pr-test-bundle" \
+            -maxdepth 1 -type f -name '*.zip' | head -n 1)"
+          if [[ -z "${zip_path}" ]]; then
+            echo "::error::The build job uploaded no bundle ZIP."
+            exit 1
+          fi
+          echo "path=${zip_path}" >> "${GITHUB_OUTPUT}"
+
+      # Authoritative verification. The build job is untrusted, so nothing it
+      # claimed counts until the trusted verifier and smoke test agree.
+      - name: Verify bundle contents (authoritative)
+        run: |
+          python3 ci/verify_bundle.py \
+            "${{ steps.bundle.outputs.path }}" --platform win
+
+      - name: Smoke test the bundle (authoritative)
+        run: ci/smoke_test_bundle.sh "${{ steps.bundle.outputs.path }}"
+
+      # A PR that was closed, merged or force-pushed between planning and now
+      # must block publishing: the advertised "PR #47 @ sha" facts would be
+      # lies. The step is continue-on-error so the staleness reaches Discord
+      # as a explanation instead of a bare failure.
+      - name: Re-check every PR is still open and unchanged
+        id: recheck
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 ci/pr_build_plan.py recheck \
+            --plan "${RUNNER_TEMP}/artifacts/pr-test-plan/plan.json"
+
+      - name: Stop when the plan went stale
+        id: stale
+        shell: bash
+        run: |
+          if [[ "${{ steps.recheck.outcome }}" == "failure" ]]; then
+            echo "stale=true" >> "${GITHUB_OUTPUT}"
+            echo "::error::A planned PR changed; the build was not published."
+            exit 1
+          fi
+          echo "stale=false" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish the temporary test prerelease
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIP_PATH: ${{ steps.bundle.outputs.path }}
+          TAG: ${{ needs.plan.outputs.tag }}
+          DIGEST: ${{ needs.plan.outputs.digest }}
+          BASE_SHA: ${{ needs.plan.outputs.base_sha }}
+          REQUESTER: ${{ inputs.requester }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          plan_json="${RUNNER_TEMP}/artifacts/pr-test-plan/plan.json"
+          # Machine-readable lines for the cleanup workflow: which PRs are
+          # included and when the release expires.
+          pr_numbers="$(python3 -c '
+          import json, sys
+          plan = json.load(open(sys.argv[1]))
+          print(",".join(str(p["number"]) for p in plan["pulls"]))
+          ' "${plan_json}")"
+          pr_details="$(python3 -c '
+          import json, sys
+          plan = json.load(open(sys.argv[1]))
+          for p in plan["pulls"]:
+              print(f"- #{p[\"number\"]} `{p[\"head_sha\"]}` {p[\"title\"]}")
+          ' "${plan_json}")"
+          expires="$(date -u -d "+${EXPIRY_DAYS} days" '+%Y-%m-%d')"
+
+          asset="frostguard-pr-test-${DIGEST}.zip"
+          staged="$(dirname "${ZIP_PATH}")/${asset}"
+          cp "${ZIP_PATH}" "${staged}"
+
+          notes="$(printf '%s\n' \
+            "## ⚠️ Temporary UNMERGED test build" \
+            "" \
+            "This bundle combines unreviewed pull-request code for testing" \
+            "only. It is NOT a nightly and NOT a release." \
+            "" \
+            "PRs: ${pr_numbers}" \
+            "Base: ${BASE_SHA}" \
+            "Expires: ${expires}" \
+            "" \
+            "### Included pull requests (merge order, pinned)" \
+            "${pr_details}" \
+            "" \
+            "Requested by: ${REQUESTER:-manual dispatch}" \
+            "Verified: bundle structure, manifest classpath, launch smoke test." \
+            "" \
+            "**Install:** unzip anywhere, then run \`java -jar frostguard-*.jar\`" \
+            "(Java 21+ required)." \
+            "" \
+            "This release is deleted automatically after ${EXPIRY_DAYS} days or" \
+            "when every included PR is closed.")"
+
+          # The tag is the digest over (base SHA + ordered pinned heads), so
+          # re-running the same request lands on the same tag. Recreate it so
+          # a retry never leaves a half-updated release behind.
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release delete "${TAG}" --yes --cleanup-tag
+          fi
+
+          # --target pins the tag to the planned base commit: the merged tree
+          # exists only inside the runners and must not be pushed anywhere.
+          gh release create "${TAG}" "${staged}" \
+            --title "PR test build ${pr_numbers//,/+} (${DIGEST})" \
+            --notes "${notes}" \
+            --prerelease \
+            --target "${BASE_SHA}"
+
+          # Read the URL back from the API instead of predicting it, and prove
+          # it serves bytes before it is advertised in Discord.
+          url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            --jq ".assets[] | select(.name == \"${asset}\") | .browser_download_url")"
+          if [[ -z "${url}" ]]; then
+            echo "::error::Asset ${asset} is not attached to ${TAG}."
+            exit 1
+          fi
+          code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
+            --retry 3 --retry-delay 5 -r 0-1023 "${url}")"
+          if [[ "${code}" != "200" && "${code}" != "206" ]]; then
+            echo "::error::Download URL ${url} returned HTTP ${code}."
+            exit 1
+          fi
+
+          {
+            echo "download_url=${url}"
+            echo "expires=${expires}"
+            echo "bundle_bytes=$(stat -c%s "${staged}")"
+          } >> "${GITHUB_OUTPUT}"
+          echo "Published and verified ${asset} at ${url} (HTTP ${code})"
+
+  notify:
+    name: Report the outcome to Discord
+    needs: [plan, build, publish]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Download the plan
+        # The plan artifact exists even for rejected requests; only an
+        # infrastructure failure in the plan job itself leaves it missing.
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-test-plan
+          path: ${{ runner.temp }}/plan
+
+      - name: Post the status message
+        env:
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          PLAN_OK: ${{ needs.plan.outputs.ok }}
+          REUSE_URL: ${{ needs.plan.outputs.reuse_url }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          PUBLISH_STALE: ${{ needs.publish.outputs.stale }}
+          STALE_PROBLEMS: ${{ needs.publish.outputs.stale_problems }}
+          DOWNLOAD_URL: ${{ needs.publish.outputs.download_url }}
+          EXPIRES: ${{ needs.publish.outputs.expires }}
+          BUNDLE_BYTES: ${{ needs.publish.outputs.bundle_bytes }}
+          REQUESTER: ${{ inputs.requester }}
+          REQUESTED: ${{ inputs.prs }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          plan_path="${RUNNER_TEMP}/plan/plan.json"
+
+          # Work out which of the five message kinds describes this run.
+          kind="failure"
+          extra=()
+          if [[ "${PLAN_OK}" != "true" ]]; then
+            # Distinguish "PRs conflict" from "request was invalid" using the
+            # conflict list inside the plan document itself.
+            if [[ -f "${plan_path}" ]] && python3 -c '
+          import json, sys
+          plan = json.load(open(sys.argv[1]))
+          sys.exit(0 if (plan.get("merge") or {}).get("conflicts") else 1)
+          ' "${plan_path}"; then
+              kind="conflict"
+            else
+              kind="rejected"
+            fi
+          elif [[ -n "${REUSE_URL}" ]]; then
+            kind="success"
+            extra+=(--download-url "${REUSE_URL}" --reused)
+          elif [[ "${PUBLISH_STALE}" == "true" ]]; then
+            kind="stale"
+            extra+=(--problems "${STALE_PROBLEMS}")
+          elif [[ "${PUBLISH_RESULT}" == "success" && -n "${DOWNLOAD_URL}" ]]; then
+            kind="success"
+            extra+=(--download-url "${DOWNLOAD_URL}"
+                    --expires-utc "${EXPIRES}"
+                    --bundle-bytes "${BUNDLE_BYTES:-0}")
+          fi
+
+          args=(--kind "${kind}" --run-url "${RUN_URL}"
+                --requester "${REQUESTER}" --requested "${REQUESTED}")
+          if [[ -f "${plan_path}" ]]; then
+            args+=(--plan "${plan_path}")
+          else
+            args+=(--reason "The planning step crashed before producing a plan; see the workflow log.")
+          fi
+
+          python3 ci/pr_test_notify.py "${args[@]}" "${extra[@]}"

--- a/setup/github-workflows/pr-test-cleanup.yml
+++ b/setup/github-workflows/pr-test-cleanup.yml
@@ -1,0 +1,106 @@
+# Expire temporary combined-PR test releases (issue #68).
+#
+# Every /build-pr result is published as a prerelease under a pr-test-<digest>
+# tag with two machine-readable lines in its notes:
+#
+#   PRs: 47,49
+#   Expires: 2026-08-07
+#
+# This workflow deletes a test release (and its tag) when either
+#   - its expiry date has passed, or
+#   - every PR listed in its notes is closed or merged
+# so stale unmerged test builds cannot circulate forever. The rolling
+# `nightly` release and real releases are untouched: only tags with the
+# pr-test- prefix are ever considered.
+
+name: PR Test Release Cleanup
+
+on:
+  schedule:
+    - cron: "43 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pr-test-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete expired or orphaned test releases
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Remove test releases that expired or whose PRs all closed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          today="$(date -u '+%Y-%m-%d')"
+          deleted=0
+          kept=0
+
+          # 100 per page is far above the realistic number of live test tags;
+          # the per-request cooldown in the Discord bot keeps creation slow.
+          releases="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq '[.[] | select(.tag_name | startswith("pr-test-"))
+                   | {tag: .tag_name, body: .body}]')"
+
+          count="$(jq 'length' <<< "${releases}")"
+          echo "Found ${count} temporary test release(s)."
+
+          for row in $(jq -r 'to_entries[] | .key' <<< "${releases}"); do
+            tag="$(jq -r ".[${row}].tag" <<< "${releases}")"
+            body="$(jq -r ".[${row}].body" <<< "${releases}")"
+
+            expires="$(grep -oE '^Expires: [0-9]{4}-[0-9]{2}-[0-9]{2}' \
+              <<< "${body}" | head -n1 | cut -d' ' -f2 || true)"
+            prs="$(grep -oE '^PRs: [0-9,]+' <<< "${body}" \
+              | head -n1 | cut -d' ' -f2 || true)"
+
+            reason=""
+
+            # A test release without parseable notes cannot prove it is still
+            # wanted; date-expire it conservatively rather than keep it forever.
+            if [[ -z "${expires}" ]]; then
+              reason="its notes carry no parseable expiry"
+            elif [[ "${today}" > "${expires}" ]]; then
+              reason="it expired on ${expires}"
+            elif [[ -n "${prs}" ]]; then
+              all_closed=1
+              IFS=',' read -ra numbers <<< "${prs}"
+              for number in "${numbers[@]}"; do
+                state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}" \
+                  --jq '.state' 2>/dev/null || echo "unknown")"
+                if [[ "${state}" == "open" || "${state}" == "unknown" ]]; then
+                  # Treat an API hiccup as "still open": deleting on a guess
+                  # would break a link somebody may be using right now.
+                  all_closed=0
+                  break
+                fi
+              done
+              if [[ "${all_closed}" -eq 1 ]]; then
+                reason="every included PR (${prs}) is closed or merged"
+              fi
+            fi
+
+            if [[ -n "${reason}" ]]; then
+              echo "Deleting ${tag}: ${reason}."
+              gh release delete "${tag}" --yes --cleanup-tag
+              deleted=$((deleted + 1))
+            else
+              echo "Keeping ${tag} (expires ${expires}, PRs ${prs:-unknown})."
+              kept=$((kept + 1))
+            fi
+          done
+
+          {
+            echo "### PR test release cleanup"
+            echo
+            echo "- Deleted: ${deleted}"
+            echo "- Kept: ${kept}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/setup/install-workflows.sh
+++ b/setup/install-workflows.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Install the PR-test-build workflow files into .github/workflows/.
+#
+# Why this exists: GitHub refuses pushes that create or modify files under
+# .github/workflows/ unless the pushing credential has the `workflows`
+# permission. The automation that authored this feature only holds a
+# repo-scoped app token without it, so the three workflow files are staged
+# here and a human with normal push rights applies them with one command:
+#
+#   bash setup/install-workflows.sh
+#   git add .github/workflows
+#   git commit -m "ci: install PR test build workflows"
+#   git push
+#
+# The staged files are:
+#   pr-test-build.yml         NEW  - the /build-pr combined PR test pipeline
+#   pr-test-cleanup.yml       NEW  - expires temporary pr-test-* releases
+#   daily-windows-bundle.yml  MOD  - the LFS pointer-stub check now calls the
+#                                    shared ci/check_lfs_assets.sh instead of
+#                                    carrying its own inline copy (no
+#                                    behaviour change)
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${here}/.." && pwd)"
+target="${repo_root}/.github/workflows"
+
+mkdir -p "${target}"
+for file in pr-test-build.yml pr-test-cleanup.yml daily-windows-bundle.yml; do
+  cp "${here}/github-workflows/${file}" "${target}/${file}"
+  echo "installed .github/workflows/${file}"
+done
+
+echo
+echo "Now commit and push:"
+echo "  git add .github/workflows"
+echo "  git commit -m 'ci: install PR test build workflows'"
+echo "  git push"


### PR DESCRIPTION
Closes #68.

Lets approved Discord testers request a public Windows test build that combines one or more **open** pull requests — including stacked PRs — without merging anything:

```
/build-pr prs: 47 48 49 65
```

The same feature also works with no Discord at all, from **Actions → PR Test Build → Run workflow** with `prs: 47,48,49,65` (the issue's suggested first iteration).

## What's in this PR

| Path | What |
|---|---|
| `ci/pr_build_plan.py` | Trusted planner: `plan` / `merge` / `recheck` subcommands |
| `ci/pr_test_notify.py` | Discord result messages (success / conflict / rejected / stale / failure) |
| `ci/check_lfs_assets.sh` | LFS pointer-stub guard factored out of the nightly, shared by both pipelines |
| `setup/github-workflows/pr-test-build.yml` | The 4-job build pipeline (see below) |
| `setup/github-workflows/pr-test-cleanup.yml` | Daily expiry of temporary test releases |
| `setup/github-workflows/daily-windows-bundle.yml` | Nightly, now calling the shared LFS script (no behaviour change) |
| `setup/install-workflows.sh` | One-command install of the three workflow files (see note) |
| `discord-bot/` | Cloudflare Worker for the `/build-pr` slash command + registration script + full setup guide |
| `ci/test_pr_build_plan.py`, `ci/test_pr_test_notify.py`, `discord-bot/test_worker.mjs` | 67 new tests |

> **Note — workflows are staged, not installed:** GitHub rejects pushes touching `.github/workflows/` from tokens without the `workflows` permission, which the token used to author this PR lacks. After merging, run `bash setup/install-workflows.sh`, commit and push (takes ~30 seconds). Everything else is live immediately.

## How it maps to the acceptance criteria

- **Multiple open PRs and stacked PRs can be requested** — the planner fetches `refs/pull/N/head`, detects ancestry with `git merge-base --is-ancestor`, drops PRs already contained in `main` or in another requested head, and orders base-to-tip (ascending PR number, or an explicit `order` override).
- **Closed or merged PRs are rejected with a useful explanation** — per-PR messages ("PR #12 is already merged; its changes are in `main`"), non-numeric tokens named, duplicates deduplicated, max 6 PRs per request.
- **Pinned SHAs** — pinned once at Discord confirmation, re-resolved at planning, and `recheck` runs immediately before publishing; a push/close/merge in between **withholds the release** with an explanation instead of shipping unadvertised code.
- **Conflicts stop for an informed confirmation instead of being hidden** — the trial merge aborts, the Discord message lists the conflicting files per PR, binary conflicts are flagged as needing a manual choice, and nothing is ever resolved with `ours`/`theirs`.
- **No requested build changes repository branches** — all merging happens on a detached HEAD in the runner's disposable checkout; the release tag `--target`s the base commit on `main`, and the unit tests assert branches don't move.
- **Untrusted build code cannot access publishing or Discord secrets** — the `build` job has `permissions: contents: read` and zero `secrets.*`; the verifier/smoke-test copies it uses are stashed from pristine `main` *before* PR code is merged in; the authoritative verification, staleness re-check and publishing run in a separate job on a fresh runner checked out from `main`. The `merge` subcommand refuses to build any tree that isn't bit-identical to the planned one.
- **Public, temporary download + Discord status** — a `pr-test-<digest>` prerelease (digest = base SHA + ordered pinned heads, so identical requests **reuse** the existing build), clearly labelled **UNMERGED TEST BUILD**, completely separate from `nightly`; the Discord message carries the download URL, all PR numbers, titles and pinned SHAs.
- **Expiry** — `pr-test-cleanup.yml` deletes each test release after 7 days or once every included PR is closed; `nightly` and real releases are never considered.
- **Guardrails** — channel/role allowlists in the worker (plus Discord's own integration permissions), a confirmation embed with **Build / Cancel** buttons that only the requester may press, 10-minute cooldown, and one combined build at a time (fail-closed if the check can't run).




Plus end-to-end integration runs of `plan`/`merge`/`recheck` against a local origin with `refs/pull/N/head` refs covering stacked containment, explicit order, moved-pin rejection and tree reproduction. All three workflow YAML files parse cleanly.
