### PR TITLE
fix(releases): retry CDN propagation delays

### DIFF
--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -268,8 +268,11 @@ jobs:
 
           # Prove the link actually serves the file before it is advertised.
           # A release asset redirects to a signed CDN URL, so follow redirects.
+          # GitHub's release API can expose the asset before its CDN download
+          # route has propagated. Treat the initial 404 as retryable.
           code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
-            --retry 3 --retry-delay 5 -r 0-1023 "${url}")"
+            --fail --retry 12 --retry-delay 5 --retry-all-errors \
+            -r 0-1023 "${url}" || true)"
           if [[ "${code}" != "200" && "${code}" != "206" ]]; then
             echo "::error::Download URL ${url} returned HTTP ${code}."
             exit 1

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -414,8 +414,11 @@ jobs:
             echo "::error::Asset ${asset} is not attached to ${TAG}."
             exit 1
           fi
+          # GitHub's release API can expose the asset before its CDN download
+          # route has propagated. Treat the initial 404 as retryable.
           code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
-            --retry 3 --retry-delay 5 -r 0-1023 "${url}")"
+            --fail --retry 12 --retry-delay 5 --retry-all-errors \
+            -r 0-1023 "${url}" || true)"
           if [[ "${code}" != "200" && "${code}" != "206" ]]; then
             echo "::error::Download URL ${url} returned HTTP ${code}."
             exit 1

--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -142,8 +142,11 @@ jobs:
           release_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${tag}"
           download_url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
             --jq ".assets[] | select(.name == \"${asset}\") | .browser_download_url")"
+          # GitHub's release API can expose the asset before its CDN download
+          # route has propagated. Treat the initial 404 as retryable.
           code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
-            --retry 3 --retry-delay 5 -r 0-1023 "${download_url}")"
+            --fail --retry 12 --retry-delay 5 --retry-all-errors \
+            -r 0-1023 "${download_url}" || true)"
           if [[ "${code}" != "200" && "${code}" != "206" ]]; then
             echo "::error::Published stable download returned HTTP ${code}."
             exit 1

--- a/setup/github-workflows/daily-windows-bundle.yml
+++ b/setup/github-workflows/daily-windows-bundle.yml
@@ -268,8 +268,11 @@ jobs:
 
           # Prove the link actually serves the file before it is advertised.
           # A release asset redirects to a signed CDN URL, so follow redirects.
+          # GitHub's release API can expose the asset before its CDN download
+          # route has propagated. Treat the initial 404 as retryable.
           code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
-            --retry 3 --retry-delay 5 -r 0-1023 "${url}")"
+            --fail --retry 12 --retry-delay 5 --retry-all-errors \
+            -r 0-1023 "${url}" || true)"
           if [[ "${code}" != "200" && "${code}" != "206" ]]; then
             echo "::error::Download URL ${url} returned HTTP ${code}."
             exit 1

--- a/setup/github-workflows/pr-test-build.yml
+++ b/setup/github-workflows/pr-test-build.yml
@@ -414,8 +414,11 @@ jobs:
             echo "::error::Asset ${asset} is not attached to ${TAG}."
             exit 1
           fi
+          # GitHub's release API can expose the asset before its CDN download
+          # route has propagated. Treat the initial 404 as retryable.
           code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
-            --retry 3 --retry-delay 5 -r 0-1023 "${url}")"
+            --fail --retry 12 --retry-delay 5 --retry-all-errors \
+            -r 0-1023 "${url}" || true)"
           if [[ "${code}" != "200" && "${code}" != "206" ]]; then
             echo "::error::Download URL ${url} returned HTTP ${code}."
             exit 1


### PR DESCRIPTION
## What changed

- treat an initially unavailable GitHub release asset as retryable
- retry HTTP errors for up to roughly one minute before failing
- apply the same verification behavior to Daily, Stable, and requested PR releases
- keep installed workflow copies synchronized

## Why

Daily run `30751106426` successfully built, verified, smoke-tested, uploaded, and created the `nightly` release, but the public CDN route returned HTTP 404 immediately after creation. The existing curl retries did not retry HTTP 404 responses, so Discord notification was correctly skipped.

## Validation

- workflow source and setup copies are identical
- `git diff --check` passes
- `actionlint` reports only pre-existing informational Shellcheck findings outside this change

## Remaining verification

After merge, rerun Daily Windows Bundle on `main` and confirm the public download plus first Discord message.