### PR TITLE
fix(discord): return PR builds to requesting channel

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -51,6 +51,31 @@ on:
         required: false
         type: string
         default: ""
+      discord_guild_id:
+        description: "Discord guild that originated the request (empty for manual runs)"
+        required: false
+        type: string
+        default: ""
+      discord_channel_id:
+        description: "Discord channel that originated the request"
+        required: false
+        type: string
+        default: ""
+      discord_requester_id:
+        description: "Discord user to notify when the build finishes"
+        required: false
+        type: string
+        default: ""
+      discord_message_id:
+        description: "Original /build-pr status message to reply to"
+        required: false
+        type: string
+        default: ""
+      discord_request_id:
+        description: "Unique Discord interaction ID for traceability"
+        required: false
+        type: string
+        default: ""
 
 # One combined build at a time. Queuing instead of cancelling means a burst of
 # requests degrades to a slow queue, not to lost builds.
@@ -452,9 +477,16 @@ jobs:
           name: pr-test-plan
           path: ${{ runner.temp }}/plan
 
-      - name: Post the status message
+      - name: Reply with the final status in the requesting Discord channel
         env:
-          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_ALLOWED_GUILD_ID: ${{ vars.DISCORD_PR_BUILD_GUILD_ID }}
+          DISCORD_ALLOWED_CHANNEL_IDS: ${{ vars.DISCORD_PR_BUILD_CHANNEL_IDS }}
+          DISCORD_GUILD_ID: ${{ inputs.discord_guild_id }}
+          DISCORD_CHANNEL_ID: ${{ inputs.discord_channel_id }}
+          DISCORD_REQUESTER_ID: ${{ inputs.discord_requester_id }}
+          DISCORD_MESSAGE_ID: ${{ inputs.discord_message_id }}
+          DISCORD_REQUEST_ID: ${{ inputs.discord_request_id }}
           PLAN_OK: ${{ needs.plan.outputs.ok }}
           REUSE_URL: ${{ needs.plan.outputs.reuse_url }}
           BUILD_RESULT: ${{ needs.build.result }}
@@ -502,6 +534,13 @@ jobs:
 
           args=(--kind "${kind}" --run-url "${RUN_URL}"
                 --requester "${REQUESTER}" --requested "${REQUESTED}")
+          args+=(--guild-id "${DISCORD_GUILD_ID}"
+                 --channel-id "${DISCORD_CHANNEL_ID}"
+                 --requester-id "${DISCORD_REQUESTER_ID}"
+                 --message-id "${DISCORD_MESSAGE_ID}"
+                 --request-id "${DISCORD_REQUEST_ID}"
+                 --allowed-guild-id "${DISCORD_ALLOWED_GUILD_ID}"
+                 --allowed-channel-ids "${DISCORD_ALLOWED_CHANNEL_IDS}")
           if [[ -f "${plan_path}" ]]; then
             args+=(--plan "${plan_path}")
           else

--- a/ci/README.md
+++ b/ci/README.md
@@ -201,7 +201,7 @@ it into `.github/workflows/`) with four jobs that enforce a strict trust split:
 | `plan` | trusted | [`pr_build_plan.py plan`](pr_build_plan.py): rejects closed/merged/non-numeric PRs with reasons, pins every head SHA, drops PRs already contained in another requested head or in `main` (stacked PRs), orders base-to-tip, trial-merges on a detached HEAD and reports conflicting files (binary conflicts flagged). Never executes PR code. |
 | `build` | **untrusted** | `pr_build_plan.py merge` reproduces the planned merge and fails unless the tree is bit-identical to the planned one, then runs the full Maven build. Read-only token, **no secrets**. Its verification is advisory only. |
 | `publish` | trusted | Fresh runner, pristine `main`: re-verifies the bundle with the trusted `verify_bundle.py` + `smoke_test_bundle.sh`, re-checks (`pr_build_plan.py recheck`) that every PR is still open and unchanged, then publishes the `pr-test-<digest>` prerelease. The digest covers base SHA + ordered pinned heads, so identical requests reuse the existing release. |
-| `notify` | trusted | [`pr_test_notify.py`](pr_test_notify.py) posts the outcome to the existing `DISCORD_NIGHTLY_WEBHOOK_URL`: download link (marked **UNMERGED TEST BUILD**), conflict report, rejection reasons, staleness explanation, or failure link. |
+| `notify` | trusted | [`pr_test_notify.py`](pr_test_notify.py) validates the Discord guild/channel context, replies to the original `/build-pr` status through the bot API and mentions only the requester. Manual dispatches without Discord context do not notify. |
 
 No job ever pushes to `main` or a PR branch; the merged tree exists only
 inside the runners. [`pr-test-cleanup.yml`](../setup/github-workflows/pr-test-cleanup.yml)

--- a/ci/pr_test_notify.py
+++ b/ci/pr_test_notify.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Post a combined-PR test build status message to a Discord webhook.
+"""Reply with a combined-PR test build result through the Discord bot API.
 
 This is the reporting half of the `/build-pr` feature (issue #68). It reads
 the plan.json written by ci/pr_build_plan.py and renders one of four message
@@ -15,9 +15,9 @@ kinds:
 - failure    The build itself failed; links the workflow log.
 
 Every download is explicitly marked as an UNMERGED TEST BUILD so nobody
-mistakes it for a nightly. The webhook URL comes from the environment, never
-argv, for the same process-list reason as ci/discord_notify.py, whose
-delivery machinery (retries, rate limits, redaction) is reused here.
+mistakes it for a nightly. Discord IDs are validated against the configured
+guild/channel allowlist before the bot token is used. Manual runs with no
+Discord context remain valid and intentionally send no message.
 """
 
 from __future__ import annotations
@@ -26,12 +26,14 @@ import argparse
 import json
 import os
 import sys
+import time
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from discord_notify import (  # noqa: E402
-    CONTENT_LIMIT,
     EMBED_DESCRIPTION_LIMIT,
     EMBED_FIELD_NAME_LIMIT,
     EMBED_FIELD_VALUE_LIMIT,
@@ -39,10 +41,8 @@ from discord_notify import (  # noqa: E402
     EMBED_TITLE_LIMIT,
     human_size,
     lenient_int,
-    post,
     truncate,
 )
-import re
 
 KIND_STYLE = {
     "success": (0x2ECC71, "Test build ready"),
@@ -235,13 +235,23 @@ def build_payload(args: argparse.Namespace, plan: dict) -> dict:
     embed["footer"] = {"text": truncate(footer, EMBED_FOOTER_LIMIT)}
 
     payload = {
-        "username": args.username,
         "embeds": [embed],
         # A PR title is contributor-controlled text; never let it ping.
         "allowed_mentions": {"parse": []},
     }
-    if args.kind == "success" and args.download_url.startswith("http"):
-        payload["content"] = truncate(args.download_url, CONTENT_LIMIT)
+    if args.requester_id:
+        payload["content"] = f"<@{args.requester_id}>"
+        payload["allowed_mentions"] = {
+            "parse": [],
+            "users": [args.requester_id],
+        }
+    if args.message_id:
+        payload["message_reference"] = {
+            "message_id": args.message_id,
+            "channel_id": args.channel_id,
+            "guild_id": args.guild_id,
+            "fail_if_not_exists": False,
+        }
     return payload
 
 
@@ -263,11 +273,79 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
                         help="single-line rejection reason when no plan exists")
     parser.add_argument("--problems", default="",
                         help="newline-separated staleness findings")
-    parser.add_argument("--username", default="Frostguard PR Test Builds")
-    parser.add_argument("--webhook-env", default="DISCORD_NIGHTLY_WEBHOOK_URL")
+    parser.add_argument("--guild-id", default="")
+    parser.add_argument("--channel-id", default="")
+    parser.add_argument("--requester-id", default="")
+    parser.add_argument("--message-id", default="")
+    parser.add_argument("--request-id", default="")
+    parser.add_argument("--allowed-guild-id", default="")
+    parser.add_argument("--allowed-channel-ids", default="")
+    parser.add_argument("--token-env", default="DISCORD_BOT_TOKEN")
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--dry-run", action="store_true")
     return parser.parse_args(argv)
+
+
+def valid_snowflake(value: str) -> bool:
+    return value.isdigit() and 5 <= len(value) <= 20
+
+
+def validate_discord_context(args: argparse.Namespace) -> str:
+    values = [args.guild_id, args.channel_id, args.requester_id, args.message_id]
+    if not any(values):
+        return "missing"
+    if not all(valid_snowflake(value) for value in values):
+        return "Discord context contains a missing or invalid ID"
+    if args.request_id and not valid_snowflake(args.request_id):
+        return "Discord request ID is invalid"
+    if not valid_snowflake(args.allowed_guild_id):
+        return "configured Discord guild allowlist is missing or invalid"
+    if args.guild_id != args.allowed_guild_id:
+        return "Discord guild is not allowlisted"
+    channels = {
+        value.strip() for value in args.allowed_channel_ids.split(",")
+        if value.strip()
+    }
+    if not channels or not all(valid_snowflake(value) for value in channels):
+        return "configured Discord channel allowlist is missing or invalid"
+    if args.channel_id not in channels:
+        return "Discord channel is not allowlisted"
+    return ""
+
+
+def post_bot_message(token: str, channel_id: str, payload: dict,
+                     timeout: float) -> None:
+    url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
+    body = json.dumps(payload).encode("utf-8")
+    for attempt in range(4):
+        request = urllib.request.Request(
+            url,
+            data=body,
+            method="POST",
+            headers={
+                "Authorization": f"Bot {token}",
+                "Content-Type": "application/json",
+                "User-Agent": "frostguard-ci/1.0",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                if response.status < 300:
+                    return
+        except urllib.error.HTTPError as error:
+            if error.code == 429 or 500 <= error.code < 600:
+                retry_after = error.headers.get("Retry-After", "1")
+                time.sleep(min(float(retry_after), 30.0))
+                continue
+            raise RuntimeError(
+                f"Discord API rejected the notification with HTTP {error.code}"
+            ) from error
+        except urllib.error.URLError as error:
+            if attempt < 3:
+                time.sleep(2 ** attempt)
+                continue
+            raise RuntimeError("Discord API notification failed") from error
+    raise RuntimeError("Discord API notification failed after retries")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -279,18 +357,23 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
 
-    webhook = os.environ.get(args.webhook_env, "").strip()
-    if not webhook:
-        print(f"::warning::{args.webhook_env} is empty; no Discord message sent.")
+    context_error = validate_discord_context(args)
+    if context_error == "missing":
+        print("Manual run has no Discord context; no Discord message sent.")
         return 0
-    if not re.match(r"^https://(canary\.|ptb\.)?discord(app)?\.com/api/webhooks/", webhook):
-        print(
-            f"::error::{args.webhook_env} does not look like a Discord webhook URL."
-        )
+    if context_error:
+        print(f"::warning::{context_error}; no Discord message sent.")
+        return 0
+
+    token = os.environ.get(args.token_env, "").strip()
+    if not token:
+        print(f"::warning::{args.token_env} is empty; no Discord message sent.")
+        return 0
+    if any(character.isspace() for character in token):
+        print(f"::error::{args.token_env} is malformed.")
         return 1
 
-    post(webhook, json.dumps(payload).encode("utf-8"), "application/json",
-         args.timeout)
+    post_bot_message(token, args.channel_id, payload, args.timeout)
     return 0
 
 

--- a/ci/test_pr_test_notify.py
+++ b/ci/test_pr_test_notify.py
@@ -8,12 +8,12 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import pr_test_notify as notify
 from discord_notify import (
-    CONTENT_LIMIT,
     EMBED_DESCRIPTION_LIMIT,
     EMBED_FIELD_NAME_LIMIT,
     EMBED_FIELD_VALUE_LIMIT,
@@ -88,8 +88,10 @@ class SuccessPayloadTest(unittest.TestCase):
         text = self.payload()["embeds"][0]["description"]
         self.assertIn("UNMERGED TEST BUILD", text)
 
-    def test_content_carries_the_bare_download_url(self):
-        self.assertEqual(self.payload()["content"], self.URL)
+    def test_download_url_stays_inside_the_embed(self):
+        payload = self.payload()
+        self.assertNotIn("content", payload)
+        self.assertIn(self.URL, payload["embeds"][0]["description"])
 
     def test_lists_every_pr_with_number_title_and_pinned_sha(self):
         text = all_text(self.payload())
@@ -224,7 +226,6 @@ class LimitsTest(unittest.TestCase):
         embed = payload["embeds"][0]
         self.assertLessEqual(len(embed["title"]), EMBED_TITLE_LIMIT)
         self.assertLessEqual(len(embed["description"]), EMBED_DESCRIPTION_LIMIT)
-        self.assertLessEqual(len(payload.get("content", "")), CONTENT_LIMIT)
         self.assertLessEqual(len(embed["fields"]), 10)
         for field in embed["fields"]:
             self.assertLessEqual(len(field["name"]), EMBED_FIELD_NAME_LIMIT)
@@ -250,23 +251,70 @@ class MissingPlanTest(unittest.TestCase):
             os.unlink(path)
 
 
-class WebhookGuardTest(unittest.TestCase):
-    def test_missing_webhook_warns_but_does_not_fail(self):
-        env_var = "FG_PR_TEST_ABSENT"
-        os.environ.pop(env_var, None)
-        code = notify.main(["--kind", "rejected", "--reason", "x",
-                            "--webhook-env", env_var])
+class DiscordContextTest(unittest.TestCase):
+    def context_args(self) -> list[str]:
+        return [
+            "--guild-id", "11111", "--channel-id", "22222",
+            "--requester-id", "33333", "--message-id", "44444",
+            "--request-id", "55555", "--allowed-guild-id", "11111",
+            "--allowed-channel-ids", "22222,66666",
+        ]
+
+    def test_manual_run_without_context_does_not_post(self):
+        code = notify.main(["--kind", "rejected", "--reason", "x"])
         self.assertEqual(code, 0)
 
-    def test_non_discord_webhook_is_rejected(self):
-        env_var = "FG_PR_TEST_BAD_HOOK"
-        os.environ[env_var] = "https://example.com/not-a-webhook"
-        try:
-            code = notify.main(["--kind", "rejected", "--reason", "x",
-                                "--webhook-env", env_var])
-        finally:
-            del os.environ[env_var]
-        self.assertEqual(code, 1)
+    def test_context_requires_the_configured_guild(self):
+        args = notify.parse_args(
+            ["--kind", "failure", *self.context_args()]
+        )
+        args.allowed_guild_id = "99999"
+        self.assertIn("not allowlisted", notify.validate_discord_context(args))
+
+    def test_context_requires_an_allowlisted_channel(self):
+        args = notify.parse_args(
+            ["--kind", "failure", *self.context_args()]
+        )
+        args.channel_id = "77777"
+        self.assertIn("not allowlisted", notify.validate_discord_context(args))
+
+    def test_payload_replies_and_mentions_only_the_requester(self):
+        payload = payload_for(
+            "failure", sample_plan(), guild_id="11111", channel_id="22222",
+            requester_id="33333", message_id="44444",
+        )
+        self.assertEqual(payload["content"], "<@33333>")
+        self.assertEqual(payload["allowed_mentions"], {
+            "parse": [], "users": ["33333"],
+        })
+        self.assertEqual(payload["message_reference"]["message_id"], "44444")
+
+    def test_bot_api_posts_to_the_validated_channel(self):
+        response = mock.MagicMock()
+        response.status = 200
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+
+        with mock.patch.object(notify.urllib.request, "urlopen",
+                               return_value=response) as urlopen:
+            notify.post_bot_message(
+                "secret-token", "22222", {"content": "<@33333>"}, 5.0,
+            )
+
+        request = urlopen.call_args.args[0]
+        self.assertEqual(
+            request.full_url,
+            "https://discord.com/api/v10/channels/22222/messages",
+        )
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(request.get_header("Authorization"),
+                         "Bot secret-token")
+
+    def test_partial_discord_context_is_rejected(self):
+        args = notify.parse_args([
+            "--kind", "failure", "--guild-id", "11111",
+        ])
+        self.assertIn("missing or invalid", notify.validate_discord_context(args))
 
 
 if __name__ == "__main__":

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -1,6 +1,6 @@
 # `/build-pr` — combined PR test builds from Discord
 
-Lets approved Discord testers request a public Windows test build that
+Lets Discord users request a public Windows test build that
 combines one or more **open** pull requests (including stacked PRs) without
 merging anything, e.g.:
 
@@ -24,7 +24,7 @@ GitHub **Actions tab → PR Test Build → Run workflow** with `prs: 47,48,49,65
    ▼
 Cloudflare Worker (this directory)
    • verifies the Discord Ed25519 signature
-   • checks channel + tester role
+   • checks the configured channel
    • validates numbers, rejects closed/merged PRs with reasons
    • pins the exact head SHA of every PR
    • shows the merge plan with Build / Cancel buttons
@@ -38,8 +38,8 @@ GitHub Actions: pr-test-build.yml
    • publish (trusted)   fresh runner re-verifies the bundle, re-checks every
                          PR is still open and unchanged, publishes the
                          temporary pr-test-<digest> prerelease
-   • notify  (trusted)   posts the download link / conflict report / failure
-                         to the existing Discord webhook
+   • notify  (trusted)   replies in the requesting channel and mentions only
+                         the requester
    ▼
 pr-test-cleanup.yml deletes the release after 7 days
 or when every included PR is closed.
@@ -73,16 +73,15 @@ fine), and repo admin on GitHub.
    → name it e.g. `Frostguard Test Builds`.
 2. On **General Information**, note the **Application ID** and the
    **Public Key**.
-3. On **Bot**, click **Reset Token** and note the **Bot Token** (needed only
-   for command registration, not by the worker).
-4. On **Installation**, pick *Guild Install*; under OAuth2 scopes the bot
-   needs only `applications.commands`. Install it to your server via the
-   generated link.
+3. On **Bot**, click **Reset Token** and note the **Bot Token** (needed for
+   command registration and the trusted workflow notification job).
+4. On **Installation**, pick *Guild Install*. Enable the `applications.commands`
+   and `bot` scopes. Grant only **View Channels**, **Send Messages** and
+   **Read Message History**, then install it through the generated link.
 
-> A webhook alone is not enough for slash commands: webhooks can only *post*
-> messages. Slash commands need an application with an **interactions
-> endpoint**, which is what this worker provides. Your existing
-> `DISCORD_NIGHTLY_WEBHOOK_URL` webhook is still used — for posting results.
+> A webhook alone is not enough for this flow. Slash commands need an
+> application with an **interactions endpoint**, and the final result uses the
+> same bot identity so it can reply to the original status message.
 
 ### 2. Create the fine-grained GitHub token for the worker
 
@@ -99,7 +98,7 @@ This token cannot push, merge or create releases even if leaked.
 
 ```bash
 cd discord-bot
-# Fill DISCORD_APPLICATION_ID (and optionally the channel/role IDs) in
+# Fill DISCORD_APPLICATION_ID (and optionally the channel IDs) in
 # wrangler.toml, then:
 npx wrangler deploy
 npx wrangler secret put DISCORD_PUBLIC_KEY   # from step 1.2
@@ -126,23 +125,23 @@ DISCORD_GUILD_ID=<your server id> node register-command.mjs
 With `DISCORD_GUILD_ID` the command appears instantly; without it Discord
 takes up to an hour to propagate it globally.
 
-### 6. Restrict who can use it
+### 6. Configure result routing
 
-Two independent layers; use either or both:
+Configure the channel in both systems so the workflow can validate the worker's
+Discord context again before it uses the bot token:
 
-- **Worker config** (`wrangler.toml`): set `ALLOWED_CHANNEL_IDS` and/or
-  `ALLOWED_ROLE_IDS` (enable Developer Mode in Discord, right-click a
-  channel/role → Copy ID), then `npx wrangler deploy` again.
-- **Discord UI**: Server Settings → Integrations → your app → `/build-pr` →
-  limit to specific roles/channels.
+- **Worker config** (`wrangler.toml`): set `ALLOWED_CHANNEL_IDS`, then deploy.
+- **GitHub secret**: `DISCORD_BOT_TOKEN`.
+- **GitHub variable**: `DISCORD_PR_BUILD_GUILD_ID`.
+- **GitHub variable**: `DISCORD_PR_BUILD_CHANNEL_IDS` (CSV).
 
 ### 7. Verify end-to-end
 
 1. In the allowed channel run `/build-pr prs: <an open PR number>`.
 2. Check the plan shows the pinned SHA, press **Build**.
 3. Watch the run under Actions → *PR Test Build*.
-4. The result message (or conflict report) arrives via the existing
-   nightly webhook.
+4. The result arrives as a reply to the original status message and mentions
+   only the requester.
 
 ## Configuration reference
 
@@ -151,11 +150,12 @@ Two independent layers; use either or both:
 | `wrangler.toml` | `GITHUB_REPO` | repo whose PRs are built |
 | `wrangler.toml` | `DISCORD_APPLICATION_ID` | application (client) ID |
 | `wrangler.toml` | `ALLOWED_CHANNEL_IDS` | CSV channel allowlist (empty = all) |
-| `wrangler.toml` | `ALLOWED_ROLE_IDS` | CSV role allowlist (empty = all) |
 | `wrangler.toml` | `COOLDOWN_MINUTES` | flood-control gap between builds |
 | worker secret | `DISCORD_PUBLIC_KEY` | interaction signature verification |
 | worker secret | `GITHUB_TOKEN` | fine-grained dispatch-only token |
-| repo secret | `DISCORD_NIGHTLY_WEBHOOK_URL` | already configured; reused for results |
+| repo secret | `DISCORD_BOT_TOKEN` | bot token used only by the trusted notify job |
+| repo variable | `DISCORD_PR_BUILD_GUILD_ID` | allowed server ID |
+| repo variable | `DISCORD_PR_BUILD_CHANNEL_IDS` | allowed result channel IDs (CSV) |
 
 ## Tests
 

--- a/discord-bot/test_worker.mjs
+++ b/discord-bot/test_worker.mjs
@@ -111,19 +111,13 @@ test("parses valid hex and rejects everything else", () => {
 // --- accessError -------------------------------------------------------------
 
 test("wrong channel is refused when channels are configured", () => {
-  const env = { ALLOWED_CHANNEL_IDS: "111,222", ALLOWED_ROLE_IDS: "" };
+  const env = { ALLOWED_CHANNEL_IDS: "111,222" };
   assert.ok(accessError(env, { channel_id: "333", member: { roles: [] } }));
   assert.equal(accessError(env, { channel_id: "222", member: { roles: [] } }), "");
 });
 
-test("missing role is refused when roles are configured", () => {
-  const env = { ALLOWED_CHANNEL_IDS: "", ALLOWED_ROLE_IDS: "rrr" };
-  assert.ok(accessError(env, { channel_id: "1", member: { roles: ["other"] } }));
-  assert.equal(accessError(env, { channel_id: "1", member: { roles: ["rrr"] } }), "");
-});
-
 test("no configuration means open access", () => {
-  const env = { ALLOWED_CHANNEL_IDS: "", ALLOWED_ROLE_IDS: "" };
+  const env = { ALLOWED_CHANNEL_IDS: "" };
   assert.equal(accessError(env, { channel_id: "1", member: { roles: [] } }), "");
 });
 

--- a/discord-bot/worker.js
+++ b/discord-bot/worker.js
@@ -19,7 +19,7 @@
  *   key, so nobody can forge build requests by POSTing to the worker URL.
  *
  * Guardrails:
- * - Requests are limited to configured channels and roles.
+ * - Requests are limited to configured channels.
  * - PR numbers are deduplicated; non-numeric, closed and merged entries are
  *   rejected with a per-entry explanation.
  * - Head SHAs are pinned at confirmation time and passed to the workflow,
@@ -179,7 +179,7 @@ async function checkCooldownAndConcurrency(env) {
   return "";
 }
 
-async function dispatchWorkflow(env, { prs, order, pinned, requester }) {
+async function dispatchWorkflow(env, { prs, order, pinned, requester, discordContext }) {
   const response = await fetch(
     `https://api.github.com/repos/${env.GITHUB_REPO}/actions/workflows/pr-test-build.yml/dispatches`,
     {
@@ -187,7 +187,17 @@ async function dispatchWorkflow(env, { prs, order, pinned, requester }) {
       headers: { ...githubHeaders(env), "Content-Type": "application/json" },
       body: JSON.stringify({
         ref: env.GITHUB_DEFAULT_BRANCH || "main",
-        inputs: { prs, order, pinned, requester },
+        inputs: {
+          prs,
+          order,
+          pinned,
+          requester,
+          discord_guild_id: discordContext.guildId,
+          discord_channel_id: discordContext.channelId,
+          discord_requester_id: discordContext.requesterId,
+          discord_message_id: discordContext.messageId,
+          discord_request_id: discordContext.requestId,
+        },
       }),
     },
   );
@@ -257,13 +267,6 @@ export function accessError(env, interaction) {
   const channels = csv(env.ALLOWED_CHANNEL_IDS);
   if (channels.length && !channels.includes(String(interaction.channel_id))) {
     return "`/build-pr` only works in the designated test-build channel.";
-  }
-  const roles = csv(env.ALLOWED_ROLE_IDS);
-  if (roles.length) {
-    const memberRoles = (interaction.member && interaction.member.roles) || [];
-    if (!memberRoles.some((r) => roles.includes(String(r)))) {
-      return "You need the tester role to request test builds. Ask a moderator.";
-    }
   }
   return "";
 }
@@ -420,6 +423,13 @@ async function handleButton(env, interaction) {
       order: state.order.join(","),
       pinned,
       requester: `${requester.name} (Discord)`,
+      discordContext: {
+        guildId: String(interaction.guild_id || ""),
+        channelId: String(interaction.channel_id || ""),
+        requesterId: requester.id,
+        messageId: String(message.id || ""),
+        requestId: String(interaction.id || ""),
+      },
     });
   } catch (error) {
     return ephemeralReply(`Could not start the build: ${String(error.message).slice(0, 300)}`);
@@ -435,8 +445,7 @@ async function handleButton(env, interaction) {
           `Building PRs ${state.order.map((n) => `#${n}`).join(", ")} with pinned heads.`,
           "",
           "The result (download link, conflict report or failure) will be",
-          "posted in this channel when the workflow finishes — typically",
-          "30–45 minutes. Progress: " +
+          "posted as a reply here when the workflow finishes. Progress: " +
           `<https://github.com/${env.GITHUB_REPO}/actions/workflows/pr-test-build.yml>`,
         ].join("\n"),
         footer: undefined,

--- a/discord-bot/wrangler.toml
+++ b/discord-bot/wrangler.toml
@@ -20,9 +20,6 @@ GITHUB_DEFAULT_BRANCH = "main"
 DISCORD_APPLICATION_ID = "1532693190879215767"
 # Comma-separated Discord channel IDs where /build-pr is allowed.
 # Empty = every channel the command is visible in.
-ALLOWED_CHANNEL_IDS = ""
-# Comma-separated Discord role IDs allowed to request builds.
-# Empty = everyone in the allowed channels.
-ALLOWED_ROLE_IDS = ""
+ALLOWED_CHANNEL_IDS = "1490710978805895298"
 # Minutes to wait between test builds (flood control).
 COOLDOWN_MINUTES = "10"

--- a/setup/github-workflows/pr-test-build.yml
+++ b/setup/github-workflows/pr-test-build.yml
@@ -51,6 +51,31 @@ on:
         required: false
         type: string
         default: ""
+      discord_guild_id:
+        description: "Discord guild that originated the request (empty for manual runs)"
+        required: false
+        type: string
+        default: ""
+      discord_channel_id:
+        description: "Discord channel that originated the request"
+        required: false
+        type: string
+        default: ""
+      discord_requester_id:
+        description: "Discord user to notify when the build finishes"
+        required: false
+        type: string
+        default: ""
+      discord_message_id:
+        description: "Original /build-pr status message to reply to"
+        required: false
+        type: string
+        default: ""
+      discord_request_id:
+        description: "Unique Discord interaction ID for traceability"
+        required: false
+        type: string
+        default: ""
 
 # One combined build at a time. Queuing instead of cancelling means a burst of
 # requests degrades to a slow queue, not to lost builds.
@@ -452,9 +477,16 @@ jobs:
           name: pr-test-plan
           path: ${{ runner.temp }}/plan
 
-      - name: Post the status message
+      - name: Reply with the final status in the requesting Discord channel
         env:
-          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_ALLOWED_GUILD_ID: ${{ vars.DISCORD_PR_BUILD_GUILD_ID }}
+          DISCORD_ALLOWED_CHANNEL_IDS: ${{ vars.DISCORD_PR_BUILD_CHANNEL_IDS }}
+          DISCORD_GUILD_ID: ${{ inputs.discord_guild_id }}
+          DISCORD_CHANNEL_ID: ${{ inputs.discord_channel_id }}
+          DISCORD_REQUESTER_ID: ${{ inputs.discord_requester_id }}
+          DISCORD_MESSAGE_ID: ${{ inputs.discord_message_id }}
+          DISCORD_REQUEST_ID: ${{ inputs.discord_request_id }}
           PLAN_OK: ${{ needs.plan.outputs.ok }}
           REUSE_URL: ${{ needs.plan.outputs.reuse_url }}
           BUILD_RESULT: ${{ needs.build.result }}
@@ -502,6 +534,13 @@ jobs:
 
           args=(--kind "${kind}" --run-url "${RUN_URL}"
                 --requester "${REQUESTER}" --requested "${REQUESTED}")
+          args+=(--guild-id "${DISCORD_GUILD_ID}"
+                 --channel-id "${DISCORD_CHANNEL_ID}"
+                 --requester-id "${DISCORD_REQUESTER_ID}"
+                 --message-id "${DISCORD_MESSAGE_ID}"
+                 --request-id "${DISCORD_REQUEST_ID}"
+                 --allowed-guild-id "${DISCORD_ALLOWED_GUILD_ID}"
+                 --allowed-channel-ids "${DISCORD_ALLOWED_CHANNEL_IDS}")
           if [[ -f "${plan_path}" ]]; then
             args+=(--plan "${plan_path}")
           else


### PR DESCRIPTION
## Summary

- pass the originating Discord guild, channel, requester and status-message IDs into the PR test workflow
- reply through the FrostGuard bot in the requesting channel and mention only the requester
- remove PR test results from the nightly/release webhook and remove the optional role gate
- validate destination IDs against configured GitHub variables before using the bot token

## Why

`/build-pr` currently starts in the bot channel but completes in `#releases`, mixing temporary unmerged builds with regular downloads and failing to notify the requester. This completes issue #74 while preserving manual workflow dispatches without Discord notifications.

## Validation

- `node discord-bot/test_worker.mjs` — 11 passed
- `python3 ci/test_pr_build_plan.py` — 31 passed
- `python3 ci/test_pr_test_notify.py` — 28 passed
- `python3 ci/check_workflow_python.py` — all snippets compile
- `actionlint` — no new findings
- no live Discord end-to-end test yet

## Risks

Live activation requires the Discord bot to be installed, `DISCORD_BOT_TOKEN` to be configured, and the Cloudflare Worker to be redeployed.

Closes #74.