### PR TITLE
fix(releases): stop pinging stable announcements

### DIFF
--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -166,7 +166,7 @@ jobs:
           echo "release_url=${release_url}" >> "${GITHUB_OUTPUT}"
           echo "download_url=${latest_download_url}" >> "${GITHUB_OUTPUT}"
 
-      - name: Announce the stable release to everyone
+      - name: Announce the stable release
         env:
           DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
           VERSION: ${{ inputs.version }}

--- a/ci/stable_release_notify.py
+++ b/ci/stable_release_notify.py
@@ -25,16 +25,14 @@ def build_payload(args: argparse.Namespace) -> dict:
         f" • [🗂️ Previous stable releases]({args.archive_url})"
     )
     return {
-        "content": "@everyone",
+        "content": "",
         "username": "Frostguard Releases",
         "embeds": [{
             "title": f"✅ Frostguard {args.version} is now available",
             "description": truncate(description, 4096),
             "color": 0x2ECC71,
         }],
-        # This workflow is the one intentional mass-notification path. No
-        # contributor-controlled text is included in content or mentions.
-        "allowed_mentions": {"parse": ["everyone"]},
+        "allowed_mentions": {"parse": []},
     }
 
 

--- a/ci/test_stable_release_notify.py
+++ b/ci/test_stable_release_notify.py
@@ -16,10 +16,10 @@ class StablePayloadTest(unittest.TestCase):
             "--dry-run",
         ])
 
-    def test_mentions_everyone_explicitly(self):
+    def test_does_not_ping_anyone(self):
         payload = notify.build_payload(self.args())
-        self.assertEqual(payload["content"], "@everyone")
-        self.assertEqual(payload["allowed_mentions"], {"parse": ["everyone"]})
+        self.assertEqual(payload["content"], "")
+        self.assertEqual(payload["allowed_mentions"], {"parse": []})
 
     def test_contains_only_stable_release_facts(self):
         text = str(notify.build_payload(self.args()))


### PR DESCRIPTION
## Summary

- remove the `@everyone` content from future Stable Discord announcements
- disable all Discord mentions structurally
- rename the workflow step to match the notification behavior

## Why

Stable releases should remain visible in the download channel without pinging the entire server.

## Validation

- `python3 ci/test_stable_release_notify.py`
- `git diff --check`

## Risks

None known.
