### PR TITLE
fix(analytics): soften delivery timeout logging

### DIFF
--- a/fg-engine/src/main/java/dev/frostguard/engine/service/AnalyticsService.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/service/AnalyticsService.java
@@ -273,12 +273,22 @@ public class AnalyticsService {
 						logger.info("Analytics event sent: {}", eventName);
 					}
 				} catch (Exception e) {
-					logger.error("Failed to send analytics event {}: {}", eventName, e.getMessage(), e);
+					if (!isSilentMode()) {
+						logger.warn("Analytics event {} could not be sent; application operation is unaffected: {}",
+								eventName, describeDeliveryFailure(e));
+					}
 				}
 			});
 		} catch (Exception e) {
 			logger.error("Failed to build analytics event {}: {}", eventName, e.getMessage(), e);
 		}
+	}
+
+	static String describeDeliveryFailure(Exception exception) {
+		String message = exception.getMessage();
+		return message == null || message.isBlank()
+				? exception.getClass().getSimpleName()
+				: message;
 	}
 
 	/**

--- a/fg-engine/src/test/java/dev/frostguard/engine/service/AnalyticsServiceTest.java
+++ b/fg-engine/src/test/java/dev/frostguard/engine/service/AnalyticsServiceTest.java
@@ -1,0 +1,24 @@
+package dev.frostguard.engine.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.SocketTimeoutException;
+
+import org.junit.jupiter.api.Test;
+
+class AnalyticsServiceTest {
+
+    @Test
+    void describesDeliveryFailureWithoutStackTrace() {
+        Exception failure = new SocketTimeoutException("Connect timed out");
+
+        assertEquals("Connect timed out", AnalyticsService.describeDeliveryFailure(failure));
+    }
+
+    @Test
+    void fallsBackToExceptionTypeWhenDeliveryFailureHasNoMessage() {
+        Exception failure = new SocketTimeoutException();
+
+        assertEquals("SocketTimeoutException", AnalyticsService.describeDeliveryFailure(failure));
+    }
+}


### PR DESCRIPTION
## Summary

- downgrade optional analytics delivery failures from fatal-looking errors to concise warnings
- respect the existing "Hide analytics logs" setting for failed deliveries
- avoid printing network stack traces while clarifying that application operation is unaffected
- cover timeout descriptions and missing exception messages with regression tests

## Why

When Mixpanel is blocked or unavailable, the asynchronous `app_launched` delivery can time out. The exception is already contained and does not affect startup, emulator control, or ADB, but it was logged as an `ERROR` with a full stack trace. This made a harmless analytics outage look like an application startup failure.

Closes #117.

## Validation

- `mvn -pl fg-engine -am -Dtest=AnalyticsServiceTest -Dsurefire.failIfNoSpecifiedTests=false test` — passed, 2 tests
- `git diff --check` — passed
- `mvn -pl fg-engine -am test` — 83 tests passed; 4 unrelated OCR frame tests errored because `libtesseract.dylib` is unavailable in the local macOS environment

Evidence level: automated tests. No live blocked-network verification was performed.

## Risks

Low. Analytics delivery remains asynchronous and best-effort. The behavioral change is limited to the visibility, severity, and formatting of delivery-failure logs.
