### PR TITLE
fix(ci): separate Linux tests from Windows packaging

### DIFF
--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -70,13 +70,14 @@ jobs:
           cache: maven
 
       # The saved-frame vision tests run OCR through tess4j, which binds the host
-      # libtesseract/libleptonica at runtime. OpenCV itself needs no system
-      # package: the openpnp artifact ships the Linux native image.
-      - name: Install Tesseract native libraries
+      # libtesseract/libleptonica at runtime. JavaFX controller tests need a
+      # virtual display on this headless Linux runner. OpenCV itself needs no
+      # system package: the openpnp artifact ships the Linux native image.
+      - name: Install Linux test runtimes
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            tesseract-ocr libtesseract-dev libleptonica-dev
+            tesseract-ocr libtesseract-dev libleptonica-dev xvfb
 
       # Guards the bundle verifier itself. A verification script that cannot fail
       # would turn a broken release artifact into a green check mark.
@@ -103,11 +104,19 @@ jobs:
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "Project version: ${version}"
 
-      # Tests are intentionally NOT skipped. The vision/OCR suites are the ones
-      # most likely to regress, and they run correctly on Linux now that the
-      # OpenCV native image is selected per platform.
+      # Run tests with host-native Linux dependencies before selecting Windows
+      # JavaFX for packaging. A single Maven invocation with javafx.platform=win
+      # tries to start Windows JavaFX natives on Linux when a controller test
+      # launches the toolkit, which fails before the bundle can be assembled.
+      - name: Test on Linux
+        run: |
+          read -r -a maven_args <<< "${MAVEN_ARGS}"
+          xvfb-run --auto-servernum mvn "${maven_args[@]}" clean test
+
       - name: Build Windows desktop bundle
-        run: mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
+        run: |
+          read -r -a maven_args <<< "${MAVEN_ARGS}"
+          mvn "${maven_args[@]}" install -DskipTests -Djavafx.platform=win
 
       - name: Locate the desktop bundle
         id: bundle

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -229,16 +229,24 @@ jobs:
           java-version: "21"
           cache: maven
 
-      - name: Install Tesseract native libraries
+      - name: Install Linux test runtimes
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            tesseract-ocr libtesseract-dev libleptonica-dev
+            tesseract-ocr libtesseract-dev libleptonica-dev xvfb
 
-      # Tests are intentionally NOT skipped: a combined build that fails its
-      # own suite is exactly what the requester needs to know.
+      # Test the combined tree with host-native Linux dependencies. Selecting
+      # Windows JavaFX during this phase prevents controller tests from starting
+      # a toolkit on the Linux runner, even when a virtual display is present.
+      - name: Test the combined tree on Linux
+        run: |
+          read -r -a maven_args <<< "${MAVEN_ARGS}"
+          xvfb-run --auto-servernum mvn "${maven_args[@]}" clean test
+
       - name: Build Windows desktop bundle from the merged tree
-        run: mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
+        run: |
+          read -r -a maven_args <<< "${MAVEN_ARGS}"
+          mvn "${maven_args[@]}" install -DskipTests -Djavafx.platform=win
 
       - name: Locate the desktop bundle
         id: bundle


### PR DESCRIPTION
## Summary

- run the Maven test suite with host-native Linux JavaFX under Xvfb
- build the Windows desktop bundle separately with Windows JavaFX and skipped tests
- apply the same split to daily bundles and combined PR test builds

## Why

The Linux runner currently executes `mvn clean install -Djavafx.platform=win`. That selects Windows JavaFX natives before tests run, so any controller test that starts the JavaFX toolkit fails with `RuntimeException: No toolkit found`. The failure surfaced in PR #51, but it is a cross-platform CI concern rather than Bear Trap behavior.

Separating the phases keeps the full test suite meaningful on Linux while still packaging and verifying the Windows runtime.

## Validation

- `actionlint` on both changed workflows; only three pre-existing informational ShellCheck findings remain
- `python3 ci/test_verify_bundle.py`
- `python3 ci/test_discord_notify.py`
- `python3 ci/test_pr_build_plan.py`
- `python3 ci/test_pr_test_notify.py`
- `python3 ci/check_workflow_python.py`
- `git diff --check`

The draft PR's GitHub Actions run provides the end-to-end validation for Xvfb, Linux JavaFX tests, and Windows bundle assembly.
