### PR TITLE
feat(discord): simplify download announcements

### DIFF
--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           lfs: true
 
       # The Windows OpenCV .dll, adb.exe and the .traineddata OCR models are all
@@ -239,7 +240,18 @@ jobs:
           # leave the `nightly` tag pinned to the first commit it was ever cut
           # from while the notes claimed a newer SHA. --cleanup-tag removes the
           # tag too, so the recreated one points at this build.
+          previous_sha=""
           if gh release view nightly >/dev/null 2>&1; then
+            previous_sha="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
+              --jq '.target_commitish')"
+          fi
+          changes="$(python3 ci/nightly_changes.py \
+            --repository "${GITHUB_REPOSITORY}" \
+            --previous "${previous_sha}" \
+            --current "${GITHUB_SHA}")"
+
+          if [[ -n "${previous_sha}" ]]; then
             gh release delete nightly --yes --cleanup-tag
           fi
 
@@ -279,6 +291,11 @@ jobs:
           fi
 
           echo "download_url=${url}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "changes<<FROSTGUARD_CHANGES"
+            printf '%s\n' "${changes}"
+            echo "FROSTGUARD_CHANGES"
+          } >> "${GITHUB_OUTPUT}"
           echo "Published and verified ${asset} at ${url} (HTTP ${code})"
 
       # Keep one maintained Daily message instead of adding one post per run.
@@ -301,6 +318,7 @@ jobs:
           JAR_COUNT: ${{ steps.metrics.outputs.jar_count }}
           TEST_COUNT: ${{ steps.metrics.outputs.test_count }}
           DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
+          NIGHTLY_CHANGES: ${{ steps.release.outputs.changes }}
           VERSION: ${{ steps.version.outputs.version }}
         shell: bash
         run: |
@@ -330,4 +348,5 @@ jobs:
             --commit "${GITHUB_SHA}" \
             --commit-message "${COMMIT_MESSAGE}" \
             --actor "${GITHUB_ACTOR}" \
+            --changes "${NIGHTLY_CHANGES}" \
             --message-id "${DISCORD_DAILY_MESSAGE_ID}"

--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -151,8 +151,16 @@ jobs:
             echo "::error::Published stable download returned HTTP ${code}."
             exit 1
           fi
+          latest_download_url="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/${asset}"
+          latest_code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
+            --fail --retry 12 --retry-delay 5 --retry-all-errors \
+            -r 0-1023 "${latest_download_url}" || true)"
+          if [[ "${latest_code}" != "200" && "${latest_code}" != "206" ]]; then
+            echo "::error::Latest stable download returned HTTP ${latest_code}."
+            exit 1
+          fi
           echo "release_url=${release_url}" >> "${GITHUB_OUTPUT}"
-          echo "download_url=${download_url}" >> "${GITHUB_OUTPUT}"
+          echo "download_url=${latest_download_url}" >> "${GITHUB_OUTPUT}"
 
       - name: Announce the stable release to everyone
         env:

--- a/ci/discord_notify.py
+++ b/ci/discord_notify.py
@@ -3,10 +3,9 @@
 
 The nightly bundle is ~220 MB, far above Discord's per-message upload ceiling,
 and a GitHub Actions artifact link only works for signed-in users with access to
-the repository. So the message this script posts carries the **public release
-asset URL** as plain message content (tappable on mobile, no login required)
-plus an embed with the facts a tester needs before downloading: version, size,
-staged runtime JAR count, executed test count, trigger, branch and commit.
+the repository. The maintained Nightly message therefore links the public
+release asset from a compact user-facing embed and lists the PRs or direct
+commits added since the previous Nightly. CI-only metrics stay in Actions.
 
 The webhook URL is read from the environment rather than argv, because anything
 passed on a command line shows up in the process list and in `set -x` traces.
@@ -99,53 +98,10 @@ def redact(text: str) -> str:
 
 def build_payload(args: argparse.Namespace) -> dict:
     color, headline = STATUS_STYLE.get(args.status, STATUS_STYLE["failure"])
-
     version = args.version or "unknown"
-    title = (
-        f"Frostguard {version} — Windows desktop bundle"
-        if args.status == "success"
-        else f"Frostguard {version} — {headline.lower()}"
-    )
-
+    description_parts: list[str] = []
     fields: list[dict] = []
 
-    def add_field(name: str, value: str, inline: bool = True) -> None:
-        value = truncate(value, EMBED_FIELD_VALUE_LIMIT)
-        if value:
-            fields.append(
-                {
-                    "name": truncate(name, EMBED_FIELD_NAME_LIMIT),
-                    "value": value,
-                    "inline": inline,
-                }
-            )
-
-    add_field("Version", f"`{version}`")
-    if args.bundle_bytes > 0:
-        add_field("Download size", human_size(args.bundle_bytes))
-    if args.jar_count > 0:
-        add_field("Runtime JARs", str(args.jar_count))
-    if args.test_count > 0:
-        add_field("JUnit tests", f"{args.test_count} passed")
-    if args.trigger:
-        add_field("Trigger", f"`{args.trigger}`")
-    if args.branch:
-        add_field("Branch", f"`{args.branch}`")
-
-    if args.commit:
-        short = args.commit[:7]
-        subject = first_line(args.commit_message)
-        commit_url = (
-            f"https://github.com/{args.repository}/commit/{args.commit}"
-            if args.repository
-            else ""
-        )
-        link = f"[`{short}`]({commit_url})" if commit_url else f"`{short}`"
-        if subject:
-            link += f" {truncate(subject, 200)}"
-        add_field("Commit", link, inline=False)
-
-    description_parts: list[str] = []
     if args.status == "success":
         if args.download_url and not args.download_url.startswith("http"):
             # A half-populated URL means the release step was skipped or failed.
@@ -157,18 +113,23 @@ def build_payload(args: argparse.Namespace) -> dict:
             args.download_url = ""
         if args.download_url:
             description_parts.append(
-                f"**[⬇ Download {args.bundle_name or 'the bundle'}]"
+                "The newest automated development build. It may contain "
+                "unfinished or unstable changes."
+            )
+            description_parts.append(
+                f"**[⬇️ Download Frostguard {version} for Windows]"
                 f"({args.download_url})**"
             )
-            # The assembly ships no launcher .bat for the app itself (only
-            # fg-watcher.bat), so `java -jar` is the real entry point. Naming a
-            # script that is not in the ZIP would send every tester into a
-            # support question.
             description_parts.append(
-                "Verified: bundle structure, manifest classpath and launch "
-                "smoke test. Extract the complete ZIP, then double-click "
-                "`Start Frostguard.bat` (Java 21+ required)."
+                "Extract the complete archive and use the included Frostguard "
+                "launcher. Java 21 or newer is required."
             )
+            if args.changes:
+                fields.append({
+                    "name": "Changes since the previous Nightly",
+                    "value": truncate(args.changes, EMBED_FIELD_VALUE_LIMIT),
+                    "inline": False,
+                })
         elif args.run_url:
             description_parts.append(
                 f"Build passed. The artifact is attached to "
@@ -182,28 +143,22 @@ def build_payload(args: argparse.Namespace) -> dict:
         )
 
     embed = {
-        "title": truncate(title, EMBED_TITLE_LIMIT),
+        "title": truncate(
+            f"Latest Nightly — Frostguard {version}"
+            if args.status == "success"
+            else f"Frostguard {version} — {headline.lower()}",
+            EMBED_TITLE_LIMIT,
+        ),
         "color": color,
         "description": truncate("\n\n".join(description_parts), EMBED_DESCRIPTION_LIMIT),
         "fields": fields,
         "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     }
-    if args.run_url:
-        embed["url"] = args.run_url
-
-    footer = args.repository or ""
-    if args.run_number:
-        footer = f"{footer} • run #{args.run_number}".strip(" •")
-    if args.actor:
-        footer = f"{footer} • {args.actor}".strip(" •")
-    if footer:
-        embed["footer"] = {"text": truncate(footer, EMBED_FOOTER_LIMIT)}
-
-    # The bare URL as message content stays tappable in the mobile client and in
-    # notification previews, where embed links are easy to miss.
-    content = ""
     if args.status == "success" and args.download_url:
-        content = truncate(args.download_url, CONTENT_LIMIT)
+        embed["url"] = args.download_url
+        embed["footer"] = {"text": "Nightly • updated automatically"}
+    elif args.run_url:
+        embed["url"] = args.run_url
 
     payload = {
         "username": args.username,
@@ -211,8 +166,6 @@ def build_payload(args: argparse.Namespace) -> dict:
         # Never let a commit subject containing @everyone ping the channel.
         "allowed_mentions": {"parse": []},
     }
-    if content:
-        payload["content"] = content
     return payload
 
 
@@ -333,6 +286,7 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--commit", default="")
     parser.add_argument("--commit-message", default="")
     parser.add_argument("--actor", default="")
+    parser.add_argument("--changes", default="")
     parser.add_argument("--username", default="Frostguard Builds")
     parser.add_argument(
         "--attach",

--- a/ci/nightly_changes.py
+++ b/ci/nightly_changes.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Summarise first-parent changes since the previous Frostguard Nightly."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+
+MERGE_PR = re.compile(r"^Merge pull request #(\d+)\b")
+SQUASH_PR = re.compile(r"^(.*?)\s*\(#(\d+)\)$")
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, text=True, stdout=subprocess.PIPE
+    ).stdout.strip()
+
+
+def escape_link_text(value: str) -> str:
+    value = " ".join((value or "").split())
+    return value.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+
+
+def describe(repository: str, commit: str) -> str:
+    subject = git("show", "-s", "--format=%s", commit)
+    merge = MERGE_PR.match(subject)
+    if merge:
+        number = merge.group(1)
+        try:
+            title = git("show", "-s", "--format=%s", f"{commit}^2")
+        except subprocess.CalledProcessError:
+            title = subject
+        return f"• [#{number}](https://github.com/{repository}/pull/{number}) {escape_link_text(title)}"
+
+    squash = SQUASH_PR.match(subject)
+    if squash:
+        title, number = squash.groups()
+        return f"• [#{number}](https://github.com/{repository}/pull/{number}) {escape_link_text(title)}"
+
+    short = commit[:7]
+    return (
+        f"• [`{short}`](https://github.com/{repository}/commit/{commit}) "
+        f"{escape_link_text(subject)}"
+    )
+
+
+def summary(repository: str, previous: str, current: str, limit: int = 5) -> str:
+    if not previous or not current or previous == current:
+        return "No new changes since the previous Nightly."
+    try:
+        commits = git(
+            "rev-list", "--first-parent", "--reverse", f"{previous}..{current}"
+        ).splitlines()
+    except subprocess.CalledProcessError:
+        return "Change history is unavailable for this Nightly."
+    commits = [commit for commit in commits if commit]
+    if not commits:
+        return "No new changes since the previous Nightly."
+
+    omitted = max(0, len(commits) - limit)
+    lines = [describe(repository, commit) for commit in commits[-limit:]]
+    if omitted:
+        lines.insert(0, f"• …and {omitted} earlier change{'s' if omitted != 1 else ''}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--previous", default="")
+    parser.add_argument("--current", required=True)
+    parser.add_argument("--limit", type=int, default=5)
+    args = parser.parse_args()
+    print(summary(args.repository, args.previous, args.current, max(1, args.limit)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/stable_release_notify.py
+++ b/ci/stable_release_notify.py
@@ -16,16 +16,18 @@ from discord_notify import post, truncate  # noqa: E402
 
 def build_payload(args: argparse.Namespace) -> dict:
     description = (
-        f"**[Download Frostguard {args.version}]({args.download_url})**\n\n"
-        "This is the recommended stable Windows version. Extract the complete "
-        "ZIP and double-click `Start Frostguard.bat` (Java 21+ required).\n\n"
-        f"[Release notes]({args.release_url})"
+        "This is the tested version recommended for normal use.\n\n"
+        f"**[⬇️ Download Frostguard {args.version} for Windows]"
+        f"({args.download_url})**\n\n"
+        "Extract the complete archive and use the included Frostguard launcher. "
+        "Java 21 or newer is "
+        f"required.\n\n[📋 View release notes]({args.release_url})"
     )
     return {
         "content": "@everyone",
         "username": "Frostguard Releases",
         "embeds": [{
-            "title": f"Frostguard {args.version} is available",
+            "title": f"✅ Frostguard {args.version} is now available",
             "description": truncate(description, 4096),
             "color": 0x2ECC71,
         }],

--- a/ci/test_discord_notify.py
+++ b/ci/test_discord_notify.py
@@ -45,6 +45,7 @@ BASE_ARGS = [
     "--commit", "b962083c0ffee1234567890abcdefabcdefabcde",
     "--commit-message", "fix(intel): claim final rewards\n\nbody line ignored",
     "--actor", "Shederator",
+    "--changes", "• [#79](https://github.com/Shederator/wosbot/pull/79) Cleaner downloads",
 ]
 
 
@@ -55,16 +56,16 @@ def payload(extra: list[str] | None = None) -> dict:
 
 class PayloadTest(unittest.TestCase):
 
-    def test_success_payload_carries_the_download_link_as_content(self):
-        # The bare URL in `content` is what stays tappable in the mobile client
-        # and in the notification preview; embed links are easy to miss there.
+    def test_success_payload_has_no_bare_url_content(self):
         result = payload()
-        self.assertIn("releases/download/nightly", result["content"])
+        self.assertNotIn("content", result)
+        self.assertIn("releases/download/nightly", result["embeds"][0]["description"])
 
     def test_success_embed_is_green_and_names_the_version(self):
         embed = payload()["embeds"][0]
         self.assertEqual(0x2ECC71, embed["color"])
         self.assertIn("2.1.0", embed["title"])
+        self.assertIn("Latest Nightly", embed["title"])
 
     def test_failure_payload_is_red_and_links_the_log_not_a_download(self):
         result = payload(["--status", "failure"])
@@ -79,24 +80,22 @@ class PayloadTest(unittest.TestCase):
         result = payload(["--commit-message", "@everyone please test this"])
         self.assertEqual({"parse": []}, result["allowed_mentions"])
 
-    def test_uses_only_the_commit_subject(self):
+    def test_lists_changes_since_the_previous_nightly(self):
         fields = payload()["embeds"][0]["fields"]
-        commit = next(f for f in fields if f["name"] == "Commit")
-        self.assertIn("fix(intel): claim final rewards", commit["value"])
-        self.assertNotIn("body line ignored", commit["value"])
+        changes = next(
+            field for field in fields
+            if field["name"] == "Changes since the previous Nightly"
+        )
+        self.assertIn("#79", changes["value"])
 
-    def test_reports_size_in_human_units(self):
-        fields = payload()["embeds"][0]["fields"]
-        size = next(f for f in fields if f["name"] == "Download size")
-        self.assertEqual("231.0 MB", size["value"])
-
-    def test_omits_metrics_that_were_not_measured(self):
-        # A zero test count means the summary grep found nothing, not that zero
-        # tests passed. Printing "0 passed" would be a lie in a release notice.
-        result = payload(["--test-count", "0", "--jar-count", "0"])
+    def test_omits_internal_ci_metrics(self):
+        result = payload()
         names = {f["name"] for f in result["embeds"][0]["fields"]}
         self.assertNotIn("JUnit tests", names)
         self.assertNotIn("Runtime JARs", names)
+        self.assertNotIn("Trigger", names)
+        self.assertNotIn("Branch", names)
+        self.assertNotIn("Commit", names)
 
     def test_respects_every_discord_length_limit(self):
         long = "x" * 6000

--- a/ci/test_nightly_changes.py
+++ b/ci/test_nightly_changes.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest import mock
+
+import nightly_changes as changes
+
+
+class NightlyChangesTest(unittest.TestCase):
+    def test_merge_commit_uses_pr_number_and_second_parent_title(self):
+        with mock.patch.object(changes, "git", side_effect=[
+            "Merge pull request #80 from example/fix",
+            "fix(releases): retry CDN propagation delays",
+        ]):
+            line = changes.describe("Shederator/wosbot", "abcdef123")
+        self.assertIn("[#80]", line)
+        self.assertIn("retry CDN propagation delays", line)
+        self.assertNotIn("example/fix", line)
+
+    def test_squash_commit_links_the_pr(self):
+        with mock.patch.object(
+            changes, "git", return_value="feat(ui): cleaner downloads (#79)"
+        ):
+            line = changes.describe("Shederator/wosbot", "123456789")
+        self.assertIn("[#79]", line)
+        self.assertIn("cleaner downloads", line)
+
+    def test_direct_commit_links_the_commit(self):
+        with mock.patch.object(changes, "git", return_value="docs: explain Nightly"):
+            line = changes.describe("Shederator/wosbot", "123456789")
+        self.assertIn("[`1234567`]", line)
+        self.assertIn("/commit/123456789", line)
+
+    def test_summary_keeps_latest_changes_and_reports_omitted_count(self):
+        commits = "\n".join(f"commit{i}" for i in range(7))
+        with mock.patch.object(changes, "git", return_value=commits), \
+                mock.patch.object(changes, "describe", side_effect=lambda _, c: c):
+            result = changes.summary("Shederator/wosbot", "old", "new", limit=5)
+        self.assertIn("2 earlier changes", result)
+        self.assertNotIn("commit0", result)
+        self.assertIn("commit6", result)
+
+    def test_missing_history_is_a_readable_fallback(self):
+        error = subprocess.CalledProcessError(128, ["git"])
+        with mock.patch.object(changes, "git", side_effect=error):
+            result = changes.summary("Shederator/wosbot", "old", "new")
+        self.assertIn("unavailable", result)
+
+    def test_markdown_in_titles_is_escaped(self):
+        self.assertEqual(r"fix \[text\]", changes.escape_link_text(r"fix [text]"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ci/test_stable_release_notify.py
+++ b/ci/test_stable_release_notify.py
@@ -10,7 +10,7 @@ class StablePayloadTest(unittest.TestCase):
     def args(self):
         return notify.parse_args([
             "--version", "2.1.0",
-            "--download-url", "https://github.com/Shederator/wosbot/releases/download/v2.1.0/frostguard-windows-desktop-bundle.zip",
+            "--download-url", "https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip",
             "--release-url", "https://github.com/Shederator/wosbot/releases/tag/v2.1.0",
             "--dry-run",
         ])
@@ -23,7 +23,8 @@ class StablePayloadTest(unittest.TestCase):
     def test_contains_only_stable_release_facts(self):
         text = str(notify.build_payload(self.args()))
         self.assertIn("2.1.0", text)
-        self.assertIn("Start Frostguard.bat", text)
+        self.assertIn("included Frostguard launcher", text)
+        self.assertIn("releases/latest/download", text)
         self.assertNotIn("commit", text.lower())
 
     def test_rejects_non_semantic_version(self):

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -24,41 +24,54 @@ re-runs structural and launch verification, creates the immutable `vX.Y.Z`
 release, verifies its public download URL and then sends the one permitted
 `@everyone` release announcement. Existing stable tags are never replaced.
 
-## Discord `#downloads`
+## Discord `#download`
 
-Keep the channel read-only for regular users. It should contain two maintained
-messages rather than a chronological build log.
+Keep the channel read-only for regular users. Pin one short guide, keep
+permanent Stable announcements as release history, and maintain exactly one
+Nightly message that is edited in place.
 
-### Stable message
+### Pinned guide
 
 ```text
-✅ Frostguard Stable — Recommended
+📥 Frostguard Downloads
 
-The latest tested Windows version for regular use.
-Download: <latest stable release URL>
+Stable — recommended
+The tested version for normal use:
+https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip
 
-Install Java 21+, extract the complete ZIP, then double-click
-Start Frostguard.bat.
+Nightly — testing
+The newest automated development build. It may contain unfinished changes:
+https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip
+
+Extract the complete archive and use the included Frostguard launcher.
+Java 21 or newer is required.
 ```
 
-Replace this message only when a new stable release is published. The release
-workflow sends the one-time server notification separately.
+The Stable URL is deliberately a direct, version-independent asset URL. GitHub
+redirects it to the asset on the latest non-prerelease release.
 
-### Daily message
+### Nightly message
 
 ```text
-🧪 Frostguard Daily — Latest Development Build
+Latest Nightly — Frostguard <version>
 
-Includes the newest changes from main and may be less stable.
-Download: https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip
+The newest automated development build. It may contain unfinished or unstable
+changes.
 
-No GitHub login is required. Install Java 21+, extract the complete ZIP, then
-double-click Start Frostguard.bat.
+Download Frostguard <version> for Windows
+
+Changes since the previous Nightly
+- <linked PR title or direct commit subject>
+
+Extract the complete archive and use the included Frostguard launcher.
+Java 21 or newer is required.
 ```
 
 The URL is deliberately version-independent. Do not post a new Discord message
 for every daily build. Store the webhook-owned message ID in the repository
-variable `DISCORD_DAILY_MESSAGE_ID`; successful builds edit that message.
+variable `DISCORD_DAILY_MESSAGE_ID`; successful builds edit that message. Show
+at most five linked first-parent changes since the previous Nightly and collapse
+older entries into a count.
 Build failures remain visible in Actions and do not replace the last working
 public download.
 

--- a/setup/github-workflows/daily-windows-bundle.yml
+++ b/setup/github-workflows/daily-windows-bundle.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           lfs: true
 
       # The Windows OpenCV .dll, adb.exe and the .traineddata OCR models are all
@@ -239,7 +240,18 @@ jobs:
           # leave the `nightly` tag pinned to the first commit it was ever cut
           # from while the notes claimed a newer SHA. --cleanup-tag removes the
           # tag too, so the recreated one points at this build.
+          previous_sha=""
           if gh release view nightly >/dev/null 2>&1; then
+            previous_sha="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
+              --jq '.target_commitish')"
+          fi
+          changes="$(python3 ci/nightly_changes.py \
+            --repository "${GITHUB_REPOSITORY}" \
+            --previous "${previous_sha}" \
+            --current "${GITHUB_SHA}")"
+
+          if [[ -n "${previous_sha}" ]]; then
             gh release delete nightly --yes --cleanup-tag
           fi
 
@@ -279,6 +291,11 @@ jobs:
           fi
 
           echo "download_url=${url}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "changes<<FROSTGUARD_CHANGES"
+            printf '%s\n' "${changes}"
+            echo "FROSTGUARD_CHANGES"
+          } >> "${GITHUB_OUTPUT}"
           echo "Published and verified ${asset} at ${url} (HTTP ${code})"
 
       # Keep one maintained Daily message instead of adding one post per run.
@@ -301,6 +318,7 @@ jobs:
           JAR_COUNT: ${{ steps.metrics.outputs.jar_count }}
           TEST_COUNT: ${{ steps.metrics.outputs.test_count }}
           DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
+          NIGHTLY_CHANGES: ${{ steps.release.outputs.changes }}
           VERSION: ${{ steps.version.outputs.version }}
         shell: bash
         run: |
@@ -330,4 +348,5 @@ jobs:
             --commit "${GITHUB_SHA}" \
             --commit-message "${COMMIT_MESSAGE}" \
             --actor "${GITHUB_ACTOR}" \
+            --changes "${NIGHTLY_CHANGES}" \
             --message-id "${DISCORD_DAILY_MESSAGE_ID}"


### PR DESCRIPTION
## What changed

- replace the CI-heavy Nightly card with a compact user-facing download message
- remove the bare URL and link the download from the embed title/body
- list up to five linked PRs or direct commits added since the previous Nightly
- update the existing Discord message in place through `DISCORD_DAILY_MESSAGE_ID`
- make Stable announcements use the permanent direct `releases/latest/download` asset URL
- document the pinned `#download` guide and Stable/Nightly channel structure

## Why

The current card exposes runtime JAR counts, test counts, trigger, branch, actor and workflow metadata that are useful in Actions but confusing in a user download channel. It also does not tell testers what changed since the previous Nightly.

## Safety

- Nightly change text is normalized and Markdown-escaped
- Discord mentions remain structurally disabled for Nightly
- Stable remains the only intentional `@everyone` path
- the Stable workflow verifies both the immutable version URL and permanent latest URL before announcing
- archives and packaging are unchanged; issue #81 remains separate

## Validation

- `python3 ci/test_nightly_changes.py` — 6 passed
- `python3 ci/test_discord_notify.py` — 23 passed
- `python3 ci/test_stable_release_notify.py` — 3 passed
- installed and active Daily workflow copies are identical
- `git diff --check` passes
- `actionlint` reports only the existing informational Shellcheck findings in unchanged Maven/glob commands

## Rollout

After merge, manually run Daily Windows Bundle on `main`. The configured message ID `1533475915571527701` will cause the existing `#download` Nightly message to be edited rather than creating a new post.