### PR TITLE
feat(runtime): isolate bot workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ── Maven build output ──
 target/
+.frostguard-dev/
 **/target/
 dependency-reduced-pom.xml
 

--- a/build-support/verification/smoke_test_bundle.sh
+++ b/build-support/verification/smoke_test_bundle.sh
@@ -120,12 +120,14 @@ echo "  no classpath resolution errors from java -jar"
 echo "Booting the Telegram watcher from the bundle..."
 watcher_log="${workdir}/watcher.log"
 watcher_home="${workdir}/watcher-home"
+watcher_workspace="${workdir}/.frostguard-dev"
 mkdir -p "${watcher_home}"
 set +e
-# -Duser.home: the watcher derives its config path from user.home, which the JVM
-# reads from the OS account rather than $HOME. Redirect it so the smoke test
-# never touches a real developer profile.
-timeout 90s java -Duser.home="${watcher_home}" -jar "${watcher_jar}" \
+# Keep both user.home and the explicit workspace inside the disposable smoke
+# directory. The override makes the test deterministic even when a host Java
+# process does not inherit the shell's changed working directory.
+timeout 90s java -Duser.home="${watcher_home}" \
+  -Dfrostguard.workspace="${watcher_workspace}" -jar "${watcher_jar}" \
   > "${watcher_log}" 2>&1
 watcher_status=$?
 set -e
@@ -154,8 +156,8 @@ if ! grep -q "telegram-watcher.properties" "${watcher_log}" \
   exit 1
 fi
 
-if [[ ! -f "${watcher_home}/.frostguard/telegram-watcher.properties" ]]; then
-  echo "::error::The watcher did not create its config template under user.home."
+if [[ ! -f "${watcher_workspace}/watcher/telegram-watcher.properties" ]]; then
+  echo "::error::The watcher did not create its config template in the development workspace."
   sed 's/^/    /' "${watcher_log}" | head -n 30
   exit 1
 fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,7 +134,18 @@ FXML and CSS resources live in `modules/desktop/src/main/resources/layout` and `
 
 ## Runtime Decomposition
 
-At runtime, one process contains the JavaFX app or headless bootstrap, shared singleton services, and one task queue per enabled profile.
+At runtime, one process owns one exclusive workspace, then contains the JavaFX
+app or headless bootstrap, shared singleton services, and one task queue per
+enabled profile. `WorkspaceSession` creates and locks the workspace before
+logging or persistence initializes. All mutable state is resolved through
+`WorkspacePaths`; the installation and caller working directory are read-only
+runtime inputs.
+
+Installed defaults are `~/.frostguard/workspaces/<channel>/<name>`. Source and
+IDE launches detected inside a repository use its ignored `.frostguard-dev/`
+workspace. SQLite, logs, custom tasks, diagnostic/cache output, and Telegram
+watcher configuration and locking belong to that selected workspace. The
+watcher passes the same workspace identity to any bot process it launches.
 
 ```mermaid
 sequenceDiagram

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -121,11 +121,19 @@ Run the application from the repository root through the same Maven Wrapper:
 On Windows Command Prompt, use `mvnw.cmd javafx:run`; in PowerShell, use
 `.\mvnw.cmd javafx:run`. The JavaFX goal compiles the required reactor modules
 and starts only the desktop module; developers do not need to locate a
-versioned JAR or assemble its classpath.
+versioned JAR or assemble its classpath. It automatically uses the ignored
+`.frostguard-dev/` workspace in that clone or worktree. No runtime argument is
+required, and simultaneous production and worktree runs do not share data.
+
+Installed runs use named workspaces below
+`%USERPROFILE%\.frostguard\workspaces\<channel>\<name>\`. Each workspace owns
+its database, configuration, logs, custom tasks, cache, Telegram watcher state,
+and process lock. A workspace can be opened by only one Frostguard process at a
+time; use a different workspace for another bot instance.
 
 ## Migrating an older installation
 
-Do not overwrite a new installation with an entire old Frostguard folder.
-Migration of legacy configuration and database files is not yet automated; keep
-a backup and copy individual `database.*` files only when intentionally carrying
-existing settings forward.
+Do not overwrite a new workspace with an entire old Frostguard folder. Frostguard
+3.0 does not migrate the legacy flat `.frostguard` watcher files or a 2.x
+database. Keep a backup and recreate settings; copy only reviewed custom-task
+source files into the new workspace.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -66,6 +66,11 @@ For a source build, run from the repository root:
 .\mvnw.cmd javafx:run
 ```
 
+This automatically creates and uses `<worktree>\.frostguard-dev\`. Each
+worktree therefore has isolated database, logs, custom tasks, cache, and
+Telegram watcher state. `git clean -xdf` intentionally removes this disposable
+development workspace.
+
 For automatic startup through scripts or Task Scheduler:
 
 ```powershell

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/RuntimeChannel.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/RuntimeChannel.java
@@ -1,0 +1,24 @@
+package dev.frostguard.api.runtime;
+
+import java.util.Locale;
+
+public enum RuntimeChannel {
+    DEVELOPMENT,
+    NIGHTLY,
+    STABLE;
+
+    public String directoryName() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    public static RuntimeChannel from(String value) {
+        if (value == null || value.isBlank()) {
+            return STABLE;
+        }
+        try {
+            return valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            throw new IllegalArgumentException("Unsupported Frostguard channel: " + value);
+        }
+    }
+}

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspacePaths.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspacePaths.java
@@ -1,0 +1,77 @@
+package dev.frostguard.api.runtime;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public record WorkspacePaths(Path root, RuntimeChannel channel) {
+    public static final String WORKSPACE_PROPERTY = "frostguard.workspace";
+    public static final String CHANNEL_PROPERTY = "frostguard.channel";
+
+    public WorkspacePaths {
+        root = root.toAbsolutePath().normalize();
+    }
+
+    public static WorkspacePaths current() {
+        String configuredChannel = System.getProperty(CHANNEL_PROPERTY);
+        if (configuredChannel == null || configuredChannel.isBlank()) {
+            configuredChannel = System.getenv("FROSTGUARD_CHANNEL");
+        }
+        String override = System.getProperty(WORKSPACE_PROPERTY);
+        if (override == null || override.isBlank()) {
+            override = System.getenv("FROSTGUARD_WORKSPACE");
+        }
+        Path developmentRoot = findDevelopmentRoot();
+        if ((override == null || override.isBlank()) && configuredChannel == null && developmentRoot != null) {
+            configuredChannel = RuntimeChannel.DEVELOPMENT.directoryName();
+            override = developmentRoot.resolve(".frostguard-dev").toString();
+        }
+        RuntimeChannel channel = RuntimeChannel.from(configuredChannel);
+        Path root = override == null || override.isBlank()
+                ? Path.of(System.getProperty("user.home"), ".frostguard", "workspaces",
+                        channel.directoryName(), "default")
+                : Path.of(override);
+        return new WorkspacePaths(root, channel);
+    }
+
+    private static Path findDevelopmentRoot() {
+        Path candidate = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        for (int depth = 0; candidate != null && depth < 6; depth++, candidate = candidate.getParent()) {
+            if (Files.isRegularFile(candidate.resolve("pom.xml"))
+                    && Files.isDirectory(candidate.resolve("modules").resolve("desktop"))) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    public Path marker() { return root.resolve("frostguard-workspace.json"); }
+    public Path database() { return root.resolve("frostguard.db"); }
+    public Path config() { return root.resolve("config"); }
+    public Path logs() { return root.resolve("logs"); }
+    public Path customTasks() { return root.resolve("custom-tasks"); }
+    public Path cache() { return root.resolve("cache"); }
+    public Path watcher() { return root.resolve("watcher"); }
+    public Path watcherConfig() { return watcher().resolve("telegram-watcher.properties"); }
+    public Path watcherLock() { return watcher().resolve("watcher.lock"); }
+    public Path applicationLock() { return root.resolve("frostguard.lock"); }
+
+    public String identity() {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest((channel.directoryName() + "\n" + root)
+                    .getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is not available", impossible);
+        }
+    }
+
+    public int defaultLocalPort() {
+        long prefix = Long.parseUnsignedLong(identity().substring(0, 8), 16);
+        return 20_000 + (int) (prefix % 40_000);
+    }
+}

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
@@ -1,0 +1,85 @@
+package dev.frostguard.api.runtime;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+public final class WorkspaceSession implements AutoCloseable {
+    private final WorkspacePaths paths;
+    private final FileChannel lockChannel;
+    private final FileLock lock;
+
+    private WorkspaceSession(WorkspacePaths paths, FileChannel lockChannel, FileLock lock) {
+        this.paths = paths;
+        this.lockChannel = lockChannel;
+        this.lock = lock;
+    }
+
+    public static WorkspaceSession open(WorkspacePaths paths) {
+        try {
+            createLayout(paths);
+            FileChannel channel = FileChannel.open(paths.applicationLock(),
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            FileLock lock;
+            try {
+                lock = channel.tryLock();
+            } catch (OverlappingFileLockException alreadyLocked) {
+                lock = null;
+            }
+            if (lock == null) {
+                channel.close();
+                throw new IllegalStateException("Frostguard workspace is already in use: " + paths.root());
+            }
+            System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, paths.root().toString());
+            System.setProperty("frostguard.log.dir", paths.logs().toString());
+            return new WorkspaceSession(paths, channel, lock);
+        } catch (IOException cause) {
+            throw new IllegalStateException("Could not initialize Frostguard workspace: " + paths.root(), cause);
+        }
+    }
+
+    private static void createLayout(WorkspacePaths paths) throws IOException {
+        Files.createDirectories(paths.root());
+        Files.createDirectories(paths.config());
+        Files.createDirectories(paths.logs());
+        Files.createDirectories(paths.customTasks());
+        Files.createDirectories(paths.cache());
+        Files.createDirectories(paths.watcher());
+        if (Files.exists(paths.marker())) {
+            String marker = Files.readString(paths.marker(), StandardCharsets.UTF_8);
+            String expectedChannel = "\"channel\": \"" + paths.channel().directoryName() + "\"";
+            if (!marker.contains(expectedChannel)) {
+                throw new IllegalStateException("Workspace channel does not match "
+                        + paths.channel().directoryName() + ": " + paths.root());
+            }
+        } else {
+            String name = paths.root().getFileName().toString().replace("\\", "\\\\").replace("\"", "\\\"");
+            String json = "{\n"
+                    + "  \"schemaVersion\": 1,\n"
+                    + "  \"name\": \"" + name + "\",\n"
+                    + "  \"channel\": \"" + paths.channel().directoryName() + "\"\n"
+                    + "}\n";
+            Files.writeString(paths.marker(), json, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
+        }
+    }
+
+    public WorkspacePaths paths() {
+        return paths;
+    }
+
+    @Override
+    public void close() {
+        try {
+            lock.release();
+        } catch (IOException ignored) {
+        }
+        try {
+            lockChannel.close();
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
@@ -1,0 +1,106 @@
+package dev.frostguard.api.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WorkspaceSessionTest {
+    @TempDir
+    Path tempDir;
+
+    private String previousWorkspace;
+    private String previousLogDir;
+
+    @BeforeEach
+    void rememberRuntimeProperties() {
+        previousWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        previousLogDir = System.getProperty("frostguard.log.dir");
+    }
+
+    @AfterEach
+    void restoreRuntimeProperties() {
+        restore(WorkspacePaths.WORKSPACE_PROPERTY, previousWorkspace);
+        restore("frostguard.log.dir", previousLogDir);
+    }
+
+    @Test
+    void createsACompleteWorkspaceAndRejectsConcurrentUse() {
+        WorkspacePaths paths = new WorkspacePaths(tempDir.resolve("bot-1"), RuntimeChannel.STABLE);
+
+        try (WorkspaceSession ignored = WorkspaceSession.open(paths)) {
+            assertTrue(paths.marker().toFile().isFile());
+            assertTrue(paths.config().toFile().isDirectory());
+            assertTrue(paths.logs().toFile().isDirectory());
+            assertTrue(paths.customTasks().toFile().isDirectory());
+            assertTrue(paths.cache().toFile().isDirectory());
+            assertTrue(paths.watcher().toFile().isDirectory());
+            assertThrows(IllegalStateException.class, () -> WorkspaceSession.open(paths));
+        }
+    }
+
+    @Test
+    void derivesDefaultPortsAndIdentitiesFromTheWorkspace() {
+        WorkspacePaths first = new WorkspacePaths(tempDir.resolve("bot-1"), RuntimeChannel.STABLE);
+        WorkspacePaths second = new WorkspacePaths(tempDir.resolve("bot-2"), RuntimeChannel.STABLE);
+
+        assertTrue(first.defaultLocalPort() >= 20_000 && first.defaultLocalPort() < 60_000);
+        assertTrue(second.defaultLocalPort() >= 20_000 && second.defaultLocalPort() < 60_000);
+        assertNotEquals(first.identity(), second.identity());
+    }
+
+    @Test
+    void derivesIdentityIndependentlyOfJavaStringHashCollisions() {
+        WorkspacePaths first = new WorkspacePaths(tempDir.resolve("Aa"), RuntimeChannel.STABLE);
+        WorkspacePaths second = new WorkspacePaths(tempDir.resolve("BB"), RuntimeChannel.STABLE);
+
+        assertEquals(first.root().toString().hashCode(), second.root().toString().hashCode());
+        assertNotEquals(first.identity(), second.identity());
+    }
+
+    @Test
+    void rejectsOpeningAWorkspaceWithAnotherChannelIdentity() {
+        Path root = tempDir.resolve("shared");
+        try (WorkspaceSession ignored = WorkspaceSession.open(
+                new WorkspacePaths(root, RuntimeChannel.STABLE))) {
+            // Marker is persisted while the first channel owns the workspace.
+        }
+
+        assertThrows(IllegalStateException.class, () -> WorkspaceSession.open(
+                new WorkspacePaths(root, RuntimeChannel.NIGHTLY)));
+    }
+
+    @Test
+    void resolvesNamedChannelWorkspaceByDefault() {
+        String oldHome = System.getProperty("user.home");
+        String oldChannel = System.getProperty(WorkspacePaths.CHANNEL_PROPERTY);
+        String oldWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        try {
+            System.setProperty("user.home", tempDir.toString());
+            System.setProperty(WorkspacePaths.CHANNEL_PROPERTY, "nightly");
+            System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+
+            assertEquals(tempDir.resolve(".frostguard/workspaces/nightly/default").toAbsolutePath(),
+                    WorkspacePaths.current().root());
+        } finally {
+            restore("user.home", oldHome);
+            restore(WorkspacePaths.CHANNEL_PROPERTY, oldChannel);
+            restore(WorkspacePaths.WORKSPACE_PROPERTY, oldWorkspace);
+        }
+    }
+
+    private static void restore(String property, String value) {
+        if (value == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, value);
+        }
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -1,5 +1,7 @@
 package dev.frostguard.engine.schedule;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -807,16 +809,24 @@ public class TaskQueue {
             String tm = DateTimeFormatter.ofPattern("HH:mm").format(wake);
             String dt = DateTimeFormatter.ofPattern("MM/dd/yyyy").format(wake);
             String jar = resolveDesktopJarForAutostart();
-            new ProcessBuilder("schtasks","/create","/TN","Frostguard_AutoStart","/TR",
-                    "javaw.exe -jar \""+jar+"\" --autostart","/SC","ONCE","/ST",tm,"/SD",dt,"/RL","HIGHEST","/F")
+            WorkspacePaths workspace = WorkspacePaths.current();
+            String scheduledTaskName = "Frostguard_AutoStart_"
+                    + Integer.toUnsignedString(workspace.root().toString().hashCode(), 36);
+            new ProcessBuilder("schtasks","/create","/TN",scheduledTaskName,"/TR",
+                    "javaw.exe -D" + WorkspacePaths.WORKSPACE_PROPERTY + "=\"" + workspace.root()
+                            + "\" -D" + WorkspacePaths.CHANNEL_PROPERTY + "=" + workspace.channel().directoryName()
+                            + " -jar \""+jar+"\" --autostart",
+                    "/SC","ONCE","/ST",tm,"/SD",dt,"/RL","HIGHEST","/F")
                     .redirectErrorStream(true).start().waitFor();
-            java.nio.file.Path ws = java.nio.file.Paths.get(System.getProperty("user.dir"),"fg_wake.ps1");
+            java.nio.file.Path runtimeCache = workspace.cache().resolve("runtime");
+            java.nio.file.Files.createDirectories(runtimeCache);
+            java.nio.file.Path ws = runtimeCache.resolve("fg_wake.ps1");
             java.nio.file.Files.writeString(ws,
                     "$s=New-ScheduledTaskSettingsSet -WakeToRun -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -Priority 1\n"+
-                    "Set-ScheduledTask -TaskName 'Frostguard_AutoStart' -Settings $s\n");
+                    "Set-ScheduledTask -TaskName '" + scheduledTaskName + "' -Settings $s\n");
             new ProcessBuilder("powershell.exe","-NoProfile","-ExecutionPolicy","Bypass","-File",ws.toString())
                     .redirectErrorStream(true).start().waitFor();
-            java.nio.file.Path ss = java.nio.file.Paths.get(System.getProperty("user.dir"),"fg_sleep.ps1");
+            java.nio.file.Path ss = runtimeCache.resolve("fg_sleep.ps1");
             java.nio.file.Files.writeString(ss,
                     "Start-Sleep -Seconds 2\nAdd-Type -AssemblyName System.Windows.Forms\n"+
                     "[System.Windows.Forms.Application]::SetSuspendState('Suspend',$false,$false)\n");

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/CustomTaskService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/CustomTaskService.java
@@ -1,5 +1,7 @@
 package dev.frostguard.engine.service;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.engine.schedule.CustomTaskConfigurable;
@@ -155,7 +157,7 @@ public class CustomTaskService {
     // ========================================================================
 
     private CustomTaskService() {
-        compiledDir = Paths.get(System.getProperty("user.dir"), "custom_tasks");
+        compiledDir = WorkspacePaths.current().customTasks();
         jsonFile = compiledDir.resolve("custom_tasks.json");
         try {
             Files.createDirectories(compiledDir);

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
@@ -10,6 +10,7 @@ import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.AutomationBlueprint;
 import dev.frostguard.api.domain.AutomationStep;
+import dev.frostguard.api.runtime.WorkspacePaths;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -23,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Service that manages a Task Builder recording session.
@@ -52,7 +52,7 @@ public class TaskBuilderService {
 
     public TaskBuilderService() {
         this.emuManager = EmulatorController.getInstance();
-        this.customTasksDir = Paths.get(System.getProperty("user.dir"), "custom_tasks");
+        this.customTasksDir = WorkspacePaths.current().customTasks();
         this.mapper = new ObjectMapper()
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramBotService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramBotService.java
@@ -1,5 +1,7 @@
 package dev.frostguard.engine.service;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
@@ -14,7 +16,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Properties;
 
 import javax.imageio.ImageIO;
@@ -54,8 +55,6 @@ import java.util.ArrayList;
  * /status → reply with current running state
  */
 public class TelegramBotService implements BotStateListener {
-
-    static final String CURRENT_LOG_PATH = "log/frostguard.log";
 
     private static final Logger logger = LoggerFactory.getLogger(TelegramBotService.class);
     private static final String API_BASE = "https://api.telegram.org/bot";
@@ -147,17 +146,18 @@ public class TelegramBotService implements BotStateListener {
     /** Read localPort from the shared watcher properties file (default 8765). */
     private static int readLocalPort() {
         try {
-            Path cfg = Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+            Path cfg = WorkspacePaths.current().watcherConfig();
             if (Files.exists(cfg)) {
                 Properties props = new Properties();
                 try (FileInputStream fis = new FileInputStream(cfg.toFile())) { props.load(fis); }
-                return Integer.parseInt(props.getProperty("localPort", "8765").trim());
+                return Integer.parseInt(props.getProperty("localPort",
+                        String.valueOf(WorkspacePaths.current().defaultLocalPort())).trim());
             }
         } catch (Exception e) {
             LoggerFactory.getLogger(TelegramBotService.class)
                     .warn("Could not read localPort from config, defaulting to 8765: {}", e.getMessage());
         }
-        return 8765;
+        return WorkspacePaths.current().defaultLocalPort();
     }
 
     // ── public command dispatch (called by WatcherCommandServer) ─────────────
@@ -852,7 +852,7 @@ public class TelegramBotService implements BotStateListener {
                 }
                 case "log_dl" -> {
                     answerCallbackQuery(callbackId, "📥 Downloading...");
-                    sendDocument(chatId, CURRENT_LOG_PATH);
+                    sendDocument(chatId, currentLogPath().toString());
                 }
                 default -> answerCallbackQuery(callbackId, "");
             }
@@ -1208,6 +1208,10 @@ public class TelegramBotService implements BotStateListener {
         markup.set("inline_keyboard", kb);
 
         sendOrEditMessage(chatId, -1L, text, markup, "MarkdownV2");
+    }
+
+    static Path currentLogPath() {
+        return WorkspacePaths.current().logs().resolve("frostguard.log");
     }
 
     private void sendDocument(long chatId, String filePath) {

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
@@ -1,10 +1,15 @@
 package dev.frostguard.engine.service;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.StandardOpenOption;
 import java.util.Properties;
 
 import org.slf4j.Logger;
@@ -27,6 +32,9 @@ public class TelegramWatcherLauncher {
             try {
                 ProcessBuilder pb = new ProcessBuilder("cmd", "/c", "start", "\"FG-TG-Watcher\"", "/b", batFile.getName());
                 pb.directory(batFile.getParentFile());
+                pb.environment().put("FROSTGUARD_WORKSPACE", WorkspacePaths.current().root().toString());
+                pb.environment().put("FROSTGUARD_CHANNEL",
+                        WorkspacePaths.current().channel().directoryName());
                 pb.start();
                 logger.info("Executed {}", batFile.getAbsolutePath());
             } catch (IOException e) {
@@ -38,29 +46,27 @@ public class TelegramWatcherLauncher {
     }
 
     private static boolean isWatcherRunning() {
+        Path lockPath = WorkspacePaths.current().watcherLock();
         try {
-            return ProcessHandle.allProcesses()
-                    .filter(ph -> ph.info().command().map(c -> c.toLowerCase().contains("java")).orElse(false))
-                    .filter(ph -> ph.info().arguments().map(args -> {
-                        for (String a : args) {
-                            if (a.toLowerCase().contains("frostguard-watcher")) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    }).orElse(false))
-                    .findFirst()
-                    .isPresent();
+            Files.createDirectories(lockPath.getParent());
+            try (FileChannel channel = FileChannel.open(lockPath,
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+                try (FileLock lock = channel.tryLock()) {
+                    return lock == null;
+                } catch (OverlappingFileLockException lockedInThisProcess) {
+                    return true;
+                }
+            }
         } catch (Exception e) {
-            logger.error("Error checking if watcher is running", e);
+            logger.warn("Could not inspect watcher lock {}: {}", lockPath, e.getMessage());
             return false;
         }
     }
 
     private static File resolveBatFile() {
-        // Try to load the jar path from ~/.frostguard/telegram-watcher.properties
+        // Try to load the jar path from the active workspace.
         try {
-            Path cfg = Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+            Path cfg = WorkspacePaths.current().watcherConfig();
             if (Files.exists(cfg)) {
                 Properties props = new Properties();
                 try (java.io.FileInputStream fis = new java.io.FileInputStream(cfg.toFile())) {

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/WatcherCommandServer.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/WatcherCommandServer.java
@@ -7,6 +7,8 @@ import com.sun.net.httpserver.HttpServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
@@ -33,11 +35,13 @@ public class WatcherCommandServer {
     private final int               port;
     private final TelegramBotService botService;
     private final ObjectMapper       mapper = new ObjectMapper();
+    private final String             workspaceId;
     private HttpServer               server;
 
     public WatcherCommandServer(int port, TelegramBotService botService) {
         this.port       = port;
         this.botService = botService;
+        this.workspaceId = WorkspacePaths.current().identity();
     }
 
     public void start() throws IOException {
@@ -72,10 +76,20 @@ public class WatcherCommandServer {
         try {
             String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
             JsonNode req  = mapper.readTree(body);
+            if (!workspaceId.equals(req.path("workspaceId").asText())) {
+                responseBytes = "{\"ok\":false,\"error\":\"workspace mismatch\"}"
+                        .getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(409, responseBytes.length);
+                exchange.getResponseBody().write(responseBytes);
+                exchange.close();
+                return;
+            }
             String   type = req.path("type").asText("message");
             long   chatId = req.path("chatId").asLong(-1);
 
-            if ("callback".equals(type)) {
+            if ("ping".equals(type)) {
+                // Identity validation above is the complete ping operation.
+            } else if ("callback".equals(type)) {
                 String callbackId = req.path("callbackId").asText("");
                 long   messageId  = req.path("messageId").asLong(-1);
                 String data       = req.path("data").asText("noop");
@@ -110,8 +124,10 @@ public class WatcherCommandServer {
         }
 
         try {
-            long pid = ProcessHandle.current().pid();
-            String response = "{\"pid\":" + pid + "}";
+            String response = mapper.createObjectNode()
+                    .put("pid", ProcessHandle.current().pid())
+                    .put("workspaceId", workspaceId)
+                    .toString();
             byte[] responseBytes = response.getBytes(StandardCharsets.UTF_8);
             exchange.sendResponseHeaders(200, responseBytes.length);
             exchange.getResponseBody().write(responseBytes);

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.io.TempDir;
 import dev.frostguard.api.configs.FlowStepKind;
 import dev.frostguard.api.domain.AutomationBlueprint;
 import dev.frostguard.api.domain.AutomationStep;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 class TaskBuilderServiceTest {
 
@@ -20,8 +21,8 @@ class TaskBuilderServiceTest {
 
     @Test
     void savesBuilderJsonAndGeneratedJavaBesideIt() throws Exception {
-        String originalUserDir = System.getProperty("user.dir");
-        System.setProperty("user.dir", tempDir.toString());
+        String originalWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
         try {
             TaskBuilderService service = new TaskBuilderService();
             service.startSession("Expert Idle Exploration", "0");
@@ -31,7 +32,7 @@ class TaskBuilderServiceTest {
             step.setParam("durationMs", "200");
             service.addNode(step);
 
-            Path builderFile = tempDir.resolve("custom_tasks").resolve("expert_idle_exploration.json");
+            Path builderFile = tempDir.resolve("custom-tasks").resolve("expert_idle_exploration.json");
             TaskBuilderService.CustomTaskSaveResult saved =
                     service.saveCurrentTaskToCustomTasks("Expert Idle Exploration", builderFile);
 
@@ -47,7 +48,11 @@ class TaskBuilderServiceTest {
             assertEquals("Pause before bag", loaded.getNodes().get(0).getNodeName());
             assertEquals("1", service.getActiveEmulatorNumber());
         } finally {
-            System.setProperty("user.dir", originalUserDir);
+            if (originalWorkspace == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, originalWorkspace);
+            }
         }
     }
 }

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/TelegramBotServiceTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/TelegramBotServiceTest.java
@@ -1,13 +1,20 @@
 package dev.frostguard.engine.service;
 
 import dev.frostguard.api.configs.TpDailyTaskEnum;
+import dev.frostguard.api.runtime.WorkspacePaths;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TelegramBotServiceTest {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void standardQueueExcludesCustomTaskPlaceholder() {
@@ -16,7 +23,18 @@ class TelegramBotServiceTest {
     }
 
     @Test
-    void logDownloadUsesConfiguredFrostguardLogName() {
-        assertEquals("log/frostguard.log", TelegramBotService.CURRENT_LOG_PATH);
+    void logDownloadUsesTheSelectedWorkspace() {
+        String previous = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        try {
+            System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+            assertEquals(tempDir.resolve("logs/frostguard.log").toAbsolutePath(),
+                    TelegramBotService.currentLogPath());
+        } finally {
+            if (previous == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, previous);
+            }
+        }
     }
 }

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/WatcherCommandServerTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/WatcherCommandServerTest.java
@@ -1,0 +1,72 @@
+package dev.frostguard.engine.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+class WatcherCommandServerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void rejectsCommandsFromAnotherWorkspaceAndIdentifiesItsPid() throws Exception {
+        String previous = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        WatcherCommandServer server = null;
+        try {
+            System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+            int port;
+            try (ServerSocket availablePort = new ServerSocket(0)) {
+                port = availablePort.getLocalPort();
+            }
+
+            server = new WatcherCommandServer(port, null);
+            server.start();
+            HttpClient client = HttpClient.newHttpClient();
+
+            HttpResponse<String> mismatch = client.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/command"))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(
+                            "{\"type\":\"ping\",\"workspaceId\":\"another-workspace\"}"))
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            assertEquals(409, mismatch.statusCode());
+
+            String workspaceId = WorkspacePaths.current().identity();
+            HttpResponse<String> matching = client.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/command"))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(
+                            "{\"type\":\"ping\",\"workspaceId\":\"" + workspaceId + "\"}"))
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, matching.statusCode());
+
+            HttpResponse<String> pid = client.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/pid"))
+                    .GET()
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, pid.statusCode());
+            assertTrue(pid.body().contains("\"workspaceId\":\"" + workspaceId + "\""));
+        } finally {
+            if (server != null) {
+                server.stop();
+            }
+            if (previous == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, previous);
+            }
+        }
+    }
+}

--- a/modules/desktop/pom.xml
+++ b/modules/desktop/pom.xml
@@ -131,6 +131,8 @@
 					<runtimePathOption>CLASSPATH</runtimePathOption>
 					<options>
 						<option>--enable-native-access=ALL-UNNAMED</option>
+						<option>-Dfrostguard.channel=development</option>
+						<option>-Dfrostguard.workspace=${maven.multiModuleProjectDirectory}/.frostguard-dev</option>
 					</options>
 				</configuration>
 			</plugin>

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
@@ -3,11 +3,14 @@ package dev.frostguard.app.bootstrap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.api.runtime.WorkspaceSession;
 import dev.frostguard.engine.service.AnalyticsService;
 import dev.frostguard.tasks.TaskRegistrations;
 import dev.frostguard.vision.logging.ProfileContextLogger;
 
 public class Main {
+	private static final WorkspaceSession WORKSPACE = WorkspaceSession.open(WorkspacePaths.current());
 	private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
 	public static void main(String[] args) {
@@ -27,13 +30,14 @@ public class Main {
 			java.util.logging.Logger.getLogger("com.sun.javafx").setLevel(java.util.logging.Level.SEVERE);
 			java.util.logging.Logger.getLogger("javax.swing").setLevel(java.util.logging.Level.SEVERE);
 
-			logger.info("Initializing Frostguard...");
+			logger.info("Initializing Frostguard with workspace {}", WORKSPACE.paths().root());
 
 			// 2. Setup Shutdown Hook
 			Runtime.getRuntime().addShutdownHook(new Thread(() -> {
 				logger.info("Closing down subsystems.");
 				try { AnalyticsService.getInstance().trackAppShutdown(); } catch (Exception ignored) {}
 				ProfileContextLogger.shutdown();
+				WORKSPACE.close();
 			}, "frostguard-shutdown"));
 
 			// 3. Initialize Services

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/console/ConsoleLogLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/console/ConsoleLogLayoutController.java
@@ -1,5 +1,7 @@
 package dev.frostguard.app.panel.console;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.awt.Desktop;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -111,7 +113,7 @@ public class ConsoleLogLayoutController implements ProfileDataChangeListener {
 	@FXML
 	void handleButtonOpenLogFolder(ActionEvent event) {
 		try {
-			Path logsDir = Path.of("log");
+			Path logsDir = WorkspacePaths.current().logs();
 			Files.createDirectories(logsDir);
 			Desktop.getDesktop().open(logsDir.toFile());
 		} catch (IOException e) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
@@ -1,5 +1,7 @@
 package dev.frostguard.app.panel.misc;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -189,7 +191,7 @@ public class TelegramLayoutController {
             
             // Ensure localPort exists
             if (!props.containsKey("localPort")) {
-                props.setProperty("localPort", "8765");
+                props.setProperty("localPort", String.valueOf(WorkspacePaths.current().defaultLocalPort()));
             }
             
             try (FileOutputStream fos = new FileOutputStream(cfg.toFile())) {
@@ -266,7 +268,7 @@ public class TelegramLayoutController {
 
     /** Mirrors TelegramWatcher.configFilePath() – path convention kept in sync manually. */
     private static Path watcherConfigPath() {
-        return Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+        return WorkspacePaths.current().watcherConfig();
     }
 
     // ── Startup registration ──────────────────────────────────────────────────
@@ -289,11 +291,12 @@ public class TelegramLayoutController {
         }
         Path shortcut = startupFolder().resolve(SHORTCUT_NAME);
         try {
+            Path workspaceLauncher = writeWorkspaceWatcherLauncher(batFile);
             String vbs =
                 "Set oWS = WScript.CreateObject(\"WScript.Shell\")\n" +
-                "Set oLink = oWS.CreateShortcut(\"" + shortcut.toString().replace("\\", "\\\\") + "\")\n" +
-                "oLink.TargetPath = \"" + batFile.getAbsolutePath().replace("\\", "\\\\") + "\"\n" +
-                "oLink.WorkingDirectory = \"" + batFile.getParent().replace("\\", "\\\\") + "\"\n" +
+                "Set oLink = oWS.CreateShortcut(\"" + escapeVbsString(shortcut.toString()) + "\")\n" +
+                "oLink.TargetPath = \"" + escapeVbsString(workspaceLauncher.toString()) + "\"\n" +
+                "oLink.WorkingDirectory = \"" + escapeVbsString(workspaceLauncher.getParent().toString()) + "\"\n" +
                 "oLink.Description = \"Frostguard Telegram Watcher (auto-start)\"\n" +
                 "oLink.WindowStyle = 0\n" +
                 "oLink.Save\n";
@@ -315,6 +318,30 @@ public class TelegramLayoutController {
             showError("Failed to register startup shortcut: " + e.getMessage());
             checkBoxAutoStart.setSelected(false);
         }
+    }
+
+    private static Path writeWorkspaceWatcherLauncher(File batFile) throws IOException {
+        WorkspacePaths workspace = WorkspacePaths.current();
+        Path launcher = workspace.watcher().resolve("Start-Frostguard-Watcher.cmd");
+        Files.createDirectories(launcher.getParent());
+        Files.writeString(launcher, workspaceWatcherLauncherContent(batFile.toPath(), workspace));
+        return launcher;
+    }
+
+    static String workspaceWatcherLauncherContent(Path batFile, WorkspacePaths workspace) {
+        return "@echo off\r\n"
+                + "setlocal DisableDelayedExpansion\r\n"
+                + "set \"FROSTGUARD_WORKSPACE=" + escapeBatchValue(workspace.root().toString()) + "\"\r\n"
+                + "set \"FROSTGUARD_CHANNEL=" + workspace.channel().directoryName() + "\"\r\n"
+                + "call \"" + escapeBatchValue(batFile.toAbsolutePath().normalize().toString()) + "\"\r\n";
+    }
+
+    private static String escapeBatchValue(String value) {
+        return value.replace("^", "^^").replace("%", "%%");
+    }
+
+    private static String escapeVbsString(String value) {
+        return value.replace("\"", "\"\"");
     }
 
     private void removeStartup() {

--- a/modules/desktop/src/main/resources/logback.xml
+++ b/modules/desktop/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration scan="true" scanPeriod="30 seconds">
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
-    <property name="LOG_DIR" value="log"/>
+    <property name="LOG_DIR" value="${frostguard.log.dir:-log}"/>
     <property name="LOG_FILE" value="${LOG_DIR}/frostguard.log"/>
     <property name="APP_PATTERN" value="%d{HH:mm:ss.SSS} %-5level [%thread] %logger{32} - %msg%n"/>
     <property name="FILE_PATTERN" value="%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] %logger{48} - %msg%n"/>

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/TelegramLayoutControllerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/TelegramLayoutControllerTest.java
@@ -1,0 +1,30 @@
+package dev.frostguard.app.panel.misc;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+class TelegramLayoutControllerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void startupWrapperPreservesWorkspaceIdentity() {
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("Bot 1"), RuntimeChannel.STABLE);
+        Path watcherLauncher = tempDir.resolve("install/Start-Frostguard-Watcher.bat");
+
+        String script = TelegramLayoutController.workspaceWatcherLauncherContent(
+                watcherLauncher, workspace);
+
+        assertTrue(script.contains("set \"FROSTGUARD_WORKSPACE=" + workspace.root() + "\""));
+        assertTrue(script.contains("set \"FROSTGUARD_CHANNEL=stable\""));
+        assertTrue(script.contains("call \"" + watcherLauncher.toAbsolutePath().normalize() + "\""));
+    }
+}

--- a/modules/persistence/src/main/java/dev/frostguard/data/access/DataStore.java
+++ b/modules/persistence/src/main/java/dev/frostguard/data/access/DataStore.java
@@ -1,5 +1,6 @@
 package dev.frostguard.data.access;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -13,6 +14,7 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.TypedQuery;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 /**
  * Centralized transactional gateway for all Frostguard persistence operations.
@@ -31,7 +33,10 @@ public final class DataStore implements AutoCloseable {
 
 	private DataStore(Map<String, Object> overrides) {
 		try {
-			this.emf = Persistence.createEntityManagerFactory(PERSISTENCE_UNIT, overrides);
+			Map<String, Object> effectiveOverrides = new HashMap<>(overrides);
+			effectiveOverrides.putIfAbsent("jakarta.persistence.jdbc.url",
+					"jdbc:sqlite:" + WorkspacePaths.current().database() + "?busy_timeout=1000&journal_mode=WAL");
+			this.emf = Persistence.createEntityManagerFactory(PERSISTENCE_UNIT, effectiveOverrides);
 			DataSeeder.populate(this);
 			LOG.info("Frostguard data store initialized");
 		} catch (Exception cause) {

--- a/modules/persistence/src/test/java/dev/frostguard/data/access/DataStoreWorkspaceTest.java
+++ b/modules/persistence/src/test/java/dev/frostguard/data/access/DataStoreWorkspaceTest.java
@@ -1,0 +1,32 @@
+package dev.frostguard.data.access;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+class DataStoreWorkspaceTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void opensTheDefaultDatabaseInsideTheSelectedWorkspace() {
+        String previous = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+        try (DataStore ignored = DataStore.openIsolated(Map.of("hibernate.hbm2ddl.auto", "create"))) {
+            assertTrue(Files.isRegularFile(tempDir.resolve("frostguard.db")));
+        } finally {
+            if (previous == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, previous);
+            }
+        }
+    }
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/logging/ProfileContextLogger.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/logging/ProfileContextLogger.java
@@ -3,10 +3,10 @@ package dev.frostguard.vision.logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 import java.io.*;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
@@ -62,7 +62,7 @@ public final class ProfileContextLogger {
 
     private void ensureLogDirectory() {
         try {
-            Files.createDirectories(Paths.get("logs"));
+            Files.createDirectories(WorkspacePaths.current().logs());
         } catch (IOException e) {
             rootLog.error("Base directory creation failed: {}", e.getMessage());
         }
@@ -71,8 +71,8 @@ public final class ProfileContextLogger {
     private synchronized void initWriter(AccountDescriptor acc) throws IOException {
         if (writerRegistry.containsKey(acc.getId())) return;
 
-        String path = String.format("logs/account_%s_%d.log", cleanPath(acc.getName()), acc.getId());
-        File handle = new File(path);
+        File handle = WorkspacePaths.current().logs()
+                .resolve(String.format("account_%s_%d.log", cleanPath(acc.getName()), acc.getId())).toFile();
 
         if (handle.exists() && handle.length() > MAX_BYTES) {
             rollover(handle);
@@ -186,8 +186,8 @@ public final class ProfileContextLogger {
     private void enforceSizeLimit() {
         if (profile == null) return;
         
-        String path = String.format("logs/account_%s_%d.log", cleanPath(profile.getName()), profile.getId());
-        File handle = new File(path);
+        File handle = WorkspacePaths.current().logs()
+                .resolve(String.format("account_%s_%d.log", cleanPath(profile.getName()), profile.getId())).toFile();
         
         if (handle.exists() && handle.length() > MAX_BYTES) {
             try {

--- a/modules/vision/src/main/java/dev/frostguard/vision/match/OpenCvPatternLocator.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/match/OpenCvPatternLocator.java
@@ -29,6 +29,7 @@ import dev.frostguard.api.domain.SizeData;
 import dev.frostguard.api.configs.TemplatesEnum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 /**
  * Performs normalised cross-correlation between device screen captures
@@ -1943,7 +1944,7 @@ public class OpenCvPatternLocator {
         String[] segments = resourcePath.split("/");
         String fileName = segments[segments.length - 1];
 
-        Path targetDir = Path.of("lib", "opencv");
+        Path targetDir = WorkspacePaths.current().cache().resolve("native").resolve("opencv");
         Files.createDirectories(targetDir);
         Path dest = targetDir.resolve(fileName);
 

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
@@ -21,6 +21,7 @@ import net.sourceforge.tess4j.Tesseract;
 import net.sourceforge.tess4j.TesseractException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 /**
  * Provides text recognition from captured device screens or local image
@@ -364,14 +365,14 @@ public final class TesseractOcrProvider {
     // =====================================================================
 
     /**
-     * Writes a side-by-side diagnostic PNG to {@code <cwd>/temp/}.
+     * Writes a side-by-side diagnostic PNG to the active workspace cache.
      */
     private static void exportDiagnosticImage(RawImageData capture, BufferedImage processed,
             int cx, int cy, int cw, int ch,
             TesseractSettingsData cfg, String text) {
         long t0 = System.currentTimeMillis();
         try {
-            Path tempDir = Paths.get(System.getProperty("user.dir")).resolve("temp");
+            Path tempDir = WorkspacePaths.current().cache().resolve("ocr");
             Files.createDirectories(tempDir);
 
             String summary = formatSettingsSummary(cfg, text);

--- a/modules/watcher/pom.xml
+++ b/modules/watcher/pom.xml
@@ -18,6 +18,10 @@
 
 	<!-- ─── Runtime dependencies ─── -->
 	<dependencies>
+		<dependency>
+			<groupId>dev.frostguard</groupId>
+			<artifactId>frostguard-api</artifactId>
+		</dependency>
 		<!-- JSON serialisation (version managed by parent) -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
+++ b/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
@@ -1,5 +1,7 @@
 package dev.frostguard.watcher;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -19,7 +21,6 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.Properties;
@@ -43,10 +44,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * Everything else is forwarded to http://127.0.0.1:{localPort}/command.
  * Callback queries (inline keyboard taps) are also forwarded to the app.
  *
- * Single-instance guarantee: a FileLock on %USERPROFILE%/.frostguard/watcher.lock
- * prevents multiple watcher processes from running simultaneously.
+ * Single-instance guarantee: a FileLock in the selected workspace's watcher
+ * directory prevents duplicate watcher processes for that workspace.
  *
- * Configuration: %USERPROFILE%\.frostguard\telegram-watcher.properties
+ * Configuration: &lt;workspace&gt;/watcher/telegram-watcher.properties
  *   token=<BotFather token>
  *   chatId=<your Telegram numeric chat-ID>
  *   botJarPath=<absolute path to frostguard-x.x.x.jar>
@@ -57,10 +58,9 @@ public class TelegramWatcher {
     private static final Logger logger = LoggerFactory.getLogger(TelegramWatcher.class);
     private static final String API_BASE         = "https://api.telegram.org/bot";
     private static final int    LONG_POLL_TIMEOUT = 30;
-    private static final int    DEFAULT_LOCAL_PORT = 8765;
 
     public static Path configFilePath() {
-        return Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+        return WorkspacePaths.current().watcherConfig();
     }
 
     // ── entry point ───────────────────────────────────────────────────────────
@@ -72,7 +72,7 @@ public class TelegramWatcher {
         System.out.println("==============================================");
 
         // ── Single-instance lock ───────────────────────────────────────────────
-        Path lockFilePath = configFilePath().resolveSibling("watcher.lock");
+        Path lockFilePath = WorkspacePaths.current().watcherLock();
         Files.createDirectories(lockFilePath.getParent());
         FileChannel lockChannel = FileChannel.open(lockFilePath,
                 StandardOpenOption.CREATE, StandardOpenOption.WRITE);
@@ -94,9 +94,10 @@ public class TelegramWatcher {
         int    localPort;
         try {
             localPort = Integer.parseInt(
-                    cfg.getProperty("localPort", String.valueOf(DEFAULT_LOCAL_PORT)).trim());
+                    cfg.getProperty("localPort",
+                            String.valueOf(WorkspacePaths.current().defaultLocalPort())).trim());
         } catch (NumberFormatException e) {
-            localPort = DEFAULT_LOCAL_PORT;
+            localPort = WorkspacePaths.current().defaultLocalPort();
         }
 
         if (token.isBlank()) {
@@ -127,6 +128,7 @@ public class TelegramWatcher {
     private final File          botJar;
     private final File          botJarDir;
     private final int           localPort;
+    private final String        workspaceId;
     private final HttpClient    httpClient;
     private final ObjectMapper  mapper = new ObjectMapper();
 
@@ -144,6 +146,7 @@ public class TelegramWatcher {
         this.botJar        = new File(jarPath);
         this.botJarDir     = botJar.getParentFile();
         this.localPort     = localPort;
+        this.workspaceId   = WorkspacePaths.current().identity();
         this.httpClient    = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
@@ -271,9 +274,15 @@ public class TelegramWatcher {
             }
             try {
                 String javaExe = ProcessHandle.current().info().command().orElse("java");
-                ProcessBuilder pb = headless
-                        ? new ProcessBuilder(javaExe, "-jar", botJar.getName(), "--headless")
-                        : new ProcessBuilder(javaExe, "-jar", botJar.getName());
+                java.util.List<String> command = new java.util.ArrayList<>();
+                command.add(javaExe);
+                command.add("-D" + WorkspacePaths.WORKSPACE_PROPERTY + "=" + WorkspacePaths.current().root());
+                command.add("-D" + WorkspacePaths.CHANNEL_PROPERTY + "="
+                        + WorkspacePaths.current().channel().directoryName());
+                command.add("-jar");
+                command.add(botJar.getAbsolutePath());
+                if (headless) command.add("--headless");
+                ProcessBuilder pb = new ProcessBuilder(command);
                 
                 // Use the parent of the bot jar as the working directory, unless it's in a 'target' dir
                 // (to support Maven multi-module dev workflows where the root is one level up).
@@ -283,9 +292,6 @@ public class TelegramWatcher {
                     workDir = botJarDir.getParentFile().getParentFile().getParentFile();
                 }
                 pb.directory(workDir);
-
-                // When changing workDir, we must execute the jar using a path relative to workDir or absolute path.
-                pb.command().set(2, botJar.getAbsolutePath());
 
                 pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
                 pb.redirectError(ProcessBuilder.Redirect.DISCARD);
@@ -319,22 +325,7 @@ public class TelegramWatcher {
         }
         
         // Try to get the PID from the bot's command server
-        Long remotePid = null;
-        try {
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create("http://127.0.0.1:" + localPort + "/pid"))
-                    .timeout(Duration.ofSeconds(2))
-                    .GET()
-                    .build();
-            HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            if (resp.statusCode() == 200) {
-                JsonNode json = mapper.readTree(resp.body());
-                remotePid = json.path("pid").asLong(-1);
-                if (remotePid == -1) remotePid = null;
-            }
-        } catch (Exception e) {
-            logger.debug("Could not get PID from /pid endpoint: {}", e.getMessage());
-        }
+        Long remotePid = fetchWorkspacePid();
         
         // If we got a PID from the server, kill that process
         if (remotePid != null) {
@@ -367,6 +358,7 @@ public class TelegramWatcher {
                         || cmdLine.contains("dev.frostguard.app.bootstrap.Main")
                         || cmdLine.contains("dev.frostguard.app.bootstrap.FXApp")
                         || cmdLine.contains("dev.frostguard.app.bootstrap.HeadlessApp");
+                    matches = matches && cmdLine.contains(WorkspacePaths.current().root().toString());
                     
                     if (matches) {
                         logger.debug("Found matching process PID {}: {}", ph.pid(), cmdLine);
@@ -412,6 +404,7 @@ public class TelegramWatcher {
             body.put("type",   "message");
             body.put("chatId", chatId);
             body.put("text",   text);
+            body.put("workspaceId", workspaceId);
 
             HttpRequest req = HttpRequest.newBuilder()
                     .uri(URI.create("http://127.0.0.1:" + localPort + "/command"))
@@ -441,6 +434,7 @@ public class TelegramWatcher {
             body.put("messageId",  messageId);
             body.put("callbackId", callbackId);
             body.put("data",       data);
+            body.put("workspaceId", workspaceId);
 
             HttpRequest req = HttpRequest.newBuilder()
                     .uri(URI.create("http://127.0.0.1:" + localPort + "/command"))
@@ -469,27 +463,8 @@ public class TelegramWatcher {
             botProcess = null; // clear stale reference
         }
         
-        // Try to connect to the bot's command server as a reliable check
-        // If the server responds (even with an error), the bot is definitely running
-        try {
-            ObjectNode testBody = mapper.createObjectNode();
-            testBody.put("type", "ping");
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create("http://127.0.0.1:" + localPort + "/command"))
-                    .timeout(Duration.ofSeconds(1))
-                    .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(testBody.toString()))
-                    .build();
-            httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            // If we get ANY response (success or error), the server is up
+        if (fetchWorkspacePid() != null) {
             logger.debug("Bot process alive via network check on port {}", localPort);
-            return true;
-        } catch (ConnectException e) {
-            // Connection refused = server not running, continue to process search
-            logger.debug("Network check failed (connection refused), trying process search");
-        } catch (Exception e) {
-            // Any other response (including errors) means the server is up
-            logger.debug("Bot process alive via network check (got response: {})", e.getClass().getSimpleName());
             return true;
         }
         
@@ -498,10 +473,11 @@ public class TelegramWatcher {
                 .filter(ph -> ph.info().command().map(c -> c.toLowerCase().contains("java")).orElse(false))
                 .filter(ph -> {
                     String cmd = ph.info().commandLine().orElse("");
-                    return cmd.contains(botJar.getName())
+                    boolean matchesApp = cmd.contains(botJar.getName())
                         || cmd.contains("dev.frostguard.app.bootstrap.Main")
                         || cmd.contains("dev.frostguard.app.bootstrap.FXApp")
                         || cmd.contains("dev.frostguard.app.bootstrap.HeadlessApp");
+                    return matchesApp && cmd.contains(WorkspacePaths.current().root().toString());
                 })
                 .findFirst()
                 .isPresent();
@@ -512,6 +488,34 @@ public class TelegramWatcher {
             logger.debug("Bot process not found via any method");
         }
         return found;
+    }
+
+    private Long fetchWorkspacePid() {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + localPort + "/pid"))
+                    .timeout(Duration.ofSeconds(2))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                logger.debug("PID endpoint on port {} replied HTTP {}", localPort, response.statusCode());
+                return null;
+            }
+            JsonNode json = mapper.readTree(response.body());
+            if (!workspaceId.equals(json.path("workspaceId").asText())) {
+                logger.warn("Ignoring command server on port {} because it belongs to another workspace", localPort);
+                return null;
+            }
+            long pid = json.path("pid").asLong(-1);
+            return pid > 0 ? pid : null;
+        } catch (ConnectException connectionRefused) {
+            logger.debug("No command server listening on port {}", localPort);
+            return null;
+        } catch (Exception failure) {
+            logger.debug("Could not read matching PID from port {}: {}", localPort, failure.getMessage());
+            return null;
+        }
     }
 
     private static String buildHelpMessage() {
@@ -616,7 +620,7 @@ public class TelegramWatcher {
                   + "token=\n"
                   + "chatId=\n"
                   + "botJarPath=\n"
-                  + "localPort=8765\n");
+                  + "localPort=" + WorkspacePaths.current().defaultLocalPort() + "\n");
             System.out.println("[INFO] Created config template at: " + cfg);
         }
         Properties props = new Properties();

--- a/packaging/desktop/src/main/windows/Start-Frostguard-Watcher.bat
+++ b/packaging/desktop/src/main/windows/Start-Frostguard-Watcher.bat
@@ -45,6 +45,5 @@ exit /b 1
 :found
 echo Starting Frostguard Telegram Watcher (background)...
 echo JAR: %JAR%
-echo Log: %USERPROFILE%\.frostguard\tg-watcher.log
 start "FG-TG-Watcher" /b javaw -jar "%JAR%"
 exit /b 0

--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,12 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven.surefire.plugin.version}</version>
+					<configuration>
+						<systemPropertyVariables>
+							<frostguard.channel>development</frostguard.channel>
+							<frostguard.workspace>${project.build.directory}/test-workspace</frostguard.workspace>
+						</systemPropertyVariables>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

- introduce explicit Development, Stable, and Nightly runtime workspace identities
- keep normal source and IDE launches isolated in the checkout-local `.frostguard-dev/` workspace without required arguments
- route the database, logs, custom tasks, caches, Telegram watcher state, locks, and default command ports through the selected workspace
- preserve the selected workspace in scheduled launches and Windows watcher autostart
- prevent two application processes from opening the same workspace concurrently
- bind watcher/app commands to a cryptographic workspace identity so a port collision cannot route or kill another bot

## Why

Frostguard must support installed Bot 1, installed Bot 2, and development launches from independent worktrees without sharing or corrupting mutable state. Application binaries and source checkouts therefore remain separate from named runtime workspaces.

This implements #150 as part of #130.

## Dependency and review scope

Depends on #145 / #147.

This branch intentionally contains one commit on top of PR #147: `380d8b9 feat(runtime): isolate bot workspaces`. Because PR #147 is a cross-repository PR from the same fork, GitHub cannot use its head branch as the base of an upstream stacked PR. Until #147 merges, GitHub therefore also displays the project-layout changes in this draft. After #147 merges into `main`, the effective diff reduces to the 33 runtime-workspace files in `380d8b9`.

## Developer and user impact

- `./mvnw javafx:run` and `mvnw.cmd javafx:run` require no workspace arguments and use `<checkout>/.frostguard-dev/`.
- Installed identities default to named workspaces under `~/.frostguard/workspaces/<channel>/<name>`.
- Telegram log downloads and watcher autostart remain scoped to the selected workspace.
- Existing Frostguard 2.x state is not migrated automatically.
- Portable mode and the installed first-run workspace picker remain follow-up work.

## Validation

- `mvnw.cmd package`: passed with all reactor tests green.
- Focused API, persistence, automation, desktop, and watcher tests: passed.
- Workspace command-server tests verify that mismatched identities are rejected and `/pid` identifies its owner.
- Windows watcher-launcher tests verify that workspace and channel are preserved.
- Project-layout verification: 6 tests passed.
- Visible root `mvnw.cmd javafx:run` smoke test: created the database/WAL, logs, cache, marker, and locks only under the worktree-local `.frostguard-dev/` workspace.
- A subsequent package build left the development workspace unchanged.

## Risks

- The installed workspace-picker UI and installer integration are not part of this PR.
- Live verification currently covers the source-development identity; installed Stable/Nightly packaging remains dependent on later #130 workstreams.
- A default local-port collision remains mathematically possible, but workspace identity validation prevents cross-workspace command dispatch and PID termination; the port remains configurable per workspace.
- The draft temporarily shows PR #147's layout diff until that dependency merges.

