### PR TITLE
fix(gather): preserve resource and hero specialization

### DIFF
--- a/modules/api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
+++ b/modules/api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
@@ -219,6 +219,7 @@ public enum ConfigurationKeyEnum {
     GATHER_ONLY_FULL_RESOURCES_BOOL ("false",               Boolean.class,  ConfigCategory.GATHERING),
     GATHER_DOWNGRADE_LEVEL_BOOL     ("true",                Boolean.class,  ConfigCategory.GATHERING),
     GATHER_REMOVE_HEROS_BOOL        ("true",                Boolean.class,  ConfigCategory.GATHERING),
+    GATHER_NO_HERO_FALLBACK_BOOL    ("false",               Boolean.class,  ConfigCategory.GATHERING),
     GATHER_ROTATION_POOL            ("",                    String.class,   ConfigCategory.GATHERING),
     // pernerch/2026-07-02: timestamp of the last gather recall (Intel/Bear), stored per-profile task instance
     // to track troop return window and avoid re-deploying before troops are home.

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/economy/GatherLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/economy/GatherLayoutController.java
@@ -21,7 +21,7 @@ public class GatherLayoutController extends AbstractProfileController {
 	private CheckBox checkBoxGatherResources, checkBoxGatherCoal, checkBoxGatherIron,
 			checkBoxGatherMeat, checkBoxGatherWood,
 			checkBoxGatherSpeedBoost, checkBoxOnlyFullResources, checkBoxDowngradeLevel,
-			checkBoxRemoveHeros, checkBoxTestPreemption;
+			checkBoxRemoveHeros, checkBoxNoHeroFallback, checkBoxTestPreemption;
 	@FXML
 	private ComboBox<Integer> comboBoxActiveMarchQueue, comboBoxLevelCoal,
 			comboBoxLevelIron, comboBoxLevelMeat,
@@ -53,6 +53,7 @@ public class GatherLayoutController extends AbstractProfileController {
 			new GatherSwitch(checkBoxOnlyFullResources, ConfigurationKeyEnum.GATHER_ONLY_FULL_RESOURCES_BOOL),
 			new GatherSwitch(checkBoxDowngradeLevel, ConfigurationKeyEnum.GATHER_DOWNGRADE_LEVEL_BOOL),
 			new GatherSwitch(checkBoxRemoveHeros, ConfigurationKeyEnum.GATHER_REMOVE_HEROS_BOOL),
+			new GatherSwitch(checkBoxNoHeroFallback, ConfigurationKeyEnum.GATHER_NO_HERO_FALLBACK_BOOL),
 			new GatherSwitch(checkBoxTestPreemption, ConfigurationKeyEnum.TEST_GATHER_DEPLOY_PREEMPTION_BOOL)
 		);
 	}

--- a/modules/desktop/src/main/resources/layout/GatherLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/GatherLayout.fxml
@@ -59,6 +59,7 @@
                                                         <CheckBox fx:id="checkBoxOnlyFullResources" mnemonicParsing="false" text="Only search for full resources" />
                                                         <CheckBox fx:id="checkBoxDowngradeLevel" mnemonicParsing="false" text="Downgrade level if no node is found" />
                                                         <CheckBox fx:id="checkBoxRemoveHeros" mnemonicParsing="false" text="Remove 2nd and 3rd hero from march" />
+                                                        <CheckBox fx:id="checkBoxNoHeroFallback" mnemonicParsing="false" text="Send without heroes if Gather hero is unavailable" />
                                                     </children>
                                                 </VBox>
 

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherHeroSelectionPolicy.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherHeroSelectionPolicy.java
@@ -1,0 +1,24 @@
+package dev.frostguard.tasks.economy;
+
+final class GatherHeroSelectionPolicy {
+
+    private GatherHeroSelectionPolicy() {
+    }
+
+    static Action select(boolean preferredHeroFound, boolean removeAdditionalHeroes,
+            boolean noHeroFallback) {
+        if (!preferredHeroFound && noHeroFallback) {
+            return Action.REMOVE_ALL;
+        }
+        if (removeAdditionalHeroes) {
+            return Action.REMOVE_ADDITIONAL;
+        }
+        return Action.KEEP_DEFAULT;
+    }
+
+    enum Action {
+        KEEP_DEFAULT,
+        REMOVE_ADDITIONAL,
+        REMOVE_ALL
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherRotationSelectionPolicy.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherRotationSelectionPolicy.java
@@ -1,0 +1,46 @@
+package dev.frostguard.tasks.economy;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import dev.frostguard.tasks.economy.GatherRoutine.GatherType;
+
+final class GatherRotationSelectionPolicy {
+
+    private GatherRotationSelectionPolicy() {
+    }
+
+    static Refill refill(List<GatherType> enabledTypes, List<GatherType> activeTypes,
+            Set<GatherType> unavailableTypes) {
+        Set<GatherType> active = new LinkedHashSet<>(activeTypes);
+        Set<GatherType> unavailable = new LinkedHashSet<>(unavailableTypes);
+
+        List<GatherType> missing = enabledTypes.stream()
+                .filter(type -> !active.contains(type))
+                .filter(type -> !unavailable.contains(type))
+                .toList();
+        if (!missing.isEmpty()) {
+            return new Refill(missing, RefillMode.MISSING_TYPES);
+        }
+
+        boolean allEnabledTypesActive = enabledTypes.stream().allMatch(active::contains);
+        if (!allEnabledTypesActive) {
+            return new Refill(List.of(), RefillMode.UNAVAILABLE_MISSING_TYPES);
+        }
+
+        List<GatherType> duplicates = enabledTypes.stream()
+                .filter(type -> !unavailable.contains(type))
+                .toList();
+        return new Refill(duplicates, RefillMode.DUPLICATES);
+    }
+
+    enum RefillMode {
+        MISSING_TYPES,
+        DUPLICATES,
+        UNAVAILABLE_MISSING_TYPES
+    }
+
+    record Refill(List<GatherType> candidates, RefillMode mode) {
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
@@ -306,6 +306,7 @@ public class GatherRoutine extends DelayedTask {
         int noNode = 0;
         int blocked = 0;
         int sameTargetBlocked = 0;
+        Set<GatherType> unavailableThisRun = new HashSet<>();
         logInfo(String.format("Gather fill: active=%d/%d idleSlots=%d freeSlots=%d pool=%s",
                 currentActive, activeQueues, idleSlotCount, freeSlots, rotationPool));
 
@@ -313,13 +314,6 @@ public class GatherRoutine extends DelayedTask {
         if (rotationPool.removeAll(activeMarches)) {
             logDebug("Removed active gather types from pool: " + activeMarches);
             saveRotationPool();
-        }
-
-        // If pool is empty after removing active marches but there are free slots,
-        // allow duplicate types so we can fill all available march queues
-        if (rotationPool.isEmpty() && freeSlots > 0) {
-            logDebug("Gather pool empty after removing active types; allowing duplicates for remaining slots.");
-            rotationPool = new ArrayList<>(enabledTypes);
         }
 
         if (freeSlots <= 0) {
@@ -332,17 +326,14 @@ public class GatherRoutine extends DelayedTask {
 
         int remaining = freeSlots;
         int safetyLoop = 0;
-        Set<GatherType> unavailableThisRun = new HashSet<>();
 
         while (remaining > 0 && safetyLoop++ < 10) {
 
             // Refill if empty
             if (rotationPool.isEmpty()) {
-                logDebug("Gather pool empty. Resetting.");
-                rotationPool = new ArrayList<>(enabledTypes);
-                rotationPool.removeAll(unavailableThisRun);
-                // Don't remove active marches on refill â€” duplicates are needed
-                // to fill remaining slots when activeQueues > enabledTypes.size()
+                if (!refillRotationPool(activeMarches, unavailableThisRun)) {
+                    break;
+                }
                 Collections.shuffle(rotationPool);
             }
 
@@ -368,7 +359,7 @@ public class GatherRoutine extends DelayedTask {
                     rotationPool.remove(type);
                     progress = true;
                     StatisticsService.obtain().addToCounter(profile, "Gather Marches Deployed", 1);
-                    activeMarches.add(type); // Add to avoid re-picking if we loop
+                    activeMarches.add(type);
                 } else {
                     if (deployResult == GatherDeployResult.NO_TROOPS_AVAILABLE) {
                         remaining = 0;
@@ -397,6 +388,22 @@ public class GatherRoutine extends DelayedTask {
 
         saveRotationPool();
         return new GatherFillResult(deployed, noNode, blocked, sameTargetBlocked, false, remaining);
+    }
+
+    private boolean refillRotationPool(List<GatherType> activeMarches, Set<GatherType> unavailableThisRun) {
+        GatherRotationSelectionPolicy.Refill refill = GatherRotationSelectionPolicy.refill(
+                enabledTypes, activeMarches, unavailableThisRun);
+        rotationPool = new ArrayList<>(refill.candidates());
+
+        switch (refill.mode()) {
+            case MISSING_TYPES -> logDebug("Gather pool exhausted; prioritizing missing types: " + rotationPool);
+            case DUPLICATES -> logDebug(
+                    "All enabled gather types are active; allowing duplicate types for additional slots: "
+                            + rotationPool);
+            case UNAVAILABLE_MISSING_TYPES -> logInfo(
+                    "Gather pool cannot refill because a missing resource type is unavailable in this run.");
+        }
+        return !rotationPool.isEmpty();
     }
 
     private void loadRotationPool() {

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
@@ -114,6 +114,7 @@ public class GatherRoutine extends DelayedTask {
     // ========== State & Configuration ==========
     private int activeQueues;
     private boolean removeHeroes;
+    private boolean noHeroFallback;
     private boolean intelSmart;
     private boolean intelRecall;
     private boolean intelEnabled;
@@ -260,6 +261,7 @@ public class GatherRoutine extends DelayedTask {
         this.activeQueues = GatherQueuePolicy.resolveActiveQueueLimit(
                 get(ConfigurationKeyEnum.GATHER_ACTIVE_MARCH_QUEUE_INT, DEFAULT_QUEUES));
         this.removeHeroes = get(ConfigurationKeyEnum.GATHER_REMOVE_HEROS_BOOL, DEFAULT_REMOVE_HEROES);
+        this.noHeroFallback = get(ConfigurationKeyEnum.GATHER_NO_HERO_FALLBACK_BOOL, false);
         this.intelSmart = get(ConfigurationKeyEnum.INTEL_SMART_PROCESSING_BOOL, DEFAULT_INTEL_SMART);
         this.intelRecall = get(ConfigurationKeyEnum.INTEL_RECALL_GATHER_TROOPS_BOOL, false);
         this.intelEnabled = get(ConfigurationKeyEnum.INTEL_BOOL, false);
@@ -788,12 +790,14 @@ public class GatherRoutine extends DelayedTask {
         ImageSearchResultData hero = templateSearchHelper.locatePattern(type.preferredHero,
                 SearchConfig.builder().withCoordinates(new PointData(51, 231), new PointData(295, 649)).build());
 
-        if (!hero.isFound()) {
+        if (!hero.isFound() && !noHeroFallback) {
             logDebug("Preferred hero not found for " + type + ". Proceeding with default march.");
         }
-
-        if (removeHeroes)
-            removeDefaultHeroes();
+        GatherHeroSelectionPolicy.Action heroAction = GatherHeroSelectionPolicy.select(
+                hero.isFound(), removeHeroes, noHeroFallback);
+        if (!applyHeroSelection(type, heroAction)) {
+            return GatherDeployResult.BLOCKED;
+        }
 
         if (deploymentHelper.hasNoDeployableTroops()) {
             logInfo("No deployable troops found on gather formation screen.");
@@ -833,10 +837,47 @@ public class GatherRoutine extends DelayedTask {
         return readNumberValue(LEVEL_DISPLAY_TL, LEVEL_DISPLAY_BR, s);
     }
 
-    private void removeDefaultHeroes() {
-        List<ImageSearchResultData> btns = templateSearchHelper.locateAllPatterns(
+    private boolean applyHeroSelection(GatherType type, GatherHeroSelectionPolicy.Action action) {
+        return switch (action) {
+            case KEEP_DEFAULT -> true;
+            case REMOVE_ADDITIONAL -> {
+                removeDefaultHeroes();
+                yield true;
+            }
+            case REMOVE_ALL -> removeAllHeroes(type);
+        };
+    }
+
+    private boolean removeAllHeroes(GatherType type) {
+        List<ImageSearchResultData> buttons = locateSelectedHeroRemoveButtons();
+        if (buttons.isEmpty()) {
+            logWarning("Preferred hero not found for " + type
+                    + ", but selected heroes could not be identified. Cancelling gather deployment.");
+            return false;
+        }
+
+        buttons.sort(Comparator.comparingInt(result -> result.getPoint().getX()));
+        tapInside(buttons.getFirst());
+        sleepTask(500);
+
+        if (!locateSelectedHeroRemoveButtons().isEmpty()) {
+            logWarning("Preferred hero not found for " + type
+                    + ", but the hero selection did not clear. Cancelling gather deployment.");
+            return false;
+        }
+
+        logInfo("Preferred hero not found for " + type + ". Deploying gather march without heroes.");
+        return true;
+    }
+
+    private List<ImageSearchResultData> locateSelectedHeroRemoveButtons() {
+        return templateSearchHelper.locateAllPatterns(
                 TemplatesEnum.RALLY_REMOVE_HERO_BUTTON,
                 SearchConfig.builder().withThreshold(90).withMaxResults(3).build());
+    }
+
+    private void removeDefaultHeroes() {
+        List<ImageSearchResultData> btns = locateSelectedHeroRemoveButtons();
 
         if (btns.isEmpty())
             return;

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/economy/GatherHeroSelectionPolicyTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/economy/GatherHeroSelectionPolicyTest.java
@@ -1,0 +1,29 @@
+package dev.frostguard.tasks.economy;
+
+import static dev.frostguard.tasks.economy.GatherHeroSelectionPolicy.Action.KEEP_DEFAULT;
+import static dev.frostguard.tasks.economy.GatherHeroSelectionPolicy.Action.REMOVE_ADDITIONAL;
+import static dev.frostguard.tasks.economy.GatherHeroSelectionPolicy.Action.REMOVE_ALL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class GatherHeroSelectionPolicyTest {
+
+    @Test
+    void removesAllHeroesWhenPreferredHeroIsMissingAndFallbackIsEnabled() {
+        assertEquals(REMOVE_ALL, GatherHeroSelectionPolicy.select(false, false, true));
+        assertEquals(REMOVE_ALL, GatherHeroSelectionPolicy.select(false, true, true));
+    }
+
+    @Test
+    void keepsExistingBehaviorWhenNoHeroFallbackIsDisabled() {
+        assertEquals(KEEP_DEFAULT, GatherHeroSelectionPolicy.select(false, false, false));
+        assertEquals(REMOVE_ADDITIONAL, GatherHeroSelectionPolicy.select(false, true, false));
+    }
+
+    @Test
+    void preservesPreferredHeroWhenItIsAvailable() {
+        assertEquals(KEEP_DEFAULT, GatherHeroSelectionPolicy.select(true, false, true));
+        assertEquals(REMOVE_ADDITIONAL, GatherHeroSelectionPolicy.select(true, true, true));
+    }
+}

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/economy/GatherRotationSelectionPolicyTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/economy/GatherRotationSelectionPolicyTest.java
@@ -1,0 +1,55 @@
+package dev.frostguard.tasks.economy;
+
+import static dev.frostguard.tasks.economy.GatherRotationSelectionPolicy.RefillMode.DUPLICATES;
+import static dev.frostguard.tasks.economy.GatherRotationSelectionPolicy.RefillMode.MISSING_TYPES;
+import static dev.frostguard.tasks.economy.GatherRotationSelectionPolicy.RefillMode.UNAVAILABLE_MISSING_TYPES;
+import static dev.frostguard.tasks.economy.GatherRoutine.GatherType.COAL;
+import static dev.frostguard.tasks.economy.GatherRoutine.GatherType.IRON;
+import static dev.frostguard.tasks.economy.GatherRoutine.GatherType.MEAT;
+import static dev.frostguard.tasks.economy.GatherRoutine.GatherType.WOOD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class GatherRotationSelectionPolicyTest {
+
+    private static final List<GatherRoutine.GatherType> ALL_TYPES = List.of(MEAT, WOOD, COAL, IRON);
+
+    @Test
+    void prioritizesTypesMissingAfterPersistedPoolIsConsumed() {
+        GatherRotationSelectionPolicy.Refill refill = GatherRotationSelectionPolicy.refill(
+                ALL_TYPES, List.of(MEAT), Set.of());
+
+        assertEquals(MISSING_TYPES, refill.mode());
+        assertEquals(List.of(WOOD, COAL, IRON), refill.candidates());
+    }
+
+    @Test
+    void allowsDuplicatesOnlyAfterEveryEnabledTypeIsActive() {
+        GatherRotationSelectionPolicy.Refill refill = GatherRotationSelectionPolicy.refill(
+                ALL_TYPES, ALL_TYPES, Set.of());
+
+        assertEquals(DUPLICATES, refill.mode());
+        assertEquals(ALL_TYPES, refill.candidates());
+    }
+
+    @Test
+    void supportsDuplicateMarchesWhenOnlyOneTypeIsEnabled() {
+        GatherRotationSelectionPolicy.Refill refill = GatherRotationSelectionPolicy.refill(
+                List.of(IRON), List.of(IRON), Set.of());
+
+        assertEquals(DUPLICATES, refill.mode());
+        assertEquals(List.of(IRON), refill.candidates());
+    }
+
+    @Test
+    void doesNotReplaceAnUnavailableMissingTypeWithADuplicate() {
+        GatherRotationSelectionPolicy.Refill refill = GatherRotationSelectionPolicy.refill(
+                ALL_TYPES, List.of(MEAT, WOOD, COAL), Set.of(IRON));
+
+        assertEquals(UNAVAILABLE_MISSING_TYPES, refill.mode());
+        assertEquals(List.of(), refill.candidates());
+    }
+}


### PR DESCRIPTION
## Summary

- prioritize enabled resource types without an active Gather march before allowing duplicates
- keep duplicate marches available after every enabled resource is represented, or when fewer resource types are enabled than queues are requested
- add an opt-in `Send without heroes if Gather hero is unavailable` profile setting
- clear the complete hero selection through the leftmost remove control and verify it is empty before deployment
- preserve the existing option that removes only the second and third heroes

## Why

The persisted Gather rotation can contain only the final unconsumed resource from the previous cycle. After deploying that type, the old refill logic restored every enabled type without including the march it had just launched. A reproduced run therefore ended as Meat/Meat/Wood/Coal while Iron was still missing.

The duplicate march also demonstrated a second problem: once a resource-specific blue Gather hero is outside, Frostguard falls back to whatever heroes the game selected. That uses an unrelated hero and can keep the preferred Gather specialist unavailable for a later matching march.

This PR treats active resource coverage as the rotation boundary. Separately, profiles can opt into sending no heroes when the preferred resource hero is absent. The game removes all three selected heroes when the leftmost remove control is pressed; Frostguard re-detects the controls afterward and cancels the attempt if it cannot prove that the formation is empty.

## Behavior

| Preferred resource hero | No-hero fallback | Existing remove-heroes option | Result |
| --- | --- | --- | --- |
| Available | Any | Off | Keep all selected heroes |
| Available | Any | On | Keep preferred hero; remove second and third |
| Missing | Off | Off | Keep the game's default formation |
| Missing | Off | On | Keep first hero; remove second and third |
| Missing | On | Any | Remove all heroes; deploy only after empty-state verification |

## Validation

- Automated: `mvnw.cmd package`
  - 438 tests
  - 0 failures
  - 0 errors
  - 0 skipped
  - desktop package built successfully
- Added policy tests for missing-resource prioritization, duplicate eligibility, unavailable resource handling, and every hero-fallback combination.
- Saved real-frame verification: the existing remove-button template detects all three selected-hero controls at `97.15-98.07%` across three formation frames; sorting by x-coordinate reliably selects the leftmost control.
- Live evidence: the original duplicate-resource failure was reproduced in account logs. The leftmost-control behavior was observed live: removing it clears all three heroes, while removing the middle hero leaves the third selected.
- Live no-hero confirmation: Wood specialist absent; all three remove controls detected; no controls remained after the leftmost tap; the game accepted the deployment without queue-full or same-target rejection.

## Risks

- Resource coverage still depends on correct March Queue resource classification.
- A preferred-hero template miss intentionally selects the safer no-hero path when the option is enabled.
- If the remove controls cannot be found or remain visible after the tap, the deployment is cancelled and retried by normal Gather scheduling.

Closes #219