### PR TITLE
fix(discord): reorder maintained download messages

### DIFF
--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -18,6 +18,12 @@ on:
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:
+    inputs:
+      recreate_discord_message:
+        description: "Post a new maintained Nightly below Stable and retire the old message"
+        required: false
+        default: false
+        type: boolean
 
 # `contents: write` is needed to publish the rolling `nightly` release that the
 # Discord message links to. An Actions artifact URL requires a signed-in GitHub
@@ -302,6 +308,7 @@ jobs:
       # Failures remain visible in Actions and never overwrite the last working
       # public download.
       - name: Update the Daily Discord message
+        id: discord
         if: success() && github.event_name != 'pull_request'
         continue-on-error: true
         env:
@@ -320,6 +327,7 @@ jobs:
           DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
           NIGHTLY_CHANGES: ${{ steps.release.outputs.changes }}
           VERSION: ${{ steps.version.outputs.version }}
+          RECREATE_DISCORD_MESSAGE: ${{ inputs.recreate_discord_message || false }}
         shell: bash
         run: |
           set -euo pipefail
@@ -330,6 +338,11 @@ jobs:
           COMMIT_MESSAGE="${COMMIT_MESSAGE:-}"
           if [[ -z "${COMMIT_MESSAGE}" ]]; then
             COMMIT_MESSAGE="$(git log -1 --pretty=%s || true)"
+          fi
+
+          discord_target=(--message-id "${DISCORD_DAILY_MESSAGE_ID}")
+          if [[ "${RECREATE_DISCORD_MESSAGE}" == "true" ]]; then
+            discord_target=(--message-id-output "${GITHUB_OUTPUT}")
           fi
 
           python3 ci/discord_notify.py \
@@ -349,4 +362,20 @@ jobs:
             --commit-message "${COMMIT_MESSAGE}" \
             --actor "${GITHUB_ACTOR}" \
             --changes "${NIGHTLY_CHANGES}" \
-            --message-id "${DISCORD_DAILY_MESSAGE_ID}"
+            "${discord_target[@]}"
+
+      - name: Delete the superseded Discord message
+        if: success() && inputs.recreate_discord_message
+        env:
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          OLD_MESSAGE_ID: ${{ vars.DISCORD_DAILY_MESSAGE_ID }}
+          NEW_MESSAGE_ID: ${{ steps.discord.outputs.message_id }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${OLD_MESSAGE_ID}" =~ ^[0-9]+$ || "${OLD_MESSAGE_ID}" == "${NEW_MESSAGE_ID}" ]]; then
+            echo "::error::Refusing to delete an invalid or current Discord message ID."
+            exit 1
+          fi
+          curl --fail --silent --show-error \
+            --request DELETE \
+            "${DISCORD_NIGHTLY_WEBHOOK_URL%/}/messages/${OLD_MESSAGE_ID}"

--- a/ci/discord_notify.py
+++ b/ci/discord_notify.py
@@ -213,7 +213,7 @@ def retry_after_seconds(error: urllib.error.HTTPError, body: str) -> float:
 
 
 def post(webhook: str, body: bytes, content_type: str, timeout: float,
-         method: str = "POST") -> None:
+         method: str = "POST") -> bytes:
     """Send a webhook request with retries for rate limits and transient errors."""
     last_error = "no attempt was made"
     for attempt in range(1, MAX_ATTEMPTS + 1):
@@ -228,8 +228,9 @@ def post(webhook: str, body: bytes, content_type: str, timeout: float,
         )
         try:
             with urllib.request.urlopen(request, timeout=timeout) as response:
+                response_body = response.read()
                 print(f"Discord accepted the notification (HTTP {response.status}).")
-                return
+                return response_body
         except urllib.error.HTTPError as error:
             detail = ""
             try:
@@ -311,6 +312,11 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         help="edit this existing webhook message instead of creating a new one",
     )
     parser.add_argument(
+        "--message-id-output",
+        default="",
+        help="write the ID of a newly created message to this GitHub output file",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="print the payload instead of posting it",
@@ -371,8 +377,23 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         destination = f"{webhook.rstrip('/')}/messages/{args.message_id}"
         method = "PATCH"
+    elif args.message_id_output:
+        # Discord only returns the created message when wait=true is requested.
+        separator = "&" if "?" in webhook else "?"
+        destination = f"{webhook}{separator}wait=true"
 
-    post(destination, body, content_type, args.timeout, method=method)
+    response_body = post(destination, body, content_type, args.timeout, method=method)
+    if args.message_id_output:
+        try:
+            message_id = str(json.loads(response_body).get("id", ""))
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            message_id = ""
+        if not message_id.isdigit():
+            print("::error::Discord did not return a valid created message ID.")
+            return 1
+        with open(args.message_id_output, "a", encoding="utf-8") as output:
+            output.write(f"message_id={message_id}\n")
+        print(f"Created maintained Discord message {message_id}.")
     return 0
 
 

--- a/ci/test_discord_notify.py
+++ b/ci/test_discord_notify.py
@@ -174,6 +174,47 @@ class WebhookHandlingTest(unittest.TestCase):
         )
         self.assertEqual("PATCH", sender.call_args.kwargs["method"])
 
+    def test_new_daily_message_writes_its_id(self):
+        env_var = "FG_TEST_DAILY_WEBHOOK"
+        os.environ[env_var] = WEBHOOK
+        with tempfile.NamedTemporaryFile(mode="r+", delete=False) as output:
+            output_path = output.name
+        try:
+            with mock.patch.object(
+                discord_notify,
+                "post",
+                return_value=b'{"id":"1533475915571527701"}',
+            ) as sender:
+                code = discord_notify.main(
+                    BASE_ARGS + ["--webhook-env", env_var,
+                                 "--message-id-output", output_path]
+                )
+            with open(output_path, encoding="utf-8") as output:
+                written = output.read()
+        finally:
+            del os.environ[env_var]
+            os.unlink(output_path)
+        self.assertEqual(0, code)
+        self.assertEqual("message_id=1533475915571527701\n", written)
+        self.assertEqual(f"{WEBHOOK}?wait=true", sender.call_args.args[0])
+        self.assertEqual("POST", sender.call_args.kwargs["method"])
+
+    def test_rejects_missing_id_in_create_response(self):
+        env_var = "FG_TEST_DAILY_WEBHOOK"
+        os.environ[env_var] = WEBHOOK
+        with tempfile.NamedTemporaryFile(delete=False) as output:
+            output_path = output.name
+        try:
+            with mock.patch.object(discord_notify, "post", return_value=b'{}'):
+                code = discord_notify.main(
+                    BASE_ARGS + ["--webhook-env", env_var,
+                                 "--message-id-output", output_path]
+                )
+        finally:
+            del os.environ[env_var]
+            os.unlink(output_path)
+        self.assertEqual(1, code)
+
     def test_rejects_non_numeric_daily_message_id(self):
         env_var = "FG_TEST_DAILY_WEBHOOK"
         os.environ[env_var] = WEBHOOK

--- a/setup/github-workflows/daily-windows-bundle.yml
+++ b/setup/github-workflows/daily-windows-bundle.yml
@@ -18,6 +18,12 @@ on:
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:
+    inputs:
+      recreate_discord_message:
+        description: "Post a new maintained Nightly below Stable and retire the old message"
+        required: false
+        default: false
+        type: boolean
 
 # `contents: write` is needed to publish the rolling `nightly` release that the
 # Discord message links to. An Actions artifact URL requires a signed-in GitHub
@@ -302,6 +308,7 @@ jobs:
       # Failures remain visible in Actions and never overwrite the last working
       # public download.
       - name: Update the Daily Discord message
+        id: discord
         if: success() && github.event_name != 'pull_request'
         continue-on-error: true
         env:
@@ -320,6 +327,7 @@ jobs:
           DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
           NIGHTLY_CHANGES: ${{ steps.release.outputs.changes }}
           VERSION: ${{ steps.version.outputs.version }}
+          RECREATE_DISCORD_MESSAGE: ${{ inputs.recreate_discord_message || false }}
         shell: bash
         run: |
           set -euo pipefail
@@ -330,6 +338,11 @@ jobs:
           COMMIT_MESSAGE="${COMMIT_MESSAGE:-}"
           if [[ -z "${COMMIT_MESSAGE}" ]]; then
             COMMIT_MESSAGE="$(git log -1 --pretty=%s || true)"
+          fi
+
+          discord_target=(--message-id "${DISCORD_DAILY_MESSAGE_ID}")
+          if [[ "${RECREATE_DISCORD_MESSAGE}" == "true" ]]; then
+            discord_target=(--message-id-output "${GITHUB_OUTPUT}")
           fi
 
           python3 ci/discord_notify.py \
@@ -349,4 +362,20 @@ jobs:
             --commit-message "${COMMIT_MESSAGE}" \
             --actor "${GITHUB_ACTOR}" \
             --changes "${NIGHTLY_CHANGES}" \
-            --message-id "${DISCORD_DAILY_MESSAGE_ID}"
+            "${discord_target[@]}"
+
+      - name: Delete the superseded Discord message
+        if: success() && inputs.recreate_discord_message
+        env:
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          OLD_MESSAGE_ID: ${{ vars.DISCORD_DAILY_MESSAGE_ID }}
+          NEW_MESSAGE_ID: ${{ steps.discord.outputs.message_id }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${OLD_MESSAGE_ID}" =~ ^[0-9]+$ || "${OLD_MESSAGE_ID}" == "${NEW_MESSAGE_ID}" ]]; then
+            echo "::error::Refusing to delete an invalid or current Discord message ID."
+            exit 1
+          fi
+          curl --fail --silent --show-error \
+            --request DELETE \
+            "${DISCORD_NIGHTLY_WEBHOOK_URL%/}/messages/${OLD_MESSAGE_ID}"


### PR DESCRIPTION
## Summary

- add an explicit manual migration option for the maintained Nightly message
- capture the ID returned when Discord creates a replacement message
- delete the superseded Nightly only after the replacement exists
- keep the installed workflow copy synchronized

## Why

Discord keeps edited messages at their original chronological position. Recreating the maintained Nightly once places it below the new Stable announcement while future Daily runs continue editing a single message.

## Validation

- `python3 ci/test_discord_notify.py`
- `python3 ci/test_nightly_changes.py`
- workflow copies compared byte-for-byte
- `git diff --check`
- `actionlint .github/workflows/daily-windows-bundle.yml` (only existing informational shellcheck findings)

## Risks

The repository variable must be updated to the newly returned message ID immediately after the one-time migration run. The live migration will be monitored through completion.
