### PR TITLE
fix(discord): link reporting channels

### DIFF
--- a/discord-bot/wrangler.toml
+++ b/discord-bot/wrangler.toml
@@ -25,5 +25,5 @@ ALLOWED_CHANNEL_IDS = "1533460326111117322"
 COOLDOWN_MINUTES = "10"
 # Channels linked by /please-dont-make-me-say-it-again. Leave either empty to
 # use the readable #bug-reports or #suggestions fallback instead of a link.
-BUG_REPORT_CHANNEL_ID = ""
-SUGGESTIONS_CHANNEL_ID = ""
+BUG_REPORT_CHANNEL_ID = "1479015808775749793"
+SUGGESTIONS_CHANNEL_ID = "1479016010924298312"


### PR DESCRIPTION
## Summary

- configure the Frostguard Discord suggestions channel
- configure the Frostguard Discord bug-report channel
- make `/please-dont-make-me-say-it-again` render both destinations as clickable channel references

## Why

The initial command deployment used readable channel-name fallbacks because the channel IDs were not yet available. Discord requires the `<#CHANNEL_ID>` format to render a clickable channel reference; the Worker already produces that format when IDs are configured.

Closes #132.

## Validation

- `node discord-bot/test_worker.mjs` — 13 tests passed
- `git diff --check` — passed
- channel IDs were taken from the server links supplied by the maintainer

No live invocation with the configured links has been performed yet.

## Risks

If either Discord channel is deleted or replaced, its configured ID must be updated and the Worker redeployed.