### PR TITLE
fix(launcher): update uptime display

### DIFF
--- a/fg-app/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
@@ -197,6 +197,8 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
     private boolean allQueuesPaused = false;
     final private Map<Long, QueueProfileStateData> activeQueueStates = new HashMap<>();
     private Timeline autoStartTimeline;
+    private Timeline uptimeTimeline;
+    private long uptimeStartedAtNanos;
     private int autoStartSecondsRemaining;
     private boolean isStartup = true;
 
@@ -222,6 +224,7 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
         initializeExternalLibraries();
         initializeTelegramBot();
         showVersion();
+        initializeUptime();
         buttonStartStop.setDisable(false);
         buttonPauseResume.setDisable(true);
         configurePauseMenu();
@@ -229,6 +232,26 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
         initializeQuickNav();
         initializeSearch();
         setupSocialIcons();
+    }
+
+    private void initializeUptime() { /* internal */
+        uptimeStartedAtNanos = System.nanoTime();
+        updateUptimeLabel();
+        uptimeTimeline = new Timeline(new KeyFrame(Duration.seconds(1), event -> updateUptimeLabel()));
+        uptimeTimeline.setCycleCount(Animation.INDEFINITE);
+        uptimeTimeline.play();
+    }
+
+    private void updateUptimeLabel() { /* internal */
+        long elapsedSeconds = (System.nanoTime() - uptimeStartedAtNanos) / 1_000_000_000L;
+        labelRunTime.setText("Uptime: " + formatUptime(elapsedSeconds));
+    }
+
+    static String formatUptime(long elapsedSeconds) {
+        long hours = elapsedSeconds / 3_600;
+        long minutes = elapsedSeconds % 3_600 / 60;
+        long seconds = elapsedSeconds % 60;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
     }
 
     private void setupSocialIcons() { /* internal */

--- a/fg-app/src/test/java/dev/frostguard/app/panel/launcher/LauncherLayoutControllerTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/launcher/LauncherLayoutControllerTest.java
@@ -1,0 +1,19 @@
+package dev.frostguard.app.panel.launcher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class LauncherLayoutControllerTest {
+
+    @Test
+    void formatsUptimeFromElapsedSeconds() {
+        assertEquals("00:00:00", LauncherLayoutController.formatUptime(0));
+        assertEquals("01:01:01", LauncherLayoutController.formatUptime(3_661));
+    }
+
+    @Test
+    void keepsHoursBeyondOneDay() {
+        assertEquals("25:00:00", LauncherLayoutController.formatUptime(90_000));
+    }
+}


### PR DESCRIPTION
## Summary

- Update the launcher uptime label once per second from application startup.
- Use a monotonic clock so wall-clock changes do not distort elapsed time.
- Preserve cumulative hours beyond 24 and add formatting coverage.

## Why

The launcher FXML defined `Uptime: 00:00:00`, but no controller logic ever updated the label, so it remained at its static initial value.

## Validation

- `mvn -pl fg-app -am -DskipTests install` — passed.
- `mvn -pl fg-app -am -Dtest=LauncherLayoutControllerTest -Dsurefire.failIfNoSpecifiedTests=false test` — passed; 2 tests.
- `git diff --check` — passed.
- Full `mvn -pl fg-app -am test` — blocked by four pre-existing `fg-engine` OCR test errors because native `libtesseract.dylib` is unavailable on this macOS host.
- Live UI verification was not performed.

## Risks

Low. The change is isolated to the JavaFX launcher label and its elapsed-time formatting.

Resolves #121.