### PR TITLE
fix(nightly): show complete change summaries

### DIFF
--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -266,6 +266,12 @@ jobs:
             --previous "${previous_sha}" \
             --current "${GITHUB_SHA}")"
 
+          notes="${notes}
+
+          ## Changes since the previous Nightly
+
+          ${changes}"
+
           if [[ -n "${previous_sha}" ]]; then
             gh release delete nightly --yes --cleanup-tag
           fi

--- a/ci/discord_notify.py
+++ b/ci/discord_notify.py
@@ -43,6 +43,7 @@ EMBED_FOOTER_LIMIT = 2048
 # and falls back to a link when the file is larger, because a failed upload
 # would otherwise swallow the notification entirely.
 ATTACHMENT_LIMIT_BYTES = 8 * 1024 * 1024
+MAX_CHANGE_FIELDS = 4
 
 STATUS_STYLE = {
     # Amber distinguishes an intentionally unstable Nightly from the green
@@ -89,6 +90,33 @@ def first_line(text: str) -> str:
     return (text or "").strip().splitlines()[0].strip() if (text or "").strip() else ""
 
 
+def change_fields(changes: str, repository: str) -> list[dict]:
+    """Split Nightly changes across readable fields within Discord's limits."""
+    lines = [truncate(line, EMBED_FIELD_VALUE_LIMIT) for line in changes.splitlines()
+             if line.strip()]
+    chunks: list[list[str]] = []
+    for line in lines:
+        if not chunks or len("\n".join([*chunks[-1], line])) > EMBED_FIELD_VALUE_LIMIT:
+            chunks.append([line])
+        else:
+            chunks[-1].append(line)
+
+    if len(chunks) > MAX_CHANGE_FIELDS:
+        chunks = chunks[-MAX_CHANGE_FIELDS:]
+        release_url = f"https://github.com/{repository}/releases/tag/nightly"
+        link = f"• Earlier changes: [view the complete Nightly changelog]({release_url})"
+        while chunks[0] and len("\n".join([link, *chunks[0]])) > EMBED_FIELD_VALUE_LIMIT:
+            chunks[0].pop(0)
+        chunks[0].insert(0, link)
+
+    return [{
+        "name": "Changes since the previous Nightly"
+        if index == 0 else "Changes since the previous Nightly (continued)",
+        "value": "\n".join(chunk),
+        "inline": False,
+    } for index, chunk in enumerate(chunks)]
+
+
 def redact(text: str) -> str:
     """Strip anything that looks like a webhook token out of diagnostics."""
     return re.sub(
@@ -127,11 +155,7 @@ def build_payload(args: argparse.Namespace) -> dict:
                 "launcher. Java 21 or newer is required."
             )
             if args.changes:
-                fields.append({
-                    "name": "Changes since the previous Nightly",
-                    "value": truncate(args.changes, EMBED_FIELD_VALUE_LIMIT),
-                    "inline": False,
-                })
+                fields.extend(change_fields(args.changes, args.repository))
         elif args.run_url:
             description_parts.append(
                 f"Build passed. The artifact is attached to "

--- a/ci/nightly_changes.py
+++ b/ci/nightly_changes.py
@@ -45,7 +45,7 @@ def describe(repository: str, commit: str) -> str:
     )
 
 
-def summary(repository: str, previous: str, current: str, limit: int = 5) -> str:
+def summary(repository: str, previous: str, current: str) -> str:
     if not previous or not current or previous == current:
         return "No new changes since the previous Nightly."
     try:
@@ -58,11 +58,7 @@ def summary(repository: str, previous: str, current: str, limit: int = 5) -> str
     if not commits:
         return "No new changes since the previous Nightly."
 
-    omitted = max(0, len(commits) - limit)
-    lines = [describe(repository, commit) for commit in commits[-limit:]]
-    if omitted:
-        lines.insert(0, f"• …and {omitted} earlier change{'s' if omitted != 1 else ''}")
-    return "\n".join(lines)
+    return "\n".join(describe(repository, commit) for commit in commits)
 
 
 def main() -> int:
@@ -70,9 +66,8 @@ def main() -> int:
     parser.add_argument("--repository", required=True)
     parser.add_argument("--previous", default="")
     parser.add_argument("--current", required=True)
-    parser.add_argument("--limit", type=int, default=5)
     args = parser.parse_args()
-    print(summary(args.repository, args.previous, args.current, max(1, args.limit)))
+    print(summary(args.repository, args.previous, args.current))
     return 0
 
 

--- a/ci/test_discord_notify.py
+++ b/ci/test_discord_notify.py
@@ -89,6 +89,22 @@ class PayloadTest(unittest.TestCase):
         )
         self.assertIn("#79", changes["value"])
 
+    def test_splits_many_changes_instead_of_truncating_at_five(self):
+        changes = "\n".join(f"• change {index} " + "x" * 180 for index in range(12))
+        fields = payload(["--changes", changes])["embeds"][0]["fields"]
+        text = "\n".join(field["value"] for field in fields)
+        self.assertGreater(len(fields), 1)
+        self.assertIn("change 0", text)
+        self.assertIn("change 11", text)
+
+    def test_overflow_links_the_complete_release_changelog(self):
+        changes = "\n".join(f"• change {index} " + "x" * 900 for index in range(8))
+        fields = payload(["--changes", changes])["embeds"][0]["fields"]
+        text = "\n".join(field["value"] for field in fields)
+        self.assertEqual(len(fields), discord_notify.MAX_CHANGE_FIELDS)
+        self.assertIn("releases/tag/nightly", text)
+        self.assertIn("change 7", text)
+
     def test_omits_internal_ci_metrics(self):
         result = payload()
         names = {f["name"] for f in result["embeds"][0]["fields"]}

--- a/ci/test_nightly_changes.py
+++ b/ci/test_nightly_changes.py
@@ -33,13 +33,12 @@ class NightlyChangesTest(unittest.TestCase):
         self.assertIn("[`1234567`]", line)
         self.assertIn("/commit/123456789", line)
 
-    def test_summary_keeps_latest_changes_and_reports_omitted_count(self):
+    def test_summary_keeps_every_change(self):
         commits = "\n".join(f"commit{i}" for i in range(7))
         with mock.patch.object(changes, "git", return_value=commits), \
                 mock.patch.object(changes, "describe", side_effect=lambda _, c: c):
-            result = changes.summary("Shederator/wosbot", "old", "new", limit=5)
-        self.assertIn("2 earlier changes", result)
-        self.assertNotIn("commit0", result)
+            result = changes.summary("Shederator/wosbot", "old", "new")
+        self.assertIn("commit0", result)
         self.assertIn("commit6", result)
 
     def test_missing_history_is_a_readable_fallback(self):


### PR DESCRIPTION
## Summary

- remove the fixed five-change Nightly summary cap
- split normal change lists across multiple Discord fields within documented limits
- link the complete Nightly changelog only when Discord capacity is exhausted
- include the complete change list in the GitHub Nightly release notes


## Why

The maintained Discord message replaced every change beyond the newest five with an opaque omitted-count line, even when Discord still had room to show the actual entries.

## Validation

- `python3 ci/test_nightly_changes.py`
- `python3 ci/test_discord_notify.py`
- Python compilation for both changed modules
- `actionlint .github/workflows/daily-windows-bundle.yml` (passes with two pre-existing informational ShellCheck findings)
- `git diff --check`

Evidence level: automated tests. No live Nightly was triggered before merge.

## Risks

Discord still has a hard total embed limit. Extremely large change sets show the newest entries that fit and link the complete release changelog; normal Nightlies show every entry directly.