### PR TITLE
feat(releases): publish verified stable Windows builds

### DIFF
--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -278,14 +278,15 @@ jobs:
           echo "download_url=${url}" >> "${GITHUB_OUTPUT}"
           echo "Published and verified ${asset} at ${url} (HTTP ${code})"
 
-      # Runs even when the build failed, so a broken nightly is visible in the
-      # channel instead of being silently absent. `continue-on-error` keeps a
-      # Discord outage from turning a good build red.
-      - name: Notify Discord
-        if: always() && github.event_name != 'pull_request'
+      # Keep one maintained Daily message instead of adding one post per run.
+      # Failures remain visible in Actions and never overwrite the last working
+      # public download.
+      - name: Update the Daily Discord message
+        if: success() && github.event_name != 'pull_request'
         continue-on-error: true
         env:
           DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          DISCORD_DAILY_MESSAGE_ID: ${{ vars.DISCORD_DAILY_MESSAGE_ID }}
           # A commit message is attacker-controlled text. Interpolating it
           # straight into the `run:` block would let `$(...)` or a backtick in a
           # commit subject execute on the runner, with the webhook secret in
@@ -325,4 +326,5 @@ jobs:
             --trigger "${GITHUB_EVENT_NAME}" \
             --commit "${GITHUB_SHA}" \
             --commit-message "${COMMIT_MESSAGE}" \
-            --actor "${GITHUB_ACTOR}"
+            --actor "${GITHUB_ACTOR}" \
+            --message-id "${DISCORD_DAILY_MESSAGE_ID}"

--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -1,0 +1,164 @@
+name: Stable Windows Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Stable version in X.Y.Z format (must match pom.xml)"
+        required: true
+        type: string
+      daily_run_id:
+        description: "Successful Daily Windows Bundle run ID from main"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: stable-windows-release
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Verify and publish the stable Windows release
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Validate the selected daily run
+        id: source
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ inputs.daily_run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${RUN_ID}" =~ ^[0-9]+$ ]]; then
+            echo "::error::daily_run_id must be numeric."
+            exit 1
+          fi
+          run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}")"
+          conclusion="$(jq -r '.conclusion' <<< "${run}")"
+          branch="$(jq -r '.head_branch' <<< "${run}")"
+          event="$(jq -r '.event' <<< "${run}")"
+          workflow="$(jq -r '.path' <<< "${run}")"
+          sha="$(jq -r '.head_sha' <<< "${run}")"
+          if [[ "${conclusion}" != "success" || "${branch}" != "main" ]]; then
+            echo "::error::Selected run must be successful and built from main."
+            exit 1
+          fi
+          if [[ "${event}" != "schedule" && "${event}" != "workflow_dispatch" ]]; then
+            echo "::error::Selected run must be a scheduled or manual daily build."
+            exit 1
+          fi
+          if [[ "${workflow}" != ".github/workflows/daily-windows-bundle.yml" ]]; then
+            echo "::error::Selected run does not belong to Daily Windows Bundle."
+            exit 1
+          fi
+          echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check out the exact verified commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.source.outputs.sha }}
+          lfs: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Validate version and notification code
+        env:
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must use X.Y.Z format."
+            exit 1
+          fi
+          project_version="$(mvn -B --no-transfer-progress -q help:evaluate -Dexpression=project.version -DforceStdout)"
+          if [[ "${VERSION}" != "${project_version}" ]]; then
+            echo "::error::Requested ${VERSION}, but pom.xml declares ${project_version}."
+            exit 1
+          fi
+          python3 ci/test_verify_bundle.py
+          python3 ci/test_stable_release_notify.py
+
+      - name: Download the selected daily artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ inputs.daily_run_id }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh run download "${RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name "frostguard-windows-desktop-bundle-${VERSION}" \
+            --dir "${RUNNER_TEMP}/stable"
+
+      - name: Locate and re-verify the bundle
+        id: bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          path="$(find "${RUNNER_TEMP}/stable" -type f -name '*-desktop-bundle.zip' | head -n 1)"
+          if [[ -z "${path}" ]]; then
+            echo "::error::The selected run has no desktop bundle artifact."
+            exit 1
+          fi
+          python3 ci/verify_bundle.py "${path}" --platform win
+          ci/smoke_test_bundle.sh "${path}"
+          echo "path=${path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish immutable stable release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          ZIP_PATH: ${{ steps.bundle.outputs.path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="v${VERSION}"
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            echo "::error::Stable release ${tag} already exists and will not be replaced."
+            exit 1
+          fi
+          asset="frostguard-windows-desktop-bundle.zip"
+          staged="${RUNNER_TEMP}/${asset}"
+          cp "${ZIP_PATH}" "${staged}"
+          gh release create "${tag}" "${staged}" \
+            --target "${SOURCE_SHA}" \
+            --title "Frostguard ${VERSION}" \
+            --generate-notes \
+            --latest
+          release_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${tag}"
+          download_url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
+            --jq ".assets[] | select(.name == \"${asset}\") | .browser_download_url")"
+          code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
+            --retry 3 --retry-delay 5 -r 0-1023 "${download_url}")"
+          if [[ "${code}" != "200" && "${code}" != "206" ]]; then
+            echo "::error::Published stable download returned HTTP ${code}."
+            exit 1
+          fi
+          echo "release_url=${release_url}" >> "${GITHUB_OUTPUT}"
+          echo "download_url=${download_url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Announce the stable release to everyone
+        env:
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          VERSION: ${{ inputs.version }}
+          DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
+          RELEASE_URL: ${{ steps.release.outputs.release_url }}
+        run: |
+          python3 ci/stable_release_notify.py \
+            --version "${VERSION}" \
+            --download-url "${DOWNLOAD_URL}" \
+            --release-url "${RELEASE_URL}"

--- a/ci/README.md
+++ b/ci/README.md
@@ -162,6 +162,24 @@ substitution really took effect in both directions.
   ci/smoke_test_bundle.sh fg-app/target/frostguard-*-desktop-bundle.zip
   ```
 
+## Stable Windows releases
+
+[`stable-windows-release.yml`](../.github/workflows/stable-windows-release.yml)
+promotes a successful Daily Windows Bundle run from `main` instead of rebuilding
+a potentially different tree. A maintainer supplies the `X.Y.Z` version and
+daily run ID. The workflow validates the source run and Maven version, pins its
+commit, downloads and re-verifies its bundle, creates an immutable `vX.Y.Z`
+release and checks the public URL before announcing it.
+
+[`stable_release_notify.py`](stable_release_notify.py) is the only notification
+path allowed to mention `@everyone`. Its payload contains fixed release facts,
+not contributor-controlled PR titles or commit messages. Stable releases use
+the same `DISCORD_NIGHTLY_WEBHOOK_URL` credential but are announced only once;
+daily builds must not mass-mention users.
+
+Release policy and the `#downloads` channel templates live in
+[`docs/releases.md`](../docs/releases.md).
+
 ## Combined PR test builds (`/build-pr`)
 
 Testers can request a temporary Windows bundle that combines one or more

--- a/ci/discord_notify.py
+++ b/ci/discord_notify.py
@@ -253,14 +253,15 @@ def retry_after_seconds(error: urllib.error.HTTPError, body: str) -> float:
         return 5.0
 
 
-def post(webhook: str, body: bytes, content_type: str, timeout: float) -> None:
-    """POST with retries for rate limits and transient server errors."""
+def post(webhook: str, body: bytes, content_type: str, timeout: float,
+         method: str = "POST") -> None:
+    """Send a webhook request with retries for rate limits and transient errors."""
     last_error = "no attempt was made"
     for attempt in range(1, MAX_ATTEMPTS + 1):
         request = urllib.request.Request(
             webhook,
             data=body,
-            method="POST",
+            method=method,
             headers={
                 "Content-Type": content_type,
                 "User-Agent": "frostguard-ci/1.0 (+https://github.com/Shederator/wosbot)",
@@ -345,6 +346,11 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     )
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument(
+        "--message-id",
+        default="",
+        help="edit this existing webhook message instead of creating a new one",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="print the payload instead of posting it",
@@ -394,7 +400,19 @@ def main(argv: list[str] | None = None) -> int:
         body = json.dumps(payload).encode("utf-8")
         content_type = "application/json"
 
-    post(webhook, body, content_type, args.timeout)
+    destination = webhook
+    method = "POST"
+    if args.message_id:
+        if not args.message_id.isdigit():
+            print("::error::Discord message ID must be numeric.")
+            return 1
+        if args.attach:
+            print("::error::Attachments are not supported when editing a message.")
+            return 1
+        destination = f"{webhook.rstrip('/')}/messages/{args.message_id}"
+        method = "PATCH"
+
+    post(destination, body, content_type, args.timeout, method=method)
     return 0
 
 

--- a/ci/stable_release_notify.py
+++ b/ci/stable_release_notify.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Notify Discord once when a verified Frostguard stable release is published."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from discord_notify import post, truncate  # noqa: E402
+
+
+def build_payload(args: argparse.Namespace) -> dict:
+    description = (
+        f"**[Download Frostguard {args.version}]({args.download_url})**\n\n"
+        "This is the recommended stable Windows version. Extract the complete "
+        "ZIP and double-click `Start Frostguard.bat` (Java 21+ required).\n\n"
+        f"[Release notes]({args.release_url})"
+    )
+    return {
+        "content": "@everyone",
+        "username": "Frostguard Releases",
+        "embeds": [{
+            "title": f"Frostguard {args.version} is available",
+            "description": truncate(description, 4096),
+            "color": 0x2ECC71,
+        }],
+        # This workflow is the one intentional mass-notification path. No
+        # contributor-controlled text is included in content or mentions.
+        "allowed_mentions": {"parse": ["everyone"]},
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--download-url", required=True)
+    parser.add_argument("--release-url", required=True)
+    parser.add_argument("--webhook-env", default="DISCORD_NIGHTLY_WEBHOOK_URL")
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not re.fullmatch(r"\d+\.\d+\.\d+", args.version):
+        print("::error::Stable version must use X.Y.Z format.")
+        return 1
+    for label, value in (("download", args.download_url),
+                         ("release", args.release_url)):
+        if not value.startswith("https://github.com/"):
+            print(f"::error::Stable {label} URL must be a GitHub HTTPS URL.")
+            return 1
+
+    payload = build_payload(args)
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    webhook = os.environ.get(args.webhook_env, "").strip()
+    if not webhook:
+        print(f"::error::{args.webhook_env} is empty; stable announcement not sent.")
+        return 1
+    if not re.match(r"^https://(canary\.|ptb\.)?discord(app)?\.com/api/webhooks/", webhook):
+        print(f"::error::{args.webhook_env} is not a Discord webhook URL.")
+        return 1
+    post(webhook, json.dumps(payload).encode(), "application/json", args.timeout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/test_discord_notify.py
+++ b/ci/test_discord_notify.py
@@ -14,10 +14,12 @@ Run with:  python3 ci/test_discord_notify.py
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 import unittest
 import urllib.error
+from unittest import mock
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -154,6 +156,35 @@ class PayloadTest(unittest.TestCase):
 
 class WebhookHandlingTest(unittest.TestCase):
 
+    def test_existing_daily_message_uses_patch(self):
+        env_var = "FG_TEST_DAILY_WEBHOOK"
+        os.environ[env_var] = WEBHOOK
+        try:
+            with mock.patch.object(discord_notify, "post") as sender:
+                code = discord_notify.main(
+                    BASE_ARGS + ["--webhook-env", env_var, "--message-id",
+                                 "1490710978805895298"]
+                )
+        finally:
+            del os.environ[env_var]
+        self.assertEqual(0, code)
+        self.assertEqual(
+            f"{WEBHOOK}/messages/1490710978805895298",
+            sender.call_args.args[0],
+        )
+        self.assertEqual("PATCH", sender.call_args.kwargs["method"])
+
+    def test_rejects_non_numeric_daily_message_id(self):
+        env_var = "FG_TEST_DAILY_WEBHOOK"
+        os.environ[env_var] = WEBHOOK
+        try:
+            code = discord_notify.main(
+                BASE_ARGS + ["--webhook-env", env_var, "--message-id", "bad"]
+            )
+        finally:
+            del os.environ[env_var]
+        self.assertEqual(1, code)
+
     def test_missing_secret_warns_but_does_not_fail_the_build(self):
         # A build that produced a good artifact must not be marked failed just
         # because the channel notification could not be addressed.
@@ -161,7 +192,6 @@ class WebhookHandlingTest(unittest.TestCase):
         self.assertEqual(0, code)
 
     def test_rejects_a_secret_that_is_not_a_discord_webhook(self):
-        import os
         os.environ["FG_TEST_WEBHOOK"] = "https://example.com/not-a-webhook"
         try:
             code = discord_notify.main(

--- a/ci/test_stable_release_notify.py
+++ b/ci/test_stable_release_notify.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+
+import stable_release_notify as notify
+
+
+class StablePayloadTest(unittest.TestCase):
+    def args(self):
+        return notify.parse_args([
+            "--version", "2.1.0",
+            "--download-url", "https://github.com/Shederator/wosbot/releases/download/v2.1.0/frostguard-windows-desktop-bundle.zip",
+            "--release-url", "https://github.com/Shederator/wosbot/releases/tag/v2.1.0",
+            "--dry-run",
+        ])
+
+    def test_mentions_everyone_explicitly(self):
+        payload = notify.build_payload(self.args())
+        self.assertEqual(payload["content"], "@everyone")
+        self.assertEqual(payload["allowed_mentions"], {"parse": ["everyone"]})
+
+    def test_contains_only_stable_release_facts(self):
+        text = str(notify.build_payload(self.args()))
+        self.assertIn("2.1.0", text)
+        self.assertIn("Start Frostguard.bat", text)
+        self.assertNotIn("commit", text.lower())
+
+    def test_rejects_non_semantic_version(self):
+        argv = [
+            "--version", "nightly", "--download-url", "https://github.com/a",
+            "--release-url", "https://github.com/b", "--dry-run",
+        ]
+        self.assertEqual(1, notify.main(argv))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,70 @@
+# Releases
+
+Frostguard publishes three distinct Windows bundle types. Do not mix their
+notifications or download locations.
+
+| Type | Audience | Lifetime | Discord notification |
+|---|---|---|---|
+| Stable `vX.Y.Z` | Regular users | Permanent | Notify everyone once |
+| Daily `nightly` | Testers | Replaced daily | Update the daily download, no mass mention |
+| PR test `pr-test-*` | Requester/testers | Temporary | Reply only to the requester |
+
+## Stable promotion
+
+Stable releases promote an already successful `Daily Windows Bundle` run from
+`main`; they do not rebuild a different tree. Run **Stable Windows Release**
+manually with:
+
+- `version`: the `X.Y.Z` value declared in `pom.xml`;
+- `daily_run_id`: a successful scheduled or manually triggered daily run from
+  `main` after the intended release commit.
+
+The workflow pins the run's exact commit, downloads its versioned artifact,
+re-runs structural and launch verification, creates the immutable `vX.Y.Z`
+release, verifies its public download URL and then sends the one permitted
+`@everyone` release announcement. Existing stable tags are never replaced.
+
+## Discord `#downloads`
+
+Keep the channel read-only for regular users. It should contain two maintained
+messages rather than a chronological build log.
+
+### Stable message
+
+```text
+✅ Frostguard Stable — Recommended
+
+The latest tested Windows version for regular use.
+Download: <latest stable release URL>
+
+Install Java 21+, extract the complete ZIP, then double-click
+Start Frostguard.bat.
+```
+
+Replace this message only when a new stable release is published. The release
+workflow sends the one-time server notification separately.
+
+### Daily message
+
+```text
+🧪 Frostguard Daily — Latest Development Build
+
+Includes the newest changes from main and may be less stable.
+Download: https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip
+
+No GitHub login is required. Install Java 21+, extract the complete ZIP, then
+double-click Start Frostguard.bat.
+```
+
+The URL is deliberately version-independent. Do not post a new Discord message
+for every daily build. Build failures belong in a maintainer channel, not in
+`#downloads`.
+
+## Migration
+
+1. Create `#downloads` and post the Stable and Daily messages.
+2. Publish the first real stable release before calling it recommended.
+3. Point the nightly webhook away from the public downloads channel or change
+   it to edit the maintained Daily message.
+4. Move `/build-pr` results to `#request-a-build`.
+5. Archive `#release` and `#download` after their links have been replaced.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -57,8 +57,10 @@ double-click Start Frostguard.bat.
 ```
 
 The URL is deliberately version-independent. Do not post a new Discord message
-for every daily build. Build failures belong in a maintainer channel, not in
-`#downloads`.
+for every daily build. Store the webhook-owned message ID in the repository
+variable `DISCORD_DAILY_MESSAGE_ID`; successful builds edit that message.
+Build failures remain visible in Actions and do not replace the last working
+public download.
 
 ## Migration
 

--- a/setup/github-workflows/daily-windows-bundle.yml
+++ b/setup/github-workflows/daily-windows-bundle.yml
@@ -278,14 +278,15 @@ jobs:
           echo "download_url=${url}" >> "${GITHUB_OUTPUT}"
           echo "Published and verified ${asset} at ${url} (HTTP ${code})"
 
-      # Runs even when the build failed, so a broken nightly is visible in the
-      # channel instead of being silently absent. `continue-on-error` keeps a
-      # Discord outage from turning a good build red.
-      - name: Notify Discord
-        if: always() && github.event_name != 'pull_request'
+      # Keep one maintained Daily message instead of adding one post per run.
+      # Failures remain visible in Actions and never overwrite the last working
+      # public download.
+      - name: Update the Daily Discord message
+        if: success() && github.event_name != 'pull_request'
         continue-on-error: true
         env:
           DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          DISCORD_DAILY_MESSAGE_ID: ${{ vars.DISCORD_DAILY_MESSAGE_ID }}
           # A commit message is attacker-controlled text. Interpolating it
           # straight into the `run:` block would let `$(...)` or a backtick in a
           # commit subject execute on the runner, with the webhook secret in
@@ -325,4 +326,5 @@ jobs:
             --trigger "${GITHUB_EVENT_NAME}" \
             --commit "${GITHUB_SHA}" \
             --commit-message "${COMMIT_MESSAGE}" \
-            --actor "${GITHUB_ACTOR}"
+            --actor "${GITHUB_ACTOR}" \
+            --message-id "${DISCORD_DAILY_MESSAGE_ID}"


### PR DESCRIPTION
## What changed

- add a manual stable-release workflow that promotes a successful Daily Windows Bundle run
- verify the selected run, commit, bundle structure, launcher, and smoke test before publishing
- publish immutable `vX.Y.Z` GitHub releases with a fixed Windows bundle asset name
- notify `@everyone` once for stable releases through the existing Discord webhook
- keep the Daily Discord channel clean by updating one existing webhook message
- document the Stable, Daily, and requested PR-build model and migration steps

## Why

Users currently have to choose between an old Google Drive download and repetitive nightly messages. This creates one canonical stable download, one continuously updated Daily message, and a separate requested-build flow.

## Validation

- `python3 -m unittest ci.test_stable_release_notify` — 3 passed
- `python3 -m unittest ci.test_discord_notify` — 24 passed
- `actionlint` — no new workflow errors; existing shellcheck informational output remains
- both copies of the Daily workflow were compared and are identical

## Remaining rollout

After merge, point the existing Frostguard Builds webhook to `#download`. Run Daily once without `DISCORD_DAILY_MESSAGE_ID`, copy the created webhook message ID into that repository variable, then use the Stable workflow for the next release.