### PR TITLE
docs(readme): link public project roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,15 @@ C:\LDPlayer\LDPlayer9\ldconsole.exe
 ## 🚀 Roadmap
 
 <div align="center">
-  <i>We are continuously working to expand the bot's capabilities.</i>
+  <i>Follow planned work, priorities, and current progress on the public FrostGuard workboard.</i>
+
+  <br/><br/>
+
+  <a href="https://github.com/users/Shederator/projects/2"><img src="https://img.shields.io/badge/Open_FrostGuard_Project-415a77?style=for-the-badge&logo=github&logoColor=white" alt="Open FrostGuard Project" /></a>
+
+  <br/><br/>
+
+  The project board is the source of truth for the roadmap. The table below highlights selected larger features.
 </div>
 
 <br/>


### PR DESCRIPTION
## Summary

- add a direct FrostGuard Project button to the repository roadmap
- identify the public project board as the roadmap source of truth
- retain the existing roadmap table as a set of selected highlights

## Why

The linked GitHub Project currently requires navigating through the repository's Projects tab and selecting the board. A direct README link makes the public roadmap easier to reach, while the Project README now provides the reverse link back to the repository.

## Validation

- `git diff --check`
- manually verified both repository and project URLs
- no build or automated tests run; documentation-only change

## Risks

None known.
