### PR TITLE
fix(gather): apply enabled type changes to rotation

### DIFF
--- a/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
+++ b/fg-api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
@@ -218,6 +218,7 @@ public enum ConfigurationKeyEnum {
     GATHER_ONLY_FULL_RESOURCES_BOOL ("false",               Boolean.class,  ConfigCategory.GATHERING),
     GATHER_DOWNGRADE_LEVEL_BOOL     ("true",                Boolean.class,  ConfigCategory.GATHERING),
     GATHER_REMOVE_HEROS_BOOL        ("true",                Boolean.class,  ConfigCategory.GATHERING),
+    GATHER_ROTATION_ENABLED_TYPES_STRING ("",               String.class,   ConfigCategory.GATHERING),
     GATHER_ROTATION_POOL            ("",                    String.class,   ConfigCategory.GATHERING),
     // pernerch/2026-07-02: timestamp of the last gather recall (Intel/Bear), stored per-profile task instance
     // to track troop return window and avoid re-deploying before troops are home.

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/economy/GatherRotationPoolPolicy.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/economy/GatherRotationPoolPolicy.java
@@ -1,0 +1,56 @@
+package dev.frostguard.tasks.economy;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import dev.frostguard.tasks.economy.GatherRoutine.GatherType;
+
+final class GatherRotationPoolPolicy {
+
+    private GatherRotationPoolPolicy() {
+    }
+
+    static Reconciliation initialize(List<GatherType> pool, List<GatherType> currentEnabled) {
+        return new Reconciliation(pruneDisabled(pool, currentEnabled), List.of(), List.of());
+    }
+
+    static Reconciliation reconcile(List<GatherType> pool, List<GatherType> previousEnabled,
+            List<GatherType> currentEnabled) {
+        Set<GatherType> previous = new LinkedHashSet<>(previousEnabled);
+        Set<GatherType> current = new LinkedHashSet<>(currentEnabled);
+
+        List<GatherType> newlyEnabled = current.stream()
+                .filter(type -> !previous.contains(type))
+                .toList();
+        List<GatherType> disabled = previous.stream()
+                .filter(type -> !current.contains(type))
+                .toList();
+
+        List<GatherType> reconciledPool = pruneDisabled(pool, currentEnabled);
+        for (GatherType type : newlyEnabled) {
+            if (!reconciledPool.contains(type)) {
+                reconciledPool.add(type);
+            }
+        }
+        return new Reconciliation(reconciledPool, newlyEnabled, disabled);
+    }
+
+    static List<GatherType> pruneDisabled(List<GatherType> pool, List<GatherType> currentEnabled) {
+        Set<GatherType> current = new LinkedHashSet<>(currentEnabled);
+        Set<GatherType> retained = new LinkedHashSet<>();
+        if (pool != null) {
+            for (GatherType type : pool) {
+                if (current.contains(type)) {
+                    retained.add(type);
+                }
+            }
+        }
+        return new ArrayList<>(retained);
+    }
+
+    record Reconciliation(List<GatherType> pool, List<GatherType> newlyEnabled,
+                          List<GatherType> disabled) {
+    }
+}

--- a/fg-tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
+++ b/fg-tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
@@ -44,6 +44,8 @@ import dev.frostguard.engine.service.StatisticsService;
  */
 public class GatherRoutine extends DelayedTask {
 
+    private static final String EMPTY_ROTATION_ENABLED_TYPES = "NONE";
+
     // ========== Constants & Config Keys ==========
     private static final int DEFAULT_QUEUES = 6;
     private static final int DEFAULT_LEVEL = 5;
@@ -280,10 +282,7 @@ public class GatherRoutine extends DelayedTask {
                 .collect(Collectors.toList());
 
         loadRotationPool();
-        if (rotationPool != null) {
-            rotationPool.retainAll(enabledTypes);
-            saveRotationPool(); // Ensure consistent state
-        }
+        reconcileRotationPoolWithConfig();
 
         this.textHelper = new ResilientOcrExecutor<>(provider);
         this.earliestReschedule = null;
@@ -432,6 +431,66 @@ public class GatherRoutine extends DelayedTask {
         String val = rotationPool.stream().map(Enum::name).collect(Collectors.joining(","));
         logDebug("Saving gather pool config: '" + val + "'");
         profile.setConfig(ConfigurationKeyEnum.GATHER_ROTATION_POOL, val);
+        setShouldUpdateConfig(true);
+    }
+
+    private void reconcileRotationPoolWithConfig() {
+        String savedEnabledTypes = profile.getConfig(
+                ConfigurationKeyEnum.GATHER_ROTATION_ENABLED_TYPES_STRING, String.class);
+        List<GatherType> previousEnabledTypes = parseGatherTypes(savedEnabledTypes);
+
+        if (previousEnabledTypes == null) {
+            GatherRotationPoolPolicy.Reconciliation initialization =
+                    GatherRotationPoolPolicy.initialize(rotationPool, enabledTypes);
+            if (!initialization.pool().equals(rotationPool)) {
+                rotationPool = initialization.pool();
+                saveRotationPool();
+            }
+            logDebug("Initializing gather rotation enabled-type baseline: " + enabledTypes);
+            saveRotationEnabledTypes();
+            return;
+        }
+
+        GatherRotationPoolPolicy.Reconciliation reconciliation = GatherRotationPoolPolicy.reconcile(
+                rotationPool, previousEnabledTypes, enabledTypes);
+        if (!reconciliation.pool().equals(rotationPool)) {
+            rotationPool = reconciliation.pool();
+            saveRotationPool();
+        }
+        if (!previousEnabledTypes.equals(enabledTypes)) {
+            logInfo(String.format(
+                    "Applied gather configuration change: enabled=%s disabled=%s pool=%s",
+                    reconciliation.newlyEnabled(), reconciliation.disabled(), rotationPool));
+            saveRotationEnabledTypes();
+        }
+    }
+
+    private List<GatherType> parseGatherTypes(String saved) {
+        if (saved == null || saved.isBlank()) {
+            return null;
+        }
+        if (EMPTY_ROTATION_ENABLED_TYPES.equals(saved)) {
+            return List.of();
+        }
+        try {
+            return Arrays.stream(saved.split(","))
+                    .map(String::trim)
+                    .filter(value -> !value.isEmpty())
+                    .map(GatherType::valueOf)
+                    .distinct()
+                    .collect(Collectors.toList());
+        } catch (IllegalArgumentException e) {
+            logWarning("Could not parse gather rotation enabled-type baseline; reinitializing it: "
+                    + e.getMessage());
+            return null;
+        }
+    }
+
+    private void saveRotationEnabledTypes() {
+        String value = enabledTypes.isEmpty()
+                ? EMPTY_ROTATION_ENABLED_TYPES
+                : enabledTypes.stream().map(Enum::name).collect(Collectors.joining(","));
+        profile.setConfig(ConfigurationKeyEnum.GATHER_ROTATION_ENABLED_TYPES_STRING, value);
         setShouldUpdateConfig(true);
     }
 

--- a/fg-tasks/src/test/java/dev/frostguard/tasks/economy/GatherRotationPoolPolicyTest.java
+++ b/fg-tasks/src/test/java/dev/frostguard/tasks/economy/GatherRotationPoolPolicyTest.java
@@ -1,0 +1,58 @@
+package dev.frostguard.tasks.economy;
+
+import static dev.frostguard.tasks.economy.GatherRoutine.GatherType.COAL;
+import static dev.frostguard.tasks.economy.GatherRoutine.GatherType.IRON;
+import static dev.frostguard.tasks.economy.GatherRoutine.GatherType.MEAT;
+import static dev.frostguard.tasks.economy.GatherRoutine.GatherType.WOOD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GatherRotationPoolPolicyTest {
+
+    @Test
+    void addsOnlyNewlyEnabledTypesToCurrentRotation() {
+        GatherRotationPoolPolicy.Reconciliation result = GatherRotationPoolPolicy.reconcile(
+                List.of(WOOD, COAL),
+                List.of(MEAT, WOOD, COAL),
+                List.of(MEAT, WOOD, COAL, IRON));
+
+        assertEquals(List.of(WOOD, COAL, IRON), result.pool());
+        assertEquals(List.of(IRON), result.newlyEnabled());
+        assertEquals(List.of(), result.disabled());
+    }
+
+    @Test
+    void preservesPreviouslyConsumedTypesWhenConfigurationIsUnchanged() {
+        GatherRotationPoolPolicy.Reconciliation result = GatherRotationPoolPolicy.reconcile(
+                List.of(COAL, IRON),
+                List.of(MEAT, WOOD, COAL, IRON),
+                List.of(MEAT, WOOD, COAL, IRON));
+
+        assertEquals(List.of(COAL, IRON), result.pool());
+        assertEquals(List.of(), result.newlyEnabled());
+        assertEquals(List.of(), result.disabled());
+    }
+
+    @Test
+    void removesDisabledTypesWithoutResettingRemainingRotation() {
+        GatherRotationPoolPolicy.Reconciliation result = GatherRotationPoolPolicy.reconcile(
+                List.of(WOOD, COAL, IRON),
+                List.of(MEAT, WOOD, COAL, IRON),
+                List.of(MEAT, COAL, IRON));
+
+        assertEquals(List.of(COAL, IRON), result.pool());
+        assertEquals(List.of(), result.newlyEnabled());
+        assertEquals(List.of(WOOD), result.disabled());
+    }
+
+    @Test
+    void initialBaselineOnlyPrunesDisabledAndDuplicateEntries() {
+        assertEquals(
+                List.of(COAL, IRON),
+                GatherRotationPoolPolicy.initialize(
+                        List.of(WOOD, COAL, IRON, COAL),
+                        List.of(MEAT, COAL, IRON)).pool());
+    }
+}


### PR DESCRIPTION
## Summary
- track the gather types that were enabled when the persisted rotation was last updated
- add only genuinely newly enabled types to the current rotation and remove disabled types
- preserve types that are absent because they were already consumed in the current rotation cycle
- initialize existing profiles conservatively without resetting their current cycle

## Scope
- active/manual marches continue to be handled by the existing `fillQueues(...)` logic
- runtime propagation of saved profile changes remains separate and is tracked by #95

## Validation
- `mvn -pl fg-tasks -am test` (pass: 198 tests, 0 failures/errors/skips)

## Evidence level
- automated tests
- live account-log confirmation not performed