### PR TITLE
fix(discord): prepare guild command and worker deployment

### DIFF
--- a/.github/workflows/deploy-discord-build-pr-worker.yml
+++ b/.github/workflows/deploy-discord-build-pr-worker.yml
@@ -1,0 +1,32 @@
+name: Deploy Discord Build PR Worker
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Test and deploy the Cloudflare Worker
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Test the interaction worker
+        run: node --test discord-bot/test_worker.mjs
+
+      - name: Deploy the worker
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: discord-bot
+          command: deploy

--- a/.github/workflows/sync-discord-build-pr-command.yml
+++ b/.github/workflows/sync-discord-build-pr-command.yml
@@ -1,0 +1,30 @@
+name: Sync Discord Build PR Command
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sync:
+    name: Keep the guild command and remove the global duplicate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Test command synchronisation
+        run: node --test discord-bot/test_register_command.mjs
+
+      - name: Synchronise /build-pr
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_APPLICATION_ID: "1532693190879215767"
+          DISCORD_GUILD_ID: "1475434539495981137"
+        run: node discord-bot/register-command.mjs

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -108,13 +108,18 @@ npx wrangler secret put GITHUB_TOKEN         # from step 2
 Wrangler prints the worker URL, e.g.
 `https://frostguard-build-pr.<your-subdomain>.workers.dev`.
 
+For repeatable deployments, add `CLOUDFLARE_API_TOKEN` and
+`CLOUDFLARE_ACCOUNT_ID` as GitHub repository secrets, then run **Deploy Discord
+Build PR Worker** from the Actions tab. Existing Worker secrets remain stored
+at Cloudflare and are not committed or printed by the workflow.
+
 ### 4. Point Discord at the worker
 
 Developer Portal → your application → **General Information** →
 **Interactions Endpoint URL** → paste the worker URL → Save. Discord sends a
 signed PING; if the save succeeds, signature verification works.
 
-### 5. Register the slash command
+### 5. Synchronise the slash command
 
 ```bash
 cd discord-bot
@@ -122,8 +127,14 @@ DISCORD_BOT_TOKEN=... DISCORD_APPLICATION_ID=... \
 DISCORD_GUILD_ID=<your server id> node register-command.mjs
 ```
 
-With `DISCORD_GUILD_ID` the command appears instantly; without it Discord
-takes up to an hour to propagate it globally.
+The script requires a guild ID, upserts that guild's `/build-pr`, and removes
+any global `/build-pr` registered for the same application. This intentionally
+leaves one command in the Frostguard server instead of a duplicate global and
+guild entry.
+
+Alternatively, store the bot token as the GitHub repository secret
+`DISCORD_BOT_TOKEN` and run **Sync Discord Build PR Command** from the Actions
+tab. The secret value is never printed.
 
 ### 6. Configure result routing
 
@@ -142,6 +153,23 @@ Discord context again before it uses the bot token:
 3. Watch the run under Actions → *PR Test Build*.
 4. The result arrives as a reply to the original status message and mentions
    only the requester.
+
+## Maintainer handoff
+
+The committed configuration targets application `1532693190879215767`, server
+`1475434539495981137`, and `#request-a-build`
+(`1533460326111117322`). To make repository changes live, the application owner
+only needs to:
+
+1. Add `DISCORD_BOT_TOKEN`, `CLOUDFLARE_API_TOKEN`, and
+   `CLOUDFLARE_ACCOUNT_ID` as GitHub repository secrets.
+2. Confirm the existing Cloudflare Worker still has `DISCORD_PUBLIC_KEY` and
+   its fine-grained `GITHUB_TOKEN` Worker secrets.
+3. Install the Frostguard bot user in the server if final Actions results should
+   be posted to Discord.
+4. Run **Deploy Discord Build PR Worker**.
+5. Run **Sync Discord Build PR Command**.
+6. Test `/build-pr` in `#request-a-build` with a non-admin account.
 
 ## Configuration reference
 

--- a/discord-bot/register-command.mjs
+++ b/discord-bot/register-command.mjs
@@ -1,72 +1,100 @@
 #!/usr/bin/env node
 /**
- * Register (or update) the /build-pr slash command on the Discord application.
+ * Synchronise the guild-scoped /build-pr command and remove its global copy.
  *
- * Run once after creating the Discord application, and again whenever the
- * command definition changes. Registering is idempotent: Discord upserts by
- * command name.
- *
- * Usage:
- *   DISCORD_BOT_TOKEN=... DISCORD_APPLICATION_ID=... node register-command.mjs
- *
- * Optionally register to a single guild for instant availability (global
- * commands can take up to an hour to propagate):
- *   DISCORD_GUILD_ID=... node register-command.mjs
+ * Frostguard currently targets one Discord server. Keeping only the guild
+ * command prevents Discord from showing a duplicate global + guild command.
  */
 
-const token = process.env.DISCORD_BOT_TOKEN;
-const applicationId = process.env.DISCORD_APPLICATION_ID;
-const guildId = process.env.DISCORD_GUILD_ID || "";
+import { pathToFileURL } from "node:url";
 
-if (!token || !applicationId) {
-  console.error(
-    "Set DISCORD_BOT_TOKEN and DISCORD_APPLICATION_ID in the environment.",
-  );
-  process.exit(1);
-}
+const API = "https://discord.com/api/v10";
 
-const command = {
+export const buildPrCommand = {
   name: "build-pr",
   description:
     "Request a temporary Windows test build combining one or more open PRs",
   options: [
     {
-      type: 3, // STRING
+      type: 3,
       name: "prs",
       description: "PR numbers to combine, e.g. 47 48 49 65",
       required: true,
     },
     {
-      type: 3, // STRING
+      type: 3,
       name: "order",
       description: "Optional explicit merge order, e.g. 49 47 (default: ascending)",
       required: false,
     },
   ],
-  // No DMs: the access checks are channel/role based.
   dm_permission: false,
 };
 
-const url = guildId
-  ? `https://discord.com/api/v10/applications/${applicationId}/guilds/${guildId}/commands`
-  : `https://discord.com/api/v10/applications/${applicationId}/commands`;
-
-const response = await fetch(url, {
-  method: "POST",
-  headers: {
-    Authorization: `Bot ${token}`,
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify(command),
-});
-
-if (!response.ok) {
-  console.error(`Discord returned ${response.status}:`, await response.text());
-  process.exit(1);
+async function discordRequest(fetchImpl, token, url, options = {}) {
+  const response = await fetchImpl(url, {
+    ...options,
+    headers: {
+      Authorization: `Bot ${token}`,
+      ...(options.body ? { "Content-Type": "application/json" } : {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Discord returned ${response.status}: ${await response.text()}`);
+  }
+  return response.status === 204 ? null : response.json();
 }
 
-const data = await response.json();
-console.log(
-  `Registered /${data.name} (id ${data.id}) ` +
-  (guildId ? `in guild ${guildId}` : "globally (may take up to 1 hour)"),
-);
+export async function syncCommand(env = process.env, fetchImpl = fetch) {
+  const token = env.DISCORD_BOT_TOKEN;
+  const applicationId = env.DISCORD_APPLICATION_ID;
+  const guildId = env.DISCORD_GUILD_ID;
+  if (!token || !/^\d+$/.test(applicationId || "") || !/^\d+$/.test(guildId || "")) {
+    throw new Error(
+      "Set DISCORD_BOT_TOKEN plus numeric DISCORD_APPLICATION_ID and DISCORD_GUILD_ID values.",
+    );
+  }
+
+  const guildUrl = `${API}/applications/${applicationId}/guilds/${guildId}/commands`;
+  const registered = await discordRequest(fetchImpl, token, guildUrl, {
+    method: "POST",
+    body: JSON.stringify(buildPrCommand),
+  });
+
+  const globalUrl = `${API}/applications/${applicationId}/commands`;
+  const globalCommands = await discordRequest(fetchImpl, token, globalUrl);
+  const duplicates = globalCommands.filter(
+    (candidate) => candidate.name === buildPrCommand.name && candidate.type === 1,
+  );
+  for (const duplicate of duplicates) {
+    await discordRequest(
+      fetchImpl,
+      token,
+      `${globalUrl}/${duplicate.id}`,
+      { method: "DELETE" },
+    );
+  }
+
+  return { registered, deletedGlobalIds: duplicates.map(({ id }) => id) };
+}
+
+async function main() {
+  const result = await syncCommand();
+  console.log(
+    `Registered guild /${result.registered.name} (id ${result.registered.id}).`,
+  );
+  if (result.deletedGlobalIds.length) {
+    console.log(
+      `Deleted ${result.deletedGlobalIds.length} global /build-pr duplicate(s).`,
+    );
+  } else {
+    console.log("No global /build-pr duplicate was present.");
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/discord-bot/test_register_command.mjs
+++ b/discord-bot/test_register_command.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { syncCommand } from "./register-command.mjs";
+
+const ENV = {
+  DISCORD_BOT_TOKEN: "test-token",
+  DISCORD_APPLICATION_ID: "1532693190879215767",
+  DISCORD_GUILD_ID: "1475434539495981137",
+};
+
+function response(status, body = null) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+test("registers the guild command before deleting the global duplicate", async () => {
+  const calls = [];
+  const fetchMock = async (url, options = {}) => {
+    calls.push({ url, method: options.method || "GET", body: options.body });
+    if (options.method === "POST") {
+      return response(200, { id: "guild-command", name: "build-pr" });
+    }
+    if ((options.method || "GET") === "GET") {
+      return response(200, [
+        { id: "global-command", name: "build-pr", type: 1 },
+        { id: "other-command", name: "help", type: 1 },
+      ]);
+    }
+    return response(204);
+  };
+
+  const result = await syncCommand(ENV, fetchMock);
+
+  assert.deepEqual(result.deletedGlobalIds, ["global-command"]);
+  assert.deepEqual(calls.map(({ method }) => method), ["POST", "GET", "DELETE"]);
+  assert.match(calls[0].url, /\/guilds\/1475434539495981137\/commands$/);
+  assert.match(calls[2].url, /\/commands\/global-command$/);
+  assert.equal(JSON.parse(calls[0].body).name, "build-pr");
+});
+
+test("does not delete unrelated global commands", async () => {
+  const methods = [];
+  const fetchMock = async (_url, options = {}) => {
+    methods.push(options.method || "GET");
+    if (options.method === "POST") {
+      return response(200, { id: "guild-command", name: "build-pr" });
+    }
+    return response(200, [{ id: "other-command", name: "help", type: 1 }]);
+  };
+
+  const result = await syncCommand(ENV, fetchMock);
+
+  assert.deepEqual(result.deletedGlobalIds, []);
+  assert.deepEqual(methods, ["POST", "GET"]);
+});
+
+test("rejects missing deployment identifiers before calling Discord", async () => {
+  let called = false;
+  await assert.rejects(
+    syncCommand({}, async () => {
+      called = true;
+    }),
+    /DISCORD_BOT_TOKEN/,
+  );
+  assert.equal(called, false);
+});

--- a/discord-bot/wrangler.toml
+++ b/discord-bot/wrangler.toml
@@ -20,6 +20,6 @@ GITHUB_DEFAULT_BRANCH = "main"
 DISCORD_APPLICATION_ID = "1532693190879215767"
 # Comma-separated Discord channel IDs where /build-pr is allowed.
 # Empty = every channel the command is visible in.
-ALLOWED_CHANNEL_IDS = "1490710978805895298"
+ALLOWED_CHANNEL_IDS = "1533460326111117322"
 # Minutes to wait between test builds (flood control).
 COOLDOWN_MINUTES = "10"


### PR DESCRIPTION
## Summary

- point the deployed Worker configuration at `#request-a-build` instead of `#download`
- make command registration guild-only and remove an existing global `/build-pr` duplicate
- test the command reconciliation without contacting Discord
- add manual GitHub workflows for Worker deployment and command synchronisation
- reduce the application owner's remaining work to adding secrets and running two workflows

## Why

The repository already contains the working `/build-pr` source, but its committed channel allowlist still targeted the old download channel and deployments were manual. A global and guild registration also caused Discord to show the command twice.

## Validation

- `node --test discord-bot/test_register_command.mjs discord-bot/test_worker.mjs`
- `actionlint .github/workflows/sync-discord-build-pr-command.yml .github/workflows/deploy-discord-build-pr-worker.yml`
- `git diff --check`

## Risks

No live Discord or Cloudflare state changes occur on merge. The owner must configure the documented secrets and manually run both workflows. Discord may cache the deleted global command briefly.
