### PR TITLE
fix(bear-trap): restore saved join formations

### DIFF
--- a/fg-app/src/main/java/dev/frostguard/app/shared/AbstractProfileController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/shared/AbstractProfileController.java
@@ -315,7 +315,8 @@ public abstract class AbstractProfileController implements IProfileLoadListener,
 		Object firstItem = checkComboBox.getItems().get(0);
 		try {
 			if (firstItem instanceof Integer) {
-				typed.getCheckModel().check(Integer.parseInt(token));
+				Object item = Integer.valueOf(token);
+				typed.getCheckModel().check(item);
 			} else {
 				typed.getCheckModel().check(token);
 			}

--- a/fg-app/src/test/java/dev/frostguard/app/shared/BearTrapTimerDateTimeUxTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/shared/BearTrapTimerDateTimeUxTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.controlsfx.control.CheckComboBox;
 
 import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import dev.frostguard.api.configs.BearTrapParticipationTriggerEnum;
@@ -380,6 +381,29 @@ class BearTrapTimerDateTimeUxTest {
         });
     }
 
+    @Test
+    void restoresBearJoinFormationsByValueInsteadOfListIndex() throws Exception {
+        runOnFxThread(() -> {
+            LoadedBearView view = loadBearView();
+            List<Change> changes = new ArrayList<>();
+            view.controller().attachProfileListener((key, value) -> changes.add(new Change(key, value)));
+            ProfileAux profile = profile(7L,
+                    config(ConfigurationKeyEnum.BEAR_TRAP_JOIN_FLAG_INT, "2,3,4"));
+
+            view.controller().onProfileLoad(profile);
+
+            assertEquals(List.of(2, 3, 4), view.joinFormations().getCheckModel().getCheckedItems());
+            assertTrue(changes.isEmpty(), "restoring saved formations must not rewrite the profile");
+
+            view.joinFormations().getCheckModel().clearCheck(Integer.valueOf(2));
+            view.joinFormations().getCheckModel().check(Integer.valueOf(7));
+
+            assertEquals(new Change(ConfigurationKeyEnum.BEAR_TRAP_JOIN_FLAG_INT, "3,4,7"),
+                    changes.get(changes.size() - 1));
+            return null;
+        });
+    }
+
     @SuppressWarnings({"rawtypes", "unchecked"})
     private static void selectItemNamed(ComboBox<?> comboBox, String label) {
         Object item = comboBox.getItems().stream()
@@ -412,7 +436,8 @@ class BearTrapTimerDateTimeUxTest {
                 (Label) namespace.get("labelParticipationTriggerInfo"),
                 (Label) namespace.get("labelParticipationHelper"),
                 (Label) namespace.get("labelParticipationWarning"),
-                (Label) namespace.get("labelSelectedTimerWarning"));
+                (Label) namespace.get("labelSelectedTimerWarning"),
+                (CheckComboBox<Integer>) namespace.get("checkComboBoxJoinFlag"));
     }
 
     private static ProfileAux profile(long id, ConfigAux... configs) {
@@ -471,6 +496,7 @@ class BearTrapTimerDateTimeUxTest {
             Label participationTriggerInfo,
             Label participationHelper,
             Label participationWarning,
-            Label selectedTimerWarning) {
+            Label selectedTimerWarning,
+            CheckComboBox<Integer> joinFormations) {
     }
 }


### PR DESCRIPTION
## Summary

- Restore numeric multi-select configuration values by their actual item value.
- Add Bear Trap UI regression coverage for loading and changing saved join formations.

## Why

Bear Trap join formations were restored through the index-based `check(int)` overload. Because the UI list is zero-based while formation numbers start at 1, a saved selection such as `2,3,4` appeared as `3,4,5` after reloading the profile or restarting Frostguard.

## Validation

- Automated tests: `mvn -pl fg-app -am test` ? 187 tests, 0 failures, 0 errors, 0 skipped.
- Live UI: user-confirmed on 2026-08-09 that the selected Bear Trap join formations remain correct in the task-worktree build.
- Saved-frame verification: not applicable; this is configuration restoration rather than game-screen automation.

## Risks

Low. The shared fix affects numeric `CheckComboBox` restoration by selecting the stored item value instead of treating it as a list index. String-valued controls are unchanged.
