### PR TITLE
feat(config): add explicit keep-running idle behavior

### DIFF
--- a/fg-api/src/main/java/dev/frostguard/api/configs/IdleBehaviorEnum.java
+++ b/fg-api/src/main/java/dev/frostguard/api/configs/IdleBehaviorEnum.java
@@ -10,6 +10,7 @@ import java.util.Map;
  * configured idle timeout window.
  */
 public enum IdleBehaviorEnum {
+    KEEP_RUNNING      ("Keep Running",   false),
     CLOSE_EMULATOR    ("Close Emulator", false),
     SEND_TO_BACKGROUND("Close Game",     true),
     PC_SLEEP          ("PC Sleep",       false);
@@ -49,7 +50,12 @@ public enum IdleBehaviorEnum {
      * or puts the host machine to sleep.
      */
     public boolean terminatesSession() {
-        return !backgroundsApp;
+        return this == CLOSE_EMULATOR || this == PC_SLEEP;
+    }
+
+    /** Whether this mode needs a positive idle timeout before taking action. */
+    public boolean requiresIdleTimeout() {
+        return this != KEEP_RUNNING;
     }
 
     /**

--- a/fg-app/src/main/java/dev/frostguard/app/panel/emulator/EmuConfigLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/emulator/EmuConfigLayoutController.java
@@ -217,9 +217,10 @@ public class EmuConfigLayoutController {
 				cfg.getOrDefault(ConfigurationKeyEnum.MAX_RUNNING_EMULATORS_INT.name(),
 						ConfigurationKeyEnum.MAX_RUNNING_EMULATORS_INT.getDefaultValue()));
 
-		textfieldMaxIdleTime.setText(
-				cfg.getOrDefault(ConfigurationKeyEnum.MAX_IDLE_TIME_INT.name(),
-						ConfigurationKeyEnum.MAX_IDLE_TIME_INT.getDefaultValue()));
+		String maxIdleTime = normalizePositiveMinutes(
+				cfg.get(ConfigurationKeyEnum.MAX_IDLE_TIME_INT.name()),
+				ConfigurationKeyEnum.MAX_IDLE_TIME_INT.getDefaultValue());
+		textfieldMaxIdleTime.setText(maxIdleTime);
 
 		boolean maxActiveTimeOn = Boolean.parseBoolean(
 				cfg.getOrDefault(ConfigurationKeyEnum.PROFILE_MAX_ACTIVE_TIME_ENABLED_BOOL.name(),
@@ -247,8 +248,21 @@ public class EmuConfigLayoutController {
 		addFocusLostSaver(textfieldMaxConcurrentInstances,
 				ConfigurationKeyEnum.MAX_RUNNING_EMULATORS_INT);
 
-		addFocusLostSaver(textfieldMaxIdleTime,
-				ConfigurationKeyEnum.MAX_IDLE_TIME_INT);
+		textfieldMaxIdleTime.focusedProperty().addListener((obs, prev, hasFocus) -> {
+			if (hasFocus || textfieldMaxIdleTime.isDisabled()) {
+				return;
+			}
+			String rawValue = textfieldMaxIdleTime.getText();
+			String value = normalizePositiveMinutes(
+					rawValue,
+					ConfigurationKeyEnum.MAX_IDLE_TIME_INT.getDefaultValue());
+			textfieldMaxIdleTime.setText(value);
+			ScheduleService.obtain().persistEmulatorPath(
+					ConfigurationKeyEnum.MAX_IDLE_TIME_INT.name(), value);
+			if (!isPositiveMinutes(rawValue)) {
+				displayInvalidMaxIdleTimeWarning(rawValue, value);
+			}
+		});
 
 		checkboxProfileMaxActiveTimeEnabled.selectedProperty().addListener((obs, prev, active) -> {
 			textfieldProfileMaxActiveTimeMinutes.setDisable(!active);
@@ -306,10 +320,12 @@ public class EmuConfigLayoutController {
 		IdleBehaviorEnum savedIdle = IdleBehaviorEnum.fromString(
 				cfg.getOrDefault(ConfigurationKeyEnum.IDLE_BEHAVIOR_STRING.name(), "CLOSE_EMULATOR"));
 		comboboxInactivityPolicy.setValue(savedIdle);
+		updateMaxIdleTimeAvailability(savedIdle);
 
 		comboboxInactivityPolicy.setOnAction(evt -> {
 			IdleBehaviorEnum chosenBehavior = comboboxInactivityPolicy.getValue();
 			if (chosenBehavior != null) {
+				updateMaxIdleTimeAvailability(chosenBehavior);
 				ScheduleService.obtain().persistEmulatorPath(
 						ConfigurationKeyEnum.IDLE_BEHAVIOR_STRING.name(),
 						chosenBehavior.name());
@@ -318,6 +334,27 @@ public class EmuConfigLayoutController {
 				}
 			}
 		});
+	}
+
+	private void updateMaxIdleTimeAvailability(IdleBehaviorEnum behavior) {
+		textfieldMaxIdleTime.setDisable(!behavior.requiresIdleTimeout());
+	}
+
+	static String normalizePositiveMinutes(String rawValue, String defaultValue) {
+		try {
+			int value = Integer.parseInt(rawValue == null ? "" : rawValue.trim());
+			return value > 0 ? String.valueOf(value) : defaultValue;
+		} catch (NumberFormatException ex) {
+			return defaultValue;
+		}
+	}
+
+	static boolean isPositiveMinutes(String rawValue) {
+		try {
+			return Integer.parseInt(rawValue == null ? "" : rawValue.trim()) > 0;
+		} catch (NumberFormatException ex) {
+			return false;
+		}
 	}
 
 	private void configureStopBehaviorDropdowns(Map<String, String> cfg) {
@@ -479,5 +516,16 @@ public class EmuConfigLayoutController {
 		errorAlert.setHeaderText(null);
 		errorAlert.setContentText(detail);
 		errorAlert.showAndWait();
+	}
+
+	private void displayInvalidMaxIdleTimeWarning(String rawValue, String fallbackValue) {
+		String enteredValue = rawValue == null || rawValue.isBlank() ? "an empty value" : "'" + rawValue + "'";
+		Alert warning = new Alert(Alert.AlertType.WARNING);
+		warning.setTitle("Invalid Max Idle Time");
+		warning.setHeaderText("Enter a positive whole number of minutes");
+		warning.setContentText(
+				enteredValue + " is not a valid maximum idle time. The value was reset to "
+				+ fallbackValue + " minutes. Select 'Keep Running' if no idle action should occur.");
+		warning.showAndWait();
 	}
 }

--- a/fg-app/src/test/java/dev/frostguard/app/panel/emulator/EmuConfigLayoutControllerTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/emulator/EmuConfigLayoutControllerTest.java
@@ -1,0 +1,32 @@
+package dev.frostguard.app.panel.emulator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class EmuConfigLayoutControllerTest {
+
+    @Test
+    void acceptsPositiveIdleMinutes() {
+        assertEquals("30", EmuConfigLayoutController.normalizePositiveMinutes("30", "15"));
+        assertTrue(EmuConfigLayoutController.isPositiveMinutes("30"));
+    }
+
+    @Test
+    void replacesNonPositiveIdleMinutesWithDefault() {
+        assertEquals("15", EmuConfigLayoutController.normalizePositiveMinutes("0", "15"));
+        assertEquals("15", EmuConfigLayoutController.normalizePositiveMinutes("-2", "15"));
+        assertFalse(EmuConfigLayoutController.isPositiveMinutes("0"));
+        assertFalse(EmuConfigLayoutController.isPositiveMinutes("-2"));
+    }
+
+    @Test
+    void replacesMalformedIdleMinutesWithDefault() {
+        assertEquals("15", EmuConfigLayoutController.normalizePositiveMinutes("never", "15"));
+        assertEquals("15", EmuConfigLayoutController.normalizePositiveMinutes(null, "15"));
+        assertFalse(EmuConfigLayoutController.isPositiveMinutes("never"));
+        assertFalse(EmuConfigLayoutController.isPositiveMinutes(null));
+    }
+}

--- a/fg-app/src/test/java/dev/frostguard/app/panel/emulator/IdleBehaviorEnumTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/emulator/IdleBehaviorEnumTest.java
@@ -1,0 +1,24 @@
+package dev.frostguard.app.panel.emulator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.frostguard.api.configs.IdleBehaviorEnum;
+import org.junit.jupiter.api.Test;
+
+class IdleBehaviorEnumTest {
+
+    @Test
+    void keepRunningDoesNotRequireAnIdleTimeout() {
+        assertFalse(IdleBehaviorEnum.KEEP_RUNNING.requiresIdleTimeout());
+        assertFalse(IdleBehaviorEnum.KEEP_RUNNING.terminatesSession());
+        assertFalse(IdleBehaviorEnum.KEEP_RUNNING.backgroundsApp());
+    }
+
+    @Test
+    void actionableBehaviorsRequireAnIdleTimeout() {
+        assertTrue(IdleBehaviorEnum.CLOSE_EMULATOR.requiresIdleTimeout());
+        assertTrue(IdleBehaviorEnum.SEND_TO_BACKGROUND.requiresIdleTimeout());
+        assertTrue(IdleBehaviorEnum.PC_SLEEP.requiresIdleTimeout());
+    }
+}

--- a/fg-engine/src/main/java/dev/frostguard/engine/schedule/TaskDispatcher.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/schedule/TaskDispatcher.java
@@ -217,9 +217,20 @@ public class TaskDispatcher implements PreemptionListener, StaminaChangeListener
     // ── internal helpers ────────────────────────────────────────────
 
     private int resolveIdleLimit() {
-        return Optional.ofNullable(ConfigService.obtain().loadGlobalSettings())
+        int configured = Optional.ofNullable(ConfigService.obtain().loadGlobalSettings())
                 .map(cfg -> cfg.get(ConfigurationKeyEnum.MAX_IDLE_TIME_INT.name()))
-                .map(Integer::parseInt)
+                .map(TaskDispatcher::parseInteger)
                 .orElse(Integer.parseInt(ConfigurationKeyEnum.MAX_IDLE_TIME_INT.getDefaultValue()));
+        return configured > 0
+                ? configured
+                : Integer.parseInt(ConfigurationKeyEnum.MAX_IDLE_TIME_INT.getDefaultValue());
+    }
+
+    private static Integer parseInteger(String value) {
+        try {
+            return Integer.valueOf(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 }

--- a/fg-engine/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/fg-engine/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -602,9 +602,12 @@ public class TaskQueue {
     private void handleIdleTransitions() {
         if (Thread.currentThread().isInterrupted()) return;
         if (statusModel.getLoopState().isExecutedTask() || taskBacklog.isEmpty()) return;
-        int idleCap = Optional.ofNullable(ConfigService.obtain().loadGlobalSettings())
-                .map(c -> c.get(ConfigurationKeyEnum.MAX_IDLE_TIME_INT.name())).map(Integer::parseInt)
-                .orElse(Integer.parseInt(ConfigurationKeyEnum.MAX_IDLE_TIME_INT.getDefaultValue()));
+        IdleBehaviorEnum idleBehavior = resolveIdleBehavior();
+        if (!idleBehavior.requiresIdleTimeout()) {
+            statusModel.setIdleTimeExceeded(false);
+            return;
+        }
+        int idleCap = resolvePositiveIdleLimit();
         statusModel.setIdleTimeLimit(idleCap);
         if (runningContext != null) return;
         if (!statusModel.isIdleTimeExceeded() && statusModel.checkIdleTimeExceeded()) {
@@ -709,10 +712,7 @@ public class TaskQueue {
     }
 
     private void suspendDevice(LocalDateTime until, boolean freeSlot) {
-        IdleBehaviorEnum policy = IdleBehaviorEnum.fromString(
-                Optional.ofNullable(ConfigService.obtain().loadGlobalSettings())
-                        .map(c -> c.getOrDefault(ConfigurationKeyEnum.IDLE_BEHAVIOR_STRING.name(), ConfigurationKeyEnum.IDLE_BEHAVIOR_STRING.getDefaultValue()))
-                        .orElse(ConfigurationKeyEnum.IDLE_BEHAVIOR_STRING.getDefaultValue()));
+        IdleBehaviorEnum policy = resolveIdleBehavior();
         if (policy == IdleBehaviorEnum.SEND_TO_BACKGROUND) {
             deviceBridge.sendGameToBackground(profile.getEmulatorNumber());
             emitInfo("Device sent to background until " + until);
@@ -729,6 +729,7 @@ public class TaskQueue {
 
     private boolean enforceSessionCap() {
         if (runningContext != null || sessionOrigin == null) return false;
+        if (!resolveIdleBehavior().requiresIdleTimeout()) return false;
         Map<String,String> cfg = ConfigService.obtain().loadGlobalSettings();
         boolean on = Boolean.parseBoolean(Optional.ofNullable(cfg)
                 .map(c -> c.get(ConfigurationKeyEnum.PROFILE_MAX_ACTIVE_TIME_ENABLED_BOOL.name()))
@@ -744,6 +745,32 @@ public class TaskQueue {
         suspendDevice(statusModel.getDelayUntil(), true);
         statusModel.setIdleTimeExceeded(true);
         return true;
+    }
+
+    private IdleBehaviorEnum resolveIdleBehavior() {
+        return IdleBehaviorEnum.fromString(
+                Optional.ofNullable(ConfigService.obtain().loadGlobalSettings())
+                        .map(c -> c.getOrDefault(ConfigurationKeyEnum.IDLE_BEHAVIOR_STRING.name(),
+                                ConfigurationKeyEnum.IDLE_BEHAVIOR_STRING.getDefaultValue()))
+                        .orElse(ConfigurationKeyEnum.IDLE_BEHAVIOR_STRING.getDefaultValue()));
+    }
+
+    private int resolvePositiveIdleLimit() {
+        int configured = Optional.ofNullable(ConfigService.obtain().loadGlobalSettings())
+                .map(c -> c.get(ConfigurationKeyEnum.MAX_IDLE_TIME_INT.name()))
+                .map(TaskQueue::parseInteger)
+                .orElse(Integer.parseInt(ConfigurationKeyEnum.MAX_IDLE_TIME_INT.getDefaultValue()));
+        return configured > 0
+                ? configured
+                : Integer.parseInt(ConfigurationKeyEnum.MAX_IDLE_TIME_INT.getDefaultValue());
+    }
+
+    private static Integer parseInteger(String value) {
+        try {
+            return Integer.valueOf(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 
     private void acquireSlot() {


### PR DESCRIPTION
## Summary

- add an explicit `Keep Running` idle behavior
- disable Max Idle Time when no idle action is selected
- require a positive whole-number timeout for actionable idle behaviors
- show a clear warning and restore the default when the timeout is invalid
- defensively fall back to the configured default for invalid persisted timeout values

## Why

Using `0` as both a duration and a sentinel for “never” makes the setting ambiguous. The scheduler previously treated zero as an immediate threshold, and the UI silently replaced invalid values without explaining why. An explicit behavior keeps the intent in the behavior field while the timeout remains a positive duration.

## Validation

- `mvn package` — 192 tests passed with 0 failures, errors, or skips
- source-worktree startup — database, JavaFX UI, and OpenCV initialized successfully
- live UI verification — `Keep Running`, conditional timeout disabling, and invalid-value warning confirmed by the user

## Risks

- The actual long-idle transition was not exercised with a configured live profile; scheduler behavior is covered by implementation review and defensive configuration handling.