### PR TITLE
feat(discord): add reporting guidance command

### DIFF
--- a/.github/workflows/sync-discord-build-pr-command.yml
+++ b/.github/workflows/sync-discord-build-pr-command.yml
@@ -1,4 +1,4 @@
-name: Sync Discord Build PR Command
+name: Sync Discord Commands
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ permissions: {}
 
 jobs:
   sync:
-    name: Keep the guild command and remove the global duplicate
+    name: Keep guild commands and remove global duplicates
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -1,4 +1,19 @@
-# `/build-pr` — combined PR test builds from Discord
+# Frostguard Discord commands
+
+This Worker provides two guild-scoped commands:
+
+- `/build-pr` requests combined PR test builds.
+- `/please-dont-make-me-say-it-again` gives a friendly public reminder to put
+  bugs and suggestions in their dedicated channels and explain the underlying
+  problem or goal. It is limited to members with **Manage Messages**.
+
+Set `BUG_REPORT_CHANNEL_ID` and `SUGGESTIONS_CHANNEL_ID` in `wrangler.toml` to
+make the reminder link the server's channels. Without them it displays the
+plain-text fallbacks `#bug-reports` and `#suggestions`. Re-run the command-sync
+workflow after adding or changing commands; channel changes only require a
+Worker deployment.
+
+## `/build-pr` — combined PR test builds from Discord
 
 Lets Discord users request a public Windows test build that
 combines one or more **open** pull requests (including stacked PRs) without
@@ -126,10 +141,10 @@ DISCORD_CLIENT_SECRET=... DISCORD_APPLICATION_ID=... \
 DISCORD_GUILD_ID=<your server id> node register-command.mjs
 ```
 
-The script requires a guild ID, upserts that guild's `/build-pr`, and removes
-any global `/build-pr` registered for the same application. This intentionally
-leaves one command in the Frostguard server instead of a duplicate global and
-guild entry.
+The script requires a guild ID, upserts all configured guild commands, and
+removes global copies registered for the same application. This intentionally
+leaves one guild copy of each command instead of duplicate global and guild
+entries.
 
 Alternatively, store the client secret as the GitHub repository secret
 `DISCORD_CLIENT_SECRET` and run **Sync Discord Build PR Command** from the
@@ -185,6 +200,8 @@ only needs to:
 | `wrangler.toml` | `DISCORD_APPLICATION_ID` | application (client) ID |
 | `wrangler.toml` | `ALLOWED_CHANNEL_IDS` | CSV channel allowlist (empty = all) |
 | `wrangler.toml` | `COOLDOWN_MINUTES` | flood-control gap between builds |
+| `wrangler.toml` | `BUG_REPORT_CHANNEL_ID` | channel linked by the reporting reminder |
+| `wrangler.toml` | `SUGGESTIONS_CHANNEL_ID` | channel linked by the reporting reminder |
 | worker secret | `DISCORD_PUBLIC_KEY` | interaction signature verification |
 | worker secret | `GITHUB_TOKEN` | fine-grained dispatch-only token |
 | repo secret | `DISCORD_CLIENT_SECRET` | obtains a short-lived command-update token; no bot installation required |

--- a/discord-bot/register-command.mjs
+++ b/discord-bot/register-command.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * Synchronise the guild-scoped /build-pr command and remove its global copy.
+ * Synchronise Frostguard's guild-scoped commands and remove global copies.
  *
  * Frostguard currently targets one Discord server. Keeping only the guild
- * command prevents Discord from showing a duplicate global + guild command.
+ * commands prevents Discord from showing duplicate global + guild entries.
  */
 
 import { pathToFileURL } from "node:url";
@@ -30,6 +30,16 @@ export const buildPrCommand = {
   ],
   dm_permission: false,
 };
+
+export const reportingGuidanceCommand = {
+  name: "please-dont-make-me-say-it-again",
+  description: "Politely point bug reports and suggestions in the right direction",
+  dm_permission: false,
+  // Keep the public reminder available to members who can moderate messages.
+  default_member_permissions: "8192",
+};
+
+export const guildCommands = [buildPrCommand, reportingGuidanceCommand];
 
 async function clientCredentialsToken(fetchImpl, applicationId, clientSecret) {
   const body = new URLSearchParams({
@@ -69,7 +79,7 @@ async function discordRequest(fetchImpl, accessToken, url, options = {}) {
   return response.status === 204 ? null : response.json();
 }
 
-export async function syncCommand(env = process.env, fetchImpl = fetch) {
+export async function syncCommands(env = process.env, fetchImpl = fetch) {
   const clientSecret = env.DISCORD_CLIENT_SECRET;
   const applicationId = env.DISCORD_APPLICATION_ID;
   const guildId = env.DISCORD_GUILD_ID;
@@ -81,15 +91,19 @@ export async function syncCommand(env = process.env, fetchImpl = fetch) {
   const accessToken = await clientCredentialsToken(fetchImpl, applicationId, clientSecret);
 
   const guildUrl = `${API}/applications/${applicationId}/guilds/${guildId}/commands`;
-  const registered = await discordRequest(fetchImpl, accessToken, guildUrl, {
-    method: "POST",
-    body: JSON.stringify(buildPrCommand),
-  });
+  const registered = [];
+  for (const command of guildCommands) {
+    registered.push(await discordRequest(fetchImpl, accessToken, guildUrl, {
+      method: "POST",
+      body: JSON.stringify(command),
+    }));
+  }
 
   const globalUrl = `${API}/applications/${applicationId}/commands`;
   const globalCommands = await discordRequest(fetchImpl, accessToken, globalUrl);
+  const guildCommandNames = new Set(guildCommands.map(({ name }) => name));
   const duplicates = globalCommands.filter(
-    (candidate) => candidate.name === buildPrCommand.name && candidate.type === 1,
+    (candidate) => guildCommandNames.has(candidate.name) && candidate.type === 1,
   );
   for (const duplicate of duplicates) {
     await discordRequest(
@@ -103,17 +117,20 @@ export async function syncCommand(env = process.env, fetchImpl = fetch) {
   return { registered, deletedGlobalIds: duplicates.map(({ id }) => id) };
 }
 
+// Retain the original export for callers that predate multiple commands.
+export const syncCommand = syncCommands;
+
 async function main() {
-  const result = await syncCommand();
-  console.log(
-    `Registered guild /${result.registered.name} (id ${result.registered.id}).`,
-  );
+  const result = await syncCommands();
+  for (const command of result.registered) {
+    console.log(`Registered guild /${command.name} (id ${command.id}).`);
+  }
   if (result.deletedGlobalIds.length) {
     console.log(
-      `Deleted ${result.deletedGlobalIds.length} global /build-pr duplicate(s).`,
+      `Deleted ${result.deletedGlobalIds.length} global command duplicate(s).`,
     );
   } else {
-    console.log("No global /build-pr duplicate was present.");
+    console.log("No global command duplicate was present.");
   }
 }
 

--- a/discord-bot/test_register_command.mjs
+++ b/discord-bot/test_register_command.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { syncCommand } from "./register-command.mjs";
+import {
+  guildCommands,
+  reportingGuidanceCommand,
+  syncCommands,
+} from "./register-command.mjs";
 
 const ENV = {
   DISCORD_CLIENT_SECRET: "test-client-secret",
@@ -27,35 +31,42 @@ function oauthResponse() {
   });
 }
 
-test("registers the guild command before deleting the global duplicate", async () => {
+test("registers both guild commands before deleting global duplicates", async () => {
   const calls = [];
   const fetchMock = async (url, options = {}) => {
     calls.push({ url, method: options.method || "GET", body: options.body,
       authorization: options.headers?.Authorization });
     if (url.endsWith("/oauth2/token")) return oauthResponse();
-    if (options.method === "POST") {
-      return response(200, { id: "guild-command", name: "build-pr" });
+    if (options.method === "POST" && !url.endsWith("/oauth2/token")) {
+      const command = JSON.parse(options.body);
+      return response(200, { id: `guild-${command.name}`, name: command.name });
     }
     if ((options.method || "GET") === "GET") {
       return response(200, [
         { id: "global-command", name: "build-pr", type: 1 },
+        { id: "global-guidance", name: reportingGuidanceCommand.name, type: 1 },
         { id: "other-command", name: "help", type: 1 },
       ]);
     }
     return response(204);
   };
 
-  const result = await syncCommand(ENV, fetchMock);
+  const result = await syncCommands(ENV, fetchMock);
 
-  assert.deepEqual(result.deletedGlobalIds, ["global-command"]);
-  assert.deepEqual(calls.map(({ method }) => method), ["POST", "POST", "GET", "DELETE"]);
+  assert.deepEqual(result.deletedGlobalIds, ["global-command", "global-guidance"]);
+  assert.deepEqual(
+    calls.map(({ method }) => method),
+    ["POST", "POST", "POST", "GET", "DELETE", "DELETE"],
+  );
   assert.match(calls[0].url, /\/oauth2\/token$/);
   assert.match(String(calls[0].body), /scope=applications.commands.update/);
   assert.match(calls[0].authorization, /^Basic /);
   assert.match(calls[1].url, /\/guilds\/1475434539495981137\/commands$/);
-  assert.match(calls[3].url, /\/commands\/global-command$/);
+  assert.match(calls[4].url, /\/commands\/global-command$/);
   assert.equal(JSON.parse(calls[1].body).name, "build-pr");
+  assert.equal(JSON.parse(calls[2].body).name, reportingGuidanceCommand.name);
   assert.equal(calls[1].authorization, "Bearer test-access-token");
+  assert.equal(result.registered.length, guildCommands.length);
 });
 
 test("does not delete unrelated global commands", async () => {
@@ -64,24 +75,30 @@ test("does not delete unrelated global commands", async () => {
     methods.push(options.method || "GET");
     if (url.endsWith("/oauth2/token")) return oauthResponse();
     if (options.method === "POST") {
-      return response(200, { id: "guild-command", name: "build-pr" });
+      const command = JSON.parse(options.body);
+      return response(200, { id: `guild-${command.name}`, name: command.name });
     }
     return response(200, [{ id: "other-command", name: "help", type: 1 }]);
   };
 
-  const result = await syncCommand(ENV, fetchMock);
+  const result = await syncCommands(ENV, fetchMock);
 
   assert.deepEqual(result.deletedGlobalIds, []);
-  assert.deepEqual(methods, ["POST", "POST", "GET"]);
+  assert.deepEqual(methods, ["POST", "POST", "POST", "GET"]);
 });
 
 test("rejects missing deployment identifiers before calling Discord", async () => {
   let called = false;
   await assert.rejects(
-    syncCommand({}, async () => {
+    syncCommands({}, async () => {
       called = true;
     }),
     /DISCORD_CLIENT_SECRET/,
   );
   assert.equal(called, false);
+});
+
+test("keeps the intentionally long command name within Discord's limit", () => {
+  assert.equal(reportingGuidanceCommand.name.length, 32);
+  assert.equal(reportingGuidanceCommand.default_member_permissions, "8192");
 });

--- a/discord-bot/test_worker.mjs
+++ b/discord-bot/test_worker.mjs
@@ -14,6 +14,7 @@ import {
   encodeState,
   hexToBytes,
   parsePrNumbers,
+  reportingGuidanceResponse,
 } from "./worker.js";
 
 let passed = 0;
@@ -119,6 +120,28 @@ test("wrong channel is refused when channels are configured", () => {
 test("no configuration means open access", () => {
   const env = { ALLOWED_CHANNEL_IDS: "" };
   assert.equal(accessError(env, { channel_id: "1", member: { roles: [] } }), "");
+});
+
+// --- reporting guidance ----------------------------------------------------
+
+test("reporting guidance links configured channels and explains why", () => {
+  const response = reportingGuidanceResponse({
+    BUG_REPORT_CHANNEL_ID: "111",
+    SUGGESTIONS_CHANNEL_ID: "222",
+  });
+  const description = response.data.embeds[0].description;
+  assert.equal(response.type, 4);
+  assert.match(description, /<#111>/);
+  assert.match(description, /<#222>/);
+  assert.match(description, /why/i);
+  assert.match(description, /problem/i);
+  assert.deepEqual(response.data.allowed_mentions, { parse: [] });
+});
+
+test("reporting guidance has readable fallbacks for missing channel IDs", () => {
+  const description = reportingGuidanceResponse({}).data.embeds[0].description;
+  assert.match(description, /#bug-reports/);
+  assert.match(description, /#suggestions/);
 });
 
 console.log(`\n${passed} tests passed`);

--- a/discord-bot/worker.js
+++ b/discord-bot/worker.js
@@ -1,5 +1,5 @@
 /**
- * Frostguard /build-pr Discord command — Cloudflare Worker.
+ * Frostguard Discord commands — Cloudflare Worker.
  *
  * The Discord half of the combined-PR test build feature (issue #68). This
  * worker receives Discord interaction webhooks, validates the request, shows
@@ -234,6 +234,39 @@ function ephemeralReply(content) {
   });
 }
 
+function configuredChannel(id, fallback) {
+  return /^\d+$/.test(String(id || "")) ? `<#${id}>` : `#${fallback}`;
+}
+
+export function reportingGuidanceResponse(env) {
+  const bugs = configuredChannel(env.BUG_REPORT_CHANNEL_ID, "bug-reports");
+  const suggestions = configuredChannel(env.SUGGESTIONS_CHANNEL_ID, "suggestions");
+  return {
+    type: ResponseType.CHANNEL_MESSAGE,
+    data: {
+      embeds: [{
+        title: "Please don't make me say it again™",
+        color: 0xf1c40f,
+        description: [
+          `🐛 Found a bug? Please post it in ${bugs}.`,
+          `💡 Have an idea? Please post it in ${suggestions}.`,
+          "",
+          "And one tiny favor: tell us **why**, not only what you think",
+          "Frostguard should do. What problem are you running into? What are",
+          "you trying to achieve, and why would it help?",
+          "",
+          "That context lets us solve the actual problem — sometimes with a",
+          "better answer than the first solution that came to mind.",
+          "",
+          "Thanks for helping us keep general chat general. My remaining",
+          "sanity appreciates it. ❤️",
+        ].join("\n"),
+      }],
+      allowed_mentions: { parse: [] },
+    },
+  };
+}
+
 async function editOriginal(env, interaction, payload) {
   await fetch(
     `https://discord.com/api/v10/webhooks/${env.DISCORD_APPLICATION_ID}/${interaction.token}/messages/@original`,
@@ -462,7 +495,7 @@ async function handleButton(env, interaction) {
 export default {
   async fetch(request, env, ctx) {
     if (request.method === "GET") {
-      return new Response("frostguard /build-pr interaction endpoint", { status: 200 });
+      return new Response("frostguard Discord interaction endpoint", { status: 200 });
     }
     if (request.method !== "POST") {
       return new Response("method not allowed", { status: 405 });
@@ -483,6 +516,12 @@ export default {
 
     if (interaction.type === InteractionType.PING) {
       return json({ type: ResponseType.PONG });
+    }
+
+    if (interaction.type === InteractionType.APPLICATION_COMMAND &&
+        interaction.data &&
+        interaction.data.name === "please-dont-make-me-say-it-again") {
+      return json(reportingGuidanceResponse(env));
     }
 
     if (interaction.type === InteractionType.APPLICATION_COMMAND &&

--- a/discord-bot/wrangler.toml
+++ b/discord-bot/wrangler.toml
@@ -1,4 +1,4 @@
-# Cloudflare Worker config for the /build-pr Discord command.
+# Cloudflare Worker config for Frostguard Discord commands.
 #
 # Deploy with:  npx wrangler deploy
 # Secrets (never put these in this file):
@@ -23,3 +23,7 @@ DISCORD_APPLICATION_ID = "1532693190879215767"
 ALLOWED_CHANNEL_IDS = "1533460326111117322"
 # Minutes to wait between test builds (flood control).
 COOLDOWN_MINUTES = "10"
+# Channels linked by /please-dont-make-me-say-it-again. Leave either empty to
+# use the readable #bug-reports or #suggestions fallback instead of a link.
+BUG_REPORT_CHANNEL_ID = ""
+SUGGESTIONS_CHANNEL_ID = ""


### PR DESCRIPTION
## Summary

- add the moderator-only `/please-dont-make-me-say-it-again` guild command
- post a public, half-ironic reminder that routes bugs and suggestions to their configured channels
- ask reporters to explain the underlying problem, goal, and reason instead of prescribing only a solution
- extend command synchronization to support multiple guild commands safely

## Why

Bug reports and suggestions repeatedly land in general chat or omit the context maintainers need to understand the actual problem. This provides a consistent reminder without requiring maintainers to rewrite it each time.

Closes #132.

## Validation

- `node discord-bot/test_worker.mjs` — 13 tests passed
- `node --test discord-bot/test_register_command.mjs` — 4 tests passed
- `git diff --check` — passed

No live Discord deployment or invocation was performed.

## Risks

The real bug-report and suggestions channel IDs are not yet configured, so the deployed message uses readable `#bug-reports` and `#suggestions` fallbacks until those IDs are supplied. The command requires the Discord **Manage Messages** permission.