### PR TITLE
fix(launcher): update GitHub repository link

### DIFF
--- a/fg-app/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
@@ -1823,7 +1823,7 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
 
     @FXML
     private void openGithub() { /* internal */
-        openWebPage("https://github.com/Shederator/frostguard");
+        openWebPage("https://github.com/Shederator/wosbot");
     }
 
     private void openWebPage(String uri) { /* internal */


### PR DESCRIPTION
## Summary

- Update the launcher GitHub button to open the current `Shederator/wosbot` repository.

## Why

The button still referenced the obsolete `Shederator/frostguard` repository path, so users were sent to an outdated location.

## Validation

- `mvn -pl fg-app -am -DskipTests package` — passed after rebasing onto current `upstream/main`.
- `git diff --check upstream/main...HEAD` — passed.
- `mvn -pl fg-app -am test` — attempted before the rebase; blocked in existing OCR tests because the local native Tesseract library is unavailable.

## Risks

The link behavior was not exercised through a live desktop UI; the change is a direct URL replacement.