### PR TITLE
feat(distribution): add portable build layout

### DIFF
--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -110,6 +110,8 @@ jobs:
       # launches the toolkit, which fails before the bundle can be assembled.
       - name: Test on Linux
         run: |
+          mkdir -p .frostguard/data
+          printf 'preserve-across-clean-and-deploy\n' > .frostguard/data/ci-preservation-sentinel
           read -r -a maven_args <<< "${MAVEN_ARGS}"
           xvfb-run --auto-servernum mvn "${maven_args[@]}" clean test
 
@@ -119,6 +121,7 @@ jobs:
           mvn "${maven_args[@]}" install -DskipTests -Djavafx.platform=win \
             -Dfrostguard.platform=win -Dfrostguard.channel=nightly \
             -Dfrostguard.commit="${GITHUB_SHA}"
+          grep -Fx 'preserve-across-clean-and-deploy' .frostguard/data/ci-preservation-sentinel
 
       - name: Locate the desktop bundle
         id: bundle

--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -116,17 +116,19 @@ jobs:
       - name: Build Windows desktop bundle
         run: |
           read -r -a maven_args <<< "${MAVEN_ARGS}"
-          mvn "${maven_args[@]}" install -DskipTests -Djavafx.platform=win
+          mvn "${maven_args[@]}" install -DskipTests -Djavafx.platform=win \
+            -Dfrostguard.platform=win -Dfrostguard.channel=nightly \
+            -Dfrostguard.commit="${GITHUB_SHA}"
 
       - name: Locate the desktop bundle
         id: bundle
         shell: bash
         run: |
           set -euo pipefail
-          zip_path="$(find fg-app/target -maxdepth 1 -type f \
-            -name '*-desktop-bundle.zip' | sort | tail -n 1)"
+          zip_path="$(find fg-distribution/target -maxdepth 1 -type f \
+            -name '*-win.zip' | sort | tail -n 1)"
           if [[ -z "${zip_path}" ]]; then
-            echo "::error::No desktop bundle ZIP found under fg-app/target."
+            echo "::error::No Windows distribution ZIP found under fg-distribution/target."
             exit 1
           fi
           echo "path=${zip_path}" >> "${GITHUB_OUTPUT}"
@@ -159,7 +161,7 @@ jobs:
             bundle_name="$(basename "${zip_path}")"
             bundle_bytes="$(stat -c%s "${zip_path}")"
             jar_count="$(unzip -Z1 "${zip_path}" \
-              | grep -Ec '^lib/[^/]+\.jar$' || true)"
+              | grep -Ec '^Frostguard/app/lib/[^/]+\.jar$' || true)"
           fi
 
           # Surefire writes one XML per test class; tests="N" is the per-class
@@ -184,7 +186,7 @@ jobs:
               echo "- Archive: \`${bundle_name}\`"
               echo "- Version: \`${{ steps.version.outputs.version }}\`"
               echo "- Size: $(du -h "${zip_path}" | cut -f1)"
-              echo "- Runtime JARs under \`lib/\`: ${jar_count:-0}"
+              echo "- Runtime JARs under \`Frostguard/app/lib/\`: ${jar_count:-0}"
               echo "- Verified: structure, manifest classpath, launch smoke test"
             else
               echo "- :x: No bundle was produced."
@@ -245,7 +247,7 @@ jobs:
             "Verified: bundle structure, manifest classpath and launch smoke test." \
             "" \
             "**Install:** extract the complete ZIP, then double-click" \
-            "\`Start Frostguard.bat\`" \
+            "\`Frostguard.bat\`" \
             "(Java 21+ required)." \
             "" \
             "This tag is replaced by every nightly build; it is not a stable release.")"

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -246,17 +246,19 @@ jobs:
       - name: Build Windows desktop bundle from the merged tree
         run: |
           read -r -a maven_args <<< "${MAVEN_ARGS}"
-          mvn "${maven_args[@]}" install -DskipTests -Djavafx.platform=win
+          mvn "${maven_args[@]}" install -DskipTests -Djavafx.platform=win \
+            -Dfrostguard.platform=win -Dfrostguard.channel=pr-test \
+            -Dfrostguard.commit="${GITHUB_SHA}"
 
       - name: Locate the desktop bundle
         id: bundle
         shell: bash
         run: |
           set -euo pipefail
-          zip_path="$(find fg-app/target -maxdepth 1 -type f \
-            -name '*-desktop-bundle.zip' | sort | tail -n 1)"
+          zip_path="$(find fg-distribution/target -maxdepth 1 -type f \
+            -name '*-win.zip' | sort | tail -n 1)"
           if [[ -z "${zip_path}" ]]; then
-            echo "::error::No desktop bundle ZIP found under fg-app/target."
+            echo "::error::No Windows distribution ZIP found under fg-distribution/target."
             exit 1
           fi
           echo "path=${zip_path}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -240,6 +240,8 @@ jobs:
       # a toolkit on the Linux runner, even when a virtual display is present.
       - name: Test the combined tree on Linux
         run: |
+          mkdir -p .frostguard/data
+          printf 'preserve-across-clean-and-deploy\n' > .frostguard/data/ci-preservation-sentinel
           read -r -a maven_args <<< "${MAVEN_ARGS}"
           xvfb-run --auto-servernum mvn "${maven_args[@]}" clean test
 
@@ -249,6 +251,7 @@ jobs:
           mvn "${maven_args[@]}" install -DskipTests -Djavafx.platform=win \
             -Dfrostguard.platform=win -Dfrostguard.channel=pr-test \
             -Dfrostguard.commit="${GITHUB_SHA}"
+          grep -Fx 'preserve-across-clean-and-deploy' .frostguard/data/ci-preservation-sentinel
 
       - name: Locate the desktop bundle
         id: bundle

--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -111,7 +111,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          path="$(find "${RUNNER_TEMP}/stable" -type f -name '*-desktop-bundle.zip' | head -n 1)"
+          path="$(find "${RUNNER_TEMP}/stable" -type f -name '*-win.zip' | head -n 1)"
           if [[ -z "${path}" ]]; then
             echo "::error::The selected run has no desktop bundle artifact."
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # ── Maven build output ──
 target/
+.frostguard/
+.frostguard.next/
 **/target/
 dependency-reduced-pom.xml
 

--- a/README.md
+++ b/README.md
@@ -250,13 +250,15 @@ git clone https://github.com/Shederator/wosbot.git
 cd wosbot
 git lfs install
 git lfs pull
-mvn clean install package
-java -jar fg-app/target/frostguard-<version>.jar
+mvn clean package
+java -jar .frostguard/app/frostguard-<version>.jar
 ```
 
-The build creates the application JAR and Windows desktop bundle under
-`fg-app/target`. For the complete source setup, Windows helper and verification
-commands, see:
+The build creates the application JAR under `fg-app/target`, the verified
+Windows archive under `fg-distribution/target`, and a runnable local installation
+under `.frostguard`. Persistent files remain under `.frostguard/data`.
+
+For the complete source setup, Windows helper and verification commands, see:
 
 - **[Installation and source build](docs/installation.md)**
 - **[Windows-specific setup](docs/windows.md)**

--- a/ci/README.md
+++ b/ci/README.md
@@ -155,11 +155,11 @@ substitution really took effect in both directions.
 - Reproduce the whole pipeline locally on Linux or Windows with:
 
   ```sh
-  mvn clean install -Djavafx.platform=win
+  mvn clean package -Djavafx.platform=win -Dfrostguard.platform=win
   python3 ci/test_verify_bundle.py
   python3 ci/test_discord_notify.py
-  python3 ci/verify_bundle.py fg-app/target/frostguard-*-desktop-bundle.zip
-  ci/smoke_test_bundle.sh fg-app/target/frostguard-*-desktop-bundle.zip
+  python3 ci/verify_bundle.py fg-distribution/target/frostguard-*-win.zip
+  ci/smoke_test_bundle.sh fg-distribution/target/frostguard-*-win.zip
   ```
 
 ## Stable Windows releases

--- a/ci/smoke_test_bundle.sh
+++ b/ci/smoke_test_bundle.sh
@@ -36,8 +36,13 @@ trap 'rm -rf "${workdir}"' EXIT
 unzip -qn "${bundle_zip}" -d "${workdir}"
 cd "${workdir}"
 
-app_jar="$(find . -maxdepth 1 -name 'frostguard-*.jar' | head -n 1)"
-watcher_jar="$(find . -maxdepth 1 -name 'fg-watcher-*.jar' | head -n 1)"
+if [[ -d Frostguard ]]; then
+  cd Frostguard
+fi
+
+app_jar="$(find app . -maxdepth 1 -name 'frostguard-*.jar' 2>/dev/null | head -n 1)"
+watcher_jar="$(find app . -maxdepth 1 -name 'fg-watcher-*.jar' 2>/dev/null | head -n 1)"
+app_lib="$(dirname "${app_jar}")/lib"
 
 if [[ -z "${app_jar}" || -z "${watcher_jar}" ]]; then
   echo "::error::Bundle is missing the app or watcher JAR."
@@ -85,8 +90,8 @@ public class Probe {
 PROBE
 
 echo "Resolving launcher entry points against the bundle classpath..."
-javac -nowarn -cp "${app_jar}:lib/*" -d . Probe.java
-java -cp "${app_jar}:lib/*:." Probe
+javac -nowarn -cp "${app_jar}:${app_lib}/*" -d . Probe.java
+java -cp "${app_jar}:${app_lib}/*:." Probe
 
 # ── 2. The manifest Class-Path must be usable without an explicit -cp ──
 # `java -jar` honours only the manifest, so this proves the Class-Path really

--- a/ci/test_verify_bundle.py
+++ b/ci/test_verify_bundle.py
@@ -145,9 +145,9 @@ class VerifyBundleTest(unittest.TestCase):
         files = [f for f in OTHER_FILES if not f.endswith(".traineddata")]
         self.assertEqual(1, run(build_bundle(other_files=files)))
 
-    def test_rejects_bundle_without_the_watcher_launcher(self):
+    def test_accepts_bundle_without_a_second_visible_watcher_launcher(self):
         files = [f for f in OTHER_FILES if f != "fg-watcher.bat"]
-        self.assertEqual(1, run(build_bundle(other_files=files)))
+        self.assertEqual(0, run(build_bundle(other_files=files)))
 
     def test_rejects_bundle_without_the_app_launcher(self):
         files = [f for f in OTHER_FILES if f != "Start Frostguard.bat"]

--- a/ci/verify_bundle.py
+++ b/ci/verify_bundle.py
@@ -33,7 +33,6 @@ MINIMUM_RUNTIME_JARS = 50
 # Exact entries that must be present at these exact paths.
 REQUIRED_FILES = [
     "Start Frostguard.bat",
-    "fg-watcher.bat",
     "lib/adb/adb.exe",
     "lib/adb/AdbWinApi.dll",
     "lib/adb/AdbWinUsbApi.dll",
@@ -148,7 +147,9 @@ def check_runtime_jar_floor(names: set[str]) -> tuple[list[str], int]:
     return [], len(jars)
 
 
-def check_manifest_class_path(bundle: zipfile.ZipFile, names: set[str]) -> tuple[list[str], int]:
+def check_manifest_class_path(
+    bundle: zipfile.ZipFile, names: set[str], archive_names: dict[str, str] | None = None
+) -> tuple[list[str], int]:
     """Every Class-Path entry of the launcher JAR must exist inside the ZIP."""
     launchers = sorted(
         name for name in names if re.match(r"^frostguard-[^/]+\.jar$", name)
@@ -158,7 +159,8 @@ def check_manifest_class_path(bundle: zipfile.ZipFile, names: set[str]) -> tuple
 
     launcher = launchers[-1]
     try:
-        with bundle.open(launcher) as jar_stream, zipfile.ZipFile(jar_stream) as jar:
+        archive_launcher = (archive_names or {}).get(launcher, launcher)
+        with bundle.open(archive_launcher) as jar_stream, zipfile.ZipFile(jar_stream) as jar:
             manifest_text = jar.read("META-INF/MANIFEST.MF").decode("utf-8", "replace")
     except (KeyError, zipfile.BadZipFile) as error:
         return [f"Could not read the manifest of {launcher}: {error}"], 0
@@ -202,7 +204,39 @@ def main(argv: list[str] | None = None) -> int:
         if bundle.testzip() is not None:
             fail(f"Bundle {args.bundle} contains a corrupt entry.")
             return 1
-        names = {name for name in bundle.namelist() if not name.endswith("/")}
+        raw_names = {name for name in bundle.namelist() if not name.endswith("/")}
+        portable = any(name.endswith("/build-info.json") for name in raw_names)
+        if portable:
+            roots = {name.split("/", 1)[0] for name in raw_names if "/" in name}
+            if len(roots) != 1:
+                fail("Portable archive must contain exactly one Frostguard root directory.")
+                return 1
+            prefix = next(iter(roots)) + "/"
+            relative = {name[len(prefix):] for name in raw_names if name.startswith(prefix)}
+            visible_launchers = sorted(
+                name for name in relative if "/" not in name and name.lower().endswith((".bat", ".exe", ".app"))
+            )
+            if visible_launchers != ["Frostguard.bat"]:
+                fail("Windows portable archive must expose exactly Frostguard.bat as its launcher.")
+                return 1
+            names = set()
+            archive_names = {}
+            for name in relative:
+                if name == "Frostguard.bat":
+                    canonical = "Start Frostguard.bat"
+                elif name.startswith("app/"):
+                    canonical = name[len("app/"):]
+                elif name.startswith("resources/templates/"):
+                    canonical = "templates/" + name[len("resources/templates/"):]
+                elif name.startswith("resources/defaults/custom-tasks/"):
+                    canonical = "custom_tasks/" + name[len("resources/defaults/custom-tasks/"):]
+                else:
+                    canonical = name
+                names.add(canonical)
+                archive_names[canonical] = prefix + name
+        else:
+            names = raw_names
+            archive_names = {}
 
         problems: list[str] = []
         problems += check_required_files(names)
@@ -212,7 +246,7 @@ def main(argv: list[str] | None = None) -> int:
         floor_problems, jar_count = check_runtime_jar_floor(names)
         problems += floor_problems
 
-        manifest_problems, class_path_count = check_manifest_class_path(bundle, names)
+        manifest_problems, class_path_count = check_manifest_class_path(bundle, names, archive_names)
         problems += manifest_problems
 
     if problems:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,11 +206,15 @@ flowchart TD
     CustomTasks[custom_tasks examples] --> AppBundle
 ```
 
-`fg-app` builds the desktop artifact:
+`fg-app` builds the executable application artifact. `fg-distribution` owns the
+portable layout, launchers, metadata, staging verification, archive, and local
+installation refresh:
 
 - executable jar: `fg-app/target/frostguard-<version>.jar`
-- desktop zip: `fg-app/target/frostguard-<version>-desktop-bundle.zip`
-- runtime dependencies staged under `fg-app/target/lib`
+- Windows zip: `fg-distribution/target/frostguard-<version>-win.zip`
+- clean staging: `fg-distribution/target/staging/Frostguard`
+- local installation: `.frostguard` (with persistent `.frostguard/data`)
+- runtime dependencies staged under `Frostguard/app/lib`
 - ADB/Tesseract files staged from `tools/`
 - custom task examples staged from root `custom_tasks/`
 - template PNGs staged from `fg-vision/src/main/resources/templates`
@@ -226,4 +230,4 @@ flowchart TD
 - Add or rename a template: resource under `fg-vision/src/main/resources/templates`, mapping in `templates.properties`, enum in `TemplatesEnum`.
 - Change persisted config/profile/task state: `fg-data` entities/repositories and engine services.
 - Change UI controls or panels: `fg-app/src/main/java/dev/frostguard/app/panel/*` plus matching FXML/CSS.
-- Change runtime packaging: `fg-app/pom.xml` or `fg-app/src/main/assembly/zip.xml`.
+- Change runtime packaging: `fg-distribution/pom.xml` or its assembly descriptor.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,6 +215,15 @@ installation refresh:
 - clean staging: `fg-distribution/target/staging/Frostguard`
 - local installation: `.frostguard` (with persistent `.frostguard/data`)
 - runtime dependencies staged under `Frostguard/app/lib`
+
+The first implementation intentionally packages Windows only. Linux launchers,
+archives and macOS application bundles are follow-up platform work; they must
+reuse the same staging, metadata, application-home and data-home contracts.
+
+Local deployment prepares all replacement files outside `.frostguard`, moves
+the current managed paths to a transaction backup, and restores them if any
+replacement move fails. Neither deployment nor `mvn clean` manages anything
+below `.frostguard/data`.
 - ADB/Tesseract files staged from `tools/`
 - custom task examples staged from root `custom_tasks/`
 - template PNGs staged from `fg-vision/src/main/resources/templates`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,10 +215,15 @@ installation refresh:
 - clean staging: `fg-distribution/target/staging/Frostguard`
 - local installation: `.frostguard` (with persistent `.frostguard/data`)
 - runtime dependencies staged under `Frostguard/app/lib`
+- optional platform-native libraries under `Frostguard/app/lib/native`
 
 The first implementation intentionally packages Windows only. Linux launchers,
 archives and macOS application bundles are follow-up platform work; they must
 reuse the same staging, metadata, application-home and data-home contracts.
+The native-library location is part of that contract and can be overridden with
+`-Dfrostguard.native=/absolute/path` or `FROSTGUARD_NATIVE`. Future native
+artifacts should be resolved by Maven and staged there rather than discovered
+through package-manager-specific application code.
 
 Local deployment prepares all replacement files outside `.frostguard`, moves
 the current managed paths to a transaction backup, and restores them if any

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -143,8 +143,22 @@ an extracted portable installation. Use the entire directory as the backup and
 restore unit. An explicit location can be selected with
 `-Dfrostguard.data=C:\absolute\path\to\data`.
 
-Before moving legacy `database.db`, `database.db-wal`, `database.db-shm`, logs,
-or `custom_tasks`, stop Frostguard and back up all files together. Do not copy a
-database without its WAL/SHM companions. If multiple legacy databases exist,
-keep them separate and select the intended source manually; Frostguard must not
-guess or merge them.
+On first start, Frostguard detects legacy `database.db`, `database.db-wal`,
+`database.db-shm`, logs, temp output and `custom_tasks` relative to the checkout
+or old installation. Stop every Frostguard process before migrating. If exactly
+one source exists, Frostguard backs it up under
+`data/migration-backups/<timestamp>`, copies the SQLite files as one group, and
+records completion under `data/config/legacy-migration.properties`. The legacy
+source remains intact for the transition period.
+
+If multiple sources exist, startup stops before changing files and lists every
+candidate. Restart with the intended exact source, for example:
+
+```powershell
+java -Dfrostguard.migrate.from=C:\old\Frostguard -jar app\frostguard-<version>.jar
+```
+
+Never choose a source while another Frostguard process has its database open.
+Restore by stopping Frostguard and copying the complete timestamped backup back
+to the selected data directory. The complete `data` directory remains the
+normal backup and machine-to-machine transfer unit.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -96,7 +96,7 @@ git lfs pull
 Run the full build from the repository root:
 
 ```sh
-mvn clean install package
+mvn clean package
 ```
 
 On Windows, the helper script performs the same build with one retry for transient file-lock issues:
@@ -105,17 +105,24 @@ On Windows, the helper script performs the same build with one retry for transie
 fg-build.bat
 ```
 
-Build outputs are written under `fg-app/target`, including
-`frostguard-<version>.jar` and the desktop bundle ZIP. End users should extract
-the ZIP and launch `Start Frostguard.bat`; the `target` path is only for source
-builds.
+The executable application remains under `fg-app/target`. The verified portable
+tree and Windows archive are written under `fg-distribution/target`, and the
+same managed program files are refreshed under `.frostguard`. Builds preserve
+`.frostguard/data`.
 
 ### Run a source build
 
-Run the generated application JAR from the repository root:
+For a downloaded Windows bundle, extract the complete ZIP into an empty folder
+and double-click:
+
+```text
+Frostguard.bat
+```
+
+For a source build, run the generated local installation from the repository root:
 
 ```sh
-java -jar fg-app/target/frostguard-<version>.jar
+java -jar .frostguard/app/frostguard-<version>.jar
 ```
 
 Replace `<version>` with the generated version, for example `2.1.0`.
@@ -123,6 +130,21 @@ Replace `<version>` with the generated version, for example `2.1.0`.
 ## Migrating an older installation
 
 Do not overwrite a new installation with an entire old Frostguard folder.
-Migration of legacy configuration and database files is not yet automated; keep
-a backup and copy individual `database.*` files only when intentionally carrying
-existing settings forward.
+Before starting automation, open the Configuration screen and set the emulator executable path.
+
+Common MuMu path:
+
+```text
+C:\Program Files\Netease\MuMuPlayer\nx_main\MuMuManager.exe
+```
+
+Runtime data is under `.frostguard/data` for a source checkout and `data` beside
+an extracted portable installation. Use the entire directory as the backup and
+restore unit. An explicit location can be selected with
+`-Dfrostguard.data=C:\absolute\path\to\data`.
+
+Before moving legacy `database.db`, `database.db-wal`, `database.db-shm`, logs,
+or `custom_tasks`, stop Frostguard and back up all files together. Do not copy a
+database without its WAL/SHM companions. If multiple legacy databases exist,
+keep them separate and select the intended source manually; Frostguard must not
+guess or merge them.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -80,6 +80,11 @@ For automatic startup through scripts or Task Scheduler:
 java -jar .frostguard\app\frostguard-<version>.jar --autostart
 ```
 
+If a build cannot replace `.frostguard` because Frostguard is running, close
+that Frostguard process and retry. Deployment restores the previous managed
+program files after a failed replacement and never terminates Java or ADB
+processes globally.
+
 ## Scheduled Automation
 
 Optional Task Scheduler templates are in `docs/schedule-autostart/`.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -45,7 +45,9 @@ Or use the Windows helper:
 fg-build.bat
 ```
 
-The helper stops leftover Java and ADB processes, retries once after transient resource-copy failures, verifies the packaged application JAR, and opens the generated bundle location.
+The helper retries known transient packaging failures, verifies the packaged
+application JAR, and opens the generated bundle location. It must not stop
+unrelated Java or ADB processes.
 
 ## Runtime Requirements
 
@@ -63,19 +65,19 @@ The application currently packages Windows ADB and Tesseract assets from `tools/
 ## Starting Frostguard
 
 After downloading a desktop bundle, extract the complete ZIP into an empty
-folder and double-click `Start Frostguard.bat`. The launcher locates the
+folder and double-click `Frostguard.bat`. The launcher locates the
 versioned application JAR and reports a clear error if Java 21 is missing.
 
 For a source build, run from the repository root:
 
 ```powershell
-java -jar fg-app\target\frostguard-<version>.jar
+java -jar .frostguard\app\frostguard-<version>.jar
 ```
 
 For automatic startup through scripts or Task Scheduler:
 
 ```powershell
-java -jar fg-app\target\frostguard-<version>.jar --autostart
+java -jar .frostguard\app\frostguard-<version>.jar --autostart
 ```
 
 ## Scheduled Automation

--- a/fg-api/pom.xml
+++ b/fg-api/pom.xml
@@ -25,5 +25,10 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/fg-api/src/main/java/dev/frostguard/api/runtime/FrostguardPaths.java
+++ b/fg-api/src/main/java/dev/frostguard/api/runtime/FrostguardPaths.java
@@ -1,0 +1,151 @@
+package dev.frostguard.api.runtime;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.Objects;
+
+/** Resolves replaceable application files separately from persistent user data. */
+public final class FrostguardPaths {
+    public static final String DATA_PROPERTY = "frostguard.data";
+    public static final String HOME_PROPERTY = "frostguard.home";
+    public static final String DATA_ENVIRONMENT = "FROSTGUARD_DATA";
+
+    private final Path applicationHome;
+    private final Path dataHome;
+    private final Path codeSource;
+
+    private FrostguardPaths(Path applicationHome, Path dataHome, Path codeSource) {
+        this.applicationHome = applicationHome;
+        this.dataHome = dataHome;
+        this.codeSource = codeSource;
+    }
+
+    public static FrostguardPaths resolve(Class<?> anchor) {
+        Objects.requireNonNull(anchor, "anchor");
+        Path codeSource = codeSource(anchor);
+        Path explicitHome = propertyPath(HOME_PROPERTY);
+        Path repository = findAncestor(codeSource, FrostguardPaths::isRepository);
+        Path distribution = findAncestor(codeSource, path -> Files.isRegularFile(path.resolve("build-info.json")));
+
+        Path applicationHome;
+        if (explicitHome != null) {
+            applicationHome = explicitHome;
+        } else if (distribution != null) {
+            applicationHome = distribution;
+        } else if (repository != null) {
+            applicationHome = repository.resolve(".frostguard");
+        } else {
+            throw unresolved(codeSource, "application home");
+        }
+
+        Path explicitData = propertyPath(DATA_PROPERTY);
+        if (explicitData == null) {
+            explicitData = environmentPath(DATA_ENVIRONMENT);
+        }
+        Path dataHome;
+        if (explicitData != null) {
+            dataHome = explicitData;
+        } else if (repository != null) {
+            dataHome = repository.resolve(".frostguard/data");
+        } else if (distribution != null) {
+            dataHome = distribution.resolve("data");
+        } else {
+            throw unresolved(codeSource, "data home");
+        }
+        return new FrostguardPaths(normalize(applicationHome), normalize(dataHome), codeSource);
+    }
+
+    public Path applicationHome() {
+        return applicationHome;
+    }
+
+    public Path dataHome() {
+        return dataHome;
+    }
+
+    public Path codeSource() {
+        return codeSource;
+    }
+
+    public Path applicationJar() {
+        return Files.isRegularFile(codeSource) && codeSource.toString().toLowerCase(Locale.ROOT).endsWith(".jar")
+                ? codeSource
+                : applicationHome.resolve("app");
+    }
+
+    public Path customTasks() {
+        return dataHome.resolve("custom-tasks");
+    }
+
+    public Path logs() {
+        return dataHome.resolve("logs");
+    }
+
+    public Path temp() {
+        return dataHome.resolve("temp");
+    }
+
+    public Path resources() {
+        return applicationHome.resolve("resources");
+    }
+
+    public void createDataDirectories() {
+        try {
+            Files.createDirectories(dataHome);
+            Files.createDirectories(dataHome.resolve("config"));
+            Files.createDirectories(customTasks());
+            Files.createDirectories(logs());
+            Files.createDirectories(temp());
+        } catch (Exception cause) {
+            throw new IllegalStateException("Cannot initialize Frostguard data directory " + dataHome, cause);
+        }
+    }
+
+    private static Path codeSource(Class<?> anchor) {
+        try {
+            URI location = anchor.getProtectionDomain().getCodeSource().getLocation().toURI();
+            return normalize(Paths.get(location));
+        } catch (Exception cause) {
+            throw new IllegalStateException("Cannot determine Frostguard code source", cause);
+        }
+    }
+
+    private static Path findAncestor(Path start, java.util.function.Predicate<Path> predicate) {
+        Path current = Files.isDirectory(start) ? start : start.getParent();
+        while (current != null) {
+            if (predicate.test(current)) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        return null;
+    }
+
+    private static boolean isRepository(Path path) {
+        return Files.isRegularFile(path.resolve("pom.xml"))
+                && Files.isDirectory(path.resolve("fg-app"))
+                && Files.isDirectory(path.resolve("fg-api"));
+    }
+
+    private static Path propertyPath(String name) {
+        String value = System.getProperty(name);
+        return value == null || value.isBlank() ? null : normalize(Paths.get(value));
+    }
+
+    private static Path environmentPath(String name) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? null : normalize(Paths.get(value));
+    }
+
+    private static Path normalize(Path path) {
+        return path.toAbsolutePath().normalize();
+    }
+
+    private static IllegalStateException unresolved(Path source, String target) {
+        return new IllegalStateException("Cannot resolve Frostguard " + target + " from " + source
+                + "; set -D" + DATA_PROPERTY + "=/absolute/path (and optionally -D" + HOME_PROPERTY + "=/absolute/path)");
+    }
+}

--- a/fg-api/src/main/java/dev/frostguard/api/runtime/FrostguardPaths.java
+++ b/fg-api/src/main/java/dev/frostguard/api/runtime/FrostguardPaths.java
@@ -11,15 +11,19 @@ import java.util.Objects;
 public final class FrostguardPaths {
     public static final String DATA_PROPERTY = "frostguard.data";
     public static final String HOME_PROPERTY = "frostguard.home";
+    public static final String NATIVE_PROPERTY = "frostguard.native";
     public static final String DATA_ENVIRONMENT = "FROSTGUARD_DATA";
+    public static final String NATIVE_ENVIRONMENT = "FROSTGUARD_NATIVE";
 
     private final Path applicationHome;
     private final Path dataHome;
+    private final Path nativeHome;
     private final Path codeSource;
 
-    private FrostguardPaths(Path applicationHome, Path dataHome, Path codeSource) {
+    private FrostguardPaths(Path applicationHome, Path dataHome, Path nativeHome, Path codeSource) {
         this.applicationHome = applicationHome;
         this.dataHome = dataHome;
+        this.nativeHome = nativeHome;
         this.codeSource = codeSource;
     }
 
@@ -55,7 +59,14 @@ public final class FrostguardPaths {
         } else {
             throw unresolved(codeSource, "data home");
         }
-        return new FrostguardPaths(normalize(applicationHome), normalize(dataHome), codeSource);
+        Path explicitNative = propertyPath(NATIVE_PROPERTY);
+        if (explicitNative == null) {
+            explicitNative = environmentPath(NATIVE_ENVIRONMENT);
+        }
+        Path nativeHome = explicitNative != null
+                ? explicitNative
+                : applicationHome.resolve("app/lib/native");
+        return new FrostguardPaths(normalize(applicationHome), normalize(dataHome), normalize(nativeHome), codeSource);
     }
 
     public Path applicationHome() {
@@ -64,6 +75,10 @@ public final class FrostguardPaths {
 
     public Path dataHome() {
         return dataHome;
+    }
+
+    public Path nativeHome() {
+        return nativeHome;
     }
 
     public Path codeSource() {

--- a/fg-api/src/test/java/dev/frostguard/api/runtime/FrostguardPathsTest.java
+++ b/fg-api/src/test/java/dev/frostguard/api/runtime/FrostguardPathsTest.java
@@ -1,0 +1,46 @@
+package dev.frostguard.api.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FrostguardPathsTest {
+    @TempDir
+    Path tempDir;
+
+    @AfterEach
+    void clearOverrides() {
+        System.clearProperty(FrostguardPaths.DATA_PROPERTY);
+        System.clearProperty(FrostguardPaths.HOME_PROPERTY);
+    }
+
+    @Test
+    void explicitOverridesDoNotDependOnWorkingDirectory() {
+        Path data = tempDir.resolve("persistent");
+        Path home = tempDir.resolve("program");
+        System.setProperty(FrostguardPaths.DATA_PROPERTY, data.toString());
+        System.setProperty(FrostguardPaths.HOME_PROPERTY, home.toString());
+
+        FrostguardPaths paths = FrostguardPaths.resolve(FrostguardPathsTest.class);
+
+        assertEquals(data.toAbsolutePath(), paths.dataHome());
+        assertEquals(home.toAbsolutePath(), paths.applicationHome());
+    }
+
+    @Test
+    void explodedRepositoryClassesUseCheckoutDataDirectory() {
+        FrostguardPaths paths = FrostguardPaths.resolve(FrostguardPathsTest.class);
+
+        Path repository = Path.of(FrostguardPathsTest.class.getProtectionDomain()
+                .getCodeSource().getLocation().getPath()).toAbsolutePath();
+        while (repository != null && !java.nio.file.Files.isDirectory(repository.resolve("fg-app"))) {
+            repository = repository.getParent();
+        }
+
+        assertEquals(repository.resolve(".frostguard/data").normalize(), paths.dataHome());
+    }
+}

--- a/fg-api/src/test/java/dev/frostguard/api/runtime/FrostguardPathsTest.java
+++ b/fg-api/src/test/java/dev/frostguard/api/runtime/FrostguardPathsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -12,10 +13,16 @@ class FrostguardPathsTest {
     @TempDir
     Path tempDir;
 
+    @BeforeEach
+    void prepareOverrides() {
+        clearOverrides();
+    }
+
     @AfterEach
     void clearOverrides() {
         System.clearProperty(FrostguardPaths.DATA_PROPERTY);
         System.clearProperty(FrostguardPaths.HOME_PROPERTY);
+        System.clearProperty(FrostguardPaths.NATIVE_PROPERTY);
     }
 
     @Test
@@ -29,6 +36,20 @@ class FrostguardPathsTest {
 
         assertEquals(data.toAbsolutePath(), paths.dataHome());
         assertEquals(home.toAbsolutePath(), paths.applicationHome());
+        assertEquals(home.resolve("app/lib/native").toAbsolutePath(), paths.nativeHome());
+    }
+
+    @Test
+    void explicitNativeDirectorySupportsExternalRuntimeArtifacts() {
+        Path home = tempDir.resolve("program");
+        Path nativeHome = tempDir.resolve("native-runtime");
+        System.setProperty(FrostguardPaths.HOME_PROPERTY, home.toString());
+        System.setProperty(FrostguardPaths.DATA_PROPERTY, tempDir.resolve("data").toString());
+        System.setProperty(FrostguardPaths.NATIVE_PROPERTY, nativeHome.toString());
+
+        FrostguardPaths paths = FrostguardPaths.resolve(FrostguardPathsTest.class);
+
+        assertEquals(nativeHome.toAbsolutePath(), paths.nativeHome());
     }
 
     @Test

--- a/fg-app/pom.xml
+++ b/fg-app/pom.xml
@@ -120,27 +120,6 @@
 		<finalName>${project.build.outputName}</finalName>
 
 		<plugins>
-			<!-- Distribution archive -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>build-desktop-zip</id>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-						<configuration>
-							<finalName>${project.build.outputName}</finalName>
-							<descriptors>
-								<descriptor>src/main/assembly/zip.xml</descriptor>
-							</descriptors>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
 			<!-- Executable JAR manifest -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -166,75 +145,22 @@
 					</archive>
 				</configuration>
 			</plugin>
-
-			<!-- Collect runtime JARs.
-			     Bound to prepare-package rather than package so target/lib is fully
-			     populated before maven-assembly-plugin builds the distribution ZIP.
-			     Both plugins used to run in the package phase, where Maven honours
-			     POM declaration order: the assembly ran first and produced a ZIP with
-			     an empty lib/ unless an earlier build had already staged it. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>stage-runtime-dependencies</id>
+						<id>stage-direct-jar-runtime</id>
 						<phase>prepare-package</phase>
-						<goals>
-							<goal>copy-dependencies</goal>
-						</goals>
+						<goals><goal>copy-dependencies</goal></goals>
 						<configuration>
 							<outputDirectory>${project.build.directory}/lib</outputDirectory>
 							<includeScope>runtime</includeScope>
-							<overWriteReleases>false</overWriteReleases>
-							<overWriteSnapshots>false</overWriteSnapshots>
-							<overWriteIfNewer>true</overWriteIfNewer>
 						</configuration>
 					</execution>
 				</executions>
 			</plugin>
 
-			<!-- Bundle external tool runtimes -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-resources-plugin</artifactId>
-				<executions>
-					<!-- ADB binaries -->
-					<execution>
-						<id>stage-adb-runtime</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>copy-resources</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${project.build.directory}/lib/adb</outputDirectory>
-							<resources>
-								<resource>
-									<directory>${project.parent.basedir}/tools/adb</directory>
-									<filtering>false</filtering>
-								</resource>
-							</resources>
-						</configuration>
-					</execution>
-					<!-- Tesseract OCR binaries -->
-					<execution>
-						<id>stage-tesseract-runtime</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>copy-resources</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${project.build.directory}/lib/tesseract</outputDirectory>
-							<resources>
-								<resource>
-									<directory>${project.parent.basedir}/tools/tesseract</directory>
-									<filtering>false</filtering>
-								</resource>
-							</resources>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/fg-app/src/main/java/dev/frostguard/app/bootstrap/Main.java
+++ b/fg-app/src/main/java/dev/frostguard/app/bootstrap/Main.java
@@ -1,16 +1,18 @@
 package dev.frostguard.app.bootstrap;
 
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dev.frostguard.api.runtime.FrostguardPaths;
 import dev.frostguard.engine.service.AnalyticsService;
 import dev.frostguard.tasks.TaskRegistrations;
 import dev.frostguard.vision.logging.ProfileContextLogger;
 
 public class Main {
-	private static final Logger logger = LoggerFactory.getLogger(Main.class);
-
 	public static void main(String[] args) {
+		FrostguardPaths paths = FrostguardPaths.resolve(Main.class);
+		paths.createDataDirectories();
+		System.setProperty("frostguard.log.dir", paths.logs().toString());
+		var logger = LoggerFactory.getLogger(Main.class);
 		try {
 			boolean isHeadless = false;
 			for (String arg : args) {

--- a/fg-app/src/main/java/dev/frostguard/app/panel/misc/DebuggingLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/misc/DebuggingLayoutController.java
@@ -398,15 +398,13 @@ public class DebuggingLayoutController {
 
     private void loadTemplates() {
         List<File> possibleTemplateDirs = new ArrayList<>();
-        possibleTemplateDirs.add(new File("fg-vision/src/main/resources/templates"));
-        possibleTemplateDirs.add(new File("../fg-vision/src/main/resources/templates"));
-        possibleTemplateDirs.add(new File("../../fg-vision/src/main/resources/templates"));
-        possibleTemplateDirs.add(new File("templates"));
-
-        File currentDir = new File(System.getProperty("user.dir")).getAbsoluteFile();
-        while (currentDir != null && currentDir.exists()) {
-            possibleTemplateDirs.add(new File(currentDir, "fg-vision/src/main/resources/templates"));
-            currentDir = currentDir.getParentFile();
+        dev.frostguard.api.runtime.FrostguardPaths runtime =
+                dev.frostguard.api.runtime.FrostguardPaths.resolve(DebuggingLayoutController.class);
+        possibleTemplateDirs.add(runtime.resources().resolve("templates").toFile());
+        File repository = runtime.applicationHome().getParent() == null
+                ? null : runtime.applicationHome().getParent().toFile();
+        if (repository != null) {
+            possibleTemplateDirs.add(new File(repository, "fg-vision/src/main/resources/templates"));
         }
 
         File templateDir = null;
@@ -423,7 +421,7 @@ public class DebuggingLayoutController {
             log("Found " + allTemplates.size() + " templates.");
         } else {
             log("Template directory not found. Please verify location.");
-            log("User Dir: " + System.getProperty("user.dir"));
+            log("Application home: " + runtime.applicationHome());
         }
 
         templateListView.getItems().setAll(allTemplates);

--- a/fg-app/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
@@ -222,9 +222,7 @@ public class TelegramLayoutController {
      * Attempts to locate the running bot JAR automatically.
      * Priority:
      *   1. The running JAR itself (getCodeSource) — works in production.
-     *   2. fg-app/target/frostguard-*.jar relative to the working directory works
-     *      when launched from the project root (IDE / quick_build.bat).
-     *   3. Any frostguard-*.jar in the current working directory.
+     *   2. The application directory resolved from the code source.
      */
     private static String autoDetectBotJar() {
         // 1. Detect own JAR path (works when running as a packaged JAR)
@@ -237,13 +235,9 @@ public class TelegramLayoutController {
             }
         } catch (Exception ignored) {}
 
-        // 2. Relative path from working directory (project layout: fg-app/target/)
-        File targetDir = new File(System.getProperty("user.dir"), "fg-app" + File.separator + "target");
-        String found = findFrostguardJar(targetDir);
-        if (found != null) return found;
-
-        // 3. Current working directory itself
-        found = findFrostguardJar(new File(System.getProperty("user.dir")));
+        File appDirectory = dev.frostguard.api.runtime.FrostguardPaths.resolve(TelegramLayoutController.class)
+                .codeSource().toFile().getParentFile();
+        String found = findFrostguardJar(appDirectory);
         if (found != null) return found;
 
         return "";
@@ -372,8 +366,9 @@ public class TelegramLayoutController {
             }
         } catch (Exception ignored) {}
 
-        // 3. Walk up from user.dir (works when launched from IDE / project root)
-        File dir = new File(System.getProperty("user.dir"));
+        // 3. Walk up from the resolved application home.
+        File dir = dev.frostguard.api.runtime.FrostguardPaths.resolve(TelegramLayoutController.class)
+                .applicationHome().toFile();
         for (int i = 0; i < 5 && dir != null; i++) {
             File bat = new File(dir, "fg-watcher.bat");
             if (bat.exists()) return bat;

--- a/fg-app/src/main/resources/logback.xml
+++ b/fg-app/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration scan="true" scanPeriod="30 seconds">
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
-    <property name="LOG_DIR" value="log"/>
+    <property name="LOG_DIR" value="${frostguard.log.dir:-log}"/>
     <property name="LOG_FILE" value="${LOG_DIR}/frostguard.log"/>
     <property name="APP_PATTERN" value="%d{HH:mm:ss.SSS} %-5level [%thread] %logger{32} - %msg%n"/>
     <property name="FILE_PATTERN" value="%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] %logger{48} - %msg%n"/>

--- a/fg-build.bat
+++ b/fg-build.bat
@@ -5,15 +5,8 @@ echo      Frostguard Quick Recompile Script
 echo ==========================================
 
 echo.
-echo Stopping any running Java and ADB processes...
-taskkill /F /IM java.exe >nul 2>&1
-taskkill /F /IM javaw.exe >nul 2>&1
-taskkill /F /IM adb.exe >nul 2>&1
-timeout /t 2 >nul
-
-echo.
-echo Building project (clean + install)...
-call mvn clean install package
+echo Building verified portable distribution...
+call mvn clean package -Dfrostguard.platform=win -Djavafx.platform=win
 if errorlevel 1 (
     echo [WARN] First build attempt failed. Applying quick cleanup for transient resource-copy issues...
     if exist "fg-vision\target" rmdir /S /Q "fg-vision\target"
@@ -21,7 +14,7 @@ if errorlevel 1 (
 
     echo.
     echo Retrying build once...
-    call mvn clean install package
+    call mvn clean package -Dfrostguard.platform=win -Djavafx.platform=win
     if errorlevel 1 (
         echo [ERROR] Build failed after retry!
         pause
@@ -71,9 +64,9 @@ echo BUILD SUCCESSFUL!
 echo ==========================================
 echo.
 
-set "OUTPUT_DIR=%CD%\fg-app\target"
+set "OUTPUT_DIR=%CD%\fg-distribution\target"
 set "BUNDLE_ZIP="
-for %%F in ("fg-app\target\*desktop-bundle.zip") do set "BUNDLE_ZIP=%%~fF"
+for %%F in ("fg-distribution\target\*-win.zip") do set "BUNDLE_ZIP=%%~fF"
 
 if defined BUNDLE_ZIP (
     echo Opening desktop bundle ZIP: %BUNDLE_ZIP%

--- a/fg-data/src/main/java/dev/frostguard/data/access/DataStore.java
+++ b/fg-data/src/main/java/dev/frostguard/data/access/DataStore.java
@@ -1,9 +1,12 @@
 package dev.frostguard.data.access;
 
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import dev.frostguard.api.runtime.FrostguardPaths;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,9 +34,15 @@ public final class DataStore implements AutoCloseable {
 
 	private DataStore(Map<String, Object> overrides) {
 		try {
-			this.emf = Persistence.createEntityManagerFactory(PERSISTENCE_UNIT, overrides);
+			FrostguardPaths paths = FrostguardPaths.resolve(DataStore.class);
+			paths.createDataDirectories();
+			String url = "jdbc:sqlite:" + paths.dataHome().resolve("frostguard.db")
+					+ "?busy_timeout=1000&journal_mode=WAL";
+			Map<String, Object> properties = new HashMap<>(overrides);
+			properties.putIfAbsent("jakarta.persistence.jdbc.url", url);
+			this.emf = Persistence.createEntityManagerFactory(PERSISTENCE_UNIT, properties);
 			DataSeeder.populate(this);
-			LOG.info("Frostguard data store initialized");
+			LOG.info("Frostguard data store initialized at {}", paths.dataHome());
 		} catch (Exception cause) {
 			LOG.error("Data store initialization failed: {}", cause.getMessage(), cause);
 			throw new ExceptionInInitializerError(cause);

--- a/fg-data/src/main/java/dev/frostguard/data/access/DataStore.java
+++ b/fg-data/src/main/java/dev/frostguard/data/access/DataStore.java
@@ -7,6 +7,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import dev.frostguard.api.runtime.FrostguardPaths;
+import dev.frostguard.data.migration.LegacyDataMigrator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,13 +30,20 @@ public final class DataStore implements AutoCloseable {
 	private final EntityManagerFactory emf;
 
 	private static final class Holder {
-		private static final DataStore INSTANCE = new DataStore(Map.of());
+		private static final DataStore INSTANCE = new DataStore(Map.of(), true);
 	}
 
-	private DataStore(Map<String, Object> overrides) {
+	private DataStore(Map<String, Object> overrides, boolean migrateLegacyData) {
 		try {
 			FrostguardPaths paths = FrostguardPaths.resolve(DataStore.class);
 			paths.createDataDirectories();
+			if (migrateLegacyData) {
+				LegacyDataMigrator.MigrationResult migration = LegacyDataMigrator.migrate(paths);
+				if (migration.migrated()) {
+					LOG.info("Migrated legacy Frostguard data from {} after backing it up to {}",
+							migration.source(), migration.backup());
+				}
+			}
 			String url = "jdbc:sqlite:" + paths.dataHome().resolve("frostguard.db")
 					+ "?busy_timeout=1000&journal_mode=WAL";
 			Map<String, Object> properties = new HashMap<>(overrides);
@@ -50,7 +58,7 @@ public final class DataStore implements AutoCloseable {
 	}
 
 	public static DataStore openIsolated(Map<String, Object> overrides) {
-		return new DataStore(overrides == null ? Map.of() : overrides);
+		return new DataStore(overrides == null ? Map.of() : overrides, false);
 	}
 
 	public static DataStore getInstance() {

--- a/fg-data/src/main/java/dev/frostguard/data/migration/LegacyDataMigrator.java
+++ b/fg-data/src/main/java/dev/frostguard/data/migration/LegacyDataMigrator.java
@@ -1,0 +1,199 @@
+package dev.frostguard.data.migration;
+
+import dev.frostguard.api.runtime.FrostguardPaths;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Performs the one-time, backup-first migration from pre-distribution data locations. */
+public final class LegacyDataMigrator {
+    public static final String SOURCE_PROPERTY = "frostguard.migrate.from";
+    private static final String MARKER = "legacy-migration.properties";
+    private static final List<String> DATABASE_FILES = List.of("database.db", "database.db-wal", "database.db-shm");
+    private static final DateTimeFormatter BACKUP_TIME =
+            DateTimeFormatter.ofPattern("uuuuMMdd-HHmmss").withZone(ZoneOffset.UTC);
+
+    private LegacyDataMigrator() {
+    }
+
+    public static MigrationResult migrate(FrostguardPaths paths) {
+        return migrate(paths, Clock.systemUTC());
+    }
+
+    static MigrationResult migrate(FrostguardPaths paths, Clock clock) {
+        Path marker = paths.dataHome().resolve("config").resolve(MARKER);
+        if (Files.exists(marker) || Files.exists(paths.dataHome().resolve("frostguard.db"))) {
+            return MigrationResult.notRequired();
+        }
+
+        List<Path> candidates = candidates(paths).stream()
+                .filter(LegacyDataMigrator::containsLegacyData)
+                .toList();
+        if (candidates.isEmpty()) {
+            return MigrationResult.notRequired();
+        }
+
+        Path source = selectSource(candidates);
+        paths.createDataDirectories();
+        Path backup = paths.dataHome().resolve("migration-backups")
+                .resolve(BACKUP_TIME.format(Instant.now(clock)));
+        try {
+            verifyDatabaseUnlocked(source);
+            Files.createDirectories(backup);
+            copyLegacyFiles(source, backup, true);
+            copyDatabaseGroup(source, paths.dataHome());
+            copyDirectoryIfPresent(source.resolve("custom_tasks"), paths.customTasks());
+            copyDirectoryIfPresent(source.resolve("log"), paths.logs());
+            copyDirectoryIfPresent(source.resolve("logs"), paths.logs());
+            copyDirectoryIfPresent(source.resolve("temp"), paths.temp());
+            writeMarker(marker, source, backup, clock);
+            return new MigrationResult(true, source, backup);
+        } catch (IOException cause) {
+            throw new IllegalStateException("Legacy migration from " + source + " failed; backup location: " + backup, cause);
+        }
+    }
+
+    private static Set<Path> candidates(FrostguardPaths paths) {
+        Set<Path> result = new LinkedHashSet<>();
+        Path appHome = paths.applicationHome();
+        result.add(appHome);
+        Path parent = appHome.getParent();
+        if (appHome.getFileName() != null && ".frostguard".equals(appHome.getFileName().toString()) && parent != null) {
+            result.add(parent);
+            result.add(parent.resolve("fg-app/target"));
+        } else {
+            result.add(appHome.resolve("app"));
+        }
+        Path codeParent = Files.isDirectory(paths.codeSource()) ? paths.codeSource() : paths.codeSource().getParent();
+        if (codeParent != null) result.add(codeParent);
+        return result.stream().map(path -> path.toAbsolutePath().normalize())
+                .filter(path -> !path.equals(paths.dataHome()))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static boolean containsLegacyData(Path root) {
+        if (DATABASE_FILES.stream().map(root::resolve).anyMatch(Files::exists)) return true;
+        return hasFiles(root.resolve("custom_tasks")) || hasFiles(root.resolve("log"))
+                || hasFiles(root.resolve("logs")) || hasFiles(root.resolve("temp"));
+    }
+
+    private static boolean hasFiles(Path directory) {
+        if (!Files.isDirectory(directory)) return false;
+        try (var entries = Files.walk(directory)) {
+            return entries.anyMatch(Files::isRegularFile);
+        } catch (IOException ignored) {
+            return true;
+        }
+    }
+
+    private static Path selectSource(List<Path> candidates) {
+        String selected = System.getProperty(SOURCE_PROPERTY);
+        if (selected != null && !selected.isBlank()) {
+            Path requested = Path.of(selected).toAbsolutePath().normalize();
+            if (!candidates.contains(requested)) {
+                throw new IllegalStateException("Selected legacy source " + requested
+                        + " is not one of the detected candidates: " + candidates);
+            }
+            return requested;
+        }
+        if (candidates.size() > 1) {
+            throw new IllegalStateException("Multiple legacy Frostguard data locations were detected: "
+                    + candidates + ". Restart with -D" + SOURCE_PROPERTY + "=/exact/source/path; no files were changed.");
+        }
+        return candidates.getFirst();
+    }
+
+    private static void verifyDatabaseUnlocked(Path source) throws IOException {
+        List<FileChannel> channels = new ArrayList<>();
+        List<FileLock> locks = new ArrayList<>();
+        try {
+            for (String name : DATABASE_FILES) {
+                Path file = source.resolve(name);
+                if (!Files.exists(file)) continue;
+                FileChannel channel = FileChannel.open(file, StandardOpenOption.WRITE);
+                channels.add(channel);
+                FileLock lock = channel.tryLock();
+                if (lock == null) throw new IOException("Legacy SQLite file is locked: " + file);
+                locks.add(lock);
+            }
+        } finally {
+            for (FileLock lock : locks) lock.close();
+            for (FileChannel channel : channels) channel.close();
+        }
+    }
+
+    private static void copyLegacyFiles(Path source, Path backup, boolean includeDirectories) throws IOException {
+        for (String name : DATABASE_FILES) copyFileIfPresent(source.resolve(name), backup.resolve(name));
+        if (includeDirectories) {
+            copyDirectoryIfPresent(source.resolve("custom_tasks"), backup.resolve("custom_tasks"));
+            copyDirectoryIfPresent(source.resolve("log"), backup.resolve("log"));
+            copyDirectoryIfPresent(source.resolve("logs"), backup.resolve("logs"));
+            copyDirectoryIfPresent(source.resolve("temp"), backup.resolve("temp"));
+        }
+    }
+
+    private static void copyDatabaseGroup(Path source, Path dataHome) throws IOException {
+        copyFileIfPresent(source.resolve("database.db"), dataHome.resolve("frostguard.db"));
+        copyFileIfPresent(source.resolve("database.db-wal"), dataHome.resolve("frostguard.db-wal"));
+        copyFileIfPresent(source.resolve("database.db-shm"), dataHome.resolve("frostguard.db-shm"));
+    }
+
+    private static void copyFileIfPresent(Path source, Path target) throws IOException {
+        if (!Files.isRegularFile(source)) return;
+        Files.createDirectories(target.getParent());
+        Files.copy(source, target, StandardCopyOption.COPY_ATTRIBUTES);
+    }
+
+    private static void copyDirectoryIfPresent(Path source, Path target) throws IOException {
+        if (!Files.isDirectory(source)) return;
+        Files.walkFileTree(source, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path directory, BasicFileAttributes attributes) throws IOException {
+                Files.createDirectories(target.resolve(source.relativize(directory)));
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
+                Path destination = target.resolve(source.relativize(file));
+                if (!Files.exists(destination)) Files.copy(file, destination, StandardCopyOption.COPY_ATTRIBUTES);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static void writeMarker(Path marker, Path source, Path backup, Clock clock) throws IOException {
+        Properties properties = new Properties();
+        properties.setProperty("source", source.toString());
+        properties.setProperty("backup", backup.toString());
+        properties.setProperty("completedAt", Instant.now(clock).toString());
+        Files.createDirectories(marker.getParent());
+        try (var output = Files.newOutputStream(marker, StandardOpenOption.CREATE_NEW)) {
+            properties.store(output, "Frostguard legacy migration");
+        }
+    }
+
+    public record MigrationResult(boolean migrated, Path source, Path backup) {
+        static MigrationResult notRequired() {
+            return new MigrationResult(false, null, null);
+        }
+    }
+}

--- a/fg-data/src/test/java/dev/frostguard/data/migration/LegacyDataMigratorTest.java
+++ b/fg-data/src/test/java/dev/frostguard/data/migration/LegacyDataMigratorTest.java
@@ -1,0 +1,94 @@
+package dev.frostguard.data.migration;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.frostguard.api.runtime.FrostguardPaths;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+class LegacyDataMigratorTest {
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-02T12:34:56Z"), ZoneOffset.UTC);
+
+    @TempDir
+    Path tempDir;
+
+    @AfterEach
+    void clearProperties() {
+        System.clearProperty(FrostguardPaths.HOME_PROPERTY);
+        System.clearProperty(FrostguardPaths.DATA_PROPERTY);
+        System.clearProperty(LegacyDataMigrator.SOURCE_PROPERTY);
+    }
+
+    @Test
+    void migratesSqliteGroupAndMutableFilesAfterCreatingBackup() throws Exception {
+        Path repository = tempDir.resolve("repo");
+        Path source = repository.resolve("fg-app/target");
+        byte[] database = {1, 2, 3};
+        Files.createDirectories(source.resolve("custom_tasks"));
+        Files.write(source.resolve("database.db"), database);
+        Files.write(source.resolve("database.db-wal"), new byte[]{4});
+        Files.write(source.resolve("database.db-shm"), new byte[]{5});
+        Files.writeString(source.resolve("custom_tasks/example.java"), "class Example {}");
+        FrostguardPaths paths = paths(repository);
+
+        LegacyDataMigrator.MigrationResult result = LegacyDataMigrator.migrate(paths, CLOCK);
+
+        assertTrue(result.migrated());
+        assertArrayEquals(database, Files.readAllBytes(paths.dataHome().resolve("frostguard.db")));
+        assertTrue(Files.exists(paths.dataHome().resolve("frostguard.db-wal")));
+        assertTrue(Files.exists(paths.dataHome().resolve("frostguard.db-shm")));
+        assertTrue(Files.exists(paths.customTasks().resolve("example.java")));
+        assertTrue(Files.exists(result.backup().resolve("database.db")));
+        assertTrue(Files.exists(paths.dataHome().resolve("config/legacy-migration.properties")));
+        assertTrue(Files.exists(source.resolve("database.db")), "compatibility source remains untouched");
+    }
+
+    @Test
+    void refusesMultipleSourcesWithoutChangingData() throws Exception {
+        Path repository = tempDir.resolve("repo");
+        Files.createDirectories(repository.resolve("fg-app/target"));
+        Files.write(repository.resolve("database.db"), new byte[]{1});
+        Files.write(repository.resolve("fg-app/target/database.db"), new byte[]{2});
+        FrostguardPaths paths = paths(repository);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> LegacyDataMigrator.migrate(paths, CLOCK));
+
+        assertTrue(error.getMessage().contains(LegacyDataMigrator.SOURCE_PROPERTY));
+        assertFalse(Files.exists(paths.dataHome().resolve("frostguard.db")));
+        assertFalse(Files.exists(paths.dataHome().resolve("migration-backups")));
+    }
+
+    @Test
+    void explicitSelectionResolvesConflictingSources() throws Exception {
+        Path repository = tempDir.resolve("repo");
+        Path selected = repository.resolve("fg-app/target");
+        Files.createDirectories(selected);
+        Files.write(repository.resolve("database.db"), new byte[]{1});
+        Files.write(selected.resolve("database.db"), new byte[]{2});
+        System.setProperty(LegacyDataMigrator.SOURCE_PROPERTY, selected.toString());
+        FrostguardPaths paths = paths(repository);
+
+        LegacyDataMigrator.MigrationResult result = LegacyDataMigrator.migrate(paths, CLOCK);
+
+        assertTrue(result.migrated());
+        assertArrayEquals(new byte[]{2}, Files.readAllBytes(paths.dataHome().resolve("frostguard.db")));
+    }
+
+    private FrostguardPaths paths(Path repository) throws Exception {
+        Files.createDirectories(repository.resolve(".frostguard"));
+        System.setProperty(FrostguardPaths.HOME_PROPERTY, repository.resolve(".frostguard").toString());
+        System.setProperty(FrostguardPaths.DATA_PROPERTY, repository.resolve(".frostguard/data").toString());
+        return FrostguardPaths.resolve(LegacyDataMigratorTest.class);
+    }
+}

--- a/fg-distribution/pom.xml
+++ b/fg-distribution/pom.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.frostguard</groupId>
+        <artifactId>frostguard</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>fg-distribution</artifactId>
+    <packaging>pom</packaging>
+    <name>Frostguard Portable Distribution</name>
+
+    <properties>
+        <frostguard.platform>win</frostguard.platform>
+        <frostguard.channel>development</frostguard.channel>
+        <frostguard.commit>unknown</frostguard.commit>
+        <staging.root>${project.build.directory}/staging/Frostguard</staging.root>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.frostguard</groupId>
+            <artifactId>fg-app</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.frostguard</groupId>
+            <artifactId>fg-watcher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>stage-application-artifacts</id>
+                        <phase>prepare-package</phase>
+                        <goals><goal>copy</goal></goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>dev.frostguard</groupId><artifactId>fg-app</artifactId><version>${project.version}</version>
+                                    <outputDirectory>${staging.root}/app</outputDirectory><destFileName>frostguard-${project.version}.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>dev.frostguard</groupId><artifactId>fg-watcher</artifactId><version>${project.version}</version>
+                                    <outputDirectory>${staging.root}/app</outputDirectory><destFileName>fg-watcher-${project.version}.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stage-runtime-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals><goal>copy-dependencies</goal></goals>
+                        <configuration>
+                            <outputDirectory>${staging.root}/app/lib</outputDirectory>
+                            <includeScope>runtime</includeScope>
+                            <excludeArtifactIds>fg-app,fg-watcher</excludeArtifactIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>stage-portable-layout</id>
+                        <phase>prepare-package</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                            <outputDirectory>${staging.root}</outputDirectory>
+                            <resources>
+                                <resource><directory>${project.basedir}/src/main/resources</directory><filtering>true</filtering></resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stage-runtime-assets</id>
+                        <phase>prepare-package</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                            <outputDirectory>${staging.root}/app/lib</outputDirectory>
+                            <resources>
+                                <resource><directory>${maven.multiModuleProjectDirectory}/tools</directory><filtering>false</filtering></resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stage-templates</id>
+                        <phase>prepare-package</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                            <outputDirectory>${staging.root}/resources/templates</outputDirectory>
+                            <resources><resource><directory>${maven.multiModuleProjectDirectory}/fg-vision/src/main/resources/templates</directory><filtering>false</filtering></resource></resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stage-default-custom-tasks</id>
+                        <phase>prepare-package</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                            <outputDirectory>${staging.root}/resources/defaults/custom-tasks</outputDirectory>
+                            <resources><resource><directory>${maven.multiModuleProjectDirectory}/custom_tasks</directory><filtering>false</filtering></resource></resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stage-documentation</id>
+                        <phase>prepare-package</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                            <outputDirectory>${staging.root}/docs</outputDirectory>
+                            <resources>
+                                <resource><directory>${maven.multiModuleProjectDirectory}</directory><filtering>false</filtering><includes><include>README.md</include><include>PRIVACY.md</include></includes></resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>archive-portable-layout</id>
+                        <phase>package</phase>
+                        <goals><goal>single</goal></goals>
+                        <configuration>
+                            <finalName>frostguard-${project.version}-${frostguard.platform}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors><descriptor>src/main/assembly/distribution.xml</descriptor></descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>clear-staging</id>
+                        <phase>initialize</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration><target><delete dir="${staging.root}" quiet="true"/></target></configuration>
+                    </execution>
+                    <execution>
+                        <id>verify-staging</id>
+                        <phase>prepare-package</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <available file="${staging.root}/Frostguard.bat" property="launcher.present"/>
+                                <available file="${staging.root}/build-info.json" property="metadata.present"/>
+                                <available file="${staging.root}/app/frostguard-${project.version}.jar" property="app.present"/>
+                                <available file="${staging.root}/app/fg-watcher-${project.version}.jar" property="watcher.present"/>
+                                <available file="${staging.root}/data/README.txt" property="data.placeholder.present"/>
+                                <fail unless="launcher.present" message="Staging has no platform launcher"/>
+                                <fail unless="metadata.present" message="Staging has no build-info.json"/>
+                                <fail unless="app.present" message="Staging has no Frostguard application JAR"/>
+                                <fail unless="watcher.present" message="Staging has no watcher JAR"/>
+                                <fail unless="data.placeholder.present" message="Staging has no safe data placeholder"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>refresh-local-installation</id>
+                        <phase>package</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${maven.multiModuleProjectDirectory}/.frostguard/data"/>
+                                <delete dir="${maven.multiModuleProjectDirectory}/.frostguard.next" quiet="true"/>
+                                <copy todir="${maven.multiModuleProjectDirectory}/.frostguard.next">
+                                    <fileset dir="${staging.root}"><exclude name="data/**"/></fileset>
+                                </copy>
+                                <delete dir="${maven.multiModuleProjectDirectory}/.frostguard/app" quiet="true"/>
+                                <delete dir="${maven.multiModuleProjectDirectory}/.frostguard/resources" quiet="true"/>
+                                <delete dir="${maven.multiModuleProjectDirectory}/.frostguard/docs" quiet="true"/>
+                                <delete file="${maven.multiModuleProjectDirectory}/.frostguard/Frostguard.bat" quiet="true"/>
+                                <delete file="${maven.multiModuleProjectDirectory}/.frostguard/build-info.json" quiet="true"/>
+                                <move todir="${maven.multiModuleProjectDirectory}/.frostguard"><fileset dir="${maven.multiModuleProjectDirectory}/.frostguard.next"/></move>
+                                <delete dir="${maven.multiModuleProjectDirectory}/.frostguard.next" quiet="true"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/fg-distribution/pom.xml
+++ b/fg-distribution/pom.xml
@@ -8,7 +8,7 @@
         <version>${revision}</version>
     </parent>
     <artifactId>fg-distribution</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
     <name>Frostguard Portable Distribution</name>
 
     <properties>
@@ -23,6 +23,11 @@
             <groupId>dev.frostguard</groupId>
             <artifactId>fg-app</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>dev.frostguard</groupId>
@@ -168,25 +173,23 @@
                             </target>
                         </configuration>
                     </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec.maven.plugin.version}</version>
+                <executions>
                     <execution>
                         <id>refresh-local-installation</id>
                         <phase>package</phase>
-                        <goals><goal>run</goal></goals>
+                        <goals><goal>java</goal></goals>
                         <configuration>
-                            <target>
-                                <mkdir dir="${maven.multiModuleProjectDirectory}/.frostguard/data"/>
-                                <delete dir="${maven.multiModuleProjectDirectory}/.frostguard.next" quiet="true"/>
-                                <copy todir="${maven.multiModuleProjectDirectory}/.frostguard.next">
-                                    <fileset dir="${staging.root}"><exclude name="data/**"/></fileset>
-                                </copy>
-                                <delete dir="${maven.multiModuleProjectDirectory}/.frostguard/app" quiet="true"/>
-                                <delete dir="${maven.multiModuleProjectDirectory}/.frostguard/resources" quiet="true"/>
-                                <delete dir="${maven.multiModuleProjectDirectory}/.frostguard/docs" quiet="true"/>
-                                <delete file="${maven.multiModuleProjectDirectory}/.frostguard/Frostguard.bat" quiet="true"/>
-                                <delete file="${maven.multiModuleProjectDirectory}/.frostguard/build-info.json" quiet="true"/>
-                                <move todir="${maven.multiModuleProjectDirectory}/.frostguard"><fileset dir="${maven.multiModuleProjectDirectory}/.frostguard.next"/></move>
-                                <delete dir="${maven.multiModuleProjectDirectory}/.frostguard.next" quiet="true"/>
-                            </target>
+                            <mainClass>dev.frostguard.distribution.LocalInstallationDeployer</mainClass>
+                            <arguments>
+                                <argument>${staging.root}</argument>
+                                <argument>${maven.multiModuleProjectDirectory}/.frostguard</argument>
+                            </arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/fg-distribution/src/main/assembly/distribution.xml
+++ b/fg-distribution/src/main/assembly/distribution.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.1 https://maven.apache.org/xsd/assembly-2.1.1.xsd">
+    <id>portable</id>
+    <formats><format>zip</format></formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>Frostguard</baseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${staging.root}</directory>
+            <outputDirectory>/</outputDirectory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/fg-distribution/src/main/java/dev/frostguard/distribution/LocalInstallationDeployer.java
+++ b/fg-distribution/src/main/java/dev/frostguard/distribution/LocalInstallationDeployer.java
@@ -1,0 +1,163 @@
+package dev.frostguard.distribution;
+
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/** Replaces only Maven-managed local-installation paths and rolls back failed replacements. */
+public final class LocalInstallationDeployer {
+    static final List<String> MANAGED_PATHS = List.of(
+            "Frostguard.bat", "app", "resources", "docs", "build-info.json");
+
+    private LocalInstallationDeployer() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length != 2) {
+            throw new IllegalArgumentException("Expected <staging-root> <local-installation>");
+        }
+        deploy(Path.of(args[0]), Path.of(args[1]));
+    }
+
+    public static void deploy(Path stagingRoot, Path installationRoot) throws IOException {
+        deploy(stagingRoot, installationRoot, LocalInstallationDeployer::move);
+    }
+
+    static void deploy(Path stagingRoot, Path installationRoot, MoveOperation mover) throws IOException {
+        Path staging = stagingRoot.toAbsolutePath().normalize();
+        Path installation = installationRoot.toAbsolutePath().normalize();
+        if (!Files.isDirectory(staging) || !Files.isRegularFile(staging.resolve("build-info.json"))) {
+            throw new IOException("Refusing to deploy an unverified staging tree: " + staging);
+        }
+
+        Path parent = installation.getParent();
+        if (parent == null) throw new IOException("Local installation has no parent: " + installation);
+        Files.createDirectories(parent);
+        Files.createDirectories(installation.resolve("data"));
+        String transaction = UUID.randomUUID().toString();
+        Path next = parent.resolve(installation.getFileName() + ".next-" + transaction);
+        Path previous = parent.resolve(installation.getFileName() + ".previous-" + transaction);
+        List<String> backedUp = new ArrayList<>();
+        List<String> installed = new ArrayList<>();
+
+        try {
+            Files.createDirectories(next);
+            for (String managed : MANAGED_PATHS) {
+                Path source = staging.resolve(managed);
+                if (Files.exists(source)) copyRecursively(source, next.resolve(managed));
+            }
+
+            Files.createDirectories(previous);
+            for (String managed : MANAGED_PATHS) {
+                Path current = installation.resolve(managed);
+                if (!Files.exists(current)) continue;
+                mover.move(current, previous.resolve(managed));
+                backedUp.add(managed);
+            }
+            for (String managed : MANAGED_PATHS) {
+                Path replacement = next.resolve(managed);
+                if (!Files.exists(replacement)) continue;
+                mover.move(replacement, installation.resolve(managed));
+                installed.add(managed);
+            }
+        } catch (Exception failure) {
+            IOException rollbackFailure = rollback(installation, previous, installed, backedUp, mover);
+            IOException deploymentFailure = failure instanceof IOException io
+                    ? io : new IOException("Local installation deployment failed", failure);
+            if (rollbackFailure != null) deploymentFailure.addSuppressed(rollbackFailure);
+            throw deploymentFailure;
+        } finally {
+            deleteRecursively(next);
+            deleteRecursively(previous);
+        }
+    }
+
+    private static IOException rollback(Path installation, Path previous, List<String> installed,
+            List<String> backedUp, MoveOperation mover) {
+        IOException failure = null;
+        for (int index = installed.size() - 1; index >= 0; index--) {
+            try {
+                deleteRecursively(installation.resolve(installed.get(index)));
+            } catch (IOException cause) {
+                failure = append(failure, cause);
+            }
+        }
+        for (int index = backedUp.size() - 1; index >= 0; index--) {
+            String managed = backedUp.get(index);
+            try {
+                Path backup = previous.resolve(managed);
+                if (Files.exists(backup)) mover.move(backup, installation.resolve(managed));
+            } catch (IOException cause) {
+                failure = append(failure, cause);
+            }
+        }
+        return failure;
+    }
+
+    private static IOException append(IOException aggregate, IOException cause) {
+        if (aggregate == null) return cause;
+        aggregate.addSuppressed(cause);
+        return aggregate;
+    }
+
+    private static void move(Path source, Path target) throws IOException {
+        Files.createDirectories(target.getParent());
+        try {
+            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException ignored) {
+            Files.move(source, target);
+        }
+    }
+
+    private static void copyRecursively(Path source, Path target) throws IOException {
+        if (Files.isRegularFile(source)) {
+            Files.createDirectories(target.getParent());
+            Files.copy(source, target, StandardCopyOption.COPY_ATTRIBUTES);
+            return;
+        }
+        Files.walkFileTree(source, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path directory, BasicFileAttributes attributes) throws IOException {
+                Files.createDirectories(target.resolve(source.relativize(directory)));
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
+                Files.copy(file, target.resolve(source.relativize(file)), StandardCopyOption.COPY_ATTRIBUTES);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static void deleteRecursively(Path target) throws IOException {
+        if (!Files.exists(target)) return;
+        Files.walkFileTree(target, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path directory, IOException failure) throws IOException {
+                if (failure != null) throw failure;
+                Files.delete(directory);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    @FunctionalInterface
+    interface MoveOperation {
+        void move(Path source, Path target) throws IOException;
+    }
+}

--- a/fg-distribution/src/main/resources/Frostguard.bat
+++ b/fg-distribution/src/main/resources/Frostguard.bat
@@ -1,0 +1,8 @@
+@echo off
+setlocal EnableExtensions
+cd /d "%~dp0"
+where java >nul 2>&1 || (echo [ERROR] Java 21 or newer is required.&amp; exit /b 1)
+set "APP_JAR="
+for %%F in ("app\frostguard-*.jar") do if exist "%%~fF" set "APP_JAR=%%~fF"
+if not defined APP_JAR (echo [ERROR] Frostguard application JAR is missing.&amp; exit /b 1)
+java --enable-native-access=ALL-UNNAMED -jar "%APP_JAR%" %*

--- a/fg-distribution/src/main/resources/build-info.json
+++ b/fg-distribution/src/main/resources/build-info.json
@@ -1,0 +1,7 @@
+{
+  "version": "${project.version}",
+  "channel": "${frostguard.channel}",
+  "platform": "${frostguard.platform}",
+  "commit": "${frostguard.commit}",
+  "buildTime": "${maven.build.timestamp}"
+}

--- a/fg-distribution/src/main/resources/data/README.txt
+++ b/fg-distribution/src/main/resources/data/README.txt
@@ -1,0 +1,2 @@
+Frostguard stores the database, configuration, custom tasks, logs and temporary files here.
+Back up this complete directory before moving or updating an installation.

--- a/fg-distribution/src/main/resources/docs/README.md
+++ b/fg-distribution/src/main/resources/docs/README.md
@@ -1,0 +1,3 @@
+# Frostguard portable installation
+
+Start Frostguard with `Frostguard.bat` on Windows. Persistent files are stored in `data/`.

--- a/fg-distribution/src/test/java/dev/frostguard/distribution/LocalInstallationDeployerTest.java
+++ b/fg-distribution/src/test/java/dev/frostguard/distribution/LocalInstallationDeployerTest.java
@@ -1,0 +1,74 @@
+package dev.frostguard.distribution;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class LocalInstallationDeployerTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void replacesManagedFilesAndPreservesDataByteForByte() throws Exception {
+        Path staging = staging("new");
+        Path installation = installation("old");
+        byte[] persistent = {0, 1, 2, 3};
+        Files.write(installation.resolve("data/private.db"), persistent);
+
+        LocalInstallationDeployer.deploy(staging, installation);
+
+        assertEquals("new", Files.readString(installation.resolve("app/version.txt")));
+        assertArrayEquals(persistent, Files.readAllBytes(installation.resolve("data/private.db")));
+        assertFalse(Files.exists(installation.resolve("data/README.txt")));
+    }
+
+    @Test
+    void restoresCompletePreviousInstallationWhenReplacementMoveFails() throws Exception {
+        Path staging = staging("new");
+        Path installation = installation("old");
+        Files.writeString(installation.resolve("data/private.txt"), "keep");
+        AtomicInteger moves = new AtomicInteger();
+
+        assertThrows(IOException.class, () -> LocalInstallationDeployer.deploy(staging, installation,
+                (source, target) -> {
+                    if (moves.incrementAndGet() == 4) throw new IOException("simulated locked file");
+                    Files.createDirectories(target.getParent());
+                    Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+                }));
+
+        assertEquals("old", Files.readString(installation.resolve("app/version.txt")));
+        assertEquals("old", Files.readString(installation.resolve("build-info.json")));
+        assertEquals("keep", Files.readString(installation.resolve("data/private.txt")));
+    }
+
+    private Path staging(String version) throws Exception {
+        Path staging = tempDir.resolve("staging");
+        Files.createDirectories(staging.resolve("app"));
+        Files.createDirectories(staging.resolve("data"));
+        Files.writeString(staging.resolve("app/version.txt"), version);
+        Files.writeString(staging.resolve("build-info.json"), version);
+        Files.writeString(staging.resolve("Frostguard.bat"), version);
+        Files.writeString(staging.resolve("data/README.txt"), "must not deploy");
+        return staging;
+    }
+
+    private Path installation(String version) throws Exception {
+        Path installation = tempDir.resolve(".frostguard");
+        Files.createDirectories(installation.resolve("app"));
+        Files.createDirectories(installation.resolve("data"));
+        Files.writeString(installation.resolve("app/version.txt"), version);
+        Files.writeString(installation.resolve("build-info.json"), version);
+        Files.writeString(installation.resolve("Frostguard.bat"), version);
+        return installation;
+    }
+}

--- a/fg-engine/src/main/java/dev/frostguard/engine/emulator/EmulatorInstance.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/emulator/EmulatorInstance.java
@@ -1,6 +1,7 @@
 package dev.frostguard.engine.emulator;
 
 import java.io.*;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
@@ -8,6 +9,7 @@ import java.util.function.Function;
 
 import dev.frostguard.vision.ocr.TesseractOcrProvider;
 import dev.frostguard.api.configs.GameVersionEnum;
+import dev.frostguard.api.runtime.FrostguardPaths;
 import dev.frostguard.engine.error.ADBConnectionException;
 import dev.frostguard.api.domain.*;
 import com.android.ddmlib.*;
@@ -71,10 +73,13 @@ public abstract class EmulatorInstance {
     }
 
     private String adbPath() {
-        String wd = System.getProperty("user.dir");
-        for (String sub : new String[]{"tools", "fg-app"}) {
-            File f = new File(wd, sub + File.separator + "adb" + File.separator + "adb.exe");
-            if (f.exists()) return f.getAbsolutePath();
+        FrostguardPaths paths = FrostguardPaths.resolve(EmulatorInstance.class);
+        File bundled = paths.applicationHome().resolve("app/lib/adb/adb.exe").toFile();
+        if (bundled.exists()) return bundled.getAbsolutePath();
+        Path repository = paths.applicationHome().getParent();
+        if (repository != null) {
+            File sourceTool = repository.resolve("tools/adb/adb.exe").toFile();
+            if (sourceTool.exists()) return sourceTool.getAbsolutePath();
         }
         return consolePath + File.separator + "adb.exe";
     }

--- a/fg-engine/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -25,6 +25,7 @@ import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.ProfileStatusData;
 import dev.frostguard.api.domain.TaskQueueStatusData;
 import dev.frostguard.api.domain.TaskStateData;
+import dev.frostguard.api.runtime.FrostguardPaths;
 import dev.frostguard.engine.emulator.EmulatorController;
 import dev.frostguard.engine.emulator.QueuePositionListener;
 import dev.frostguard.engine.error.ADBConnectionException;
@@ -693,17 +694,23 @@ public class TaskQueue {
             if (wake.isBefore(LocalDateTime.now())) wake = LocalDateTime.now().plusMinutes(1);
             String tm = DateTimeFormatter.ofPattern("HH:mm").format(wake);
             String dt = DateTimeFormatter.ofPattern("MM/dd/yyyy").format(wake);
-            String jar = System.getProperty("user.dir") + "\\fg-app\\target\\frostguard.jar";
+            FrostguardPaths runtime = FrostguardPaths.resolve(TaskQueue.class);
+            java.nio.file.Path jarPath = runtime.codeSource();
+            if (!java.nio.file.Files.isRegularFile(jarPath)) {
+                throw new IllegalStateException("PC sleep scheduling requires a packaged Frostguard JAR");
+            }
+            String jar = jarPath.toString();
             new ProcessBuilder("schtasks","/create","/TN","Frostguard_AutoStart","/TR",
                     "javaw.exe -jar \""+jar+"\" --autostart","/SC","ONCE","/ST",tm,"/SD",dt,"/RL","HIGHEST","/F")
                     .redirectErrorStream(true).start().waitFor();
-            java.nio.file.Path ws = java.nio.file.Paths.get(System.getProperty("user.dir"),"fg_wake.ps1");
+            java.nio.file.Path ws = runtime.temp().resolve("fg_wake.ps1");
+            java.nio.file.Files.createDirectories(runtime.temp());
             java.nio.file.Files.writeString(ws,
                     "$s=New-ScheduledTaskSettingsSet -WakeToRun -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -Priority 1\n"+
                     "Set-ScheduledTask -TaskName 'Frostguard_AutoStart' -Settings $s\n");
             new ProcessBuilder("powershell.exe","-NoProfile","-ExecutionPolicy","Bypass","-File",ws.toString())
                     .redirectErrorStream(true).start().waitFor();
-            java.nio.file.Path ss = java.nio.file.Paths.get(System.getProperty("user.dir"),"fg_sleep.ps1");
+            java.nio.file.Path ss = runtime.temp().resolve("fg_sleep.ps1");
             java.nio.file.Files.writeString(ss,
                     "Start-Sleep -Seconds 2\nAdd-Type -AssemblyName System.Windows.Forms\n"+
                     "[System.Windows.Forms.Application]::SetSuspendState('Suspend',$false,$false)\n");

--- a/fg-engine/src/main/java/dev/frostguard/engine/service/CustomTaskService.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/service/CustomTaskService.java
@@ -155,7 +155,7 @@ public class CustomTaskService {
     // ========================================================================
 
     private CustomTaskService() {
-        compiledDir = Paths.get(System.getProperty("user.dir"), "custom_tasks");
+        compiledDir = dev.frostguard.api.runtime.FrostguardPaths.resolve(CustomTaskService.class).customTasks();
         jsonFile = compiledDir.resolve("custom_tasks.json");
         try {
             Files.createDirectories(compiledDir);
@@ -272,8 +272,9 @@ public class CustomTaskService {
 
     private String buildClasspath() {
         StringBuilder cp = new StringBuilder(System.getProperty("java.class.path"));
-        addJarsFromDir(cp, Paths.get(System.getProperty("user.dir"), "lib"));
-        addJarsFromDir(cp, Paths.get(System.getProperty("user.dir")));
+        Path appHome = dev.frostguard.api.runtime.FrostguardPaths.resolve(CustomTaskService.class).applicationHome();
+        addJarsFromDir(cp, appHome.resolve("app/lib"));
+        addJarsFromDir(cp, appHome.resolve("app"));
         cp.append(File.pathSeparator).append(compiledDir.toAbsolutePath());
         return cp.toString();
     }

--- a/fg-engine/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
@@ -2,6 +2,7 @@ package dev.frostguard.engine.service;
 
 import dev.frostguard.vision.ocr.TesseractOcrProvider;
 import dev.frostguard.api.configs.FlowStepKind;
+import dev.frostguard.api.runtime.FrostguardPaths;
 import dev.frostguard.api.configs.TemplatesEnum;
 import dev.frostguard.engine.emulator.EmulatorController;
 import dev.frostguard.api.domain.ImageSearchResultData;
@@ -20,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Service that manages a Task Builder recording session.
@@ -48,7 +48,7 @@ public class TaskBuilderService {
 
     public TaskBuilderService() {
         this.emuManager = EmulatorController.getInstance();
-        this.customTasksDir = Paths.get(System.getProperty("user.dir"), "custom_tasks");
+        this.customTasksDir = FrostguardPaths.resolve(TaskBuilderService.class).customTasks();
         this.mapper = new ObjectMapper()
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/fg-engine/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
@@ -78,8 +78,9 @@ public class TelegramWatcherLauncher {
             }
         } catch (Exception ignored) {}
 
-        // Fallback: walk up from current working dir
-        File dir = new File(System.getProperty("user.dir"));
+        // Fallback: resolve from the verified application home, never the caller CWD.
+        File dir = dev.frostguard.api.runtime.FrostguardPaths.resolve(TelegramWatcherLauncher.class)
+                .applicationHome().toFile();
         for (int i = 0; i < 5 && dir != null; i++) {
             File bat = new File(dir, "fg-watcher.bat");
             if (bat.exists()) return bat;

--- a/fg-engine/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
+++ b/fg-engine/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
@@ -20,8 +20,8 @@ class TaskBuilderServiceTest {
 
     @Test
     void savesBuilderJsonAndGeneratedJavaBesideIt() throws Exception {
-        String originalUserDir = System.getProperty("user.dir");
-        System.setProperty("user.dir", tempDir.toString());
+        String originalData = System.getProperty("frostguard.data");
+        System.setProperty("frostguard.data", tempDir.toString());
         try {
             TaskBuilderService service = new TaskBuilderService();
             service.startSession("Expert Idle Exploration", "0");
@@ -31,7 +31,7 @@ class TaskBuilderServiceTest {
             step.setParam("durationMs", "200");
             service.addNode(step);
 
-            Path builderFile = tempDir.resolve("custom_tasks").resolve("expert_idle_exploration.json");
+            Path builderFile = tempDir.resolve("custom-tasks").resolve("expert_idle_exploration.json");
             TaskBuilderService.CustomTaskSaveResult saved =
                     service.saveCurrentTaskToCustomTasks("Expert Idle Exploration", builderFile);
 
@@ -47,7 +47,8 @@ class TaskBuilderServiceTest {
             assertEquals("Pause before bag", loaded.getNodes().get(0).getNodeName());
             assertEquals("1", service.getActiveEmulatorNumber());
         } finally {
-            System.setProperty("user.dir", originalUserDir);
+            if (originalData == null) System.clearProperty("frostguard.data");
+            else System.setProperty("frostguard.data", originalData);
         }
     }
 }

--- a/fg-vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
+++ b/fg-vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
@@ -17,6 +17,7 @@ import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.TesseractSettingsData;
 import dev.frostguard.api.runtime.FrostguardPaths;
+import com.sun.jna.NativeLibrary;
 import net.sourceforge.tess4j.Tesseract;
 import net.sourceforge.tess4j.TesseractException;
 import org.slf4j.Logger;
@@ -42,6 +43,9 @@ public final class TesseractOcrProvider {
 
     /** Lazily resolved, then reused for every subsequent call. */
     private static volatile String resolvedTessdataDir;
+
+    /** Guards the process-wide JNA search-path registration. */
+    private static volatile boolean nativeLibraryPathConfigured;
 
     // =====================================================================
     //  Public entry points
@@ -170,6 +174,7 @@ public final class TesseractOcrProvider {
 
     /** Builds a single-line LSTM engine for the given language. */
     private static Tesseract configureTesseract(String lang) {
+        configureNativeLibraryPath();
         Tesseract t = new Tesseract();
         t.setDatapath(locateTessdata());
         t.setLanguage(lang);
@@ -181,6 +186,7 @@ public final class TesseractOcrProvider {
 
     /** Builds an engine whose behaviour is controlled by {@code cfg}. */
     private static Tesseract configureTesseract(TesseractSettingsData cfg) {
+        configureNativeLibraryPath();
         Tesseract t = new Tesseract();
         t.setDatapath(locateTessdata());
         t.setLanguage("eng");
@@ -194,6 +200,19 @@ public final class TesseractOcrProvider {
     private static String executeRecognition(Tesseract engine, BufferedImage img)
             throws TesseractException {
         return engine.doOCR(img).replace("\n", "").replace("\r", "").trim();
+    }
+
+    private static void configureNativeLibraryPath() {
+        if (nativeLibraryPathConfigured) return;
+        synchronized (TesseractOcrProvider.class) {
+            if (nativeLibraryPathConfigured) return;
+            Path nativeHome = FrostguardPaths.resolve(TesseractOcrProvider.class).nativeHome();
+            if (Files.isDirectory(nativeHome)) {
+                NativeLibrary.addSearchPath("tesseract", nativeHome.toString());
+                log.debug("Tesseract native-library search path includes {}", nativeHome);
+            }
+            nativeLibraryPathConfigured = true;
+        }
     }
 
     // =====================================================================

--- a/fg-vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
+++ b/fg-vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
@@ -7,7 +7,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -17,6 +16,7 @@ import javax.imageio.ImageIO;
 import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.runtime.FrostguardPaths;
 import net.sourceforge.tess4j.Tesseract;
 import net.sourceforge.tess4j.TesseractException;
 import org.slf4j.Logger;
@@ -224,11 +224,11 @@ public final class TesseractOcrProvider {
 
     private static List<Path> candidatePaths() {
         List<Path> paths = new ArrayList<>();
-        Path cwd = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
-        for (Path ancestor = cwd; ancestor != null; ancestor = ancestor.getParent()) {
-            paths.add(ancestor.resolve("lib").resolve("tesseract"));
-            paths.add(ancestor.resolve("tools").resolve("tesseract"));
-        }
+        FrostguardPaths runtime = FrostguardPaths.resolve(TesseractOcrProvider.class);
+        paths.add(runtime.applicationHome().resolve("app/lib/tesseract"));
+        paths.add(runtime.applicationHome().resolve("lib/tesseract"));
+        Path repository = runtime.applicationHome().getParent();
+        if (repository != null) paths.add(repository.resolve("tools/tesseract"));
         return paths;
     }
 
@@ -371,7 +371,7 @@ public final class TesseractOcrProvider {
             TesseractSettingsData cfg, String text) {
         long t0 = System.currentTimeMillis();
         try {
-            Path tempDir = Paths.get(System.getProperty("user.dir")).resolve("temp");
+            Path tempDir = FrostguardPaths.resolve(TesseractOcrProvider.class).temp();
             Files.createDirectories(tempDir);
 
             String summary = formatSettingsSummary(cfg, text);

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
 		<maven.assembly.plugin.version>3.7.1</maven.assembly.plugin.version>
 		<maven.shade.plugin.version>3.5.1</maven.shade.plugin.version>
 		<maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
+		<maven.clean.plugin.version>3.3.2</maven.clean.plugin.version>
 	</properties>
 
 	<!-- ──────────────────────────────────────────────
@@ -87,6 +88,7 @@
 		<module>fg-tasks</module>
 		<module>fg-watcher</module>
 		<module>fg-app</module>
+		<module>fg-distribution</module>
 	</modules>
 
 	<!-- ──────────────────────────────────────────────

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
 		<maven.shade.plugin.version>3.5.1</maven.shade.plugin.version>
 		<maven.antrun.plugin.version>3.1.0</maven.antrun.plugin.version>
 		<maven.clean.plugin.version>3.3.2</maven.clean.plugin.version>
+		<exec.maven.plugin.version>3.5.0</exec.maven.plugin.version>
 	</properties>
 
 	<!-- ──────────────────────────────────────────────
@@ -329,7 +330,34 @@
 					<artifactId>maven-antrun-plugin</artifactId>
 					<version>${maven.antrun.plugin.version}</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>${maven.clean.plugin.version}</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<inherited>false</inherited>
+				<configuration>
+					<filesets>
+						<fileset>
+							<directory>${maven.multiModuleProjectDirectory}/.frostguard</directory>
+							<includes>
+								<include>Frostguard.bat</include>
+								<include>app/**</include>
+								<include>resources/**</include>
+								<include>docs/**</include>
+								<include>build-info.json</include>
+							</includes>
+							<followSymlinks>false</followSymlinks>
+						</fileset>
+					</filesets>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 </project>

--- a/setup/github-workflows/daily-windows-bundle.yml
+++ b/setup/github-workflows/daily-windows-bundle.yml
@@ -70,13 +70,14 @@ jobs:
           cache: maven
 
       # The saved-frame vision tests run OCR through tess4j, which binds the host
-      # libtesseract/libleptonica at runtime. OpenCV itself needs no system
-      # package: the openpnp artifact ships the Linux native image.
-      - name: Install Tesseract native libraries
+      # libtesseract/libleptonica at runtime. JavaFX controller tests need a
+      # virtual display on this headless Linux runner. OpenCV itself needs no
+      # system package: the openpnp artifact ships the Linux native image.
+      - name: Install Linux test runtimes
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            tesseract-ocr libtesseract-dev libleptonica-dev
+            tesseract-ocr libtesseract-dev libleptonica-dev xvfb
 
       # Guards the bundle verifier itself. A verification script that cannot fail
       # would turn a broken release artifact into a green check mark.
@@ -103,14 +104,24 @@ jobs:
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "Project version: ${version}"
 
-      # Tests are intentionally NOT skipped. The vision/OCR suites are the ones
-      # most likely to regress, and they run correctly on Linux now that the
-      # OpenCV native image is selected per platform.
+      # Run tests with host-native Linux dependencies before selecting Windows
+      # JavaFX for packaging. A single Maven invocation with javafx.platform=win
+      # tries to start Windows JavaFX natives on Linux when a controller test
+      # launches the toolkit, which fails before the bundle can be assembled.
+      - name: Test on Linux
+        run: |
+          mkdir -p .frostguard/data
+          printf 'preserve-across-clean-and-deploy\n' > .frostguard/data/ci-preservation-sentinel
+          read -r -a maven_args <<< "${MAVEN_ARGS}"
+          xvfb-run --auto-servernum mvn "${maven_args[@]}" clean test
+
       - name: Build Windows desktop bundle
-        run: >-
-          mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
-          -Dfrostguard.platform=win -Dfrostguard.channel=nightly
-          -Dfrostguard.commit=${GITHUB_SHA}
+        run: |
+          read -r -a maven_args <<< "${MAVEN_ARGS}"
+          mvn "${maven_args[@]}" install -DskipTests -Djavafx.platform=win \
+            -Dfrostguard.platform=win -Dfrostguard.channel=nightly \
+            -Dfrostguard.commit="${GITHUB_SHA}"
+          grep -Fx 'preserve-across-clean-and-deploy' .frostguard/data/ci-preservation-sentinel
 
       - name: Locate the desktop bundle
         id: bundle
@@ -259,6 +270,12 @@ jobs:
             --repository "${GITHUB_REPOSITORY}" \
             --previous "${previous_sha}" \
             --current "${GITHUB_SHA}")"
+
+          notes="${notes}
+
+          ## Changes since the previous Nightly
+
+          ${changes}"
 
           if [[ -n "${previous_sha}" ]]; then
             gh release delete nightly --yes --cleanup-tag

--- a/setup/github-workflows/daily-windows-bundle.yml
+++ b/setup/github-workflows/daily-windows-bundle.yml
@@ -107,17 +107,20 @@ jobs:
       # most likely to regress, and they run correctly on Linux now that the
       # OpenCV native image is selected per platform.
       - name: Build Windows desktop bundle
-        run: mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
+        run: >-
+          mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
+          -Dfrostguard.platform=win -Dfrostguard.channel=nightly
+          -Dfrostguard.commit=${GITHUB_SHA}
 
       - name: Locate the desktop bundle
         id: bundle
         shell: bash
         run: |
           set -euo pipefail
-          zip_path="$(find fg-app/target -maxdepth 1 -type f \
-            -name '*-desktop-bundle.zip' | sort | tail -n 1)"
+          zip_path="$(find fg-distribution/target -maxdepth 1 -type f \
+            -name '*-win.zip' | sort | tail -n 1)"
           if [[ -z "${zip_path}" ]]; then
-            echo "::error::No desktop bundle ZIP found under fg-app/target."
+            echo "::error::No Windows distribution ZIP found under fg-distribution/target."
             exit 1
           fi
           echo "path=${zip_path}" >> "${GITHUB_OUTPUT}"
@@ -150,7 +153,7 @@ jobs:
             bundle_name="$(basename "${zip_path}")"
             bundle_bytes="$(stat -c%s "${zip_path}")"
             jar_count="$(unzip -Z1 "${zip_path}" \
-              | grep -Ec '^lib/[^/]+\.jar$' || true)"
+              | grep -Ec '^Frostguard/app/lib/[^/]+\.jar$' || true)"
           fi
 
           # Surefire writes one XML per test class; tests="N" is the per-class
@@ -175,7 +178,7 @@ jobs:
               echo "- Archive: \`${bundle_name}\`"
               echo "- Version: \`${{ steps.version.outputs.version }}\`"
               echo "- Size: $(du -h "${zip_path}" | cut -f1)"
-              echo "- Runtime JARs under \`lib/\`: ${jar_count:-0}"
+              echo "- Runtime JARs under \`Frostguard/app/lib/\`: ${jar_count:-0}"
               echo "- Verified: structure, manifest classpath, launch smoke test"
             else
               echo "- :x: No bundle was produced."
@@ -236,7 +239,7 @@ jobs:
             "Verified: bundle structure, manifest classpath and launch smoke test." \
             "" \
             "**Install:** extract the complete ZIP, then double-click" \
-            "\`Start Frostguard.bat\`" \
+            "\`Frostguard.bat\`" \
             "(Java 21+ required)." \
             "" \
             "This tag is replaced by every nightly build; it is not a stable release.")"

--- a/setup/github-workflows/pr-test-build.yml
+++ b/setup/github-workflows/pr-test-build.yml
@@ -238,17 +238,20 @@ jobs:
       # Tests are intentionally NOT skipped: a combined build that fails its
       # own suite is exactly what the requester needs to know.
       - name: Build Windows desktop bundle from the merged tree
-        run: mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
+        run: >-
+          mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
+          -Dfrostguard.platform=win -Dfrostguard.channel=pr-test
+          -Dfrostguard.commit=${GITHUB_SHA}
 
       - name: Locate the desktop bundle
         id: bundle
         shell: bash
         run: |
           set -euo pipefail
-          zip_path="$(find fg-app/target -maxdepth 1 -type f \
-            -name '*-desktop-bundle.zip' | sort | tail -n 1)"
+          zip_path="$(find fg-distribution/target -maxdepth 1 -type f \
+            -name '*-win.zip' | sort | tail -n 1)"
           if [[ -z "${zip_path}" ]]; then
-            echo "::error::No desktop bundle ZIP found under fg-app/target."
+            echo "::error::No Windows distribution ZIP found under fg-distribution/target."
             exit 1
           fi
           echo "path=${zip_path}" >> "${GITHUB_OUTPUT}"

--- a/setup/github-workflows/pr-test-build.yml
+++ b/setup/github-workflows/pr-test-build.yml
@@ -229,19 +229,29 @@ jobs:
           java-version: "21"
           cache: maven
 
-      - name: Install Tesseract native libraries
+      - name: Install Linux test runtimes
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            tesseract-ocr libtesseract-dev libleptonica-dev
+            tesseract-ocr libtesseract-dev libleptonica-dev xvfb
 
-      # Tests are intentionally NOT skipped: a combined build that fails its
-      # own suite is exactly what the requester needs to know.
+      # Test the combined tree with host-native Linux dependencies. Selecting
+      # Windows JavaFX during this phase prevents controller tests from starting
+      # a toolkit on the Linux runner, even when a virtual display is present.
+      - name: Test the combined tree on Linux
+        run: |
+          mkdir -p .frostguard/data
+          printf 'preserve-across-clean-and-deploy\n' > .frostguard/data/ci-preservation-sentinel
+          read -r -a maven_args <<< "${MAVEN_ARGS}"
+          xvfb-run --auto-servernum mvn "${maven_args[@]}" clean test
+
       - name: Build Windows desktop bundle from the merged tree
-        run: >-
-          mvn ${MAVEN_ARGS} clean install -Djavafx.platform=win
-          -Dfrostguard.platform=win -Dfrostguard.channel=pr-test
-          -Dfrostguard.commit=${GITHUB_SHA}
+        run: |
+          read -r -a maven_args <<< "${MAVEN_ARGS}"
+          mvn "${maven_args[@]}" install -DskipTests -Djavafx.platform=win \
+            -Dfrostguard.platform=win -Dfrostguard.channel=pr-test \
+            -Dfrostguard.commit="${GITHUB_SHA}"
+          grep -Fx 'preserve-across-clean-and-deploy' .frostguard/data/ci-preservation-sentinel
 
       - name: Locate the desktop bundle
         id: bundle


### PR DESCRIPTION
## Summary

- add a central runtime path contract separating replaceable application files from persistent data
- introduce `fg-distribution` as the owner of the portable Windows layout, staging tree, metadata, archive, and local `.frostguard` refresh
- move database, logs, custom tasks, OCR temp output, ADB lookup, and related runtime paths away from caller-CWD assumptions
- migrate legacy SQLite DB/WAL/SHM and mutable files only after creating a timestamped backup; refuse ambiguous sources unless explicitly selected
- deploy managed local files transactionally and restore the previous installation if a replacement fails
- remove only managed `.frostguard` files during `mvn clean`, preserving `.frostguard/data`
- update bundle verification, smoke testing, release workflows, build helper, and installation documentation for the new layout

## Why

Issue #81 identifies that source builds and downloaded builds currently use different layouts and can resolve mutable state differently depending on the shell working directory. This PR establishes the Maven-owned portable layout and the shared application/data-home model.

The initial platform artifact is intentionally Windows-only. Linux and macOS packaging remain follow-up platform work and must reuse the same path, staging, metadata, and deployment contracts.

## Validation

Automated behavior coverage:

- 15 bundle-verifier tests passed
- focused path, migration, and rollback suite passed
- migration tests cover backup-first DB/WAL/SHM migration, ambiguous-source refusal, and explicit source selection
- deployment tests cover byte-for-byte data preservation and rollback after a simulated locked-file move
- local `mvn clean` probe preserved the exact data sentinel checksum while removing all managed program paths

Packaging and launch coverage:

- portable Windows archive built successfully
- archive verification passed: 523 entries, 77 runtime JARs, 397 templates, complete manifest classpath
- extracted archive smoke test passed for application entry points, dependencies, manifest launch, and watcher startup
- GitHub Actions run 30756845128 passed the complete reactor/OCR suite with native Tesseract, the clean/deploy data-preservation sentinel, archive verification, smoke test, and artifact upload

Evidence level: automated tests, saved-frame OCR tests in CI, and archive launch smoke verification.

## Review focus

- path-resolution precedence and unsupported-context failure behavior
- backup and conflict semantics in `LegacyDataMigrator`
- rollback guarantees and actionable Windows lock failures in `LocalInstallationDeployer`
- Maven lifecycle ordering: clean, verified staging, archive, then local deployment
- release workflow consumption of the single distribution artifact

## Remaining merge evidence and risks

- live Windows account-log confirmation has not yet been performed
- the rollback path has deterministic automated failure coverage, but an actual running-JAR NTFS lock should still be confirmed before merge
- Linux and macOS packaging are intentionally outside this initial Windows implementation

Part of #81.
