### PR TITLE
fix(packaging): add a stable Windows launcher

### DIFF
--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -12,6 +12,7 @@ on:
       - "custom_tasks/**"
       - "ci/**"
       - "fg-watcher.bat"
+      - "Start Frostguard.bat"
       - ".gitattributes"
       - ".github/workflows/daily-windows-bundle.yml"
   schedule:
@@ -227,7 +228,8 @@ jobs:
             "Built from \`${GITHUB_SHA}\` on $(date -u '+%Y-%m-%d %H:%M UTC')." \
             "Verified: bundle structure, manifest classpath and launch smoke test." \
             "" \
-            "**Install:** unzip anywhere, then run \`java -jar frostguard-*.jar\`" \
+            "**Install:** extract the complete ZIP, then double-click" \
+            "\`Start Frostguard.bat\`" \
             "(Java 21+ required)." \
             "" \
             "This tag is replaced by every nightly build; it is not a stable release.")"

--- a/README.md
+++ b/README.md
@@ -203,25 +203,19 @@
 
 ## 🛠️ Installation & Setup
 
-> [!NOTE]
-> Follow these steps to compile and run the bot from source code.
-
-<br/>
-
 ### ⚡ Prefer a ready-made build?
 
-A Windows desktop bundle is built automatically every night and after every pull
-request, so you can test the latest code without installing Java or Maven.
+A verified Windows desktop bundle is built automatically every night. It does
+not require Maven or a Git checkout, but Java 21 or newer must be installed.
 
-1. Open the **[Actions tab](../../actions/workflows/daily-windows-bundle.yml)**
-2. Click the most recent green **Daily Windows Bundle** run
-3. Download the **`frostguard-windows-desktop-bundle-<version>`** artifact
-4. Extract it anywhere and run `frostguard-<version>.jar`
+1. **[Download the latest daily Windows bundle](https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip)**
+2. Extract the complete ZIP into an empty folder.
+3. Double-click **`Start Frostguard.bat`**.
 
 > [!IMPORTANT]
-> GitHub requires you to be **signed in** to download workflow artifacts, and
-> they are retained for **14 days**. Every bundle is verified in CI (structure,
-> classpath, and a real launch smoke test) before it is published.
+> Daily builds contain the latest development changes and may be less stable.
+> The public download needs no GitHub sign-in. Every bundle is checked for its
+> structure, classpath and basic startup behavior before publication.
 
 <br/>
 
@@ -263,15 +257,16 @@ request, so you can test the latest code without installing Java or Maven.
 
 ```sh
 # Clone the repository
-git clone https://github.com/Shederator/frostguard.git
-cd frostguard
+git clone https://github.com/Shederator/wosbot.git
+cd wosbot
 
 # Build the project
 mvn clean install package
 ```
 
 > [!TIP]
-> Once completed, the compiled `.jar` file will be in the `fg-app/target` directory (e.g., `frostguard-1.7.1.jar`).
+> The build produces `fg-app/target/frostguard-<version>.jar` and a complete
+> `fg-app/target/frostguard-<version>-desktop-bundle.zip`.
 
 <br/>
 
@@ -313,8 +308,8 @@ ci/smoke_test_bundle.sh fg-app/target/frostguard-*-desktop-bundle.zip
 # Navigate to the target directory
 cd fg-app/target
 
-# Run the compiled jar
-java -jar frostguard-1.7.1.jar
+# Run the compiled JAR; replace <version> with the version from pom.xml
+java -jar frostguard-<version>.jar
 ```
 
 > [!IMPORTANT]

--- a/Start Frostguard.bat
+++ b/Start Frostguard.bat
@@ -1,0 +1,55 @@
+@echo off
+setlocal EnableExtensions
+cd /d "%~dp0"
+
+where java >nul 2>&1
+if errorlevel 1 (
+    echo [ERROR] Java was not found.
+    echo.
+    echo Frostguard requires Java 21 or newer.
+    echo Download Temurin from: https://adoptium.net/temurin/releases/?version=21
+    goto :failed
+)
+
+set "JAVA_VERSION="
+set "JAVA_MAJOR="
+for /f "tokens=3" %%V in ('java -version 2^>^&1 ^| findstr /i "version"') do if not defined JAVA_VERSION set "JAVA_VERSION=%%~V"
+for /f "tokens=1 delims=." %%V in ("%JAVA_VERSION%") do set "JAVA_MAJOR=%%V"
+
+if not defined JAVA_MAJOR (
+    echo [ERROR] Could not determine the installed Java version.
+    goto :failed
+)
+set /a JAVA_MAJOR_NUMBER=JAVA_MAJOR >nul 2>&1
+if %JAVA_MAJOR_NUMBER% LSS 21 (
+    echo [ERROR] Java %JAVA_VERSION% is too old. Frostguard requires Java 21 or newer.
+    echo Download Temurin from: https://adoptium.net/temurin/releases/?version=21
+    goto :failed
+)
+
+set "APP_JAR="
+set "APP_JAR_COUNT=0"
+for %%F in ("frostguard-*.jar") do if exist "%%~fF" (
+    set /a APP_JAR_COUNT+=1
+    set "APP_JAR=%%~fF"
+)
+
+if %APP_JAR_COUNT% EQU 0 (
+    echo [ERROR] No frostguard-*.jar was found next to this launcher.
+    echo Extract the complete desktop bundle before starting Frostguard.
+    goto :failed
+)
+if %APP_JAR_COUNT% GTR 1 (
+    echo [ERROR] Multiple frostguard-*.jar files were found.
+    echo Remove old versions or extract the bundle into an empty folder.
+    goto :failed
+)
+
+echo Starting Frostguard with Java %JAVA_VERSION%...
+java --enable-native-access=ALL-UNNAMED -jar "%APP_JAR%" %*
+exit /b %errorlevel%
+
+:failed
+echo.
+pause
+exit /b 1

--- a/ci/discord_notify.py
+++ b/ci/discord_notify.py
@@ -166,8 +166,8 @@ def build_payload(args: argparse.Namespace) -> dict:
             # support question.
             description_parts.append(
                 "Verified: bundle structure, manifest classpath and launch "
-                "smoke test. Unzip anywhere, then run "
-                "`java -jar frostguard-*.jar` (Java 21+ required)."
+                "smoke test. Extract the complete ZIP, then double-click "
+                "`Start Frostguard.bat` (Java 21+ required)."
             )
         elif args.run_url:
             description_parts.append(

--- a/ci/test_verify_bundle.py
+++ b/ci/test_verify_bundle.py
@@ -38,6 +38,7 @@ RUNTIME_JARS = (
 )
 
 OTHER_FILES = [
+    "Start Frostguard.bat",
     "fg-watcher.bat",
     f"fg-watcher-{VERSION}.jar",
     "lib/adb/adb.exe",
@@ -146,6 +147,10 @@ class VerifyBundleTest(unittest.TestCase):
 
     def test_rejects_bundle_without_the_watcher_launcher(self):
         files = [f for f in OTHER_FILES if f != "fg-watcher.bat"]
+        self.assertEqual(1, run(build_bundle(other_files=files)))
+
+    def test_rejects_bundle_without_the_app_launcher(self):
+        files = [f for f in OTHER_FILES if f != "Start Frostguard.bat"]
         self.assertEqual(1, run(build_bundle(other_files=files)))
 
     def test_rejects_empty_templates_directory(self):

--- a/ci/verify_bundle.py
+++ b/ci/verify_bundle.py
@@ -32,6 +32,7 @@ MINIMUM_RUNTIME_JARS = 50
 
 # Exact entries that must be present at these exact paths.
 REQUIRED_FILES = [
+    "Start Frostguard.bat",
     "fg-watcher.bat",
     "lib/adb/adb.exe",
     "lib/adb/AdbWinApi.dll",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,11 +84,21 @@ On Windows, the helper script performs the same build with one retry for transie
 fg-build.bat
 ```
 
-Build outputs are written under `fg-app/target`, including `frostguard-<version>.jar` and the desktop bundle ZIP.
+Build outputs are written under `fg-app/target`, including
+`frostguard-<version>.jar` and the desktop bundle ZIP. End users should extract
+the ZIP and launch `Start Frostguard.bat`; the `target` path is only for source
+builds.
 
 ## Run
 
-From the repository root:
+For a downloaded desktop bundle, extract the complete ZIP into an empty folder
+and double-click:
+
+```text
+Start Frostguard.bat
+```
+
+For a source build, run from the repository root:
 
 ```sh
 java -jar fg-app/target/frostguard-<version>.jar

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -56,7 +56,11 @@ The application currently packages Windows ADB and Tesseract assets from `tools/
 
 ## Starting Frostguard
 
-From the repository root:
+After downloading a desktop bundle, extract the complete ZIP into an empty
+folder and double-click `Start Frostguard.bat`. The launcher locates the
+versioned application JAR and reports a clear error if Java 21 is missing.
+
+For a source build, run from the repository root:
 
 ```powershell
 java -jar fg-app\target\frostguard-<version>.jar

--- a/fg-app/src/main/assembly/zip.xml
+++ b/fg-app/src/main/assembly/zip.xml
@@ -6,6 +6,7 @@
         <file><source>${project.parent.basedir}/README.md</source><outputDirectory>docs</outputDirectory><destName>README.md</destName><filtered>false</filtered></file>
         <file><source>${project.parent.basedir}/PRIVACY.md</source><outputDirectory>docs</outputDirectory><destName>PRIVACY.md</destName><filtered>false</filtered></file>
         <file><source>${project.parent.basedir}/fg-watcher.bat</source><outputDirectory>.</outputDirectory><destName>fg-watcher.bat</destName><filtered>false</filtered></file>
+        <file><source>${project.parent.basedir}/Start Frostguard.bat</source><outputDirectory>.</outputDirectory><destName>Start Frostguard.bat</destName><filtered>false</filtered></file>
     </files>
     <fileSets>
         <fileSet><directory>${project.build.directory}</directory><outputDirectory>.</outputDirectory><useDefaultExcludes>true</useDefaultExcludes><fileMode>0644</fileMode><directoryMode>0755</directoryMode><includes><include>frostguard-*.jar</include></includes></fileSet>

--- a/setup/github-workflows/daily-windows-bundle.yml
+++ b/setup/github-workflows/daily-windows-bundle.yml
@@ -12,6 +12,7 @@ on:
       - "custom_tasks/**"
       - "ci/**"
       - "fg-watcher.bat"
+      - "Start Frostguard.bat"
       - ".gitattributes"
       - ".github/workflows/daily-windows-bundle.yml"
   schedule:
@@ -227,7 +228,8 @@ jobs:
             "Built from \`${GITHUB_SHA}\` on $(date -u '+%Y-%m-%d %H:%M UTC')." \
             "Verified: bundle structure, manifest classpath and launch smoke test." \
             "" \
-            "**Install:** unzip anywhere, then run \`java -jar frostguard-*.jar\`" \
+            "**Install:** extract the complete ZIP, then double-click" \
+            "\`Start Frostguard.bat\`" \
             "(Java 21+ required)." \
             "" \
             "This tag is replaced by every nightly build; it is not a stable release.")"


### PR DESCRIPTION
## Summary

- add `Start Frostguard.bat` to every desktop bundle
- locate the versioned application JAR automatically and require Java 21+
- make bundle verification fail when the launcher is missing
- update Nightly instructions and separate downloaded-bundle use from source builds
- remove stale `1.7.1` examples and correct the clone URL

## Why

Users currently receive different-looking launch instructions depending on whether they build from source or download the Daily bundle. A stable launcher filename removes version-specific commands and gives actionable Java/JAR errors.

## Validation

- `python3 ci/test_verify_bundle.py` — 15 passed
- `python3 ci/test_discord_notify.py` — 22 passed
- Windows-classified clean package built successfully
- real ZIP verification passed: 521 entries, 76 runtime JARs, all manifest entries present
- launcher presence and command verified inside the generated ZIP
- `actionlint` — no new findings
- full Maven tests reached 72 engine tests; one existing OCR test errored because local macOS `libtesseract.dylib` is unavailable

## Risks

The batch launcher has been structurally verified inside a Windows bundle but has not yet been double-clicked on a real Windows host.