### PR TITLE
docs(guidance): document workboard workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,11 @@ explicit in the handoff or pull request.
 
 ## Git And Pull Requests
 
+Use the GitHub Project workboard as the source of truth for planned work and
+work status. Before starting implementation, check for an existing work item
+and keep its status aligned with actual progress. Link related issues and pull
+requests instead of duplicating their details in the board.
+
 Start feature and fix branches from `main` unless a stacked dependency is
 intentional and documented. Keep commits reviewable and do not commit
 credentials, profile databases, emulator-specific paths, private logs, runtime


### PR DESCRIPTION
## Summary

- Define the GitHub Project workboard as the source of truth for planned work and status.
- Require checking existing work items and linking related issues and pull requests.

## Why

Agents need shared guidance now that the repository uses a GitHub Project workboard.

## Validation

- `git diff --check`
- Documentation-only change; no automated tests run.

## Risks

None known.