### PR TITLE
docs(installation): clarify build choices and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,117 +203,64 @@
 
 ## 🛠️ Installation & Setup
 
-### ⚡ Prefer a ready-made build?
+Choose the path that matches what you want to do:
 
-A verified Windows desktop bundle is built automatically every night. It does
-not require Maven or a Git checkout, but Java 21 or newer must be installed.
+| Path | What it provides | Update model |
+|:-----|:-----------------|:-------------|
+| **Stable** | A tested, versioned release | Changes only when a new Stable is published |
+| **Nightly** | The latest development state; may be unstable | Rebuilt daily from `main` |
+| **PR build** | A temporary build containing selected open pull requests | Expires automatically |
+| **Source build** | A local Maven build from the repository | Built on demand from the checked-out commit |
 
-1. **[Download the latest daily Windows bundle](https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip)**
-2. Extract the complete ZIP into an empty folder.
-3. Double-click **`Start Frostguard.bat`**.
+### ⬇️ Download a Windows bundle
+
+Frostguard currently provides verified Windows desktop bundles. Java 21 or
+newer is required; Git and Maven are not.
+
+- **[Stable for Windows](https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip)**
+- **[Nightly for Windows](https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip)**
+
+After choosing a build:
+
+1. Extract the complete ZIP into an empty folder. Do not run it from inside the ZIP.
+2. Double-click **`Start Frostguard.bat`**.
+3. Open **Configuration** and select your emulator's command-line controller.
 
 > [!IMPORTANT]
-> Daily builds contain the latest development changes and may be less stable.
-> The public download needs no GitHub sign-in. Every bundle is checked for its
-> structure, classpath and basic startup behavior before publication.
+> Keep the extracted folder together. The launcher, application JAR, runtime
+> libraries, OCR data and templates are all part of the installation.
 
-<br/>
+See the **[complete installation guide](docs/installation.md)** for Java,
+emulator and game settings.
 
-### 1️⃣ Prerequisites
+### 🧪 Test pull requests
 
-<div align="center">
+Request a temporary build of one or more open pull requests with `/build-pr` in
+the Discord `#request-a-build` channel.
 
-| Requirement | Version | Download |
-|:-----------:|:-------:|:--------:|
-| ![Java](https://img.shields.io/badge/Java_JDK-ED8B00?style=flat-square&logo=openjdk&logoColor=white) | `21` | **[Adoptium Temurin](https://adoptium.net/)** |
-| ![Maven](https://img.shields.io/badge/Apache_Maven-C71A36?style=flat-square&logo=apache-maven&logoColor=white) | `3.8+` | **[Download Maven](https://maven.apache.org/install.html)** |
+PR builds use the same Windows bundle format as Stable and Nightly, but contain
+unmerged code and expire automatically.
 
-</div>
+### 🛠️ Build from source
 
-<details>
-<summary><b>💡 Windows Users: Adding Java & Maven to PATH</b></summary>
-<br/>
-
-1. Press <kbd>Win</kbd> + <kbd>R</kbd>, type `sysdm.cpl`, and press <kbd>Enter</kbd>
-2. Go to **Advanced** → **Environment Variables**
-3. Under **System variables**, select `Path` and click **Edit**
-4. Add the `bin` directories of your Java and Maven installations:
-   ```
-   C:\Program Files\Eclipse Adoptium\jdk-21\bin
-   C:\apache-maven-3.9.9\bin
-   ```
-5. Click **OK** and restart your terminal
-6. Verify with:
-   ```sh
-   java -version
-   mvn -version
-   ```
-
-</details>
-
-<br/>
-
-### 2️⃣ Compilation
+Developers need Java 21, Maven 3.8+, Git and Git LFS:
 
 ```sh
-# Clone the repository
 git clone https://github.com/Shederator/wosbot.git
 cd wosbot
-
-# Build the project
+git lfs install
+git lfs pull
 mvn clean install package
+java -jar fg-app/target/frostguard-<version>.jar
 ```
 
-> [!TIP]
-> The build produces `fg-app/target/frostguard-<version>.jar` and a complete
-> `fg-app/target/frostguard-<version>-desktop-bundle.zip`.
+The build creates the application JAR and Windows desktop bundle under
+`fg-app/target`. For the complete source setup, Windows helper and verification
+commands, see:
 
-<br/>
-
-#### Quick Build Script (Windows)
-
-For Windows users, use the **`fg-build.bat`** script for easier compilation:
-
-```batch
-fg-build.bat
-```
-
-**What it does:**
-- ✅ Stops any running Java and ADB processes
-- ✅ Runs full build (`mvn clean install package`) with one automatic retry for transient `fg-vision` copy/package issues
-- ✅ Verifies packaged app JAR integrity (`LauncherLayoutController.class` check) and triggers one focused `fg-app` fallback rebuild if needed
-- ✅ Opens the generated desktop-bundle ZIP in Explorer after success (fallback: opens `fg-app/target`)
-- ✅ Displays clear success/error messages
-
-This script is especially useful after code changes or when local packaging occasionally fails due to transient file-lock/resource-copy issues.
-
-<br/>
-
-#### Verifying a build the way CI does
-
-The same checks that guard the nightly bundle can be run locally on Windows,
-Linux or macOS. See **[`ci/README.md`](ci/README.md)** for details.
-
-```sh
-mvn clean install -Djavafx.platform=win
-python3 ci/verify_bundle.py fg-app/target/frostguard-*-desktop-bundle.zip
-ci/smoke_test_bundle.sh fg-app/target/frostguard-*-desktop-bundle.zip
-```
-
-<br/>
-
-### 3️⃣ Running the Bot
-
-```sh
-# Navigate to the target directory
-cd fg-app/target
-
-# Run the compiled JAR; replace <version> with the version from pom.xml
-java -jar frostguard-<version>.jar
-```
-
-> [!IMPORTANT]
-> We highly recommend running via command line to access real-time logs for easier debugging. Double-clicking the `.jar` works, but console logs won't be visible.
+- **[Installation and source build](docs/installation.md)**
+- **[Windows-specific setup](docs/windows.md)**
+- **[CI and bundle verification](ci/README.md)**
 
 <br/>
 

--- a/ci/stable_release_notify.py
+++ b/ci/stable_release_notify.py
@@ -16,7 +16,7 @@ from discord_notify import post, truncate  # noqa: E402
 
 def build_payload(args: argparse.Namespace) -> dict:
     description = (
-        "This is the tested version recommended for normal use.\n\n"
+        "A tested, versioned build that changes only when a new Stable is published.\n\n"
         f"**[⬇️ Download Frostguard {args.version} for Windows]"
         f"({args.download_url})**\n\n"
         "Extract the complete archive and use the included Frostguard launcher. "

--- a/ci/test_stable_release_notify.py
+++ b/ci/test_stable_release_notify.py
@@ -32,6 +32,7 @@ class StablePayloadTest(unittest.TestCase):
         self.assertIn("included Frostguard launcher", text)
         self.assertIn("releases/latest/download", text)
         self.assertIn("Previous stable releases", text)
+        self.assertNotIn("recommended", text.lower())
         self.assertNotIn("commit", text.lower())
 
     def test_names_the_maintained_stable_download(self):

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,32 +1,30 @@
 # Installation
 
-This guide covers building and launching Frostguard from source on Windows.
+This guide covers installing a verified Frostguard build, configuring the
+required emulator, and building the project from source on Windows.
 
-## Prerequisites
+## Choose a build
 
-- Basic Git and terminal usage.
-- Windows 10 or Windows 11.
-- Java JDK 21 or newer.
-- Apache Maven 3.8 or newer.
-- Git LFS for large binary assets.
+| Build | Use it when | Download |
+|:------|:------------|:---------|
+| Stable | You want a tested, versioned build that changes only with a release | [Latest Stable](https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip) |
+| Nightly | You want the latest `main` build, updated daily | [Latest Nightly](https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip) |
+| PR build | You want to test one or more open pull requests | Run `/build-pr` in Discord `#request-a-build` |
 
-Install common tools from PowerShell:
+Stable and Nightly are public Windows desktop bundles. They require Java 21,
+but not Git, Git LFS, or Maven. Nightly may contain unfinished changes; PR
+builds additionally contain unmerged code.
 
-```powershell
-winget install Microsoft.Git
-winget install EclipseAdoptium.Temurin.21.JDK
-winget install GitHub.GitLFS
-```
+## Install a downloaded build
 
-Download Maven from <https://maven.apache.org/download.cgi> and add its `bin` directory to `PATH`.
+1. Install a Java 21 JDK, such as [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=21).
+2. Download the desired ZIP from the table above.
+3. Extract the complete ZIP into an empty folder. Do not run Frostguard from inside the ZIP.
+4. Double-click `Start Frostguard.bat`.
+5. Open **Configuration** and select the emulator command-line controller.
 
-Verify the toolchain:
-
-```powershell
-java -version
-mvn -version
-git lfs version
-```
+Keep the extracted installation together. Its launcher, application JAR,
+runtime libraries, OCR data and templates are all required.
 
 ## Emulator Setup
 
@@ -53,24 +51,47 @@ In game settings:
 - Disable snow effects.
 - Use normal graphics and 30 FPS if available.
 
-## Source Checkout
+## Configure Frostguard
+
+Open the Configuration screen and select the emulator's command-line
+controller, not its graphical executable. A common MuMu path is:
+
+```text
+C:\Program Files\Netease\MuMuPlayer\nx_main\MuMuManager.exe
+```
+
+## Build from source
+
+Source builds additionally require basic Git and terminal usage, Apache Maven
+3.8 or newer, and Git LFS. Install the common tools from PowerShell:
+
+```powershell
+winget install Microsoft.Git
+winget install EclipseAdoptium.Temurin.21.JDK
+winget install GitHub.GitLFS
+```
+
+Download Maven from <https://maven.apache.org/download.cgi>, add its `bin`
+directory to `PATH`, and verify the toolchain:
+
+```powershell
+java -version
+mvn -version
+git lfs version
+```
+
+### Source checkout
 
 Clone the repository and fetch LFS assets:
 
 ```sh
-git clone <repository-url>
-cd frostguard
+git clone https://github.com/Shederator/wosbot.git
+cd wosbot
 git lfs install
 git lfs pull
 ```
 
-If certificate configuration blocks LFS temporarily:
-
-```sh
-GIT_SSL_NO_VERIFY=true git lfs pull
-```
-
-## Build
+### Build
 
 Run the full build from the repository root:
 
@@ -89,16 +110,9 @@ Build outputs are written under `fg-app/target`, including
 the ZIP and launch `Start Frostguard.bat`; the `target` path is only for source
 builds.
 
-## Run
+### Run a source build
 
-For a downloaded desktop bundle, extract the complete ZIP into an empty folder
-and double-click:
-
-```text
-Start Frostguard.bat
-```
-
-For a source build, run from the repository root:
+Run the generated application JAR from the repository root:
 
 ```sh
 java -jar fg-app/target/frostguard-<version>.jar
@@ -106,14 +120,9 @@ java -jar fg-app/target/frostguard-<version>.jar
 
 Replace `<version>` with the generated version, for example `2.1.0`.
 
-## Configure
+## Migrating an older installation
 
-Before starting automation, open the Configuration screen and set the emulator executable path.
-
-Common MuMu path:
-
-```text
-C:\Program Files\Netease\MuMuPlayer\nx_main\MuMuManager.exe
-```
-
-Copy `database.*` files from an older Frostguard folder only when intentionally migrating existing settings.
+Do not overwrite a new installation with an entire old Frostguard folder.
+Migration of legacy configuration and database files is not yet automated; keep
+a backup and copy individual `database.*` files only when intentionally carrying
+existing settings forward.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -36,8 +36,8 @@ in place; GitHub Releases remains the permanent release history.
 ```text
 📥 Frostguard Downloads
 
-Stable — recommended
-The tested version for normal use:
+Stable — versioned
+A tested build that changes only when a new Stable is published:
 https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip
 
 Nightly — testing
@@ -82,7 +82,7 @@ public download.
 ## Migration
 
 1. Create `#download` and post the Stable and Nightly messages.
-2. Publish the first real stable release before calling it recommended.
+2. Publish the first real Stable release before presenting the Stable download.
 3. Store both maintained webhook message IDs as repository variables.
 4. Move `/build-pr` results to `#request-a-build`.
 5. Archive redundant legacy release channels after their links are replaced.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -2,6 +2,12 @@
 
 This document summarizes Windows-specific setup for Frostguard.
 
+The [latest Stable Windows bundle](https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip)
+is versioned and remains unchanged until the next Stable release. The
+[latest Nightly](https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip)
+is rebuilt daily from `main`. Git, Git LFS and Maven are needed only when
+building from source.
+
 ## Build Requirements
 
 - Windows 10 or Windows 11.


### PR DESCRIPTION
## Summary

- separate Stable, Nightly, PR-build, and source-build paths in the root README
- describe Stable and Nightly neutrally without recommending either one
- make downloaded builds the shortest path and move developer details into the installation guide
- correct the source checkout, remove the unsafe TLS workaround, and clarify emulator/configuration setup
- align Windows, release, and Stable Discord copy with the same terminology

## Why

The previous README led with Nightly, mixed Maven requirements into end-user installation, and repeated detailed CI/build instructions. Users should be able to understand each build type and install either public bundle without reading developer setup.

## Validation

- `python3 ci/test_stable_release_notify.py`
- `git diff --check`
- searched user-facing documentation for the removed Stable recommendation language

## Risks

Documentation-only behavior except for the maintained Stable Discord description. The existing Stable card will be refreshed after merge to keep it aligned.
