### PR TITLE
feat(releases): maintain one stable Discord message

### DIFF
--- a/.github/workflows/refresh-stable-discord.yml
+++ b/.github/workflows/refresh-stable-discord.yml
@@ -1,0 +1,42 @@
+name: Refresh Stable Discord Message
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    name: Update the maintained Stable download
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Test the Stable notifier
+        run: python3 ci/test_stable_release_notify.py
+
+      - name: Resolve and publish the latest Stable release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          DISCORD_STABLE_MESSAGE_ID: ${{ vars.DISCORD_STABLE_MESSAGE_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest")"
+          tag="$(jq -r '.tag_name' <<< "${release}")"
+          version="${tag#v}"
+          release_url="$(jq -r '.html_url' <<< "${release}")"
+          asset="frostguard-windows-desktop-bundle.zip"
+          download_url="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/${asset}"
+          archive_url="https://github.com/${GITHUB_REPOSITORY}/releases"
+
+          python3 ci/stable_release_notify.py \
+            --version "${version}" \
+            --download-url "${download_url}" \
+            --release-url "${release_url}" \
+            --archive-url "${archive_url}" \
+            --message-id "${DISCORD_STABLE_MESSAGE_ID}"

--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -173,9 +173,11 @@ jobs:
           DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
           RELEASE_URL: ${{ steps.release.outputs.release_url }}
           ARCHIVE_URL: https://github.com/${{ github.repository }}/releases
+          DISCORD_STABLE_MESSAGE_ID: ${{ vars.DISCORD_STABLE_MESSAGE_ID }}
         run: |
           python3 ci/stable_release_notify.py \
             --version "${VERSION}" \
             --download-url "${DOWNLOAD_URL}" \
             --release-url "${RELEASE_URL}" \
-            --archive-url "${ARCHIVE_URL}"
+            --archive-url "${ARCHIVE_URL}" \
+            --message-id "${DISCORD_STABLE_MESSAGE_ID}"

--- a/ci/README.md
+++ b/ci/README.md
@@ -171,11 +171,12 @@ daily run ID. The workflow validates the source run and Maven version, pins its
 commit, downloads and re-verifies its bundle, creates an immutable `vX.Y.Z`
 release and checks the public URL before announcing it.
 
-[`stable_release_notify.py`](stable_release_notify.py) is the only notification
-path allowed to mention `@everyone`. Its payload contains fixed release facts,
-not contributor-controlled PR titles or commit messages. Stable releases use
-the same `DISCORD_NIGHTLY_WEBHOOK_URL` credential but are announced only once;
-daily builds must not mass-mention users.
+[`stable_release_notify.py`](stable_release_notify.py) updates one maintained
+Stable message without mentioning users. Its payload contains fixed release
+facts, not contributor-controlled PR titles or commit messages. Stable releases
+use the same `DISCORD_NIGHTLY_WEBHOOK_URL` credential and the message stored in
+`DISCORD_STABLE_MESSAGE_ID`. `Refresh Stable Discord Message` can reconcile the
+card with GitHub's current Latest release without publishing a new release.
 
 Release policy and the `#downloads` channel templates live in
 [`docs/releases.md`](../docs/releases.md).

--- a/ci/stable_release_notify.py
+++ b/ci/stable_release_notify.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Notify Discord once when a verified Frostguard stable release is published."""
+"""Create or update the maintained Discord Stable download message."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ def build_payload(args: argparse.Namespace) -> dict:
         "content": "",
         "username": "Frostguard Releases",
         "embeds": [{
-            "title": f"✅ Frostguard {args.version} is now available",
+            "title": f"✅ Frostguard Stable {args.version}",
             "description": truncate(description, 4096),
             "color": 0x2ECC71,
         }],
@@ -42,6 +42,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--download-url", required=True)
     parser.add_argument("--release-url", required=True)
     parser.add_argument("--archive-url", required=True)
+    parser.add_argument(
+        "--message-id",
+        default="",
+        help="edit this maintained webhook message instead of creating a new one",
+    )
     parser.add_argument("--webhook-env", default="DISCORD_NIGHTLY_WEBHOOK_URL")
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--dry-run", action="store_true")
@@ -59,6 +64,9 @@ def main(argv: list[str] | None = None) -> int:
         if not value.startswith("https://github.com/"):
             print(f"::error::Stable {label} URL must be a GitHub HTTPS URL.")
             return 1
+    if not args.message_id.isdigit():
+        print("::error::Stable Discord message ID must be numeric.")
+        return 1
 
     payload = build_payload(args)
     if args.dry_run:
@@ -72,7 +80,18 @@ def main(argv: list[str] | None = None) -> int:
     if not re.match(r"^https://(canary\.|ptb\.)?discord(app)?\.com/api/webhooks/", webhook):
         print(f"::error::{args.webhook_env} is not a Discord webhook URL.")
         return 1
-    post(webhook, json.dumps(payload).encode(), "application/json", args.timeout)
+    destination = webhook
+    method = "POST"
+    if args.message_id:
+        destination = f"{webhook.rstrip('/')}/messages/{args.message_id}"
+        method = "PATCH"
+    post(
+        destination,
+        json.dumps(payload).encode(),
+        "application/json",
+        args.timeout,
+        method=method,
+    )
     return 0
 
 

--- a/ci/test_stable_release_notify.py
+++ b/ci/test_stable_release_notify.py
@@ -2,8 +2,12 @@
 from __future__ import annotations
 
 import unittest
+import os
+from unittest import mock
 
 import stable_release_notify as notify
+
+WEBHOOK = "https://discord.com/api/webhooks/123456789/abcdefTOKEN-value_x"
 
 
 class StablePayloadTest(unittest.TestCase):
@@ -13,6 +17,7 @@ class StablePayloadTest(unittest.TestCase):
             "--download-url", "https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip",
             "--release-url", "https://github.com/Shederator/wosbot/releases/tag/v2.1.0",
             "--archive-url", "https://github.com/Shederator/wosbot/releases",
+            "--message-id", "1533506274472235099",
             "--dry-run",
         ])
 
@@ -29,11 +34,37 @@ class StablePayloadTest(unittest.TestCase):
         self.assertIn("Previous stable releases", text)
         self.assertNotIn("commit", text.lower())
 
+    def test_names_the_maintained_stable_download(self):
+        title = notify.build_payload(self.args())["embeds"][0]["title"]
+        self.assertEqual("✅ Frostguard Stable 2.1.0", title)
+
+    def test_existing_stable_message_uses_patch(self):
+        os.environ["FG_STABLE_TEST_WEBHOOK"] = WEBHOOK
+        try:
+            with mock.patch.object(notify, "post") as sender:
+                code = notify.main([
+                    "--version", "2.1.0",
+                    "--download-url", "https://github.com/a/releases/latest/download/a.zip",
+                    "--release-url", "https://github.com/a/releases/tag/v2.1.0",
+                    "--archive-url", "https://github.com/a/releases",
+                    "--webhook-env", "FG_STABLE_TEST_WEBHOOK",
+                    "--message-id", "1533506274472235099",
+                ])
+        finally:
+            del os.environ["FG_STABLE_TEST_WEBHOOK"]
+        self.assertEqual(0, code)
+        self.assertEqual(
+            f"{WEBHOOK}/messages/1533506274472235099",
+            sender.call_args.args[0],
+        )
+        self.assertEqual("PATCH", sender.call_args.kwargs["method"])
+
     def test_rejects_non_semantic_version(self):
         argv = [
             "--version", "nightly", "--download-url", "https://github.com/a",
             "--release-url", "https://github.com/b", "--dry-run",
             "--archive-url", "https://github.com/a/releases",
+            "--message-id", "1533506274472235099",
         ]
         self.assertEqual(1, notify.main(argv))
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -5,7 +5,7 @@ notifications or download locations.
 
 | Type | Audience | Lifetime | Discord notification |
 |---|---|---|---|
-| Stable `vX.Y.Z` | Regular users | Permanent | Notify everyone once |
+| Stable `vX.Y.Z` | Regular users | Permanent | Update the maintained Stable message |
 | Daily `nightly` | Testers | Replaced daily | Update the daily download, no mass mention |
 | PR test `pr-test-*` | Requester/testers | Temporary | Reply only to the requester |
 
@@ -21,14 +21,15 @@ manually with:
 
 The workflow pins the run's exact commit, downloads its versioned artifact,
 re-runs structural and launch verification, creates the immutable `vX.Y.Z`
-release, verifies its public download URL and then sends the one permitted
-`@everyone` release announcement. Existing stable tags are never replaced.
+release, verifies its public download URL and then updates the maintained
+Stable download without mentioning users. Existing stable tags are never
+replaced.
 
 ## Discord `#download`
 
-Keep the channel read-only for regular users. Pin one short guide, keep
-permanent Stable announcements as release history, and maintain exactly one
-Nightly message that is edited in place.
+Keep the channel read-only for regular users. Pin the maintained Stable message
+and keep exactly one Nightly message directly below it. Both cards are edited
+in place; GitHub Releases remains the permanent release history.
 
 ### Pinned guide
 
@@ -48,7 +49,10 @@ Java 21 or newer is required.
 ```
 
 The Stable URL is deliberately a direct, version-independent asset URL. GitHub
-redirects it to the asset on the latest non-prerelease release.
+redirects it to the asset on the latest non-prerelease release. Store the
+webhook-owned card ID in `DISCORD_STABLE_MESSAGE_ID`. A Stable promotion updates
+the card automatically; `Refresh Stable Discord Message` repairs it manually
+from GitHub's Latest release when necessary.
 
 ### Nightly message
 
@@ -77,9 +81,8 @@ public download.
 
 ## Migration
 
-1. Create `#downloads` and post the Stable and Daily messages.
+1. Create `#download` and post the Stable and Nightly messages.
 2. Publish the first real stable release before calling it recommended.
-3. Point the nightly webhook away from the public downloads channel or change
-   it to edit the maintained Daily message.
+3. Store both maintained webhook message IDs as repository variables.
 4. Move `/build-pr` results to `#request-a-build`.
-5. Archive `#release` and `#download` after their links have been replaced.
+5. Archive redundant legacy release channels after their links are replaced.


### PR DESCRIPTION
## Summary

- update one maintained Stable Discord message for every release
- add a manual refresh workflow that reconciles the card with GitHub Latest
- remove legacy mention behavior from the existing card
- document the one-Stable/one-Nightly channel model

## Why

The permanent `releases/latest` asset URL already follows the newest Stable, but the Discord card's displayed version and release-notes link must also be refreshed. Editing one pinned card keeps Stable above the maintained Nightly and avoids channel clutter.

## Validation

- `python3 ci/test_stable_release_notify.py`
- `python3 ci/test_discord_notify.py`
- `actionlint .github/workflows/stable-windows-release.yml .github/workflows/refresh-stable-discord.yml`
- `git diff --check`

## Risks

The live webhook edit requires the configured message ID to belong to the webhook stored in `DISCORD_NIGHTLY_WEBHOOK_URL`; this will be verified by the refresh workflow after merge.
