### PR TITLE
fix(discord): prepare guild command and worker deployment

### DIFF
--- a/.github/workflows/deploy-discord-build-pr-worker.yml
+++ b/.github/workflows/deploy-discord-build-pr-worker.yml
@@ -1,0 +1,32 @@
+name: Deploy Discord Build PR Worker
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Test and deploy the Cloudflare Worker
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Test the interaction worker
+        run: node --test discord-bot/test_worker.mjs
+
+      - name: Deploy the worker
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: discord-bot
+          command: deploy

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -67,7 +67,7 @@ on:
         type: string
         default: ""
       discord_message_id:
-        description: "Original /build-pr status message to reply to"
+        description: "Original /build-pr status message to link from the result"
         required: false
         type: string
         default: ""
@@ -485,9 +485,9 @@ jobs:
           name: pr-test-plan
           path: ${{ runner.temp }}/plan
 
-      - name: Reply with the final status in the requesting Discord channel
+      - name: Post the final status in the requesting Discord channel
         env:
-          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_PR_BUILD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_BUILD_WEBHOOK_URL }}
           DISCORD_ALLOWED_GUILD_ID: ${{ vars.DISCORD_PR_BUILD_GUILD_ID }}
           DISCORD_ALLOWED_CHANNEL_IDS: ${{ vars.DISCORD_PR_BUILD_CHANNEL_IDS }}
           DISCORD_GUILD_ID: ${{ inputs.discord_guild_id }}

--- a/.github/workflows/sync-discord-build-pr-command.yml
+++ b/.github/workflows/sync-discord-build-pr-command.yml
@@ -1,0 +1,30 @@
+name: Sync Discord Build PR Command
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sync:
+    name: Keep the guild command and remove the global duplicate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Test command synchronisation
+        run: node --test discord-bot/test_register_command.mjs
+
+      - name: Synchronise /build-pr
+        env:
+          DISCORD_CLIENT_SECRET: ${{ secrets.DISCORD_CLIENT_SECRET }}
+          DISCORD_APPLICATION_ID: "1532693190879215767"
+          DISCORD_GUILD_ID: "1475434539495981137"
+        run: node discord-bot/register-command.mjs

--- a/ci/discord_notify.py
+++ b/ci/discord_notify.py
@@ -237,7 +237,8 @@ def retry_after_seconds(error: urllib.error.HTTPError, body: str) -> float:
 
 
 def post(webhook: str, body: bytes, content_type: str, timeout: float,
-         method: str = "POST") -> bytes:
+         method: str = "POST",
+         credential_name: str = "DISCORD_NIGHTLY_WEBHOOK_URL") -> bytes:
     """Send a webhook request with retries for rate limits and transient errors."""
     last_error = "no attempt was made"
     for attempt in range(1, MAX_ATTEMPTS + 1):
@@ -283,7 +284,7 @@ def post(webhook: str, body: bytes, content_type: str, timeout: float,
 
     raise SystemExit(
         f"::error::Could not deliver the Discord notification ({last_error}). "
-        "Check that the DISCORD_NIGHTLY_WEBHOOK_URL secret still points at a "
+        f"Check that the {credential_name} secret still points at a "
         "live webhook."
     )
 

--- a/ci/pr_test_notify.py
+++ b/ci/pr_test_notify.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Reply with a combined-PR test build result through the Discord bot API.
+"""Post a combined-PR test build result through a dedicated Discord webhook.
 
 This is the reporting half of the `/build-pr` feature (issue #68). It reads
 the plan.json written by ci/pr_build_plan.py and renders one of four message
@@ -16,7 +16,7 @@ kinds:
 
 Every download is explicitly marked as an UNMERGED TEST BUILD so nobody
 mistakes it for a nightly. Discord IDs are validated against the configured
-guild/channel allowlist before the bot token is used. Manual runs with no
+guild/channel allowlist before the webhook is used. Manual runs with no
 Discord context remain valid and intentionally send no message.
 """
 
@@ -25,10 +25,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
-import time
-import urllib.error
-import urllib.request
 from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -41,6 +39,7 @@ from discord_notify import (  # noqa: E402
     EMBED_TITLE_LIMIT,
     human_size,
     lenient_int,
+    post,
     truncate,
 )
 
@@ -219,6 +218,13 @@ def build_payload(args: argparse.Namespace, plan: dict) -> dict:
         add_field("Requested by", truncate(args.requester, 100), inline=True)
     if args.bundle_bytes > 0 and args.kind == "success":
         add_field("Download size", human_size(args.bundle_bytes), inline=True)
+    if args.message_id and args.guild_id and args.channel_id:
+        add_field(
+            "Request",
+            f"[Open the original request](https://discord.com/channels/"
+            f"{args.guild_id}/{args.channel_id}/{args.message_id})",
+            inline=True,
+        )
 
     embed = {
         "title": truncate(title, EMBED_TITLE_LIMIT),
@@ -244,13 +250,6 @@ def build_payload(args: argparse.Namespace, plan: dict) -> dict:
         payload["allowed_mentions"] = {
             "parse": [],
             "users": [args.requester_id],
-        }
-    if args.message_id:
-        payload["message_reference"] = {
-            "message_id": args.message_id,
-            "channel_id": args.channel_id,
-            "guild_id": args.guild_id,
-            "fail_if_not_exists": False,
         }
     return payload
 
@@ -280,7 +279,7 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--request-id", default="")
     parser.add_argument("--allowed-guild-id", default="")
     parser.add_argument("--allowed-channel-ids", default="")
-    parser.add_argument("--token-env", default="DISCORD_BOT_TOKEN")
+    parser.add_argument("--webhook-env", default="DISCORD_PR_BUILD_WEBHOOK_URL")
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--dry-run", action="store_true")
     return parser.parse_args(argv)
@@ -313,39 +312,21 @@ def validate_discord_context(args: argparse.Namespace) -> str:
     return ""
 
 
-def post_bot_message(token: str, channel_id: str, payload: dict,
-                     timeout: float) -> None:
-    url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
-    body = json.dumps(payload).encode("utf-8")
-    for attempt in range(4):
-        request = urllib.request.Request(
-            url,
-            data=body,
-            method="POST",
-            headers={
-                "Authorization": f"Bot {token}",
-                "Content-Type": "application/json",
-                "User-Agent": "frostguard-ci/1.0",
-            },
-        )
-        try:
-            with urllib.request.urlopen(request, timeout=timeout) as response:
-                if response.status < 300:
-                    return
-        except urllib.error.HTTPError as error:
-            if error.code == 429 or 500 <= error.code < 600:
-                retry_after = error.headers.get("Retry-After", "1")
-                time.sleep(min(float(retry_after), 30.0))
-                continue
-            raise RuntimeError(
-                f"Discord API rejected the notification with HTTP {error.code}"
-            ) from error
-        except urllib.error.URLError as error:
-            if attempt < 3:
-                time.sleep(2 ** attempt)
-                continue
-            raise RuntimeError("Discord API notification failed") from error
-    raise RuntimeError("Discord API notification failed after retries")
+def valid_webhook_url(value: str) -> bool:
+    return bool(re.match(
+        r"^https://(canary\.|ptb\.)?discord(app)?\.com/api/webhooks/\d+/[\w-]+$",
+        value,
+    ))
+
+
+def post_webhook_message(webhook: str, payload: dict, timeout: float) -> None:
+    post(
+        webhook,
+        json.dumps(payload).encode("utf-8"),
+        "application/json",
+        timeout,
+        credential_name="DISCORD_PR_BUILD_WEBHOOK_URL",
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -365,15 +346,15 @@ def main(argv: list[str] | None = None) -> int:
         print(f"::warning::{context_error}; no Discord message sent.")
         return 0
 
-    token = os.environ.get(args.token_env, "").strip()
-    if not token:
-        print(f"::warning::{args.token_env} is empty; no Discord message sent.")
+    webhook = os.environ.get(args.webhook_env, "").strip()
+    if not webhook:
+        print(f"::warning::{args.webhook_env} is empty; no Discord message sent.")
         return 0
-    if any(character.isspace() for character in token):
-        print(f"::error::{args.token_env} is malformed.")
+    if not valid_webhook_url(webhook):
+        print(f"::error::{args.webhook_env} is not a valid Discord webhook URL.")
         return 1
 
-    post_bot_message(token, args.channel_id, payload, args.timeout)
+    post_webhook_message(webhook, payload, args.timeout)
     return 0
 
 

--- a/ci/test_pr_test_notify.py
+++ b/ci/test_pr_test_notify.py
@@ -278,7 +278,7 @@ class DiscordContextTest(unittest.TestCase):
         args.channel_id = "77777"
         self.assertIn("not allowlisted", notify.validate_discord_context(args))
 
-    def test_payload_replies_and_mentions_only_the_requester(self):
+    def test_payload_links_request_and_mentions_only_the_requester(self):
         payload = payload_for(
             "failure", sample_plan(), guild_id="11111", channel_id="22222",
             requester_id="33333", message_id="44444",
@@ -287,28 +287,32 @@ class DiscordContextTest(unittest.TestCase):
         self.assertEqual(payload["allowed_mentions"], {
             "parse": [], "users": ["33333"],
         })
-        self.assertEqual(payload["message_reference"]["message_id"], "44444")
+        self.assertIn(
+            "https://discord.com/channels/11111/22222/44444",
+            all_text(payload),
+        )
+        self.assertNotIn("message_reference", payload)
 
-    def test_bot_api_posts_to_the_validated_channel(self):
-        response = mock.MagicMock()
-        response.status = 200
-        response.__enter__.return_value = response
-        response.__exit__.return_value = False
-
-        with mock.patch.object(notify.urllib.request, "urlopen",
-                               return_value=response) as urlopen:
-            notify.post_bot_message(
-                "secret-token", "22222", {"content": "<@33333>"}, 5.0,
+    def test_posts_through_the_dedicated_webhook(self):
+        webhook = "https://discord.com/api/webhooks/12345/test-token"
+        with mock.patch.object(notify, "post") as post:
+            notify.post_webhook_message(
+                webhook, {"content": "<@33333>"}, 5.0,
             )
 
-        request = urlopen.call_args.args[0]
+        self.assertEqual(post.call_args.args[0], webhook)
+        self.assertEqual(post.call_args.args[2], "application/json")
+        self.assertEqual(post.call_args.args[3], 5.0)
         self.assertEqual(
-            request.full_url,
-            "https://discord.com/api/v10/channels/22222/messages",
+            post.call_args.kwargs["credential_name"],
+            "DISCORD_PR_BUILD_WEBHOOK_URL",
         )
-        self.assertEqual(request.get_method(), "POST")
-        self.assertEqual(request.get_header("Authorization"),
-                         "Bot secret-token")
+
+    def test_rejects_non_discord_webhook_urls(self):
+        self.assertTrue(notify.valid_webhook_url(
+            "https://discord.com/api/webhooks/12345/test-token",
+        ))
+        self.assertFalse(notify.valid_webhook_url("https://example.com/hook"))
 
     def test_partial_discord_context_is_rejected(self):
         args = notify.parse_args([

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -38,8 +38,8 @@ GitHub Actions: pr-test-build.yml
    • publish (trusted)   fresh runner re-verifies the bundle, re-checks every
                          PR is still open and unchanged, publishes the
                          temporary pr-test-<digest> prerelease
-   • notify  (trusted)   replies in the requesting channel and mentions only
-                         the requester
+   • notify  (trusted)   posts through the dedicated channel webhook, mentions
+                         only the requester and links the original request
    ▼
 pr-test-cleanup.yml deletes the release after 7 days
 or when every included PR is closed.
@@ -73,15 +73,14 @@ fine), and repo admin on GitHub.
    → name it e.g. `Frostguard Test Builds`.
 2. On **General Information**, note the **Application ID** and the
    **Public Key**.
-3. On **Bot**, click **Reset Token** and note the **Bot Token** (needed for
-   command registration and the trusted workflow notification job).
-4. On **Installation**, pick *Guild Install*. Enable the `applications.commands`
-   and `bot` scopes. Grant only **View Channels**, **Send Messages** and
-   **Read Message History**, then install it through the generated link.
+3. On **OAuth2**, note the **Client Secret**. The command-sync workflow exchanges
+   it for a short-lived token scoped only to `applications.commands.update`.
+4. On **Installation**, keep *Guild Install* with only the
+   `applications.commands` scope. A bot user and the `bot` scope are not needed.
 
-> A webhook alone is not enough for this flow. Slash commands need an
-> application with an **interactions endpoint**, and the final result uses the
-> same bot identity so it can reply to the original status message.
+The Discord application owns the slash command, while its interactions endpoint
+is the Cloudflare Worker below. A dedicated channel webhook sends final build
+results, so no continuously running or server-installed bot is required.
 
 ### 2. Create the fine-grained GitHub token for the worker
 
@@ -108,40 +107,75 @@ npx wrangler secret put GITHUB_TOKEN         # from step 2
 Wrangler prints the worker URL, e.g.
 `https://frostguard-build-pr.<your-subdomain>.workers.dev`.
 
+For repeatable deployments, add `CLOUDFLARE_API_TOKEN` and
+`CLOUDFLARE_ACCOUNT_ID` as GitHub repository secrets, then run **Deploy Discord
+Build PR Worker** from the Actions tab. Existing Worker secrets remain stored
+at Cloudflare and are not committed or printed by the workflow.
+
 ### 4. Point Discord at the worker
 
 Developer Portal → your application → **General Information** →
 **Interactions Endpoint URL** → paste the worker URL → Save. Discord sends a
 signed PING; if the save succeeds, signature verification works.
 
-### 5. Register the slash command
+### 5. Synchronise the slash command
 
 ```bash
 cd discord-bot
-DISCORD_BOT_TOKEN=... DISCORD_APPLICATION_ID=... \
+DISCORD_CLIENT_SECRET=... DISCORD_APPLICATION_ID=... \
 DISCORD_GUILD_ID=<your server id> node register-command.mjs
 ```
 
-With `DISCORD_GUILD_ID` the command appears instantly; without it Discord
-takes up to an hour to propagate it globally.
+The script requires a guild ID, upserts that guild's `/build-pr`, and removes
+any global `/build-pr` registered for the same application. This intentionally
+leaves one command in the Frostguard server instead of a duplicate global and
+guild entry.
+
+Alternatively, store the client secret as the GitHub repository secret
+`DISCORD_CLIENT_SECRET` and run **Sync Discord Build PR Command** from the
+Actions tab. The script requests a short-lived OAuth2 client-credentials token;
+the secret and access token are never printed.
 
 ### 6. Configure result routing
 
-Configure the channel in both systems so the workflow can validate the worker's
-Discord context again before it uses the bot token:
+Create a dedicated webhook under `#request-a-build` → **Edit Channel** →
+**Integrations** → **Webhooks**. Configure the same channel in both systems so
+the workflow validates the interaction context before using that webhook:
 
 - **Worker config** (`wrangler.toml`): set `ALLOWED_CHANNEL_IDS`, then deploy.
-- **GitHub secret**: `DISCORD_BOT_TOKEN`.
+- **GitHub secret**: `DISCORD_PR_BUILD_WEBHOOK_URL` (the dedicated webhook URL).
 - **GitHub variable**: `DISCORD_PR_BUILD_GUILD_ID`.
 - **GitHub variable**: `DISCORD_PR_BUILD_CHANNEL_IDS` (CSV).
+
+Discord's documented incoming-webhook API does not support creating a native
+reply to an arbitrary existing message. The result therefore pings only the
+requester and includes an **Open the original request** link instead.
 
 ### 7. Verify end-to-end
 
 1. In the allowed channel run `/build-pr prs: <an open PR number>`.
 2. Check the plan shows the pinned SHA, press **Build**.
 3. Watch the run under Actions → *PR Test Build*.
-4. The result arrives as a reply to the original status message and mentions
-   only the requester.
+4. The result arrives in the same channel, mentions only the requester and
+   links the original status message.
+
+## Maintainer handoff
+
+The committed configuration targets application `1532693190879215767`, server
+`1475434539495981137`, and `#request-a-build`
+(`1533460326111117322`). To make repository changes live, the application owner
+only needs to:
+
+1. Create a webhook in `#request-a-build`, then add
+   `DISCORD_PR_BUILD_WEBHOOK_URL`, `DISCORD_CLIENT_SECRET`,
+   `CLOUDFLARE_API_TOKEN`, and `CLOUDFLARE_ACCOUNT_ID` as GitHub repository
+   secrets. A repository administrator can enter them; their values cannot be
+   read back from GitHub afterward.
+2. Confirm the existing Cloudflare Worker still has `DISCORD_PUBLIC_KEY` and
+   its fine-grained `GITHUB_TOKEN` Worker secrets.
+3. Run **Deploy Discord Build PR Worker**.
+4. Run **Sync Discord Build PR Command**.
+5. Test `/build-pr` in `#request-a-build` with a non-admin account.
 
 ## Configuration reference
 
@@ -153,7 +187,8 @@ Discord context again before it uses the bot token:
 | `wrangler.toml` | `COOLDOWN_MINUTES` | flood-control gap between builds |
 | worker secret | `DISCORD_PUBLIC_KEY` | interaction signature verification |
 | worker secret | `GITHUB_TOKEN` | fine-grained dispatch-only token |
-| repo secret | `DISCORD_BOT_TOKEN` | bot token used only by the trusted notify job |
+| repo secret | `DISCORD_CLIENT_SECRET` | obtains a short-lived command-update token; no bot installation required |
+| repo secret | `DISCORD_PR_BUILD_WEBHOOK_URL` | dedicated `#request-a-build` result webhook |
 | repo variable | `DISCORD_PR_BUILD_GUILD_ID` | allowed server ID |
 | repo variable | `DISCORD_PR_BUILD_CHANNEL_IDS` | allowed result channel IDs (CSV) |
 

--- a/discord-bot/register-command.mjs
+++ b/discord-bot/register-command.mjs
@@ -1,72 +1,125 @@
 #!/usr/bin/env node
 /**
- * Register (or update) the /build-pr slash command on the Discord application.
+ * Synchronise the guild-scoped /build-pr command and remove its global copy.
  *
- * Run once after creating the Discord application, and again whenever the
- * command definition changes. Registering is idempotent: Discord upserts by
- * command name.
- *
- * Usage:
- *   DISCORD_BOT_TOKEN=... DISCORD_APPLICATION_ID=... node register-command.mjs
- *
- * Optionally register to a single guild for instant availability (global
- * commands can take up to an hour to propagate):
- *   DISCORD_GUILD_ID=... node register-command.mjs
+ * Frostguard currently targets one Discord server. Keeping only the guild
+ * command prevents Discord from showing a duplicate global + guild command.
  */
 
-const token = process.env.DISCORD_BOT_TOKEN;
-const applicationId = process.env.DISCORD_APPLICATION_ID;
-const guildId = process.env.DISCORD_GUILD_ID || "";
+import { pathToFileURL } from "node:url";
 
-if (!token || !applicationId) {
-  console.error(
-    "Set DISCORD_BOT_TOKEN and DISCORD_APPLICATION_ID in the environment.",
-  );
-  process.exit(1);
-}
+const API = "https://discord.com/api/v10";
 
-const command = {
+export const buildPrCommand = {
   name: "build-pr",
   description:
     "Request a temporary Windows test build combining one or more open PRs",
   options: [
     {
-      type: 3, // STRING
+      type: 3,
       name: "prs",
       description: "PR numbers to combine, e.g. 47 48 49 65",
       required: true,
     },
     {
-      type: 3, // STRING
+      type: 3,
       name: "order",
       description: "Optional explicit merge order, e.g. 49 47 (default: ascending)",
       required: false,
     },
   ],
-  // No DMs: the access checks are channel/role based.
   dm_permission: false,
 };
 
-const url = guildId
-  ? `https://discord.com/api/v10/applications/${applicationId}/guilds/${guildId}/commands`
-  : `https://discord.com/api/v10/applications/${applicationId}/commands`;
-
-const response = await fetch(url, {
-  method: "POST",
-  headers: {
-    Authorization: `Bot ${token}`,
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify(command),
-});
-
-if (!response.ok) {
-  console.error(`Discord returned ${response.status}:`, await response.text());
-  process.exit(1);
+async function clientCredentialsToken(fetchImpl, applicationId, clientSecret) {
+  const body = new URLSearchParams({
+    grant_type: "client_credentials",
+    scope: "applications.commands.update",
+  });
+  const credentials = Buffer.from(`${applicationId}:${clientSecret}`).toString("base64");
+  const response = await fetchImpl(`${API}/oauth2/token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+  if (!response.ok) {
+    throw new Error(`Discord OAuth returned ${response.status}: ${await response.text()}`);
+  }
+  const result = await response.json();
+  if (!result.access_token || result.token_type !== "Bearer") {
+    throw new Error("Discord OAuth did not return a Bearer access token.");
+  }
+  return result.access_token;
 }
 
-const data = await response.json();
-console.log(
-  `Registered /${data.name} (id ${data.id}) ` +
-  (guildId ? `in guild ${guildId}` : "globally (may take up to 1 hour)"),
-);
+async function discordRequest(fetchImpl, accessToken, url, options = {}) {
+  const response = await fetchImpl(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      ...(options.body ? { "Content-Type": "application/json" } : {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Discord returned ${response.status}: ${await response.text()}`);
+  }
+  return response.status === 204 ? null : response.json();
+}
+
+export async function syncCommand(env = process.env, fetchImpl = fetch) {
+  const clientSecret = env.DISCORD_CLIENT_SECRET;
+  const applicationId = env.DISCORD_APPLICATION_ID;
+  const guildId = env.DISCORD_GUILD_ID;
+  if (!clientSecret || !/^\d+$/.test(applicationId || "") || !/^\d+$/.test(guildId || "")) {
+    throw new Error(
+      "Set DISCORD_CLIENT_SECRET plus numeric DISCORD_APPLICATION_ID and DISCORD_GUILD_ID values.",
+    );
+  }
+  const accessToken = await clientCredentialsToken(fetchImpl, applicationId, clientSecret);
+
+  const guildUrl = `${API}/applications/${applicationId}/guilds/${guildId}/commands`;
+  const registered = await discordRequest(fetchImpl, accessToken, guildUrl, {
+    method: "POST",
+    body: JSON.stringify(buildPrCommand),
+  });
+
+  const globalUrl = `${API}/applications/${applicationId}/commands`;
+  const globalCommands = await discordRequest(fetchImpl, accessToken, globalUrl);
+  const duplicates = globalCommands.filter(
+    (candidate) => candidate.name === buildPrCommand.name && candidate.type === 1,
+  );
+  for (const duplicate of duplicates) {
+    await discordRequest(
+      fetchImpl,
+      accessToken,
+      `${globalUrl}/${duplicate.id}`,
+      { method: "DELETE" },
+    );
+  }
+
+  return { registered, deletedGlobalIds: duplicates.map(({ id }) => id) };
+}
+
+async function main() {
+  const result = await syncCommand();
+  console.log(
+    `Registered guild /${result.registered.name} (id ${result.registered.id}).`,
+  );
+  if (result.deletedGlobalIds.length) {
+    console.log(
+      `Deleted ${result.deletedGlobalIds.length} global /build-pr duplicate(s).`,
+    );
+  } else {
+    console.log("No global /build-pr duplicate was present.");
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/discord-bot/test_register_command.mjs
+++ b/discord-bot/test_register_command.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { syncCommand } from "./register-command.mjs";
+
+const ENV = {
+  DISCORD_CLIENT_SECRET: "test-client-secret",
+  DISCORD_APPLICATION_ID: "1532693190879215767",
+  DISCORD_GUILD_ID: "1475434539495981137",
+};
+
+function response(status, body = null) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function oauthResponse() {
+  return response(200, {
+    access_token: "test-access-token",
+    token_type: "Bearer",
+    expires_in: 604800,
+    scope: "applications.commands.update",
+  });
+}
+
+test("registers the guild command before deleting the global duplicate", async () => {
+  const calls = [];
+  const fetchMock = async (url, options = {}) => {
+    calls.push({ url, method: options.method || "GET", body: options.body,
+      authorization: options.headers?.Authorization });
+    if (url.endsWith("/oauth2/token")) return oauthResponse();
+    if (options.method === "POST") {
+      return response(200, { id: "guild-command", name: "build-pr" });
+    }
+    if ((options.method || "GET") === "GET") {
+      return response(200, [
+        { id: "global-command", name: "build-pr", type: 1 },
+        { id: "other-command", name: "help", type: 1 },
+      ]);
+    }
+    return response(204);
+  };
+
+  const result = await syncCommand(ENV, fetchMock);
+
+  assert.deepEqual(result.deletedGlobalIds, ["global-command"]);
+  assert.deepEqual(calls.map(({ method }) => method), ["POST", "POST", "GET", "DELETE"]);
+  assert.match(calls[0].url, /\/oauth2\/token$/);
+  assert.match(String(calls[0].body), /scope=applications.commands.update/);
+  assert.match(calls[0].authorization, /^Basic /);
+  assert.match(calls[1].url, /\/guilds\/1475434539495981137\/commands$/);
+  assert.match(calls[3].url, /\/commands\/global-command$/);
+  assert.equal(JSON.parse(calls[1].body).name, "build-pr");
+  assert.equal(calls[1].authorization, "Bearer test-access-token");
+});
+
+test("does not delete unrelated global commands", async () => {
+  const methods = [];
+  const fetchMock = async (url, options = {}) => {
+    methods.push(options.method || "GET");
+    if (url.endsWith("/oauth2/token")) return oauthResponse();
+    if (options.method === "POST") {
+      return response(200, { id: "guild-command", name: "build-pr" });
+    }
+    return response(200, [{ id: "other-command", name: "help", type: 1 }]);
+  };
+
+  const result = await syncCommand(ENV, fetchMock);
+
+  assert.deepEqual(result.deletedGlobalIds, []);
+  assert.deepEqual(methods, ["POST", "POST", "GET"]);
+});
+
+test("rejects missing deployment identifiers before calling Discord", async () => {
+  let called = false;
+  await assert.rejects(
+    syncCommand({}, async () => {
+      called = true;
+    }),
+    /DISCORD_CLIENT_SECRET/,
+  );
+  assert.equal(called, false);
+});

--- a/discord-bot/worker.js
+++ b/discord-bot/worker.js
@@ -445,7 +445,7 @@ async function handleButton(env, interaction) {
           `Building PRs ${state.order.map((n) => `#${n}`).join(", ")} with pinned heads.`,
           "",
           "The result (download link, conflict report or failure) will be",
-          "posted as a reply here when the workflow finishes. Progress: " +
+          "posted here and you will be mentioned when the workflow finishes. Progress: " +
           `<https://github.com/${env.GITHUB_REPO}/actions/workflows/pr-test-build.yml>`,
         ].join("\n"),
         footer: undefined,

--- a/discord-bot/wrangler.toml
+++ b/discord-bot/wrangler.toml
@@ -20,6 +20,6 @@ GITHUB_DEFAULT_BRANCH = "main"
 DISCORD_APPLICATION_ID = "1532693190879215767"
 # Comma-separated Discord channel IDs where /build-pr is allowed.
 # Empty = every channel the command is visible in.
-ALLOWED_CHANNEL_IDS = "1490710978805895298"
+ALLOWED_CHANNEL_IDS = "1533460326111117322"
 # Minutes to wait between test builds (flood control).
 COOLDOWN_MINUTES = "10"

--- a/setup/github-workflows/pr-test-build.yml
+++ b/setup/github-workflows/pr-test-build.yml
@@ -67,7 +67,7 @@ on:
         type: string
         default: ""
       discord_message_id:
-        description: "Original /build-pr status message to reply to"
+        description: "Original /build-pr status message to link from the result"
         required: false
         type: string
         default: ""
@@ -477,9 +477,9 @@ jobs:
           name: pr-test-plan
           path: ${{ runner.temp }}/plan
 
-      - name: Reply with the final status in the requesting Discord channel
+      - name: Post the final status in the requesting Discord channel
         env:
-          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_PR_BUILD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_BUILD_WEBHOOK_URL }}
           DISCORD_ALLOWED_GUILD_ID: ${{ vars.DISCORD_PR_BUILD_GUILD_ID }}
           DISCORD_ALLOWED_CHANNEL_IDS: ${{ vars.DISCORD_PR_BUILD_CHANNEL_IDS }}
           DISCORD_GUILD_ID: ${{ inputs.discord_guild_id }}


### PR DESCRIPTION
## What this PR changes

### Keep `/build-pr` in one channel

- changes the Worker allowlist from the old `#download` channel to `#request-a-build` (`1533460326111117322`)
- keeps the Worker-side check as the authoritative restriction, including for administrators who can bypass Discord command permissions

### Report results without installing a bot

- replaces the final GitHub Actions bot-API notification with a dedicated `#request-a-build` incoming webhook
- posts success, rejection, conflict, stale-plan and failure results in that channel
- mentions only the requester through an explicit `allowed_mentions.users` allowlist
- links the original `/build-pr` status message
- validates the originating server and channel before using the webhook

A normal incoming webhook cannot create a documented native reply to an arbitrary application message. The result therefore links the original request instead of pretending to be a native reply. No bot user, bot installation or bot token is required.

### Remove the duplicate command without a bot token

- upserts `/build-pr` as a guild command for the Frostguard server
- removes only global chat-input commands named `/build-pr` after the guild command was registered successfully
- leaves unrelated global commands untouched
- uses Discord OAuth2 client credentials with the narrow `applications.commands.update` scope instead of a bot token

### Make activation repeatable

- adds a manual `Deploy Discord Build PR Worker` workflow
- adds a manual `Sync Discord Build PR Command` workflow
- adds command reconciliation tests and updates the setup/handoff documentation

## What already existed before this PR

- the Cloudflare Worker received and verified Discord interactions
- the Worker validated PRs, displayed Build/Cancel controls and dispatched `pr-test-build.yml`
- GitHub Actions planned, built, verified and published temporary PR test releases
- the interaction already carried the requester, guild, channel and status-message IDs into Actions
- only the requester could confirm or cancel their request

## Why

The deployed configuration still targets `#download`, Discord currently exposes global and guild copies of `/build-pr`, and the repository notification path expects a bot that is not installed on the server. A channel-specific webhook provides the required result post and requester ping without adding a bot user.

## Activation after merge

The required GitHub secrets are configured: `DISCORD_PR_BUILD_WEBHOOK_URL`, `DISCORD_CLIENT_SECRET`, `CLOUDFLARE_API_TOKEN`, and `CLOUDFLARE_ACCOUNT_ID`. The existing Cloudflare Worker has confirmed `DISCORD_PUBLIC_KEY` and its fine-grained `GITHUB_TOKEN` secrets. Merging alone still does not change Discord or Cloudflare. After merge:

1. Run `Deploy Discord Build PR Worker`.
2. Run `Sync Discord Build PR Command`.
3. Test `/build-pr` in `#request-a-build` with a non-administrator account.

## Validation

- rebased onto current `main` on 2026-08-07
- `node --test discord-bot/test_register_command.mjs discord-bot/test_worker.mjs`
- `python3 ci/test_pr_build_plan.py`
- `python3 ci/test_pr_test_notify.py`
- `python3 ci/test_discord_notify.py`
- `python3 ci/test_stable_release_notify.py`
- `python3 ci/test_nightly_changes.py`
- Python compilation for the changed notification modules
- `actionlint` for the PR-build, deployment and command-sync workflows (one pre-existing informational SC2016 finding remains)
- `git diff --check`

Evidence level: automated tests. Live Discord/Cloudflare deployment remains intentionally pending until after merge.

## External effects and risk

Reviewing or merging this PR performs no live Discord or Cloudflare mutation. Only the two manual workflows change external state. The webhook is tied to `#request-a-build`; configuring a webhook from another channel would route results incorrectly, so the end-to-end test is required.

Related: #74