### PR TITLE
feat(releases): clarify nightly and stable downloads

### DIFF
--- a/.github/release-notes/v2.1.0.md
+++ b/.github/release-notes/v2.1.0.md
@@ -1,0 +1,15 @@
+Frostguard 2.1.0 is the first release using the verified Windows desktop bundle.
+
+### Highlights
+
+- Adds a complete Windows download with a stable launcher and all runtime dependencies.
+- Verifies the bundle structure, manifest classpath, tests, and application startup before publishing.
+- Adds automated Nightly builds and temporary builds for testing open pull requests.
+- Improves task scheduling, stamina handling, deployment reading, and intelligence routines.
+- Updates installation and Windows documentation for the packaged download.
+
+### Installation
+
+Download `frostguard-windows-desktop-bundle.zip`, extract the complete archive, and use the included Frostguard launcher. Java 21 or newer is required.
+
+Nightly and pull-request builds contain development code and are not replacements for this Stable release.

--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -88,6 +88,10 @@ jobs:
             echo "::error::Requested ${VERSION}, but pom.xml declares ${project_version}."
             exit 1
           fi
+          if [[ ! -f ".github/release-notes/v${VERSION}.md" ]]; then
+            echo "::error::Missing curated release notes for v${VERSION}."
+            exit 1
+          fi
           python3 ci/test_verify_bundle.py
           python3 ci/test_stable_release_notify.py
 
@@ -137,7 +141,7 @@ jobs:
           gh release create "${tag}" "${staged}" \
             --target "${SOURCE_SHA}" \
             --title "Frostguard ${VERSION}" \
-            --generate-notes \
+            --notes-file ".github/release-notes/v${VERSION}.md" \
             --latest
           release_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${tag}"
           download_url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
@@ -168,8 +172,10 @@ jobs:
           VERSION: ${{ inputs.version }}
           DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
           RELEASE_URL: ${{ steps.release.outputs.release_url }}
+          ARCHIVE_URL: https://github.com/${{ github.repository }}/releases
         run: |
           python3 ci/stable_release_notify.py \
             --version "${VERSION}" \
             --download-url "${DOWNLOAD_URL}" \
-            --release-url "${RELEASE_URL}"
+            --release-url "${RELEASE_URL}" \
+            --archive-url "${ARCHIVE_URL}"

--- a/ci/discord_notify.py
+++ b/ci/discord_notify.py
@@ -45,7 +45,9 @@ EMBED_FOOTER_LIMIT = 2048
 ATTACHMENT_LIMIT_BYTES = 8 * 1024 * 1024
 
 STATUS_STYLE = {
-    "success": (0x2ECC71, "Build succeeded"),
+    # Amber distinguishes an intentionally unstable Nightly from the green
+    # Stable announcement without making a successful build look like a fault.
+    "success": (0xF1C40F, "Build succeeded"),
     "failure": (0xE74C3C, "Build failed"),
     "cancelled": (0x95A5A6, "Build cancelled"),
     "skipped": (0x95A5A6, "Build skipped"),
@@ -144,7 +146,7 @@ def build_payload(args: argparse.Namespace) -> dict:
 
     embed = {
         "title": truncate(
-            f"Latest Nightly — Frostguard {version}"
+            f"🧪 Frostguard Nightly {version}"
             if args.status == "success"
             else f"Frostguard {version} — {headline.lower()}",
             EMBED_TITLE_LIMIT,
@@ -156,11 +158,15 @@ def build_payload(args: argparse.Namespace) -> dict:
     }
     if args.status == "success" and args.download_url:
         embed["url"] = args.download_url
-        embed["footer"] = {"text": "Nightly • updated automatically"}
+        build_identity = f"Nightly #{args.run_number}" if args.run_number else "Nightly"
+        embed["footer"] = {"text": f"{build_identity} • updated automatically"}
     elif args.run_url:
         embed["url"] = args.run_url
 
     payload = {
+        # PATCH preserves omitted fields. Explicitly clear content so the raw
+        # URL from the original version of the maintained message disappears.
+        "content": "",
         "username": args.username,
         "embeds": [embed],
         # Never let a commit subject containing @everyone ping the channel.

--- a/ci/stable_release_notify.py
+++ b/ci/stable_release_notify.py
@@ -21,7 +21,8 @@ def build_payload(args: argparse.Namespace) -> dict:
         f"({args.download_url})**\n\n"
         "Extract the complete archive and use the included Frostguard launcher. "
         "Java 21 or newer is "
-        f"required.\n\n[📋 View release notes]({args.release_url})"
+        f"required.\n\n[📋 Release notes]({args.release_url})"
+        f" • [🗂️ Previous stable releases]({args.archive_url})"
     )
     return {
         "content": "@everyone",
@@ -42,6 +43,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--version", required=True)
     parser.add_argument("--download-url", required=True)
     parser.add_argument("--release-url", required=True)
+    parser.add_argument("--archive-url", required=True)
     parser.add_argument("--webhook-env", default="DISCORD_NIGHTLY_WEBHOOK_URL")
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--dry-run", action="store_true")
@@ -54,7 +56,8 @@ def main(argv: list[str] | None = None) -> int:
         print("::error::Stable version must use X.Y.Z format.")
         return 1
     for label, value in (("download", args.download_url),
-                         ("release", args.release_url)):
+                         ("release", args.release_url),
+                         ("archive", args.archive_url)):
         if not value.startswith("https://github.com/"):
             print(f"::error::Stable {label} URL must be a GitHub HTTPS URL.")
             return 1

--- a/ci/test_discord_notify.py
+++ b/ci/test_discord_notify.py
@@ -58,20 +58,21 @@ class PayloadTest(unittest.TestCase):
 
     def test_success_payload_has_no_bare_url_content(self):
         result = payload()
-        self.assertNotIn("content", result)
+        self.assertEqual("", result["content"])
         self.assertIn("releases/download/nightly", result["embeds"][0]["description"])
 
-    def test_success_embed_is_green_and_names_the_version(self):
+    def test_success_embed_is_amber_and_names_the_version(self):
         embed = payload()["embeds"][0]
-        self.assertEqual(0x2ECC71, embed["color"])
+        self.assertEqual(0xF1C40F, embed["color"])
         self.assertIn("2.1.0", embed["title"])
-        self.assertIn("Latest Nightly", embed["title"])
+        self.assertIn("Frostguard Nightly", embed["title"])
+        self.assertEqual("Nightly #42 • updated automatically", embed["footer"]["text"])
 
     def test_failure_payload_is_red_and_links_the_log_not_a_download(self):
         result = payload(["--status", "failure"])
         embed = result["embeds"][0]
         self.assertEqual(0xE74C3C, embed["color"])
-        self.assertNotIn("content", result)
+        self.assertEqual("", result["content"])
         self.assertIn("workflow log", embed["description"])
 
     def test_never_pings_the_channel(self):
@@ -143,13 +144,13 @@ class PayloadTest(unittest.TestCase):
         # A dead link posted to the channel is worse than no link: testers click
         # it, get a 404 and report the release as broken.
         result = payload(["--download-url", "frostguard.zip"])
-        self.assertNotIn("content", result)
+        self.assertEqual("", result["content"])
         self.assertIn("workflow run", result["embeds"][0]["description"])
 
     def test_success_without_a_release_falls_back_to_the_run_link(self):
         # Branch builds skip the release publish, so there is no public URL.
         result = payload(["--download-url", ""])
-        self.assertNotIn("content", result)
+        self.assertEqual("", result["content"])
         self.assertIn("workflow run", result["embeds"][0]["description"])
 
 

--- a/ci/test_stable_release_notify.py
+++ b/ci/test_stable_release_notify.py
@@ -12,6 +12,7 @@ class StablePayloadTest(unittest.TestCase):
             "--version", "2.1.0",
             "--download-url", "https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip",
             "--release-url", "https://github.com/Shederator/wosbot/releases/tag/v2.1.0",
+            "--archive-url", "https://github.com/Shederator/wosbot/releases",
             "--dry-run",
         ])
 
@@ -25,12 +26,14 @@ class StablePayloadTest(unittest.TestCase):
         self.assertIn("2.1.0", text)
         self.assertIn("included Frostguard launcher", text)
         self.assertIn("releases/latest/download", text)
+        self.assertIn("Previous stable releases", text)
         self.assertNotIn("commit", text.lower())
 
     def test_rejects_non_semantic_version(self):
         argv = [
             "--version", "nightly", "--download-url", "https://github.com/a",
             "--release-url", "https://github.com/b", "--dry-run",
+            "--archive-url", "https://github.com/a/releases",
         ]
         self.assertEqual(1, notify.main(argv))
 


### PR DESCRIPTION
## Summary

- distinguish the rolling Nightly from Stable with an amber design and run number
- clear the legacy raw URL when editing the maintained Discord message
- add curated Frostguard 2.1.0 release notes
- link the permanent latest download and previous Stable releases from the Stable announcement

## Why

The download channel should clearly separate the recommended Stable release from automated development builds. Discord PATCH requests also preserve omitted message content, which left the old raw Nightly URL visible above the embed.

## Validation

- `python3 ci/test_nightly_changes.py`
- `python3 ci/test_discord_notify.py`
- `python3 ci/test_stable_release_notify.py`
- `python3 ci/test_verify_bundle.py`
- `diff -u setup/github-workflows/daily-windows-bundle.yml .github/workflows/daily-windows-bundle.yml`
- `git diff --check`
- `actionlint .github/workflows/daily-windows-bundle.yml .github/workflows/stable-windows-release.yml` (only pre-existing informational shellcheck findings in the Daily workflow)

## Risks

The final Discord rendering and Stable publication require live workflow verification after merge.
