### PR TITLE
feat(profiles): manage profiles in bulk

### DIFF
--- a/fg-api/src/main/java/dev/frostguard/api/domain/AccountDescriptor.java
+++ b/fg-api/src/main/java/dev/frostguard/api/domain/AccountDescriptor.java
@@ -28,6 +28,7 @@ public class AccountDescriptor {
     private String serverName;
     private int queueSlot = Integer.MAX_VALUE;
     private List<ConfigData> entries = new ArrayList<>();
+    private List<String> tags = new ArrayList<>();
     private HashMap<String, String> globalOverrides = new HashMap<>();
 
     public AccountDescriptor(Long accountId) {
@@ -102,6 +103,8 @@ public class AccountDescriptor {
 
     public List<ConfigData> getEntries() { return entries; }
     public void setEntries(List<ConfigData> entries) { this.entries = entries; }
+    public List<String> getTags() { return tags; }
+    public void setTags(List<String> tags) { this.tags = tags == null ? new ArrayList<>() : new ArrayList<>(tags); }
 
     public HashMap<String, String> getGlobalOverrides() { return globalOverrides; }
     public void setGlobalOverrides(HashMap<String, String> overrides) { this.globalOverrides = overrides; }

--- a/fg-api/src/main/java/dev/frostguard/api/domain/ProfileTagData.java
+++ b/fg-api/src/main/java/dev/frostguard/api/domain/ProfileTagData.java
@@ -1,0 +1,4 @@
+package dev.frostguard.api.domain;
+
+public record ProfileTagData(String name, String color) {
+}

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/EditProfileController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/EditProfileController.java
@@ -13,10 +13,15 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;
+import javafx.scene.layout.FlowPane;
 import javafx.stage.Stage;
 
 import java.net.URL;
 import java.util.ResourceBundle;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeSet;
 import java.util.function.UnaryOperator;
 
 public class EditProfileController implements Initializable {
@@ -66,6 +71,14 @@ public class EditProfileController implements Initializable {
     @FXML
     private TextField txtCharacterServer;
 
+    @FXML
+    private FlowPane tagChoicesPane;
+
+    @FXML
+    private TextField txtNewTag;
+
+    private final List<CheckBox> tagChoices = new ArrayList<>();
+
     private ProfileAux profileToEdit;
     private ProfileManagerActionController actionController;
     private Stage dialogStage;
@@ -84,6 +97,7 @@ public class EditProfileController implements Initializable {
 
     public void setActionController(ProfileManagerActionController controller) {
         this.actionController = controller;
+        populateTagChoices();
     }
 
     public void setDialogStage(Stage stage) {
@@ -106,7 +120,40 @@ public class EditProfileController implements Initializable {
             txtCharacterName.setText(orBlank(profileToEdit.getCharacterName()));
             txtCharacterAllianceCode.setText(orBlank(profileToEdit.getCharacterAllianceCode()));
             txtCharacterServer.setText(orBlank(profileToEdit.getCharacterServer()));
+            populateTagChoices();
         }
+    }
+
+    private void populateTagChoices() {
+        if (profileToEdit == null || actionController == null || tagChoicesPane == null) return;
+        TreeSet<String> available = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        available.addAll(actionController.loadTags());
+        available.addAll(profileToEdit.getTags());
+        tagChoices.clear();
+        tagChoicesPane.getChildren().clear();
+        for (String tag : available) {
+            CheckBox choice = new CheckBox(tag);
+            choice.getStyleClass().add("profile-tag-choice");
+            choice.setSelected(profileToEdit.getTags().stream().anyMatch(current -> current.equalsIgnoreCase(tag)));
+            tagChoices.add(choice);
+            tagChoicesPane.getChildren().add(choice);
+        }
+    }
+
+    @FXML
+    private void handleAddTag() {
+        String name = txtNewTag.getText() == null ? "" : txtNewTag.getText().trim().replaceAll("\\s+", " ");
+        if (name.isBlank()) return;
+        tagChoices.stream().filter(choice -> choice.getText().equalsIgnoreCase(name)).findFirst()
+            .ifPresentOrElse(choice -> choice.setSelected(true), () -> {
+                CheckBox choice = new CheckBox(name.length() <= 40 ? name : name.substring(0, 40));
+                choice.getStyleClass().add("profile-tag-choice");
+                choice.setSelected(true);
+                tagChoices.add(choice);
+                tagChoices.sort(Comparator.comparing(CheckBox::getText, String.CASE_INSENSITIVE_ORDER));
+                tagChoicesPane.getChildren().setAll(tagChoices);
+            });
+        txtNewTag.clear();
     }
 
     @FXML
@@ -172,6 +219,7 @@ public class EditProfileController implements Initializable {
         profileToEdit.setCharacterName(blankToNull(txtCharacterName));
         profileToEdit.setCharacterAllianceCode(blankToNullUppercase(txtCharacterAllianceCode));
         profileToEdit.setCharacterServer(blankToNull(txtCharacterServer));
+        profileToEdit.setTags(tagChoices.stream().filter(CheckBox::isSelected).map(CheckBox::getText).toList());
     }
 
     private void requireText(TextField field, String label, StringBuilder errors) {

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/IProfileModel.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/IProfileModel.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.ProfileTagData;
 import dev.frostguard.engine.listener.ProfileStatusChangeListener;
 
 public interface IProfileModel {
@@ -17,6 +18,13 @@ public interface IProfileModel {
 	boolean deleteProfile(AccountDescriptor profile);
 
 	boolean bulkUpdateProfiles(AccountDescriptor templateProfile);
+
+	List<String> getTags();
+	default List<ProfileTagData> getTagDefinitions() { return List.of(); }
+	default boolean updateTag(String oldName, String newName, String color) { return false; }
+	default boolean deleteTag(String name) { return false; }
+
+	boolean replaceTags(Long profileId, List<String> tags);
 
 	void addProfileStatusChangeListerner(ProfileStatusChangeListener listener);
 

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileAux.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileAux.java
@@ -37,6 +37,7 @@ public class ProfileAux {
 	private final StringProperty characterServer;
 
 	private List<ConfigAux> configs = new ArrayList<>();
+	private List<String> tags = new ArrayList<>();
 
 	/* ────────────────────────────────────────────────
 	 *  Constructors
@@ -170,6 +171,14 @@ public class ProfileAux {
 
 	public void setConfigs(List<ConfigAux> incoming) {
 		this.configs = incoming == null ? new ArrayList<>() : incoming;
+	}
+
+	public List<String> getTags() {
+		return List.copyOf(tags);
+	}
+
+	public void setTags(List<String> incoming) {
+		tags = incoming == null ? new ArrayList<>() : new ArrayList<>(incoming);
 	}
 
 	public <T> T getConfig(ConfigurationKeyEnum key, Class<T> clazz) {

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerActionController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerActionController.java
@@ -5,9 +5,11 @@ import dev.frostguard.api.configs.TpMessageSeverityEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.ConfigData;
 import dev.frostguard.api.domain.ProfileStatusData;
+import dev.frostguard.api.domain.ProfileTagData;
 import dev.frostguard.app.panel.launcher.ILauncherConstants;
 import dev.frostguard.engine.listener.ProfileStatusChangeListener;
 import dev.frostguard.engine.service.LoggingService;
+import dev.frostguard.engine.service.ScheduleService;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 import javafx.scene.Parent;
@@ -19,9 +21,12 @@ import javafx.stage.Stage;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 public class ProfileManagerActionController implements ProfileStatusChangeListener {
 
@@ -29,10 +34,18 @@ public class ProfileManagerActionController implements ProfileStatusChangeListen
 
 	private Stage newProfileStage;
 	private IProfileModel iModel;
+	private final ProfileRuntimeController runtimeController;
+	private final ProfileTransferService transferService = new ProfileTransferService();
 
 	public ProfileManagerActionController(ProfileManagerLayoutController profileManagerLayoutController) {
+		this(profileManagerLayoutController, new ProfileModel(), new ScheduleProfileRuntimeController());
+	}
+
+	ProfileManagerActionController(ProfileManagerLayoutController profileManagerLayoutController,
+			IProfileModel model, ProfileRuntimeController runtimeController) {
 		this.profileManagerLayoutController = profileManagerLayoutController;
-		this.iModel = new ProfileModel();
+		this.iModel = model;
+		this.runtimeController = runtimeController;
 		this.iModel.addProfileStatusChangeListerner(this);
 	}
 
@@ -60,8 +73,185 @@ public class ProfileManagerActionController implements ProfileStatusChangeListen
 		return iModel.addProfile(profile);
 	}
 
+	public boolean duplicateProfile(ProfileAux source, List<ProfileAux> existingProfiles) {
+		if (source == null) return false;
+		String name = availableName(source.getName() + " Copy", existingProfiles.stream()
+				.map(ProfileAux::getName).toList());
+		try {
+			boolean created = iModel.addProfile(transferService.duplicate(source, name));
+			if (created) log(TpMessageSeverityEnum.INFO, "Duplicated profile '" + source.getName() + "' as '" + name + "'");
+			return created;
+		} catch (Exception ex) {
+			log(TpMessageSeverityEnum.ERROR, "Failed to duplicate profile: " + ex.getMessage());
+			return false;
+		}
+	}
+
+	public void exportProfiles(Path destination, List<ProfileAux> selectedProfiles) throws IOException {
+		transferService.write(destination, selectedProfiles);
+		log(TpMessageSeverityEnum.INFO, "Exported " + selectedProfiles.size() + " profiles to " + destination);
+	}
+
+	public ImportResult importProfiles(List<Path> sources, List<ProfileAux> existingProfiles) {
+		ImportPreview preview = prepareImport(sources, existingProfiles);
+		ImportResult imported = importPrepared(preview.profiles());
+		return new ImportResult(imported.imported(), imported.failed() + preview.errors().size());
+	}
+
+	public ImportPreview prepareImport(List<Path> sources, List<ProfileAux> existingProfiles) {
+		List<String> occupiedNames = new ArrayList<>(existingProfiles.stream().map(ProfileAux::getName).toList());
+		List<AccountDescriptor> prepared = new ArrayList<>();
+		List<String> errors = new ArrayList<>();
+		for (Path source : sources) {
+			try {
+				for (AccountDescriptor descriptor : transferService.read(source)) {
+					String name = availableName(descriptor.getName(), occupiedNames);
+					descriptor.setName(name);
+					occupiedNames.add(name);
+					prepared.add(descriptor);
+				}
+			} catch (Exception ex) {
+				errors.add(source.getFileName() + ": " + ex.getMessage());
+				log(TpMessageSeverityEnum.ERROR, "Failed to import " + source + ": " + ex.getMessage());
+			}
+		}
+		return new ImportPreview(prepared, errors);
+	}
+
+	public ImportResult importPrepared(List<AccountDescriptor> profiles) {
+		int imported = 0;
+		int failed = 0;
+		for (AccountDescriptor descriptor : profiles) {
+			if (iModel.addProfile(descriptor)) imported++; else failed++;
+		}
+		return new ImportResult(imported, failed);
+	}
+
+	private String availableName(String requested, List<String> occupiedNames) {
+		String base = requested == null || requested.isBlank() ? "Imported Profile" : requested.trim();
+		String candidate = base;
+		int suffix = 2;
+		while (containsName(occupiedNames, candidate)) {
+			candidate = base + " (" + suffix++ + ")";
+		}
+		return candidate;
+	}
+
+	private boolean containsName(List<String> names, String candidate) {
+		return names.stream().anyMatch(name -> name != null && name.equalsIgnoreCase(candidate));
+	}
+
+	public record ImportResult(int imported, int failed) {
+		public boolean successful() { return failed == 0; }
+	}
+
+	public record ImportPreview(List<AccountDescriptor> profiles, List<String> errors) {
+	}
+
 	public boolean saveProfile(ProfileAux currentProfile) {
 		return iModel.saveProfile(toDescriptor(currentProfile));
+	}
+
+	public List<String> loadTags() {
+		return iModel.getTags();
+	}
+
+	public List<ProfileTagData> loadTagDefinitions() { return iModel.getTagDefinitions(); }
+	public boolean updateTag(String oldName, String newName, String color) {
+		return iModel.updateTag(oldName, newName, color);
+	}
+	public boolean deleteTag(String name) { return iModel.deleteTag(name); }
+
+	public BulkEnabledUpdateResult updateTag(List<ProfileAux> selectedProfiles, String tagName, boolean add) {
+		if (selectedProfiles == null || selectedProfiles.isEmpty() || tagName == null || tagName.isBlank()) {
+			return new BulkEnabledUpdateResult(0, 0);
+		}
+		String normalized = tagName.trim().replaceAll("\\s+", " ");
+		int updated = 0;
+		for (ProfileAux profile : selectedProfiles) {
+			List<String> previous = profile.getTags();
+			List<String> tags = new ArrayList<>(previous);
+			tags.removeIf(tag -> tag.equalsIgnoreCase(normalized));
+			if (add) tags.add(normalized);
+			if (iModel.replaceTags(profile.getId(), tags)) {
+				profile.setTags(tags);
+				updated++;
+			} else {
+				profile.setTags(previous);
+			}
+		}
+		return new BulkEnabledUpdateResult(updated, selectedProfiles.size() - updated);
+	}
+
+	public BulkEnabledUpdateResult setProfilesEnabled(List<ProfileAux> selectedProfiles, boolean enabled) {
+		if (selectedProfiles == null || selectedProfiles.isEmpty()) {
+			return new BulkEnabledUpdateResult(0, 0);
+		}
+
+		int updated = 0;
+		for (ProfileAux profile : selectedProfiles) {
+			boolean previousEnabled = profile.isEnabled();
+			profile.setEnabled(enabled);
+			if (saveProfile(profile)) {
+				updated++;
+				if (!enabled) {
+					pauseRunningQueue(profile.getId());
+				}
+			} else {
+				profile.setEnabled(previousEnabled);
+				log(TpMessageSeverityEnum.ERROR, "Failed to " + (enabled ? "enable" : "disable")
+						+ " profile: " + profile.getName());
+			}
+		}
+		int failed = selectedProfiles.size() - updated;
+		log(failed == 0 ? TpMessageSeverityEnum.INFO : TpMessageSeverityEnum.WARNING,
+				"Bulk profile update " + (enabled ? "enabled " : "disabled ") + updated
+						+ " of " + selectedProfiles.size() + " selected profiles");
+		return new BulkEnabledUpdateResult(updated, failed);
+	}
+
+	public long countRunningProfiles(List<ProfileAux> selectedProfiles) {
+		if (selectedProfiles == null || selectedProfiles.isEmpty()) {
+			return 0;
+		}
+		Set<Long> activeIds = runtimeController.activeQueueIds();
+		return selectedProfiles.stream().filter(profile -> activeIds.contains(profile.getId())).count();
+	}
+
+	private void pauseRunningQueue(Long profileId) {
+		if (profileId == null) {
+			return;
+		}
+		if (runtimeController.activeQueueIds().contains(profileId)) {
+			runtimeController.pauseQueue(profileId);
+		}
+	}
+
+	interface ProfileRuntimeController {
+		Set<Long> activeQueueIds();
+
+		void pauseQueue(Long profileId);
+	}
+
+	private static final class ScheduleProfileRuntimeController implements ProfileRuntimeController {
+		@Override
+		public Set<Long> activeQueueIds() {
+			return ScheduleService.obtain().getCoordinator().getActiveQueueStates().stream()
+					.filter(state -> !state.isPaused())
+					.map(state -> state.getProfileId())
+					.collect(Collectors.toSet());
+		}
+
+		@Override
+		public void pauseQueue(Long profileId) {
+			ScheduleService.obtain().suspendAccountQueue(profileId);
+		}
+	}
+
+	public record BulkEnabledUpdateResult(int updated, int failed) {
+		public boolean successful() {
+			return failed == 0;
+		}
 	}
 
 	public boolean bulkUpdateSelectedProfiles(ProfileAux templateProfile, List<ProfileAux> selectedProfiles) {
@@ -181,6 +371,7 @@ public class ProfileManagerActionController implements ProfileStatusChangeListen
 		currentProfile.getConfigs().forEach(config ->
 			descriptor.getConfigs().add(new ConfigData(currentProfile.getId(), config.getName(), config.getValue()))
 		);
+		descriptor.setTags(currentProfile.getTags());
 		return descriptor;
 	}
 

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerLayoutController.java
@@ -3,9 +3,14 @@ package dev.frostguard.app.panel.profile;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.prefs.Preferences;
+import java.io.File;
 
 import org.kordamp.ikonli.javafx.FontIcon;
 
@@ -13,6 +18,7 @@ import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import dev.frostguard.api.configs.TpMessageSeverityEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.ProfileStatusData;
+import dev.frostguard.api.domain.ProfileTagData;
 import dev.frostguard.engine.service.LoggingService;
 import dev.frostguard.engine.service.ProfileService;
 import javafx.animation.TranslateTransition;
@@ -27,14 +33,23 @@ import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.ListView;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.Menu;
+import javafx.scene.control.Separator;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
+import javafx.scene.control.TextInputDialog;
 import javafx.scene.control.TextField;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.Tooltip;
@@ -46,6 +61,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.Rectangle;
 import javafx.stage.Popup;
+import javafx.stage.FileChooser;
 import javafx.util.Duration;
 
 public class ProfileManagerLayoutController implements IProfileChangeObserver {
@@ -54,6 +70,7 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	private static final String SORT_PRIORITY = "Priority";
 	private static final String SORT_STATUS = "Status";
 	private static final String SORT_EMULATOR = "Emulator";
+	private static final String ALL_PROFILES_VIEW = "All profiles";
 
 	private final ExecutorService profileQueueExecutor = Executors.newSingleThreadExecutor();
 	private final List<IProfileLoadListener> profileLoadListeners = new ArrayList<>();
@@ -62,6 +79,13 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	private FilteredList<ProfileAux> filteredProfiles;
 	private SortedList<ProfileAux> sortedProfiles;
 	private Long loadedProfileId;
+	private final Set<Long> selectedProfileIds = new HashSet<>();
+	private final CheckBox selectAllVisible = new CheckBox();
+	private final List<String> structuredFilters = new ArrayList<>();
+	private final ContextMenu searchSuggestions = new ContextMenu();
+	private Map<String, String> tagColors = Map.of();
+	private final Preferences savedViewPreferences = Preferences.userNodeForPackage(
+			ProfileManagerLayoutController.class).node("profile-search-views");
 
 	@FXML
 	private TableView<ProfileAux> tableviewLogMessages;
@@ -72,7 +96,15 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	@FXML
 	private TableColumn<ProfileAux, Boolean> columnEnabled;
 	@FXML
+	private TableColumn<ProfileAux, Void> columnSelected;
+	@FXML
 	private TableColumn<ProfileAux, String> columnProfileName;
+	@FXML
+	private TableColumn<ProfileAux, String> columnServer;
+	@FXML
+	private TableColumn<ProfileAux, String> columnAlliance;
+	@FXML
+	private TableColumn<ProfileAux, String> columnTags;
 	@FXML
 	private TableColumn<ProfileAux, Long> columnPriority;
 	@FXML
@@ -84,9 +116,29 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	@FXML
 	private Button btnBulkUpdate;
 	@FXML
+	private Button btnImportProfiles;
+	@FXML
+	private Button btnExportProfiles;
+	@FXML
+	private Button btnEnableSelected;
+	@FXML
+	private Button btnDisableSelected;
+	@FXML
+	private Button btnTagsSelected;
+	@FXML
+	private Label lblSelectionCount;
+	@FXML
+	private Separator selectionSeparator;
+	@FXML
+	private FlowPane structuredFilterPane;
+	@FXML
+	private Button btnAddFilter;
+	@FXML
 	private TextField txtSearchProfiles;
 	@FXML
 	private ComboBox<String> comboBoxSortBy;
+	@FXML
+	private ComboBox<String> comboSavedViews;
 	@FXML
 	private Button btnColumnSettings;
 
@@ -95,21 +147,158 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 		profileManagerActionController = new ProfileManagerActionController(this);
 		initializeTableView();
 		initializeSearchAndSort();
+		initializeSavedViews();
+		initializeBulkSelection();
 		loadProfiles();
 		ProfileService.obtain().registerDataObserver(dto -> Platform.runLater(() -> handleProfileDataChange(dto)));
+	}
+
+	private void initializeSavedViews() {
+		try {
+			List<String> viewNames = new ArrayList<>(List.of(savedViewPreferences.keys()));
+			viewNames.sort(String.CASE_INSENSITIVE_ORDER);
+			viewNames.addFirst(ALL_PROFILES_VIEW);
+			comboSavedViews.setItems(FXCollections.observableArrayList(viewNames));
+			comboSavedViews.setOnAction(event -> {
+				String name = comboSavedViews.getValue();
+				if (name != null) {
+					structuredFilters.clear();
+					refreshStructuredFilterChips();
+					txtSearchProfiles.setText(ALL_PROFILES_VIEW.equals(name) ? "" : savedViewPreferences.get(name, ""));
+				}
+			});
+			if (comboSavedViews.getValue() == null) comboSavedViews.setValue(ALL_PROFILES_VIEW);
+		} catch (Exception ex) {
+			comboSavedViews.setDisable(true);
+		}
+	}
+
+	@FXML
+	private void handleSaveView(ActionEvent event) {
+		String query = (String.join(" ", structuredFilters) + " " + txtSearchProfiles.getText()).trim();
+		if (query.isBlank()) {
+			showAlert(Alert.AlertType.WARNING, "Empty search", "Add at least one search or filter first.");
+			return;
+		}
+		TextInputDialog prompt = new TextInputDialog(comboSavedViews.getValue());
+		prompt.setTitle("Save profile view");
+		prompt.setHeaderText("Save the current search");
+		prompt.setContentText("View name:");
+		prompt.showAndWait().map(String::trim).filter(name -> !name.isBlank()).ifPresent(name -> {
+			if (ALL_PROFILES_VIEW.equalsIgnoreCase(name)) {
+				showAlert(Alert.AlertType.WARNING, "Reserved name", "Choose a different name for this view.");
+				return;
+			}
+			savedViewPreferences.put(name, query);
+			initializeSavedViews();
+			comboSavedViews.setValue(name);
+		});
+	}
+
+	@FXML
+	private void handleDeleteView(ActionEvent event) {
+		String name = comboSavedViews.getValue();
+		if (name == null || ALL_PROFILES_VIEW.equals(name)) return;
+		savedViewPreferences.remove(name);
+		comboSavedViews.getItems().remove(name);
+		comboSavedViews.setValue(ALL_PROFILES_VIEW);
 	}
 
 	private void initializeSearchAndSort() {
 		comboBoxSortBy.setItems(FXCollections.observableArrayList(SORT_NAME, SORT_PRIORITY, SORT_STATUS, SORT_EMULATOR));
 		comboBoxSortBy.getSelectionModel().selectFirst();
 		if (txtSearchProfiles != null) {
-			txtSearchProfiles.textProperty().addListener((obs, oldVal, newVal) -> applyFilter(newVal));
+			txtSearchProfiles.textProperty().addListener((obs, oldVal, newVal) -> {
+				applyFilter(newVal);
+				refreshSearchSuggestions();
+			});
+			txtSearchProfiles.setOnMouseClicked(event -> refreshSearchSuggestions());
+			txtSearchProfiles.focusedProperty().addListener((obs, oldVal, focused) -> {
+				if (!focused) searchSuggestions.hide();
+			});
 		}
 		comboBoxSortBy.valueProperty().addListener((obs, oldVal, newVal) -> applySort(newVal));
 	}
 
+	private void refreshSearchSuggestions() {
+		if (txtSearchProfiles == null || !txtSearchProfiles.isFocused()) return;
+		String token = currentSearchToken();
+		searchSuggestions.getItems().clear();
+		int separator = token.indexOf(':');
+		if (separator < 0) {
+			addQualifierSuggestion("server:", "Server number", token);
+			addQualifierSuggestion("alliance:", "Alliance code", token);
+			addQualifierSuggestion("tag:", "Profile tag", token);
+			addQualifierSuggestion("status:", "Current profile status", token);
+			addQualifierSuggestion("enabled:", "Enabled or disabled", token);
+			addQualifierSuggestion("character:", "Character ID or name", token);
+			addQualifierSuggestion("emulator:", "Emulator number", token);
+			addQualifierSuggestion("name:", "Profile name", token);
+		} else {
+			String qualifier = token.substring(0, separator).toLowerCase();
+			String value = token.substring(separator + 1).toLowerCase();
+			searchValues(qualifier).stream().filter(candidate -> candidate.toLowerCase().contains(value))
+					.limit(10).forEach(candidate -> addSearchSuggestion(qualifier + ":" + candidate, null));
+		}
+		if (searchSuggestions.getItems().isEmpty()) {
+			searchSuggestions.hide();
+		} else if (!searchSuggestions.isShowing()) {
+			searchSuggestions.show(txtSearchProfiles, javafx.geometry.Side.BOTTOM, 0, 2);
+		}
+	}
+
+	private void addQualifierSuggestion(String qualifier, String description, String typedToken) {
+		if (typedToken.isBlank() || qualifier.startsWith(typedToken.toLowerCase())) {
+			addSearchSuggestion(qualifier, description);
+		}
+	}
+
+	private void addSearchSuggestion(String replacement, String description) {
+		MenuItem item = new MenuItem(description == null ? replacement : replacement + "   " + description);
+		item.setOnAction(event -> replaceCurrentSearchToken(replacement));
+		searchSuggestions.getItems().add(item);
+	}
+
+	private List<String> searchValues(String qualifier) {
+		if ("enabled".equals(qualifier)) return List.of("true", "false");
+		if (profiles == null) return List.of();
+		return profiles.stream().flatMap(profile -> switch (qualifier) {
+			case "server" -> java.util.stream.Stream.of(profile.getCharacterServer());
+			case "alliance" -> java.util.stream.Stream.of(profile.getCharacterAllianceCode());
+			case "tag" -> profile.getTags().stream();
+			case "status" -> java.util.stream.Stream.of(profile.getStatus());
+			case "character" -> java.util.stream.Stream.of(profile.getCharacterId(), profile.getCharacterName());
+			case "emulator" -> java.util.stream.Stream.of(profile.getEmulatorNumber());
+			case "name" -> java.util.stream.Stream.of(profile.getName());
+			default -> java.util.stream.Stream.empty();
+		}).filter(Objects::nonNull).map(String::valueOf).filter(value -> !value.isBlank())
+				.distinct().sorted(String.CASE_INSENSITIVE_ORDER).toList();
+	}
+
+	private String currentSearchToken() {
+		String text = txtSearchProfiles.getText();
+		int caret = Math.min(txtSearchProfiles.getCaretPosition(), text.length());
+		int start = text.lastIndexOf(' ', Math.max(0, caret - 1)) + 1;
+		return text.substring(start, caret);
+	}
+
+	private void replaceCurrentSearchToken(String replacement) {
+		String text = txtSearchProfiles.getText();
+		int caret = Math.min(txtSearchProfiles.getCaretPosition(), text.length());
+		int start = text.lastIndexOf(' ', Math.max(0, caret - 1)) + 1;
+		int end = text.indexOf(' ', caret);
+		if (end < 0) end = text.length();
+		String suffix = replacement.endsWith(":") ? "" : " ";
+		txtSearchProfiles.replaceText(start, end, replacement + suffix);
+		txtSearchProfiles.positionCaret(start + replacement.length() + suffix.length());
+		Platform.runLater(this::refreshSearchSuggestions);
+	}
+
 	@FXML
 	private void handleClearSearch(ActionEvent event) {
+		structuredFilters.clear();
+		refreshStructuredFilterChips();
+		comboSavedViews.setValue(ALL_PROFILES_VIEW);
 		if (txtSearchProfiles != null) {
 			txtSearchProfiles.clear();
 		}
@@ -119,9 +308,148 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 		if (filteredProfiles == null) {
 			return;
 		}
-		String needle = searchText == null ? "" : searchText.toLowerCase().trim();
-		filteredProfiles.setPredicate(profile -> needle.isEmpty()
-				|| (profile.getName() != null && profile.getName().toLowerCase().contains(needle)));
+		String combinedQuery = String.join(" ", structuredFilters) + " " + (searchText == null ? "" : searchText);
+		filteredProfiles.setPredicate(profile -> ProfileSearchMatcher.matches(profile, combinedQuery.trim()));
+		updateBulkSelectionBar();
+	}
+
+	@FXML
+	private void handleAddFilter(ActionEvent event) {
+		ContextMenu menu = new ContextMenu();
+		addFilterOption(menu, "Server", "server");
+		addFilterOption(menu, "Alliance", "alliance");
+		addFilterOption(menu, "Tag", "tag");
+		addFilterOption(menu, "Character", "character");
+		addFilterOption(menu, "Emulator", "emulator");
+		addFilterOption(menu, "Status", "status");
+		MenuItem enabled = new MenuItem("Enabled profiles");
+		enabled.setOnAction(action -> addStructuredFilter("enabled:true"));
+		MenuItem disabled = new MenuItem("Disabled profiles");
+		disabled.setOnAction(action -> addStructuredFilter("enabled:false"));
+		menu.getItems().addAll(new javafx.scene.control.SeparatorMenuItem(), enabled, disabled);
+		menu.show(btnAddFilter, javafx.geometry.Side.BOTTOM, 0, 4);
+	}
+
+	@FXML
+	private void handleManageTags(ActionEvent event) {
+		Dialog<ButtonType> dialog = new Dialog<>();
+		dialog.setTitle("Manage profile tags");
+		dialog.setHeaderText("Rename, recolor or delete tags");
+		ListView<ProfileTagData> list = new ListView<>();
+		list.setPrefSize(380, 260);
+		list.setCellFactory(view -> new javafx.scene.control.ListCell<>() {
+			@Override protected void updateItem(ProfileTagData tag, boolean empty) {
+				super.updateItem(tag, empty);
+				setText(empty || tag == null ? null : tag.name());
+				setStyle(empty || tag == null ? "" : "-fx-border-color: " + tag.color()
+						+ "; -fx-border-width: 0 0 0 6; -fx-padding: 6 10;");
+			}
+		});
+		list.setItems(FXCollections.observableArrayList(profileManagerActionController.loadTagDefinitions()));
+		Button edit = new Button("Edit");
+		Button delete = new Button("Delete");
+		edit.disableProperty().bind(list.getSelectionModel().selectedItemProperty().isNull());
+		delete.disableProperty().bind(list.getSelectionModel().selectedItemProperty().isNull());
+		edit.setOnAction(action -> editTag(list));
+		delete.setOnAction(action -> deleteTag(list));
+		dialog.getDialogPane().setContent(new VBox(10, list, new HBox(8, edit, delete)));
+		dialog.getDialogPane().getButtonTypes().add(ButtonType.CLOSE);
+		dialog.showAndWait();
+		loadProfiles();
+	}
+
+	private void editTag(ListView<ProfileTagData> list) {
+		ProfileTagData selected = list.getSelectionModel().getSelectedItem();
+		if (selected == null) return;
+		TextField name = new TextField(selected.name());
+		TextField color = new TextField(selected.color());
+		color.setPromptText("#388bfd");
+		HBox presets = new HBox(6);
+		for (String preset : List.of("#388bfd", "#2ea043", "#d29922", "#f85149", "#a371f7", "#db61a2")) {
+			Button swatch = new Button();
+			swatch.setMinSize(24, 24); swatch.setPrefSize(24, 24);
+			swatch.setStyle("-fx-background-color: " + preset + "; -fx-background-radius: 12; -fx-cursor: hand;");
+			swatch.setTooltip(new Tooltip(preset));
+			swatch.setOnAction(event -> color.setText(preset));
+			presets.getChildren().add(swatch);
+		}
+		javafx.scene.layout.GridPane fields = new javafx.scene.layout.GridPane();
+		fields.setHgap(10); fields.setVgap(10);
+		fields.addRow(0, new Label("Name:"), name);
+		fields.addRow(1, new Label("Color:"), presets);
+		fields.addRow(2, new Label("Hex:"), color);
+		Dialog<ButtonType> editor = new Dialog<>();
+		editor.setTitle("Edit tag");
+		editor.getDialogPane().setContent(fields);
+		editor.getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+		if (editor.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.OK && !name.getText().isBlank()) {
+			String hex = color.getText().trim();
+			if (!hex.matches("#[0-9a-fA-F]{6}")) {
+				showAlert(Alert.AlertType.ERROR, "Invalid color", "Use a six-digit hex color such as #388bfd.");
+				return;
+			}
+			if (!profileManagerActionController.updateTag(selected.name(), name.getText().trim(), hex)) {
+				showAlert(Alert.AlertType.ERROR, "Tag update failed", "The name may already be in use.");
+			}
+			list.setItems(FXCollections.observableArrayList(profileManagerActionController.loadTagDefinitions()));
+		}
+	}
+
+	private void deleteTag(ListView<ProfileTagData> list) {
+		ProfileTagData selected = list.getSelectionModel().getSelectedItem();
+		if (selected == null) return;
+		Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+				"Delete tag '" + selected.name() + "' from every profile?", ButtonType.YES, ButtonType.CANCEL);
+		if (confirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.YES) {
+			profileManagerActionController.deleteTag(selected.name());
+			list.setItems(FXCollections.observableArrayList(profileManagerActionController.loadTagDefinitions()));
+		}
+	}
+
+	private void addFilterOption(ContextMenu menu, String label, String key) {
+		Menu choices = new Menu(label);
+		searchValues(key).stream().limit(30).forEach(value -> {
+			MenuItem suggestion = new MenuItem(value);
+			suggestion.setOnAction(action -> addStructuredFilter(
+					key + ":" + (value.contains(" ") ? "\"" + value + "\"" : value)));
+			choices.getItems().add(suggestion);
+		});
+		if (!choices.getItems().isEmpty()) choices.getItems().add(new javafx.scene.control.SeparatorMenuItem());
+		MenuItem custom = new MenuItem("Custom…");
+		custom.setOnAction(action -> {
+			TextInputDialog dialog = new TextInputDialog();
+			dialog.setTitle("Filter profiles");
+			dialog.setHeaderText("Filter by " + label.toLowerCase());
+			dialog.setContentText(label + ":");
+			dialog.showAndWait().map(String::trim).filter(value -> !value.isBlank())
+					.ifPresent(value -> addStructuredFilter(key + ":"
+							+ (value.contains(" ") ? "\"" + value + "\"" : value)));
+		});
+		choices.getItems().add(custom);
+		menu.getItems().add(choices);
+	}
+
+	private void addStructuredFilter(String filter) {
+		if (structuredFilters.stream().noneMatch(existing -> existing.equalsIgnoreCase(filter))) {
+			structuredFilters.add(filter);
+		}
+		refreshStructuredFilterChips();
+		applyFilter(txtSearchProfiles.getText());
+	}
+
+	private void refreshStructuredFilterChips() {
+		structuredFilterPane.getChildren().clear();
+		for (String filter : List.copyOf(structuredFilters)) {
+			Button chip = new Button(filter + "  ×");
+			chip.getStyleClass().add("profile-filter-chip");
+			chip.setOnAction(event -> {
+				structuredFilters.remove(filter);
+				refreshStructuredFilterChips();
+				applyFilter(txtSearchProfiles.getText());
+			});
+			structuredFilterPane.getChildren().add(chip);
+		}
+		setVisibleAndManaged(structuredFilterPane, !structuredFilters.isEmpty());
 	}
 
 	private void applySort(String sortBy) {
@@ -162,6 +490,9 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 		addColumnToggle(menu, "Emulator", columnEmulatorNumber);
 		addColumnToggle(menu, "Furnace Level", columnFurnaceLevel);
 		addColumnToggle(menu, "Name", columnProfileName);
+		addColumnToggle(menu, "Server", columnServer);
+		addColumnToggle(menu, "Alliance", columnAlliance);
+		addColumnToggle(menu, "Tags", columnTags);
 		addColumnToggle(menu, "Priority", columnPriority);
 		addColumnToggle(menu, "Status", columnStatus);
 		addColumnToggle(menu, "Stamina", columnStamina);
@@ -185,6 +516,45 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 		sortedProfiles = new SortedList<>(filteredProfiles);
 
 		columnProfileName.setCellValueFactory(cellData -> cellData.getValue().nameProperty());
+		columnServer.setCellValueFactory(cellData -> cellData.getValue().characterServerProperty());
+		columnAlliance.setCellValueFactory(cellData -> cellData.getValue().characterAllianceCodeProperty());
+		columnTags.setCellValueFactory(cellData -> new javafx.beans.property.SimpleStringProperty(
+				String.join(", ", cellData.getValue().getTags())));
+		columnTags.setCellFactory(column -> new TableCell<>() {
+			private final HBox tags = new HBox(5);
+			{
+				tags.setAlignment(Pos.CENTER_LEFT);
+				setAlignment(Pos.CENTER_LEFT);
+			}
+
+			@Override
+			protected void updateItem(String value, boolean empty) {
+				super.updateItem(value, empty);
+				tags.getChildren().clear();
+				if (empty || getTableRow() == null || getTableRow().getItem() == null) {
+					setGraphic(null);
+					return;
+				}
+				List<String> profileTags = getTableRow().getItem().getTags();
+				for (String tag : profileTags.stream().limit(3).toList()) {
+					Button chip = new Button(tag);
+					chip.getStyleClass().add("profile-tag-choice");
+					String color = tagColors.getOrDefault(tag.toLowerCase(), "#388bfd");
+					chip.setStyle("-fx-border-color: " + color + "; -fx-border-radius: 12;");
+					chip.setTooltip(new Tooltip("Filter by tag " + tag));
+					chip.setOnAction(event -> addSearchFilter("tag", tag));
+					tags.getChildren().add(chip);
+				}
+				if (profileTags.size() > 3) {
+					Label overflow = new Label("+" + (profileTags.size() - 3));
+					overflow.getStyleClass().add("profile-tag-overflow");
+					overflow.setTooltip(new Tooltip(String.join(", ", profileTags.subList(3, profileTags.size()))));
+					tags.getChildren().add(overflow);
+				}
+				setGraphic(tags);
+				setText(null);
+			}
+		});
 		columnEmulatorNumber.setCellValueFactory(cellData -> cellData.getValue().emulatorNumberProperty());
 		columnPriority.setCellValueFactory(cellData -> cellData.getValue().priorityProperty().asObject());
 		columnStatus.setCellValueFactory(cellData -> cellData.getValue().statusProperty());
@@ -199,9 +569,157 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 		tableviewLogMessages.setRowFactory(table -> editableProfileRow());
 		columnDelete.setCellFactory(col -> new ProfileActionsCell());
 		columnEnabled.setCellFactory(col -> new EnabledSwitchCell());
+		columnSelected.setCellFactory(col -> new ProfileSelectionCell());
+		tableviewLogMessages.setFixedCellSize(54);
 
 		bindToTableComparator();
 		tableviewLogMessages.setItems(sortedProfiles);
+	}
+
+	private void initializeBulkSelection() {
+		selectAllVisible.setAccessibleText("Select all visible profiles");
+		selectAllVisible.setTooltip(new Tooltip("Select all visible profiles"));
+		selectAllVisible.setOnAction(event -> setAllVisibleSelected(selectAllVisible.isSelected()));
+		columnSelected.setGraphic(selectAllVisible);
+		updateBulkSelectionBar();
+	}
+
+	private void setAllVisibleSelected(boolean selected) {
+		if (!selected) {
+			selectedProfileIds.clear();
+		} else {
+			for (ProfileAux profile : sortedProfiles) {
+				selectedProfileIds.add(profile.getId());
+			}
+		}
+		tableviewLogMessages.refresh();
+		updateBulkSelectionBar();
+	}
+
+	private void setProfileSelected(ProfileAux profile, boolean selected) {
+		if (profile == null || profile.getId() == null) {
+			return;
+		}
+		if (selected) {
+			selectedProfileIds.add(profile.getId());
+		} else {
+			selectedProfileIds.remove(profile.getId());
+		}
+		updateBulkSelectionBar();
+	}
+
+	private void updateBulkSelectionBar() {
+		int count = selectedProfileIds.size();
+		boolean hasSelection = count > 0;
+		lblSelectionCount.setText(count + (count == 1 ? " profile selected" : " profiles selected"));
+		setVisibleAndManaged(lblSelectionCount, hasSelection);
+		setVisibleAndManaged(btnEnableSelected, hasSelection);
+		setVisibleAndManaged(btnDisableSelected, hasSelection);
+		setVisibleAndManaged(btnTagsSelected, hasSelection);
+		setVisibleAndManaged(selectionSeparator, hasSelection);
+
+		long visibleCount = sortedProfiles.stream().filter(profile -> profile.getId() != null).count();
+		long visibleSelected = sortedProfiles.stream()
+				.filter(profile -> selectedProfileIds.contains(profile.getId())).count();
+		selectAllVisible.setIndeterminate(visibleSelected > 0 && visibleSelected < visibleCount);
+		selectAllVisible.setSelected(visibleCount > 0 && visibleSelected == visibleCount);
+	}
+
+	private void setVisibleAndManaged(Node node, boolean visible) {
+		node.setVisible(visible);
+		node.setManaged(visible);
+	}
+
+	@FXML
+	private void handleEnableSelected(ActionEvent event) {
+		applyEnabledToSelection(true);
+	}
+
+	@FXML
+	private void handleDisableSelected(ActionEvent event) {
+		List<ProfileAux> selected = selectedProfiles();
+		long running = profileManagerActionController.countRunningProfiles(selected);
+		Alert confirmation = new Alert(Alert.AlertType.CONFIRMATION);
+		confirmation.setTitle("Disable profiles");
+		confirmation.setHeaderText("Disable " + selected.size() + (selected.size() == 1 ? " profile?" : " profiles?"));
+		String runtimeNote = running == 0 ? "" : " " + running
+				+ (running == 1 ? " running queue will" : " running queues will") + " be paused immediately.";
+		confirmation.setContentText("They will remain disabled after the next restart." + runtimeNote);
+		if (confirmation.showAndWait().filter(ButtonType.OK::equals).isPresent()) {
+			applyEnabledToSelection(false);
+		}
+	}
+
+	@FXML
+	private void handleTagsSelected(ActionEvent event) {
+		List<ProfileAux> selected = selectedProfiles();
+		ContextMenu menu = new ContextMenu();
+		for (String tag : profileManagerActionController.loadTags()) {
+			CheckBox checkBox = new CheckBox(tag);
+			long tagged = selected.stream().filter(profile -> profile.getTags().stream()
+					.anyMatch(current -> current.equalsIgnoreCase(tag))).count();
+			checkBox.setAllowIndeterminate(true);
+			checkBox.setIndeterminate(tagged > 0 && tagged < selected.size());
+			checkBox.setSelected(tagged == selected.size());
+			checkBox.setOnAction(toggle -> applyTagToSelection(tag, checkBox.isSelected()));
+			javafx.scene.control.CustomMenuItem item = new javafx.scene.control.CustomMenuItem(checkBox, false);
+			menu.getItems().add(item);
+		}
+		if (!menu.getItems().isEmpty()) menu.getItems().add(new javafx.scene.control.SeparatorMenuItem());
+		MenuItem create = new MenuItem("+ Create tag");
+		create.setOnAction(action -> createTagForSelection());
+		menu.getItems().add(create);
+		menu.show(btnTagsSelected, javafx.geometry.Side.TOP, 0, -4);
+	}
+
+	private void createTagForSelection() {
+		TextInputDialog dialog = new TextInputDialog();
+		dialog.setTitle("Create tag");
+		dialog.setHeaderText("Create and assign a tag to the selected profiles");
+		dialog.setContentText("Tag name:");
+		dialog.showAndWait().map(String::trim).filter(name -> !name.isBlank())
+				.ifPresent(name -> applyTagToSelection(name, true));
+	}
+
+	private void applyTagToSelection(String tag, boolean add) {
+		var result = profileManagerActionController.updateTag(selectedProfiles(), tag, add);
+		tableviewLogMessages.refresh();
+		applyFilter(txtSearchProfiles.getText());
+		if (!result.successful()) {
+			showAlert(Alert.AlertType.WARNING, "Tags partially updated",
+					result.updated() + " updated; " + result.failed() + " failed.");
+		}
+	}
+
+	private void addSearchFilter(String qualifier, String value) {
+		String filter = qualifier + ":" + (value.contains(" ") ? "\"" + value + "\"" : value);
+		String current = txtSearchProfiles.getText().trim();
+		if (!current.toLowerCase().contains(filter.toLowerCase())) {
+			txtSearchProfiles.setText(current.isBlank() ? filter : current + " " + filter);
+		}
+		txtSearchProfiles.requestFocus();
+		txtSearchProfiles.positionCaret(txtSearchProfiles.getText().length());
+	}
+
+	private void applyEnabledToSelection(boolean enabled) {
+		List<ProfileAux> selected = selectedProfiles();
+		if (selected.isEmpty()) {
+			return;
+		}
+		var result = profileManagerActionController.setProfilesEnabled(selected, enabled);
+		tableviewLogMessages.refresh();
+		if (result.successful()) {
+			showAlert(Alert.AlertType.INFORMATION, "Profiles updated",
+					result.updated() + (result.updated() == 1 ? " profile " : " profiles ")
+							+ (enabled ? "enabled." : "disabled."));
+		} else {
+			showAlert(Alert.AlertType.WARNING, "Profiles partially updated",
+					result.updated() + " updated; " + result.failed() + " failed.");
+		}
+	}
+
+	private List<ProfileAux> selectedProfiles() {
+		return profiles.stream().filter(profile -> selectedProfileIds.contains(profile.getId())).toList();
 	}
 
 	private TableCell<ProfileAux, String> placeholderCell() {
@@ -233,6 +751,95 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	@FXML
 	void handleButtonBulkUpdateProfiles(ActionEvent event) {
 		profileManagerActionController.showBulkUpdateDialog(loadedProfileId, profiles, btnBulkUpdate);
+	}
+
+	@FXML
+	private void handleExportProfiles(ActionEvent event) {
+		List<ProfileAux> selected = selectedProfiles();
+		if (selected.isEmpty()) {
+			showAlert(Alert.AlertType.WARNING, "No profiles selected",
+					"Select one or more profiles to export.");
+			return;
+		}
+		FileChooser chooser = profileJsonChooser("Export Profiles");
+		chooser.setInitialFileName(selected.size() == 1
+				? safeFileName(selected.get(0).getName()) + ".json" : "frostguard-profiles.json");
+		File destination = chooser.showSaveDialog(btnExportProfiles.getScene().getWindow());
+		if (destination == null) return;
+		try {
+			profileManagerActionController.exportProfiles(destination.toPath(), selected);
+			showAlert(Alert.AlertType.INFORMATION, "Profiles exported",
+					selected.size() + (selected.size() == 1 ? " profile exported." : " profiles exported."));
+		} catch (Exception ex) {
+			showAlert(Alert.AlertType.ERROR, "Export failed", ex.getMessage());
+		}
+	}
+
+	@FXML
+	private void handleImportProfiles(ActionEvent event) {
+		FileChooser chooser = profileJsonChooser("Import Profiles");
+		List<File> sources = chooser.showOpenMultipleDialog(btnImportProfiles.getScene().getWindow());
+		if (sources == null || sources.isEmpty()) return;
+		var preview = profileManagerActionController.prepareImport(
+				sources.stream().map(File::toPath).toList(), new ArrayList<>(profiles));
+		List<AccountDescriptor> selected = showImportPreview(preview);
+		if (selected == null) return;
+		var result = profileManagerActionController.importPrepared(selected);
+		loadProfiles();
+		int failed = result.failed() + preview.errors().size();
+		Alert.AlertType type = failed == 0 ? Alert.AlertType.INFORMATION : Alert.AlertType.WARNING;
+		showAlert(type, "Profile import complete",
+				result.imported() + " imported; " + failed + " failed."
+						+ (preview.errors().isEmpty() ? "" : "\n" + String.join("\n", preview.errors())));
+	}
+
+	private List<AccountDescriptor> showImportPreview(ProfileManagerActionController.ImportPreview preview) {
+		Dialog<ButtonType> dialog = new Dialog<>();
+		dialog.setTitle("Import profiles");
+		dialog.setHeaderText("Select profiles and resolve names before importing");
+		VBox rows = new VBox(8);
+		List<java.util.Map.Entry<CheckBox, AccountDescriptor>> choices = new ArrayList<>();
+		for (AccountDescriptor descriptor : preview.profiles()) {
+			CheckBox selected = new CheckBox(); selected.setSelected(true);
+			TextField name = new TextField(descriptor.getName()); name.setPrefWidth(260);
+			Label details = new Label("Server " + Objects.toString(descriptor.getCharacterServer(), "—")
+					+ "  •  " + descriptor.getConfigs().size() + " settings");
+			details.setStyle("-fx-text-fill: #8b949e;");
+			name.textProperty().addListener((obs, old, value) -> descriptor.setName(value.trim()));
+			rows.getChildren().add(new HBox(10, selected, new VBox(3, name, details)));
+			choices.add(new java.util.AbstractMap.SimpleEntry<>(selected, descriptor));
+		}
+		if (!preview.errors().isEmpty()) {
+			Label errors = new Label(String.join("\n", preview.errors()));
+			errors.setStyle("-fx-text-fill: #f85149;"); rows.getChildren().add(errors);
+		}
+		ScrollPane scroll = new ScrollPane(rows); scroll.setFitToWidth(true); scroll.setPrefViewportHeight(360);
+		dialog.getDialogPane().setContent(scroll);
+		dialog.getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+		if (dialog.showAndWait().orElse(ButtonType.CANCEL) != ButtonType.OK) return null;
+		List<AccountDescriptor> result = choices.stream().filter(entry -> entry.getKey().isSelected())
+				.map(java.util.Map.Entry::getValue).filter(profile -> !profile.getName().isBlank()).toList();
+		Set<String> names = new HashSet<>();
+		Set<String> existingNames = profiles.stream().map(ProfileAux::getName).filter(Objects::nonNull)
+				.map(String::toLowerCase).collect(java.util.stream.Collectors.toSet());
+		if (result.stream().anyMatch(profile -> existingNames.contains(profile.getName().toLowerCase())
+				|| !names.add(profile.getName().toLowerCase()))) {
+			showAlert(Alert.AlertType.ERROR, "Duplicate names", "Imported profile names must be unique.");
+			return null;
+		}
+		return result;
+	}
+
+	private FileChooser profileJsonChooser(String title) {
+		FileChooser chooser = new FileChooser();
+		chooser.setTitle(title);
+		chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("Frostguard profile files", "*.json"));
+		return chooser;
+	}
+
+	private String safeFileName(String raw) {
+		String safe = raw == null ? "profile" : raw.replaceAll("[^A-Za-z0-9._-]+", "-");
+		return safe.isBlank() ? "profile" : safe;
 	}
 
 	private void showTasksPopup(ProfileAux profile, Node ownerNode) {
@@ -312,9 +919,14 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 
 	public void loadProfiles() {
 		profileManagerActionController.loadProfiles(accounts -> Platform.runLater(() -> {
+			tagColors = profileManagerActionController.loadTagDefinitions().stream().collect(
+					java.util.stream.Collectors.toMap(tag -> tag.name().toLowerCase(), ProfileTagData::color,
+							(first, second) -> first));
 			profiles.setAll(accounts.stream().map(this::toProfileAux).toList());
+			selectedProfileIds.retainAll(profiles.stream().map(ProfileAux::getId).collect(java.util.stream.Collectors.toSet()));
 			selectLoadedProfile();
 			reapplyCurrentSort();
+			updateBulkSelectionBar();
 		}));
 	}
 
@@ -333,6 +945,7 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 				account.getCharacterServer());
 		account.getConfigs().forEach(config ->
 				profileAux.getConfigs().add(new ConfigAux(config.getConfigurationName(), config.getValue())));
+		profileAux.setTags(account.getTags());
 		return profileAux;
 	}
 
@@ -403,6 +1016,7 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 		if (dto.getReconnectionTime() != null) {
 			target.setReconnectionTime(dto.getReconnectionTime());
 		}
+		target.setTags(dto.getTags());
 		if (dto.getCharacterId() != null) {
 			target.setCharacterId(dto.getCharacterId());
 		}
@@ -515,7 +1129,8 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 		private final Button btnDelete = iconButton("mdi2c-close", 16, "#f85149", "Delete Profile");
 		private final Button btnViewTasks = iconButton("mdi2f-format-list-checks", 18, "#388bfd", "View Enabled Tasks");
 		private final Button btnLoad = iconButton("mdi2p-play", 22, "#2ea043", "Load Profile");
-		private final HBox buttonContainer = new HBox(5, btnLoad, btnViewTasks, btnDelete);
+		private final Button btnDuplicate = iconButton("mdi2c-content-copy", 17, "#d2a8ff", "Duplicate Profile");
+		private final HBox buttonContainer = new HBox(5, btnLoad, btnDuplicate, btnViewTasks, btnDelete);
 
 		private ProfileActionsCell() {
 			buttonContainer.setAlignment(Pos.CENTER);
@@ -526,6 +1141,7 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 				}
 			});
 			btnDelete.setOnAction(this::deleteCurrentProfile);
+			btnDuplicate.setOnAction(event -> duplicateCurrentProfile());
 			btnLoad.setOnAction(event -> {
 				ProfileAux currentProfile = rowProfile(this);
 				if (currentProfile != null) {
@@ -533,6 +1149,16 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 					notifyProfileLoadListeners(currentProfile);
 				}
 			});
+		}
+
+		private void duplicateCurrentProfile() {
+			ProfileAux currentProfile = rowProfile(this);
+			if (currentProfile == null) return;
+			if (profileManagerActionController.duplicateProfile(currentProfile, new ArrayList<>(profiles))) {
+				loadProfiles();
+			} else {
+				showAlert(Alert.AlertType.ERROR, "Duplicate failed", "The profile could not be duplicated.");
+			}
 		}
 
 		@Override
@@ -617,6 +1243,28 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 		private void paintSwitch(boolean enabled) {
 			background.setFill(enabled ? Color.web("#ffcd53") : Color.web("#3b3f4c"));
 			knob.setTranslateX(enabled ? 8 : -8);
+		}
+	}
+
+	private final class ProfileSelectionCell extends TableCell<ProfileAux, Void> {
+		private final CheckBox checkBox = new CheckBox();
+
+		private ProfileSelectionCell() {
+			checkBox.setOnAction(event -> setProfileSelected(rowProfile(this), checkBox.isSelected()));
+			setAlignment(Pos.CENTER);
+		}
+
+		@Override
+		protected void updateItem(Void item, boolean empty) {
+			super.updateItem(item, empty);
+			ProfileAux profile = rowProfile(this);
+			if (empty || profile == null) {
+				setGraphic(null);
+				return;
+			}
+			checkBox.setSelected(selectedProfileIds.contains(profile.getId()));
+			checkBox.setAccessibleText("Select profile " + profile.getName());
+			setGraphic(checkBox);
 		}
 	}
 }

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileModel.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileModel.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.ProfileTagData;
 import dev.frostguard.engine.listener.ProfileServiceInterface;
 import dev.frostguard.engine.listener.ProfileStatusChangeListener;
 import dev.frostguard.engine.service.ProfileService;
@@ -51,6 +52,31 @@ public class ProfileModel implements IProfileModel {
 	@Override
 	public boolean bulkUpdateProfiles(AccountDescriptor templateProfile) {
 		return withProfileService(service -> service.applyBulkUpdate(templateProfile));
+	}
+
+	@Override
+	public List<String> getTags() {
+		return withProfileService(ProfileServiceInterface::fetchProfileTags);
+	}
+
+	@Override
+	public List<ProfileTagData> getTagDefinitions() {
+		return withProfileService(ProfileServiceInterface::fetchProfileTagDefinitions);
+	}
+
+	@Override
+	public boolean updateTag(String oldName, String newName, String color) {
+		return withProfileService(service -> service.updateProfileTag(oldName, newName, color));
+	}
+
+	@Override
+	public boolean deleteTag(String name) {
+		return withProfileService(service -> service.deleteProfileTag(name));
+	}
+
+	@Override
+	public boolean replaceTags(Long profileId, List<String> tags) {
+		return withProfileService(service -> service.replaceProfileTags(profileId, tags));
 	}
 
 	private <T> T withProfileService(Function<ProfileServiceInterface, T> operation) {

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileSearchMatcher.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileSearchMatcher.java
@@ -1,0 +1,55 @@
+package dev.frostguard.app.panel.profile;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+final class ProfileSearchMatcher {
+	private static final Pattern TOKEN = Pattern.compile("(?:[^\\s\\\"]|\\\"[^\\\"]*\\\")+");
+
+	private ProfileSearchMatcher() {
+	}
+
+	static boolean matches(ProfileAux profile, String query) {
+		if (profile == null || query == null || query.isBlank()) return true;
+		return TOKEN.matcher(query.trim()).results().map(result -> result.group().replace("\"", ""))
+				.allMatch(token -> matchesToken(profile, token.toLowerCase(Locale.ROOT)));
+	}
+
+	private static boolean matchesToken(ProfileAux profile, String token) {
+		int separator = token.indexOf(':');
+		if (separator > 0) {
+			String field = token.substring(0, separator);
+			String value = token.substring(separator + 1);
+			return switch (field) {
+				case "name" -> contains(profile.getName(), value);
+				case "profile", "id" -> contains(String.valueOf(profile.getId()), value);
+				case "character" -> contains(profile.getCharacterId(), value)
+						|| contains(profile.getCharacterName(), value);
+				case "server" -> contains(profile.getCharacterServer(), value);
+				case "alliance" -> contains(profile.getCharacterAllianceCode(), value);
+				case "emulator" -> contains(profile.getEmulatorNumber(), value);
+				case "tag" -> profile.getTags().stream().anyMatch(tag -> contains(tag, value));
+				case "enabled" -> Boolean.toString(profile.isEnabled()).equals(value);
+				case "status" -> contains(profile.getStatus(), value);
+				default -> matchesAnyField(profile, token);
+			};
+		}
+		return matchesAnyField(profile, token);
+	}
+
+	private static boolean matchesAnyField(ProfileAux profile, String value) {
+		return contains(profile.getName(), value)
+				|| contains(String.valueOf(profile.getId()), value)
+				|| contains(profile.getCharacterId(), value)
+				|| contains(profile.getCharacterName(), value)
+				|| contains(profile.getCharacterServer(), value)
+				|| contains(profile.getCharacterAllianceCode(), value)
+				|| contains(profile.getEmulatorNumber(), value)
+				|| contains(profile.getStatus(), value)
+				|| profile.getTags().stream().anyMatch(tag -> contains(tag, value));
+	}
+
+	private static boolean contains(String candidate, String value) {
+		return candidate != null && candidate.toLowerCase(Locale.ROOT).contains(value);
+	}
+}

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileTransferService.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileTransferService.java
@@ -1,0 +1,137 @@
+package dev.frostguard.app.panel.profile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.ConfigData;
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
+
+final class ProfileTransferService {
+
+	private static final int FORMAT_VERSION = 1;
+	private static final int MAX_IMPORTED_PROFILES = 1_000;
+	private static final long MAX_FILE_SIZE_BYTES = 5L * 1024 * 1024;
+	private static final int MAX_TEXT_LENGTH = 200;
+	private final ObjectMapper mapper;
+
+	ProfileTransferService() {
+		mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+	}
+
+	void write(Path destination, List<ProfileAux> profiles) throws IOException {
+		List<TransferredProfile> exported = profiles.stream().map(this::fromProfile).toList();
+		mapper.writeValue(destination.toFile(), new TransferFile(FORMAT_VERSION, exported));
+	}
+
+	List<AccountDescriptor> read(Path source) throws IOException {
+		if (!Files.isRegularFile(source) || Files.size(source) > MAX_FILE_SIZE_BYTES) {
+			throw new IOException("Profile file must be a regular JSON file no larger than 5 MB");
+		}
+		TransferFile transfer = mapper.readValue(source.toFile(), TransferFile.class);
+		if (transfer.formatVersion() != FORMAT_VERSION) {
+			throw new IOException("Unsupported profile export version: " + transfer.formatVersion());
+		}
+		if (transfer.profiles() == null || transfer.profiles().size() > MAX_IMPORTED_PROFILES) {
+			throw new IOException("Profile export contains an invalid number of profiles");
+		}
+		List<AccountDescriptor> profiles = new ArrayList<>();
+		for (TransferredProfile imported : transfer.profiles()) {
+			profiles.add(toDescriptor(imported));
+		}
+		return profiles;
+	}
+
+	AccountDescriptor duplicate(ProfileAux source, String newName) throws IOException {
+		TransferredProfile copy = fromProfile(source);
+		return toDescriptor(new TransferredProfile(newName, copy.emulatorNumber(), copy.enabled(), copy.priority(),
+				copy.reconnectionTime(), copy.characterId(), copy.characterName(), copy.alliance(), copy.server(),
+				copy.configs(), copy.tags()));
+	}
+
+	private TransferredProfile fromProfile(ProfileAux profile) {
+		List<TransferredConfig> configs = profile.getConfigs().stream()
+				.map(config -> new TransferredConfig(config.getName(), config.getValue()))
+				.toList();
+		return new TransferredProfile(profile.getName(), profile.getEmulatorNumber(), profile.isEnabled(),
+				profile.getPriority(), profile.getReconnectionTime(), profile.getCharacterId(),
+				profile.getCharacterName(), profile.getCharacterAllianceCode(), profile.getCharacterServer(),
+				configs, profile.getTags());
+	}
+
+	private AccountDescriptor toDescriptor(TransferredProfile imported) throws IOException {
+		if (imported == null || imported.name() == null || imported.name().isBlank()) {
+			throw new IOException("Every imported profile requires a name");
+		}
+		validateText("Profile name", imported.name(), 80);
+		validateText("Emulator", imported.emulatorNumber(), 40);
+		validateText("Character ID", imported.characterId(), MAX_TEXT_LENGTH);
+		validateText("Character name", imported.characterName(), MAX_TEXT_LENGTH);
+		validateText("Alliance", imported.alliance(), 20);
+		validateText("Server", imported.server(), 40);
+		if (imported.priority() != null && (imported.priority() < 0 || imported.priority() > 10_000)) {
+			throw new IOException("Priority must be between 0 and 10000");
+		}
+		if (imported.reconnectionTime() != null && imported.reconnectionTime() < 0) {
+			throw new IOException("Reconnection time cannot be negative");
+		}
+		AccountDescriptor descriptor = new AccountDescriptor(null, imported.name().trim(),
+				blankToDefault(imported.emulatorNumber(), "0"), Boolean.TRUE.equals(imported.enabled()),
+				imported.priority() == null ? 50L : imported.priority(),
+				imported.reconnectionTime() == null ? 0L : imported.reconnectionTime(),
+				blankToNull(imported.characterId()), blankToNull(imported.characterName()),
+				blankToNull(imported.alliance()), blankToNull(imported.server()));
+		if (imported.configs() != null) {
+			for (TransferredConfig config : imported.configs()) {
+				if (config == null || config.name() == null || config.value() == null) {
+					throw new IOException("Imported configurations require a name and value");
+				}
+				ConfigurationKeyEnum key = ConfigurationKeyEnum.fromName(config.name());
+				if (key == null) throw new IOException("Unknown configuration: " + config.name());
+				if (key.getType() == Boolean.class && !config.value().equalsIgnoreCase("true")
+						&& !config.value().equalsIgnoreCase("false")) {
+					throw new IOException("Invalid boolean value for " + config.name());
+				}
+				try { key.castValue(config.value()); }
+				catch (Exception ex) { throw new IOException("Invalid value for " + config.name(), ex); }
+				descriptor.getConfigs().add(new ConfigData(null, key.name(), config.value()));
+			}
+		}
+		if (imported.tags() != null) {
+			for (String tag : imported.tags()) validateText("Tag", tag, 40);
+		}
+		descriptor.setTags(imported.tags());
+		return descriptor;
+	}
+
+	private void validateText(String field, String value, int maxLength) throws IOException {
+		if (value != null && value.trim().length() > maxLength) {
+			throw new IOException(field + " exceeds " + maxLength + " characters");
+		}
+	}
+
+	private String blankToDefault(String value, String fallback) {
+		return value == null || value.isBlank() ? fallback : value.trim();
+	}
+
+	private String blankToNull(String value) {
+		return value == null || value.isBlank() ? null : value.trim();
+	}
+
+	record TransferFile(int formatVersion, List<TransferredProfile> profiles) {
+	}
+
+	record TransferredProfile(String name, String emulatorNumber, Boolean enabled, Long priority,
+			Long reconnectionTime, String characterId, String characterName, String alliance, String server,
+			List<TransferredConfig> configs, List<String> tags) {
+	}
+
+	record TransferredConfig(String name, String value) {
+	}
+}

--- a/fg-app/src/main/resources/layout/EditProfile.fxml
+++ b/fg-app/src/main/resources/layout/EditProfile.fxml
@@ -14,7 +14,7 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
-<BorderPane prefHeight="580.0" prefWidth="550.0"
+<BorderPane prefHeight="680.0" prefWidth="550.0"
             xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="dev.frostguard.app.panel.profile.EditProfileController">
 
@@ -81,6 +81,17 @@
                         <Label text="Server" minWidth="140" />
                         <TextField fx:id="txtCharacterServer" promptText="1234"
                                    HBox.hgrow="ALWAYS" />
+                    </HBox>
+                </VBox>
+
+                <Separator style="-fx-opacity: 0.3;" />
+
+                <VBox spacing="8">
+                    <Label text="Tags" style="-fx-font-weight: bold;" />
+                    <FlowPane fx:id="tagChoicesPane" hgap="8" vgap="8" />
+                    <HBox alignment="CENTER_LEFT" spacing="8">
+                        <TextField fx:id="txtNewTag" promptText="New tag name" HBox.hgrow="ALWAYS" />
+                        <Button mnemonicParsing="false" onAction="#handleAddTag" text="Add tag" />
                     </HBox>
                 </VBox>
             </VBox>

--- a/fg-app/src/main/resources/layout/ProfileManagerLayout.fxml
+++ b/fg-app/src/main/resources/layout/ProfileManagerLayout.fxml
@@ -11,32 +11,37 @@
    <children>
 
       <!-- Top Search + Sort Bar -->
-      <HBox alignment="CENTER_LEFT" spacing="12" styleClass="control-top-bar">
+      <VBox spacing="8" styleClass="profile-manager-top-bar">
          <children>
             <!-- Search Field -->
             <HBox alignment="CENTER_LEFT" spacing="0" HBox.hgrow="ALWAYS" styleClass="log-search-wrapper">
                <children>
                   <FontIcon iconLiteral="mdi2m-magnify" iconSize="16" iconColor="#636a75" />
-                  <TextField fx:id="txtSearchProfiles" promptText="Search profiles..."
+                  <TextField fx:id="txtSearchProfiles" promptText="Search name, ID, server, alliance, emulator or tag..."
                              HBox.hgrow="ALWAYS" styleClass="control-search-field" />
                   <Button fx:id="btnClearSearch" onAction="#handleClearSearch" styleClass="search-clear-btn" text="✕" />
                </children>
             </HBox>
 
-            <Region HBox.hgrow="ALWAYS" />
-
-            <!-- Sort By -->
-            <Label text="Sort by:" textFill="#636a75" />
-            <ComboBox fx:id="comboBoxSortBy" prefWidth="150" promptText="Name" styleClass="control-filter-combo" />
-
-            <!-- Settings Button (column visibility) -->
-            <Button fx:id="btnColumnSettings" onAction="#handleColumnSettings" styleClass="column-settings-btn">
-               <graphic>
-                  <FontIcon iconLiteral="mdi2c-cog" iconSize="18" iconColor="#636a75" />
-               </graphic>
-            </Button>
+            <FlowPane alignment="CENTER_LEFT" hgap="8" vgap="8" prefWrapLength="850">
+               <children>
+                  <Button fx:id="btnAddFilter" onAction="#handleAddFilter" text="+ Filter" styleClass="action-button-transfer" />
+                  <Button onAction="#handleManageTags" text="Manage tags" styleClass="action-button-transfer" />
+                  <ComboBox fx:id="comboSavedViews" prefWidth="145" promptText="Saved views" />
+                  <Button onAction="#handleSaveView" text="Save view" styleClass="action-button-transfer" />
+                  <Button onAction="#handleDeleteView" text="Delete view" styleClass="action-button-transfer" />
+                  <Label text="Sort by:" textFill="#636a75" />
+                  <ComboBox fx:id="comboBoxSortBy" prefWidth="150" promptText="Name" styleClass="control-filter-combo" />
+                  <Button fx:id="btnColumnSettings" onAction="#handleColumnSettings" styleClass="column-settings-btn">
+                     <graphic><FontIcon iconLiteral="mdi2c-cog" iconSize="18" iconColor="#636a75" /></graphic>
+                  </Button>
+               </children>
+            </FlowPane>
          </children>
-      </HBox>
+      </VBox>
+
+      <FlowPane fx:id="structuredFilterPane" hgap="6" vgap="6" visible="false" managed="false"
+                styleClass="profile-tag-filter-bar" />
 
       <!-- Profile Table -->
       <TableView fx:id="tableviewLogMessages" VBox.vgrow="ALWAYS"
@@ -45,28 +50,56 @@
             <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
          </columnResizePolicy>
          <columns>
+            <TableColumn fx:id="columnSelected" minWidth="42.0"
+                         maxWidth="42.0" prefWidth="42.0" resizable="false"
+                         sortable="false" style="-fx-alignment: CENTER;" />
             <TableColumn fx:id="columnEnabled" minWidth="50.0"
                          prefWidth="90.0" text="ENABLED" style="-fx-alignment: CENTER;" />
             <TableColumn fx:id="columnEmulatorNumber" minWidth="40.0"
                          prefWidth="80.0" text="EMULATOR" style="-fx-alignment: CENTER;" />
             <TableColumn fx:id="columnFurnaceLevel" minWidth="60.0"
-                         prefWidth="120.0" text="FURNACE LEVEL" style="-fx-alignment: CENTER;" />
-            <TableColumn fx:id="columnProfileName" maxWidth="Infinity"
-                         minWidth="60.0" prefWidth="200.0" text="NAME" style="-fx-alignment: CENTER;" />
+                         prefWidth="105.0" text="FURNACE LEVEL" visible="false" style="-fx-alignment: CENTER;" />
+            <TableColumn fx:id="columnProfileName"
+                         minWidth="100.0" prefWidth="180.0" text="NAME" style="-fx-alignment: CENTER;" />
+            <TableColumn fx:id="columnServer" minWidth="70.0"
+                         prefWidth="100.0" text="SERVER" style="-fx-alignment: CENTER;" />
+            <TableColumn fx:id="columnAlliance" minWidth="70.0"
+                         prefWidth="90.0" text="ALLIANCE" style="-fx-alignment: CENTER;" />
+            <TableColumn fx:id="columnTags" minWidth="100.0"
+                         prefWidth="180.0" text="TAGS" style="-fx-alignment: CENTER_LEFT;" />
             <TableColumn fx:id="columnPriority" minWidth="40.0"
                          prefWidth="90.0" text="PRIORITY" style="-fx-alignment: CENTER;" />
             <TableColumn fx:id="columnStatus" minWidth="60.0"
                          prefWidth="200.0" text="STATUS" style="-fx-alignment: CENTER;" />
             <TableColumn fx:id="columnStamina" minWidth="40.0"
-                         prefWidth="90.0" text="STAMINA" style="-fx-alignment: CENTER;" />
-            <TableColumn fx:id="columnDelete" minWidth="60.0"
-                         prefWidth="140.0" text="ACTIONS" style="-fx-alignment: CENTER;" />
+                         prefWidth="80.0" text="STAMINA" visible="false" style="-fx-alignment: CENTER;" />
+            <TableColumn fx:id="columnDelete" minWidth="130.0"
+                         prefWidth="155.0" text="ACTIONS" style="-fx-alignment: CENTER;" />
          </columns>
       </TableView>
 
       <!-- Bottom Toolbar -->
-      <HBox alignment="CENTER_RIGHT" spacing="12" styleClass="control-bottom-bar">
+      <FlowPane alignment="CENTER_RIGHT" hgap="8" vgap="8" prefWrapLength="850" styleClass="control-bottom-bar">
          <children>
+            <Label fx:id="lblSelectionCount" text="0 profiles selected"
+                   visible="false" managed="false" styleClass="bulk-selection-count" />
+            <Button fx:id="btnEnableSelected" mnemonicParsing="false"
+                    onAction="#handleEnableSelected" text="Enable"
+                    visible="false" managed="false" styleClass="action-button-enable" />
+            <Button fx:id="btnDisableSelected" mnemonicParsing="false"
+                    onAction="#handleDisableSelected" text="Disable"
+                    visible="false" managed="false" styleClass="action-button-disable" />
+            <Button fx:id="btnTagsSelected" mnemonicParsing="false"
+                    onAction="#handleTagsSelected" text="Tags ▾"
+                    visible="false" managed="false" styleClass="action-button-tags" />
+            <Separator fx:id="selectionSeparator" orientation="VERTICAL"
+                       visible="false" managed="false" prefHeight="24" />
+            <Button fx:id="btnImportProfiles" mnemonicParsing="false"
+                    onAction="#handleImportProfiles" text="Import"
+                    styleClass="action-button-transfer" />
+            <Button fx:id="btnExportProfiles" mnemonicParsing="false"
+                    onAction="#handleExportProfiles" text="Export"
+                    styleClass="action-button-transfer" />
             <Button fx:id="btnBulkUpdate" mnemonicParsing="false"
                     onAction="#handleButtonBulkUpdateProfiles" text="Bulk Update"
                     styleClass="action-button-bulk">
@@ -82,7 +115,7 @@
                </graphic>
             </Button>
          </children>
-      </HBox>
+      </FlowPane>
 
    </children>
 </VBox>

--- a/fg-app/src/main/resources/styles/style.css
+++ b/fg-app/src/main/resources/styles/style.css
@@ -897,6 +897,17 @@
     -fx-max-height: 44;
 }
 
+.profile-manager-top-bar {
+    -fx-background-color: -fg-bg-card;
+    -fx-border-color: -fg-border-subtle;
+    -fx-border-radius: 8;
+    -fx-background-radius: 8;
+    -fx-border-width: 1;
+    -fx-padding: 8 12;
+    -fx-alignment: CENTER_LEFT;
+    -fx-min-height: 86;
+}
+
 /* Bottom bar shared across Logs, Profiles, Tasks tabs */
 .control-bottom-bar {
     -fx-background-color: transparent;
@@ -904,6 +915,111 @@
     -fx-alignment: CENTER_LEFT;
     -fx-spacing: 8;
     -fx-min-height: 40;
+}
+
+.bulk-selection-count {
+    -fx-text-fill: #e6edf3;
+    -fx-font-weight: bold;
+}
+
+.action-button-enable,
+.action-button-disable,
+.action-button-tags {
+    -fx-background-radius: 4;
+    -fx-padding: 7 14;
+    -fx-font-weight: bold;
+    -fx-cursor: hand;
+}
+
+.action-button-tags {
+    -fx-background-color: #30363d;
+    -fx-text-fill: #e6edf3;
+}
+
+.action-button-tags:hover {
+    -fx-background-color: #484f58;
+}
+
+.profile-tag-filter-bar {
+    -fx-background-color: transparent;
+    -fx-padding: 2 4;
+}
+
+.profile-tag-chip {
+    -fx-background-color: #21262d;
+    -fx-border-color: #484f58;
+    -fx-border-radius: 12;
+    -fx-background-radius: 12;
+    -fx-text-fill: #c9d1d9;
+    -fx-padding: 3 10;
+    -fx-cursor: hand;
+}
+
+.profile-tag-chip:selected {
+    -fx-background-color: #1f6feb;
+    -fx-border-color: #58a6ff;
+    -fx-text-fill: white;
+}
+
+.profile-filter-chip {
+    -fx-background-color: #1f6feb;
+    -fx-background-radius: 12;
+    -fx-text-fill: white;
+    -fx-padding: 3 10;
+    -fx-cursor: hand;
+}
+
+.profile-filter-chip:hover {
+    -fx-background-color: #388bfd;
+}
+
+.profile-tag-choice {
+    -fx-background-color: #21262d;
+    -fx-background-radius: 12;
+    -fx-padding: 2 8;
+    -fx-min-height: 26;
+    -fx-max-height: 26;
+    -fx-text-fill: #c9d1d9;
+    -fx-cursor: hand;
+}
+
+.profile-tag-overflow {
+    -fx-text-fill: #8b949e;
+    -fx-font-size: 11px;
+    -fx-padding: 2 4;
+}
+
+.action-button-transfer {
+    -fx-background-color: #21262d;
+    -fx-border-color: #484f58;
+    -fx-border-radius: 4;
+    -fx-background-radius: 4;
+    -fx-text-fill: #e6edf3;
+    -fx-padding: 7 12;
+    -fx-cursor: hand;
+}
+
+.action-button-transfer:hover {
+    -fx-background-color: #30363d;
+    -fx-border-color: #8b949e;
+}
+
+.action-button-enable {
+    -fx-background-color: #2ea043;
+    -fx-text-fill: white;
+}
+
+.action-button-enable:hover {
+    -fx-background-color: #3fb950;
+}
+
+.action-button-disable {
+    -fx-background-color: #da3633;
+    -fx-text-fill: white;
+}
+
+.action-button-disable:hover {
+    -fx-background-color: #f85149;
 }
 
 /* Wrapper that groups search field + clear-X button side by side */
@@ -1645,4 +1761,3 @@
 .accent-button:hover {
     -fx-background-color: #37d47f;
 }
-

--- a/fg-app/src/test/java/dev/frostguard/app/panel/profile/ProfileManagerActionControllerTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/profile/ProfileManagerActionControllerTest.java
@@ -1,0 +1,155 @@
+package dev.frostguard.app.panel.profile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.engine.listener.ProfileStatusChangeListener;
+
+class ProfileManagerActionControllerTest {
+
+	@Test
+	void disablesSelectedProfilesAndPausesTheirRunningQueues() {
+		StubProfileModel model = new StubProfileModel();
+		StubRuntimeController runtime = new StubRuntimeController(Set.of(1L, 3L));
+		ProfileManagerActionController controller = new ProfileManagerActionController(null, model, runtime);
+		ProfileAux first = profile(1L, "First", true);
+		ProfileAux second = profile(2L, "Second", true);
+
+		var result = controller.setProfilesEnabled(List.of(first, second), false);
+
+		assertEquals(2, result.updated());
+		assertEquals(0, result.failed());
+		assertFalse(first.isEnabled());
+		assertFalse(second.isEnabled());
+		assertEquals(List.of(1L), runtime.pausedProfileIds);
+	}
+
+	@Test
+	void restoresOriginalStateWhenOneProfileCannotBeSaved() {
+		StubProfileModel model = new StubProfileModel();
+		model.failingProfileIds.add(2L);
+		StubRuntimeController runtime = new StubRuntimeController(Set.of(1L, 2L));
+		ProfileManagerActionController controller = new ProfileManagerActionController(null, model, runtime);
+		ProfileAux first = profile(1L, "First", true);
+		ProfileAux second = profile(2L, "Second", true);
+
+		var result = controller.setProfilesEnabled(List.of(first, second), false);
+
+		assertEquals(1, result.updated());
+		assertEquals(1, result.failed());
+		assertFalse(first.isEnabled());
+		assertTrue(second.isEnabled());
+		assertEquals(List.of(1L), runtime.pausedProfileIds);
+	}
+
+	@Test
+	void countsOnlySelectedProfilesWithRunningQueues() {
+		StubRuntimeController runtime = new StubRuntimeController(Set.of(2L, 4L));
+		ProfileManagerActionController controller = new ProfileManagerActionController(
+				null, new StubProfileModel(), runtime);
+
+		long running = controller.countRunningProfiles(List.of(
+				profile(1L, "First", true), profile(2L, "Second", true), profile(3L, "Third", true)));
+
+		assertEquals(1, running);
+	}
+
+	@Test
+	void addsAndRemovesTagsAcrossSelectedProfiles() {
+		StubProfileModel model = new StubProfileModel();
+		ProfileManagerActionController controller = new ProfileManagerActionController(
+				null, model, new StubRuntimeController(Set.of()));
+		ProfileAux first = profile(1L, "First", true);
+		ProfileAux second = profile(2L, "Second", true);
+		second.setTags(List.of("Farm"));
+
+		var added = controller.updateTag(List.of(first, second), " Farm ", true);
+		var removed = controller.updateTag(List.of(first, second), "farm", false);
+
+		assertTrue(added.successful());
+		assertTrue(removed.successful());
+		assertEquals(List.of(), first.getTags());
+		assertEquals(List.of(), second.getTags());
+		assertEquals(List.of("1:Farm", "2:Farm", "1:", "2:"), model.savedTagAssignments);
+	}
+
+	private ProfileAux profile(Long id, String name, boolean enabled) {
+		return new ProfileAux(id, name, String.valueOf(id), enabled, id, "NOT RUNNING", 0L,
+				null, null, null, null);
+	}
+
+	private static final class StubRuntimeController
+			implements ProfileManagerActionController.ProfileRuntimeController {
+		private final Set<Long> activeProfileIds;
+		private final List<Long> pausedProfileIds = new ArrayList<>();
+
+		private StubRuntimeController(Set<Long> activeProfileIds) {
+			this.activeProfileIds = new HashSet<>(activeProfileIds);
+		}
+
+		@Override
+		public Set<Long> activeQueueIds() {
+			return Set.copyOf(activeProfileIds);
+		}
+
+		@Override
+		public void pauseQueue(Long profileId) {
+			pausedProfileIds.add(profileId);
+			activeProfileIds.remove(profileId);
+		}
+	}
+
+	private static final class StubProfileModel implements IProfileModel {
+		private final Set<Long> failingProfileIds = new HashSet<>();
+		private final List<String> savedTagAssignments = new ArrayList<>();
+
+		@Override
+		public List<AccountDescriptor> getProfiles() {
+			return List.of();
+		}
+
+		@Override
+		public boolean addProfile(AccountDescriptor profile) {
+			return true;
+		}
+
+		@Override
+		public boolean saveProfile(AccountDescriptor profile) {
+			return !failingProfileIds.contains(profile.getId());
+		}
+
+		@Override
+		public boolean deleteProfile(AccountDescriptor profile) {
+			return true;
+		}
+
+		@Override
+		public boolean bulkUpdateProfiles(AccountDescriptor profile) {
+			return true;
+		}
+
+		@Override
+		public List<String> getTags() {
+			return List.of();
+		}
+
+		@Override
+		public boolean replaceTags(Long profileId, List<String> tags) {
+			savedTagAssignments.add(profileId + ":" + String.join(",", tags));
+			return true;
+		}
+
+		@Override
+		public void addProfileStatusChangeListerner(ProfileStatusChangeListener listener) {
+		}
+	}
+}

--- a/fg-app/src/test/java/dev/frostguard/app/panel/profile/ProfileSearchMatcherTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/profile/ProfileSearchMatcherTest.java
@@ -1,0 +1,38 @@
+package dev.frostguard.app.panel.profile;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ProfileSearchMatcherTest {
+
+	@Test
+	void searchesAcrossProfileIdentityAndTags() {
+		ProfileAux profile = profile();
+
+		assertTrue(ProfileSearchMatcher.matches(profile, "Farm"));
+		assertTrue(ProfileSearchMatcher.matches(profile, "987654"));
+		assertTrue(ProfileSearchMatcher.matches(profile, "1234"));
+		assertTrue(ProfileSearchMatcher.matches(profile, "NERD"));
+		assertTrue(ProfileSearchMatcher.matches(profile, "SVS"));
+		assertFalse(ProfileSearchMatcher.matches(profile, "PEAK"));
+	}
+
+	@Test
+	void combinesStructuredFiltersWithAndSemantics() {
+		ProfileAux profile = profile();
+
+		assertTrue(ProfileSearchMatcher.matches(profile, "server:1234 tag:svs enabled:true"));
+		assertTrue(ProfileSearchMatcher.matches(profile, "alliance:nerd emulator:7"));
+		assertFalse(ProfileSearchMatcher.matches(profile, "server:1234 tag:f2p"));
+		assertFalse(ProfileSearchMatcher.matches(profile, "enabled:false"));
+	}
+
+	private ProfileAux profile() {
+		ProfileAux profile = new ProfileAux(42L, "Farm Alpha", "7", true, 1L, "RUNNING", 0L,
+				"987654", "Chief Dave", "NERD", "1234");
+		profile.setTags(java.util.List.of("Farm", "SVS"));
+		return profile;
+	}
+}

--- a/fg-app/src/test/java/dev/frostguard/app/panel/profile/ProfileTransferServiceTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/profile/ProfileTransferServiceTest.java
@@ -1,0 +1,80 @@
+package dev.frostguard.app.panel.profile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProfileTransferServiceTest {
+
+	@TempDir
+	Path tempDirectory;
+
+	@Test
+	void roundTripsMultipleProfilesWithoutDatabaseIds() throws Exception {
+		ProfileTransferService service = new ProfileTransferService();
+		ProfileAux first = profile(7L, "Farm One");
+		ProfileAux second = profile(8L, "Farm Two");
+		Path export = tempDirectory.resolve("profiles.json");
+
+		service.write(export, List.of(first, second));
+		var imported = service.read(export);
+
+		assertEquals(2, imported.size());
+		assertNull(imported.get(0).getId());
+		assertEquals("Farm One", imported.get(0).getName());
+		assertEquals("1234", imported.get(0).getCharacterServer());
+		assertEquals(List.of("Farm", "SVS"), imported.get(0).getTags());
+		assertEquals(1, imported.get(0).getConfigs().size());
+		assertEquals("GATHER_TASK_BOOL", imported.get(0).getConfigs().get(0).getConfigurationName());
+	}
+
+	@Test
+	void duplicateUsesNewNameAndCopiesSettingsAndTags() throws Exception {
+		ProfileTransferService service = new ProfileTransferService();
+
+		var duplicate = service.duplicate(profile(7L, "Farm One"), "Farm One Copy");
+
+		assertNull(duplicate.getId());
+		assertEquals("Farm One Copy", duplicate.getName());
+		assertEquals(List.of("Farm", "SVS"), duplicate.getTags());
+		assertEquals("true", duplicate.getConfigs().get(0).getValue());
+	}
+
+	@Test
+	void rejectsUnknownConfigurationsAndInvalidTypedValues() throws Exception {
+		ProfileTransferService service = new ProfileTransferService();
+		Path unknown = tempDirectory.resolve("unknown.json");
+		Files.writeString(unknown, """
+				{"formatVersion":1,"profiles":[{"name":"Bad","configs":[{"name":"NOT_A_KEY","value":"true"}]}]}
+				""");
+		Path invalid = tempDirectory.resolve("invalid.json");
+		Files.writeString(invalid, """
+				{"formatVersion":1,"profiles":[{"name":"Bad","configs":[{"name":"GATHER_COAL_BOOL","value":"perhaps"}]}]}
+				""");
+
+		assertThrows(java.io.IOException.class, () -> service.read(unknown));
+		assertThrows(java.io.IOException.class, () -> service.read(invalid));
+	}
+
+	@Test
+	void rejectsFilesLargerThanFiveMegabytes() throws Exception {
+		Path oversized = tempDirectory.resolve("oversized.json");
+		Files.write(oversized, new byte[5 * 1024 * 1024 + 1]);
+		assertThrows(java.io.IOException.class, () -> new ProfileTransferService().read(oversized));
+	}
+
+	private ProfileAux profile(Long id, String name) {
+		ProfileAux profile = new ProfileAux(id, name, "3", true, 10L, "NOT RUNNING", 30L,
+				"98765", "Chief", "NERD", "1234");
+		profile.getConfigs().add(new ConfigAux("GATHER_TASK_BOOL", "true"));
+		profile.setTags(List.of("Farm", "SVS"));
+		return profile;
+	}
+}

--- a/fg-data/pom.xml
+++ b/fg-data/pom.xml
@@ -79,5 +79,10 @@
             <artifactId>logback-classic</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/fg-data/src/main/java/dev/frostguard/data/access/DataSeeder.java
+++ b/fg-data/src/main/java/dev/frostguard/data/access/DataSeeder.java
@@ -2,7 +2,6 @@ package dev.frostguard.data.access;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,7 +19,6 @@ import dev.frostguard.data.entity.DailyTaskTemplate;
 final class DataSeeder {
 
 	private static final Logger LOG = LoggerFactory.getLogger(DataSeeder.class);
-	private static final AtomicBoolean completed = new AtomicBoolean(false);
 
 	private record RoutineSeed(TpDailyTaskEnum type) {
 		DailyTaskTemplate toEntity() { return DailyTaskTemplate.fromRoutineType(type); }
@@ -39,8 +37,6 @@ final class DataSeeder {
 		Arrays.stream(TpConfigEnum.values()).map(SettingSeed::new).toList();
 
 	static void populate(DataStore store) {
-		if (!completed.compareAndSet(false, true)) return;
-
 		int routinesAdded = seedRoutineDefinitions(store);
 		int settingsAdded = seedSettingDefinitions(store);
 

--- a/fg-data/src/main/java/dev/frostguard/data/access/DataStore.java
+++ b/fg-data/src/main/java/dev/frostguard/data/access/DataStore.java
@@ -23,17 +23,15 @@ public final class DataStore implements AutoCloseable {
 
 	private static final Logger LOG = LoggerFactory.getLogger(DataStore.class);
 	private static final String PERSISTENCE_UNIT = "frostguardPU";
-	private static final DataStore INSTANCE = createInstance();
-
 	private final EntityManagerFactory emf;
 
-	private static DataStore createInstance() {
-		return new DataStore();
+	private static final class Holder {
+		private static final DataStore INSTANCE = new DataStore(Map.of());
 	}
 
-	private DataStore() {
+	private DataStore(Map<String, Object> overrides) {
 		try {
-			this.emf = Persistence.createEntityManagerFactory(PERSISTENCE_UNIT);
+			this.emf = Persistence.createEntityManagerFactory(PERSISTENCE_UNIT, overrides);
 			DataSeeder.populate(this);
 			LOG.info("Frostguard data store initialized");
 		} catch (Exception cause) {
@@ -42,8 +40,12 @@ public final class DataStore implements AutoCloseable {
 		}
 	}
 
+	public static DataStore openIsolated(Map<String, Object> overrides) {
+		return new DataStore(overrides == null ? Map.of() : overrides);
+	}
+
 	public static DataStore getInstance() {
-		return INSTANCE;
+		return Holder.INSTANCE;
 	}
 
 	/**

--- a/fg-data/src/main/java/dev/frostguard/data/entity/Profile.java
+++ b/fg-data/src/main/java/dev/frostguard/data/entity/Profile.java
@@ -3,6 +3,8 @@ package dev.frostguard.data.entity;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
@@ -13,6 +15,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
 import jakarta.persistence.Table;
 
 /**
@@ -93,6 +98,12 @@ public class Profile {
 
 	@OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Config> settings = new ArrayList<>();
+
+	@ManyToMany
+	@JoinTable(name = "profile_tag_assignments",
+			joinColumns = @JoinColumn(name = "profile_id"),
+			inverseJoinColumns = @JoinColumn(name = "tag_id"))
+	private Set<ProfileTag> tags = new LinkedHashSet<>();
 
 	// ── construction ─────────────────────────────────────────────────
 
@@ -193,6 +204,8 @@ public class Profile {
 	public void setRealm(String v)      { this.realm = v; }
 	public List<Config> getSettings()   { return settings; }
 	public void setSettings(List<Config> v) { this.settings = v; }
+	public Set<ProfileTag> getTags() { return tags; }
+	public void setTags(Set<ProfileTag> tags) { this.tags = tags; }
 
 	// ── object identity ──────────────────────────────────────────────
 

--- a/fg-data/src/main/java/dev/frostguard/data/entity/ProfileTag.java
+++ b/fg-data/src/main/java/dev/frostguard/data/entity/ProfileTag.java
@@ -1,0 +1,56 @@
+package dev.frostguard.data.entity;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(name = "profile_tags", uniqueConstraints = @UniqueConstraint(name = "uk_profile_tag_name", columnNames = "name"))
+public class ProfileTag {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "name", nullable = false, length = 40)
+	private String name;
+
+	@Column(name = "color", nullable = false, length = 7, columnDefinition = "varchar(7) default '#388bfd'")
+	private String color = "#388bfd";
+
+	public ProfileTag() {
+	}
+
+	public ProfileTag(String name) {
+		this.name = name;
+	}
+
+	public ProfileTag(String name, String color) {
+		this.name = name;
+		this.color = color;
+	}
+
+	public Long getId() { return id; }
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; }
+	public String getColor() { return color; }
+	public void setColor(String color) { this.color = color; }
+
+	@Override
+	public boolean equals(Object other) {
+		if (this == other) return true;
+		if (!(other instanceof ProfileTag tag)) return false;
+		return id != null ? id.equals(tag.id) : Objects.equals(name, tag.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return id != null ? id.hashCode() : Objects.hashCode(name);
+	}
+}

--- a/fg-data/src/main/java/dev/frostguard/data/repository/ProfileRepository.java
+++ b/fg-data/src/main/java/dev/frostguard/data/repository/ProfileRepository.java
@@ -9,9 +9,13 @@ import java.util.stream.Collectors;
 
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.ConfigData;
+import dev.frostguard.api.domain.ProfileTagData;
 import dev.frostguard.data.access.DataStore;
 import dev.frostguard.data.entity.Config;
+import dev.frostguard.data.entity.ConfigTemplate;
 import dev.frostguard.data.entity.Profile;
+import dev.frostguard.data.entity.ProfileTag;
+import dev.frostguard.api.configs.TpConfigEnum;
 
 /**
  * Manages {@link Profile} persistence operations and the associated
@@ -21,9 +25,11 @@ import dev.frostguard.data.entity.Profile;
 public class ProfileRepository {
 
 	private static ProfileRepository instance;
-	private final DataStore store = DataStore.getInstance();
+	private final DataStore store;
 
-	private ProfileRepository() {}
+	private ProfileRepository() { this(DataStore.getInstance()); }
+
+	public ProfileRepository(DataStore store) { this.store = java.util.Objects.requireNonNull(store); }
 
 	public static ProfileRepository getRepository() {
 		if (instance == null) {
@@ -41,6 +47,7 @@ public class ProfileRepository {
 		}
 
 		attachConfigEntries(descriptors);
+		attachTags(descriptors);
 		return descriptors;
 	}
 
@@ -49,6 +56,7 @@ public class ProfileRepository {
 
 		return findDescriptorById(id)
 			.map(this::attachSingleConfigs)
+			.map(this::attachSingleTags)
 			.orElse(null);
 	}
 
@@ -59,12 +67,121 @@ public class ProfileRepository {
 	}
 
 	public boolean addAccount(Profile profile) { return store.persist(profile); }
+
+	public Long createAccountAggregate(Profile profile, List<ConfigData> settings, List<String> tagNames) {
+		try {
+			return store.withinTransaction(em -> {
+				ConfigTemplate template = em.find(ConfigTemplate.class, TpConfigEnum.PROFILE_CONFIG.getId());
+				if (template == null) throw new IllegalStateException("Profile configuration template is missing");
+				for (ConfigData setting : settings == null ? List.<ConfigData>of() : settings) {
+					profile.getSettings().add(new Config(profile, template,
+							setting.getConfigurationName(), setting.getValue()));
+				}
+				for (String raw : tagNames == null ? List.<String>of() : tagNames) {
+					String name = normalizeTag(raw);
+					if (name.isBlank()) continue;
+					List<ProfileTag> matches = em.createQuery(
+							"SELECT t FROM ProfileTag t WHERE lower(t.name) = :name", ProfileTag.class)
+							.setParameter("name", name.toLowerCase()).getResultList();
+					ProfileTag tag = matches.isEmpty() ? new ProfileTag(name) : matches.get(0);
+					if (matches.isEmpty()) em.persist(tag);
+					profile.getTags().add(tag);
+				}
+				em.persist(profile);
+				em.flush();
+				return profile.getId();
+			});
+		} catch (Exception ex) {
+			return null;
+		}
+	}
 	public boolean saveAccount(Profile profile) { return store.merge(profile); }
 	public boolean deleteAccount(Profile profile) { return store.remove(profile); }
 
 	public Profile getAccountById(Long id) {
 		if (id == null) return null;
 		return store.lookup(Profile.class, id);
+	}
+
+	public List<String> getTagNames() {
+		return store.executeQuery("SELECT t.name FROM ProfileTag t ORDER BY lower(t.name)", String.class, null);
+	}
+
+	public List<ProfileTagData> getTags() {
+		return store.executeQuery("SELECT t FROM ProfileTag t ORDER BY lower(t.name)", ProfileTag.class, null)
+				.stream().map(tag -> new ProfileTagData(tag.getName(),
+						tag.getColor() == null ? "#388bfd" : tag.getColor())).toList();
+	}
+
+	public boolean updateTag(String oldName, String newName, String color) {
+		try {
+			return store.withinTransaction(em -> {
+				String normalizedName = normalizeTag(newName);
+				if (normalizedName.isBlank()) return false;
+				Long collisionCount = em.createQuery(
+						"SELECT count(t) FROM ProfileTag t WHERE lower(t.name) = :newName AND lower(t.name) <> :oldName",
+						Long.class).setParameter("newName", normalizedName.toLowerCase())
+						.setParameter("oldName", oldName.toLowerCase()).getSingleResult();
+				if (collisionCount > 0) return false;
+				List<ProfileTag> matches = em.createQuery(
+						"SELECT t FROM ProfileTag t WHERE lower(t.name) = :name", ProfileTag.class)
+						.setParameter("name", oldName.toLowerCase()).getResultList();
+				if (matches.isEmpty()) return false;
+				ProfileTag tag = matches.get(0);
+				tag.setName(normalizedName);
+				tag.setColor(normalizeColor(color));
+				return true;
+			});
+		} catch (Exception ex) {
+			return false;
+		}
+	}
+
+	public boolean deleteTag(String name) {
+		try {
+			return store.withinTransaction(em -> {
+				List<ProfileTag> matches = em.createQuery(
+						"SELECT t FROM ProfileTag t WHERE lower(t.name) = :name", ProfileTag.class)
+						.setParameter("name", name.toLowerCase()).getResultList();
+				if (matches.isEmpty()) return false;
+				ProfileTag tag = matches.get(0);
+				em.createNativeQuery("DELETE FROM profile_tag_assignments WHERE tag_id = ?")
+						.setParameter(1, tag.getId()).executeUpdate();
+				em.remove(tag);
+				return true;
+			});
+		} catch (Exception ex) {
+			return false;
+		}
+	}
+
+	public boolean replaceProfileTags(Long profileId, List<String> tagNames) {
+		if (profileId == null) return false;
+		try {
+			return store.withinTransaction(em -> {
+				Profile profile = em.find(Profile.class, profileId);
+				if (profile == null) return false;
+				var normalized = tagNames == null ? List.<String>of() : tagNames.stream()
+						.map(ProfileRepository::normalizeTag)
+						.filter(name -> !name.isBlank())
+						.distinct()
+						.toList();
+				var assigned = new java.util.LinkedHashSet<ProfileTag>();
+				for (String name : normalized) {
+					List<ProfileTag> matches = em.createQuery(
+							"SELECT t FROM ProfileTag t WHERE lower(t.name) = :name", ProfileTag.class)
+							.setParameter("name", name.toLowerCase())
+							.getResultList();
+					ProfileTag tag = matches.isEmpty() ? new ProfileTag(name) : matches.get(0);
+					if (matches.isEmpty()) em.persist(tag);
+					assigned.add(tag);
+				}
+				profile.setTags(assigned);
+				return true;
+			});
+		} catch (Exception ex) {
+			return false;
+		}
 	}
 
 	public List<Config> getAccountSettings(Long accountId) {
@@ -138,6 +255,34 @@ public class ProfileRepository {
 
 		descriptors.forEach(d ->
 			d.setConfigs(grouped.getOrDefault(d.getId(), new ArrayList<>())));
+	}
+
+	private void attachTags(List<AccountDescriptor> descriptors) {
+		if (descriptors.isEmpty()) return;
+		List<Object[]> rows = store.executeQuery(
+				"SELECT p.id, t.name FROM Profile p JOIN p.tags t ORDER BY lower(t.name)", Object[].class, null);
+		if (rows == null) return;
+		Map<Long, List<String>> grouped = rows.stream().collect(Collectors.groupingBy(
+				row -> (Long) row[0], Collectors.mapping(row -> (String) row[1], Collectors.toList())));
+		descriptors.forEach(descriptor -> descriptor.setTags(grouped.getOrDefault(descriptor.getId(), List.of())));
+	}
+
+	private AccountDescriptor attachSingleTags(AccountDescriptor descriptor) {
+		List<String> tags = store.executeQuery(
+				"SELECT t.name FROM Profile p JOIN p.tags t WHERE p.id = :profileId ORDER BY lower(t.name)",
+				String.class, Map.of("profileId", descriptor.getId()));
+		descriptor.setTags(tags);
+		return descriptor;
+	}
+
+	private static String normalizeTag(String raw) {
+		if (raw == null) return "";
+		String trimmed = raw.trim().replaceAll("\\s+", " ");
+		return trimmed.length() <= 40 ? trimmed : trimmed.substring(0, 40);
+	}
+
+	private static String normalizeColor(String raw) {
+		return raw != null && raw.matches("#[0-9a-fA-F]{6}") ? raw.toLowerCase() : "#388bfd";
 	}
 
 	private AccountDescriptor attachSingleConfigs(AccountDescriptor descriptor) {

--- a/fg-data/src/main/resources/META-INF/persistence.xml
+++ b/fg-data/src/main/resources/META-INF/persistence.xml
@@ -20,6 +20,7 @@
         <class>dev.frostguard.data.entity.GiftCodeClaim</class>
         <class>dev.frostguard.data.entity.Profile</class>
         <class>dev.frostguard.data.entity.ProfileBuilding</class>
+        <class>dev.frostguard.data.entity.ProfileTag</class>
 
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
         <shared-cache-mode>NONE</shared-cache-mode>

--- a/fg-data/src/test/java/dev/frostguard/data/repository/ProfileRepositoryPersistenceTest.java
+++ b/fg-data/src/test/java/dev/frostguard/data/repository/ProfileRepositoryPersistenceTest.java
@@ -1,0 +1,90 @@
+package dev.frostguard.data.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.ConfigData;
+import dev.frostguard.data.access.DataStore;
+import dev.frostguard.data.entity.Profile;
+
+class ProfileRepositoryPersistenceTest {
+
+	private Path database;
+	private DataStore store;
+	private ProfileRepository repository;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		database = Files.createTempFile("frostguard-profile-test-", ".db");
+		store = DataStore.openIsolated(Map.of(
+				"jakarta.persistence.jdbc.url", "jdbc:sqlite:" + database,
+				"hibernate.hbm2ddl.auto", "create-drop"));
+		repository = new ProfileRepository(store);
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		if (store != null) store.close();
+		Files.deleteIfExists(database);
+	}
+
+	@Test
+	void persistsRenamesRecolorsAndDeletesTagsInSQLite() {
+		Profile profile = Profile.create("Tagged", "1");
+		Long id = repository.createAccountAggregate(profile, List.of(), List.of("svs"));
+		assertNotNull(id);
+		assertEquals(List.of("svs"), repository.getAccountWithSettingsById(id).getTags());
+
+		assertTrue(repository.updateTag("svs", "BiA", "#ff8800"));
+		assertEquals("#ff8800", repository.getTags().getFirst().color());
+		assertEquals(List.of("BiA"), repository.getAccountWithSettingsById(id).getTags());
+
+		assertTrue(repository.deleteTag("BiA"));
+		assertTrue(repository.getTags().isEmpty());
+		assertTrue(repository.getAccountWithSettingsById(id).getTags().isEmpty());
+	}
+
+	@Test
+	void persistsDuplicateAndImportedAggregatesWithIndependentSettings() {
+		Profile source = Profile.create("Source", "1");
+		Long sourceId = repository.createAccountAggregate(source,
+				List.of(new ConfigData(null, "GATHER_COAL_BOOL", "true")), List.of("farm"));
+		Profile duplicate = Profile.create("Source Copy", "2");
+		Long duplicateId = repository.createAccountAggregate(duplicate,
+				List.of(new ConfigData(null, "GATHER_COAL_BOOL", "true")), List.of("farm"));
+
+		assertNotNull(sourceId);
+		assertNotNull(duplicateId);
+		assertFalse(sourceId.equals(duplicateId));
+		AccountDescriptor loaded = repository.getAccountWithSettingsById(duplicateId);
+		assertEquals("Source Copy", loaded.getName());
+		assertEquals("true", loaded.getConfigs().getFirst().getValue());
+		assertEquals(List.of("farm"), loaded.getTags());
+	}
+
+	@Test
+	void rollsBackWholeAggregateWhenProfileInsertFails() {
+		Profile invalid = Profile.create(null, "1");
+		invalid.setLabel(null);
+		Long id = repository.createAccountAggregate(invalid,
+				List.of(new ConfigData(null, "GATHER_COAL_BOOL", "true")), List.of("rollback-tag"));
+
+		assertNull(id);
+		assertFalse(repository.getTagNames().contains("rollback-tag"));
+		assertEquals(0, store.executeQuery("SELECT c FROM Config c WHERE c.identifier = :key",
+				dev.frostguard.data.entity.Config.class, Map.of("key", "GATHER_COAL_BOOL")).size());
+	}
+}

--- a/fg-engine/src/main/java/dev/frostguard/engine/listener/ProfileServiceInterface.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/listener/ProfileServiceInterface.java
@@ -1,6 +1,7 @@
 package dev.frostguard.engine.listener;
 
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.ProfileTagData;
 
 import java.util.List;
 
@@ -16,6 +17,16 @@ public interface ProfileServiceInterface {
     boolean removeAccount(AccountDescriptor profile);
 
     boolean applyBulkUpdate(AccountDescriptor templateAccount);
+
+    List<String> fetchProfileTags();
+
+    List<ProfileTagData> fetchProfileTagDefinitions();
+
+    boolean updateProfileTag(String oldName, String newName, String color);
+
+    boolean deleteProfileTag(String name);
+
+    boolean replaceProfileTags(Long profileId, List<String> tags);
 
     void registerStatusObserver(ProfileStatusChangeListener observer);
 

--- a/fg-engine/src/main/java/dev/frostguard/engine/service/ProfileService.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/service/ProfileService.java
@@ -11,6 +11,7 @@ import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import dev.frostguard.api.configs.TpConfigEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.ProfileStatusData;
+import dev.frostguard.api.domain.ProfileTagData;
 import dev.frostguard.data.entity.Config;
 import dev.frostguard.data.entity.ConfigTemplate;
 import dev.frostguard.data.entity.Profile;
@@ -75,8 +76,10 @@ public class ProfileService implements ProfileServiceInterface {
 		return withDescriptor(descriptor, "create", account -> {
 			Profile entity = new Profile();
 			copyDescriptorFields(account, entity);
-			return profiles.addAccount(entity);
-		}, null);
+			Long id = profiles.createAccountAggregate(entity, account.getConfigs(), account.getTags());
+			account.setId(id);
+			return id != null;
+		}, descriptor);
 	}
 
 	@Override
@@ -91,6 +94,9 @@ public class ProfileService implements ProfileServiceInterface {
 			}
 			copyDescriptorFields(account, entity);
 			if (!replaceProfileSettings(entity, account)) {
+				return false;
+			}
+			if (!profiles.replaceProfileTags(entity.getId(), account.getTags())) {
 				return false;
 			}
 			return profiles.saveAccount(entity);
@@ -141,6 +147,34 @@ public class ProfileService implements ProfileServiceInterface {
 			}
 		}
 		return complete;
+	}
+
+	@Override
+	public List<String> fetchProfileTags() {
+		return profiles.getTagNames();
+	}
+
+	@Override
+	public List<ProfileTagData> fetchProfileTagDefinitions() { return profiles.getTags(); }
+
+	@Override
+	public boolean updateProfileTag(String oldName, String newName, String color) {
+		return profiles.updateTag(oldName, newName, color);
+	}
+
+	@Override
+	public boolean deleteProfileTag(String name) { return profiles.deleteTag(name); }
+
+	@Override
+	public boolean replaceProfileTags(Long profileId, List<String> tags) {
+		boolean changed = profiles.replaceProfileTags(profileId, tags);
+		if (changed) {
+			AccountDescriptor updated = profiles.getAccountWithSettingsById(profileId);
+			if (updated != null) {
+				broadcastAccountDataChange(updated);
+			}
+		}
+		return changed;
 	}
 
 	public void broadcastStatusChange(ProfileStatusData state) {


### PR DESCRIPTION
## Summary

- add multi-profile selection with bulk enable, disable, tag assignment, and filtered select-all behavior
- add profile tags with colors, editing, management, search qualifiers, suggestions, and saved views
- add profile duplication plus versioned multi-profile JSON import/export with preview and conflict handling
- persist profile creation atomically with configurations and tags
- improve the profile table layout for compact rows, narrow windows, and configurable columns

## Why

Managing many profiles one at a time made event preparation and account grouping unnecessarily repetitive. The profile manager also lacked reusable organization, discoverable structured filtering, and a safe way to move or copy profile configurations.

## Validation

- `mvn -pl fg-app -am -Dtest='Profile*Test' -Dsurefire.failIfNoSpecifiedTests=false test` — passed: 10 focused application tests and 3 SQLite persistence tests
- `mvn -pl fg-app -am package -DskipTests` — passed
- `xmllint --noout fg-app/src/main/resources/layout/ProfileManagerLayout.fxml fg-app/src/main/resources/layout/EditProfile.fxml` — passed
- live application launch against an existing local profile database confirmed the schema migration and profile manager loading
- bulk selection, tag editing, duplicate/import/export, search, and saved-view flows were exercised manually during implementation

The full reactor test suite was attempted but remains blocked on this macOS environment by the existing missing native `libtesseract.dylib` dependency in two OCR tests.

## Risks

- the tag schema is migrated through Hibernate's existing automatic schema update path; SQLite persistence tests cover fresh schema behavior and the existing local database migrated successfully
- the latest compact table and filter suggestion refinements have automated compile/FXML coverage and live launch confirmation, but still benefit from review on Windows at narrow window sizes
