### PR TITLE
feat(packaging): produce the Windows desktop installer

### DIFF
--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -1,0 +1,114 @@
+name: Native Windows Package
+
+on:
+  pull_request:
+    paths:
+      - "**/pom.xml"
+      - "modules/**/src/**"
+      - "packaging/desktop/**"
+      - "build-support/packaging/**"
+      - "build-support/verification/*app_image*"
+      - "build-support/verification/smoke_test_app_image.ps1"
+      - "tools/**"
+      - "examples/custom-tasks/**"
+      - ".github/workflows/windows-native-package.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-native-package-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MAVEN_ARGS: "-B --no-transfer-progress -Dstyle.color=never"
+
+jobs:
+  package:
+    name: Build and verify native Windows package
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Verify Git LFS assets are real binaries
+        shell: bash
+        run: build-support/verification/check_lfs_assets.sh
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      # JDK 21 jpackage invokes the WiX 3 candle/light toolchain for an EXE.
+      # Pinning the Chocolatey package prevents an incompatible WiX major from
+      # silently changing the installer build underneath this workflow.
+      - name: Install WiX Toolset 3
+        shell: pwsh
+        run: |
+          choco install wixtoolset --version=3.14.1.20250415 --no-progress -y
+          $wixBin = "${env:ProgramFiles(x86)}\WiX Toolset v3.14\bin"
+          if (-not (Test-Path -LiteralPath (Join-Path $wixBin "candle.exe"))) {
+              throw "WiX candle.exe was not installed below $wixBin"
+          }
+          $wixBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Build application image and installer
+        shell: pwsh
+        run: |
+          $mavenArgs = $env:MAVEN_ARGS -split " "
+          & .\mvnw.cmd @mavenArgs "-Pwindows-app-image,windows-installer" package
+
+      - name: Test the application-image verifier
+        run: python build-support/verification/test_verify_app_image.py
+
+      - name: Verify application image
+        run: >-
+          python build-support/verification/verify_app_image.py
+          packaging/desktop/target/app-image/Frostguard
+
+      - name: Smoke test native launchers and workspace isolation
+        shell: pwsh
+        run: |
+          powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+              -File build-support/verification/smoke_test_app_image.ps1 `
+              -ImagePath packaging/desktop/target/app-image/Frostguard
+
+      - name: Verify installer boundary
+        id: installer
+        shell: pwsh
+        run: |
+          $installers = @(Get-ChildItem -LiteralPath packaging/desktop/target/installers `
+              -Filter "Frostguard-*.exe" -File)
+          if ($installers.Count -ne 1) {
+              throw "Expected exactly one versioned installer, found $($installers.Count)"
+          }
+          if ($installers[0].Length -lt 1MB) {
+              throw "Installer is unexpectedly small: $($installers[0].Length) bytes"
+          }
+          "path=$($installers[0].FullName)" | Out-File `
+              -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Upload native application image
+        uses: actions/upload-artifact@v4
+        with:
+          name: frostguard-windows-app-image
+          path: packaging/desktop/target/app-image/Frostguard
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: frostguard-windows-installer
+          path: ${{ steps.installer.outputs.path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ── Maven build output ──
 target/
+.frostguard-dev/
 **/target/
 dependency-reduced-pom.xml
 

--- a/build-support/packaging/write_windows_icon.ps1
+++ b/build-support/packaging/write_windows_icon.ps1
@@ -1,0 +1,50 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$InputPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = "Stop"
+$png = [System.IO.File]::ReadAllBytes((Resolve-Path -LiteralPath $InputPath))
+$signature = [byte[]](137, 80, 78, 71, 13, 10, 26, 10)
+if ($png.Length -lt 24) {
+    throw "The Windows icon source must be a PNG file"
+}
+for ($index = 0; $index -lt $signature.Length; $index++) {
+    if ($png[$index] -ne $signature[$index]) {
+        throw "The Windows icon source must be a PNG file"
+    }
+}
+
+# PNG stores the IHDR dimensions in big-endian order. ICO uses a zero byte for
+# a 256-pixel dimension and can embed the original PNG payload without lossy
+# conversion on supported Windows versions.
+$width = [System.Net.IPAddress]::NetworkToHostOrder([BitConverter]::ToInt32($png, 16))
+$height = [System.Net.IPAddress]::NetworkToHostOrder([BitConverter]::ToInt32($png, 20))
+if ($width -lt 1 -or $width -gt 256 -or $height -lt 1 -or $height -gt 256) {
+    throw "The PNG dimensions must be between 1 and 256 pixels"
+}
+
+$outputDirectory = Split-Path -Parent $OutputPath
+New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+$stream = [System.IO.File]::Open($OutputPath, [System.IO.FileMode]::Create)
+$writer = [System.IO.BinaryWriter]::new($stream)
+try {
+    $writer.Write([uint16]0)
+    $writer.Write([uint16]1)
+    $writer.Write([uint16]1)
+    $writer.Write([byte]($(if ($width -eq 256) { 0 } else { $width })))
+    $writer.Write([byte]($(if ($height -eq 256) { 0 } else { $height })))
+    $writer.Write([byte]0)
+    $writer.Write([byte]0)
+    $writer.Write([uint16]1)
+    $writer.Write([uint16]32)
+    $writer.Write([uint32]$png.Length)
+    $writer.Write([uint32]22)
+    $writer.Write($png)
+}
+finally {
+    $writer.Dispose()
+}

--- a/build-support/verification/smoke_test_app_image.ps1
+++ b/build-support/verification/smoke_test_app_image.ps1
@@ -1,0 +1,106 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ImagePath
+)
+
+$ErrorActionPreference = "Stop"
+$image = (Resolve-Path -LiteralPath $ImagePath).Path
+$appLauncher = Join-Path $image "Frostguard.exe"
+$watcherLauncher = Join-Path $image "FrostguardWatcher.exe"
+if (-not (Test-Path -LiteralPath $appLauncher -PathType Leaf)) {
+    throw "Frostguard.exe is missing from $image"
+}
+if (-not (Test-Path -LiteralPath $watcherLauncher -PathType Leaf)) {
+    throw "FrostguardWatcher.exe is missing from $image"
+}
+
+$versionInfo = (Get-Item -LiteralPath $appLauncher).VersionInfo
+if ($versionInfo.ProductName -ne "Frostguard" -or
+        $versionInfo.CompanyName -ne "Frostguard" -or
+        $versionInfo.FileDescription -ne "Frostguard automation desktop application") {
+    throw "Frostguard.exe has incomplete Windows application metadata"
+}
+Add-Type -AssemblyName System.Drawing
+$icon = [System.Drawing.Icon]::ExtractAssociatedIcon($appLauncher)
+if ($null -eq $icon -or $icon.Width -lt 16 -or $icon.Height -lt 16) {
+    throw "Frostguard.exe has no usable Windows application icon"
+}
+$icon.Dispose()
+
+$smokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("frostguard-native-smoke-" + [guid]::NewGuid().ToString("N"))
+$appWorkspace = Join-Path $smokeRoot "app-workspace"
+$watcherWorkspace = Join-Path $smokeRoot "watcher-workspace"
+New-Item -ItemType Directory -Path $appWorkspace, $watcherWorkspace | Out-Null
+$originalPath = $env:PATH
+$hadJavaHome = Test-Path Env:JAVA_HOME
+$originalJavaHome = $env:JAVA_HOME
+
+try {
+    Remove-Item Env:JAVA_HOME -ErrorAction SilentlyContinue
+    $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
+    $env:FROSTGUARD_WORKSPACE = $appWorkspace
+    $app = Start-Process -FilePath $appLauncher -ArgumentList "--frostguard-native-smoke-test" -Wait -PassThru
+    if ($app.ExitCode -ne 0) {
+        throw "Native Frostguard launcher exited with $($app.ExitCode)"
+    }
+    $marker = Join-Path $appWorkspace "frostguard-workspace.json"
+    if (-not (Test-Path -LiteralPath $marker)) {
+        throw "Native launcher did not create its isolated workspace marker"
+    }
+    $workspaceMetadata = Get-Content -Raw -LiteralPath $marker | ConvertFrom-Json
+    if ($workspaceMetadata.channel -ne "stable") {
+        throw "Native launcher selected '$($workspaceMetadata.channel)' instead of Stable"
+    }
+
+    $env:FROSTGUARD_WORKSPACE = $watcherWorkspace
+    $watcher = Start-Process -FilePath $watcherLauncher `
+        -ArgumentList "--frostguard-native-smoke-test" -Wait -PassThru
+    if ($watcher.ExitCode -ne 0) {
+        throw "Native Frostguard watcher launcher exited with $($watcher.ExitCode)"
+    }
+    $watcherConfig = Join-Path $watcherWorkspace "watcher/telegram-watcher.properties"
+    if (-not (Test-Path -LiteralPath $watcherConfig)) {
+        throw "Native watcher launcher did not reach workspace configuration"
+    }
+    $watcherMarker = Join-Path $watcherWorkspace "frostguard-workspace.json"
+    if (-not (Test-Path -LiteralPath $watcherMarker)) {
+        throw "Native watcher launcher did not create its workspace marker"
+    }
+    $watcherMetadata = Get-Content -Raw -LiteralPath $watcherMarker | ConvertFrom-Json
+    if ($watcherMetadata.channel -ne "stable") {
+        throw "Native watcher launcher selected '$($watcherMetadata.channel)' instead of Stable"
+    }
+    $watcherEvidencePath = Join-Path $watcherWorkspace "cache/native-watcher-smoke.properties"
+    if (-not (Test-Path -LiteralPath $watcherEvidencePath)) {
+        throw "Native watcher launcher did not write smoke-test evidence"
+    }
+    $watcherEvidence = @{}
+    Get-Content -LiteralPath $watcherEvidencePath | ForEach-Object {
+        if ($_ -match '^([^=]+)=(.*)$') {
+            $watcherEvidence[$matches[1]] = $matches[2]
+        }
+    }
+    if ($watcherEvidence["channel"] -ne "stable" -or
+            [System.IO.Path]::GetFullPath($watcherEvidence["workspace"]) -ne $watcherWorkspace -or
+            [System.IO.Path]::GetFullPath($watcherEvidence["applicationDir"]) -ne (Join-Path $image "app") -or
+            [System.IO.Path]::GetFullPath($watcherEvidence["appLauncher"]) -ne $appLauncher -or
+            [System.IO.Path]::GetFullPath($watcherEvidence["watcherLauncher"]) -ne $watcherLauncher) {
+        throw "Native watcher launcher did not receive its packaged runtime contract"
+    }
+    Write-Host "Native app-image smoke test passed (app and watcher exit 0 without system Java)."
+}
+finally {
+    Remove-Item Env:FROSTGUARD_WORKSPACE -ErrorAction SilentlyContinue
+    $env:PATH = $originalPath
+    if ($hadJavaHome) {
+        $env:JAVA_HOME = $originalJavaHome
+    } else {
+        Remove-Item Env:JAVA_HOME -ErrorAction SilentlyContinue
+    }
+    $resolvedSmokeRoot = [System.IO.Path]::GetFullPath($smokeRoot)
+    $resolvedTempRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+    if ($resolvedSmokeRoot.StartsWith($resolvedTempRoot, [System.StringComparison]::OrdinalIgnoreCase) -and
+            (Split-Path -Leaf $resolvedSmokeRoot).StartsWith("frostguard-native-smoke-")) {
+        Remove-Item -LiteralPath $resolvedSmokeRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/build-support/verification/smoke_test_bundle.sh
+++ b/build-support/verification/smoke_test_bundle.sh
@@ -120,12 +120,14 @@ echo "  no classpath resolution errors from java -jar"
 echo "Booting the Telegram watcher from the bundle..."
 watcher_log="${workdir}/watcher.log"
 watcher_home="${workdir}/watcher-home"
+watcher_workspace="${workdir}/.frostguard-dev"
 mkdir -p "${watcher_home}"
 set +e
-# -Duser.home: the watcher derives its config path from user.home, which the JVM
-# reads from the OS account rather than $HOME. Redirect it so the smoke test
-# never touches a real developer profile.
-timeout 90s java -Duser.home="${watcher_home}" -jar "${watcher_jar}" \
+# Keep both user.home and the explicit workspace inside the disposable smoke
+# directory. The override makes the test deterministic even when a host Java
+# process does not inherit the shell's changed working directory.
+timeout 90s java -Duser.home="${watcher_home}" \
+  -Dfrostguard.workspace="${watcher_workspace}" -jar "${watcher_jar}" \
   > "${watcher_log}" 2>&1
 watcher_status=$?
 set -e
@@ -154,8 +156,8 @@ if ! grep -q "telegram-watcher.properties" "${watcher_log}" \
   exit 1
 fi
 
-if [[ ! -f "${watcher_home}/.frostguard/telegram-watcher.properties" ]]; then
-  echo "::error::The watcher did not create its config template under user.home."
+if [[ ! -f "${watcher_workspace}/watcher/telegram-watcher.properties" ]]; then
+  echo "::error::The watcher did not create its config template in the development workspace."
   sed 's/^/    /' "${watcher_log}" | head -n 30
   exit 1
 fi

--- a/build-support/verification/test_verify_app_image.py
+++ b/build-support/verification/test_verify_app_image.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import verify_app_image  # noqa: E402
+
+
+class VerifyAppImageTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.image = Path(self.temp.name) / "Frostguard"
+        files = list(verify_app_image.REQUIRED_FILES) + [
+            "app/frostguard-desktop-3.0.0.jar",
+            "app/frostguard-watcher-3.0.0.jar",
+            "app/lib/opencv-4.9.0.jar",
+            "app/lib/tess4j-5.14.0.jar",
+            "app/lib/javafx-graphics-23.0.1-win.jar",
+            "app/templates/home/world.png",
+            "app/custom_tasks/shield.java",
+        ] + [f"app/lib/runtime-{index}.jar" for index in range(60)]
+        for relative in files:
+            path = self.image / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"payload")
+        common_options = "\n".join(verify_app_image.COMMON_JAVA_OPTIONS) + "\n"
+        (self.image / "app/Frostguard.cfg").write_text(
+            "app.mainclass=dev.frostguard.app.bootstrap.Main\n" + common_options,
+            encoding="utf-8")
+        (self.image / "app/FrostguardWatcher.cfg").write_text(
+            "app.mainclass=dev.frostguard.watcher.TelegramWatcher\n" + common_options,
+            encoding="utf-8")
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_accepts_complete_image(self):
+        self.assertEqual([], verify_app_image.inspect_image(self.image))
+
+    def test_rejects_missing_bundled_runtime(self):
+        (self.image / "runtime/bin/server/jvm.dll").unlink()
+        self.assertTrue(any("jvm.dll" in item for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_development_channel_launcher(self):
+        config = self.image / "app/Frostguard.cfg"
+        config.write_text(config.read_text().replace("channel=stable", "channel=development"))
+        self.assertTrue(any("channel=stable" in item for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_watcher_without_stable_channel(self):
+        config = self.image / "app/FrostguardWatcher.cfg"
+        config.write_text(config.read_text().replace("channel=stable", "channel=development"))
+        self.assertTrue(any("FrostguardWatcher.cfg" in item for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_runtime_data(self):
+        leaked = self.image / "app/logs/frostguard.log"
+        leaked.parent.mkdir(parents=True)
+        leaked.write_text("private runtime log")
+        self.assertTrue(any("leaked" in item for item in verify_app_image.inspect_image(self.image)))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/build-support/verification/verify_app_image.py
+++ b/build-support/verification/verify_app_image.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Verify a native Frostguard jpackage application image."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+MINIMUM_RUNTIME_JARS = 50
+REQUIRED_FILES = (
+    "Frostguard.exe",
+    "FrostguardWatcher.exe",
+    "runtime/bin/server/jvm.dll",
+    "app/Frostguard.cfg",
+    "app/FrostguardWatcher.cfg",
+    "app/lib/adb/adb.exe",
+    "app/lib/adb/AdbWinApi.dll",
+    "app/lib/adb/AdbWinUsbApi.dll",
+    "app/lib/tesseract/eng.traineddata",
+    "app/lib/tesseract/osd.traineddata",
+    "app/lib/tesseract/chi_sim.traineddata",
+)
+FORBIDDEN_NAMES = {
+    "frostguard-workspace.json",
+    "frostguard.db",
+    "telegram-watcher.properties",
+}
+COMMON_JAVA_OPTIONS = (
+    "java-options=-Dfrostguard.channel=stable",
+    "java-options=-Duser.dir=$APPDIR",
+    "java-options=-Dfrostguard.launcher=$APPDIR/../Frostguard.exe",
+    "java-options=-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe",
+)
+CONFIG_SETTINGS = {
+    "app/Frostguard.cfg": (
+        "app.mainclass=dev.frostguard.app.bootstrap.Main",
+        *COMMON_JAVA_OPTIONS,
+    ),
+    "app/FrostguardWatcher.cfg": (
+        "app.mainclass=dev.frostguard.watcher.TelegramWatcher",
+        *COMMON_JAVA_OPTIONS,
+    ),
+}
+
+
+def inspect_image(image: Path) -> list[str]:
+    problems: list[str] = []
+    if not image.is_dir():
+        return [f"Application image does not exist: {image}"]
+
+    files = {
+        path.relative_to(image).as_posix(): path
+        for path in image.rglob("*")
+        if path.is_file()
+    }
+    for required in REQUIRED_FILES:
+        if required not in files:
+            problems.append(f"Application image is missing {required}")
+
+    runtime_jars = [name for name in files if re.match(r"^app/lib/[^/]+\.jar$", name)]
+    if len(runtime_jars) < MINIMUM_RUNTIME_JARS:
+        problems.append(
+            f"Only {len(runtime_jars)} runtime JARs found; expected at least "
+            f"{MINIMUM_RUNTIME_JARS}"
+        )
+    for pattern, description in (
+        (r"^app/frostguard-desktop-[^/]+\.jar$", "desktop JAR"),
+        (r"^app/frostguard-watcher-[^/]+\.jar$", "watcher JAR"),
+        (r"^app/lib/opencv-[^/]+\.jar$", "OpenCV runtime"),
+        (r"^app/lib/tess4j-[^/]+\.jar$", "Tess4J runtime"),
+        (r"^app/lib/javafx-graphics-[^/]+-win\.jar$", "Windows JavaFX runtime"),
+        (r"^app/templates/.+\.png$", "template browser assets"),
+        (r"^app/custom_tasks/.+$", "custom task examples"),
+    ):
+        if not any(re.match(pattern, name) for name in files):
+            problems.append(f"Application image has no {description}")
+
+    for config_path, settings in CONFIG_SETTINGS.items():
+        if config_path not in files:
+            continue
+        config = files[config_path].read_text(encoding="utf-8")
+        for setting in settings:
+            if setting not in config:
+                problems.append(f"{Path(config_path).name} is missing: {setting}")
+
+    for relative in files:
+        path = Path(relative)
+        lower_name = path.name.lower()
+        if lower_name in FORBIDDEN_NAMES or lower_name.endswith((".db-wal", ".db-shm", ".log")):
+            problems.append(f"Runtime/user data leaked into the application image: {relative}")
+        if any(part.lower() in {".frostguard", ".frostguard-dev", "logs"} for part in path.parts):
+            problems.append(f"Runtime/user-data directory leaked into the application image: {relative}")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("image", type=Path)
+    args = parser.parse_args(argv)
+    problems = inspect_image(args.image)
+    if problems:
+        for problem in problems:
+            print(f"::error::{problem}")
+        return 1
+    print(f"Native application image verification passed: {args.image}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,9 +239,19 @@ with `./mvnw javafx:run`; its versioned JAR is not a standalone distribution.
 - executable jar: `modules/desktop/target/frostguard-desktop-<version>.jar`
 - transitional desktop zip: `packaging/desktop/target/frostguard-<version>-desktop-bundle.zip`
 - packaging inputs staged under `packaging/desktop/target/input`
+- Windows application image: `packaging/desktop/target/app-image/Frostguard`
+- Windows installer: versioned EXE under `packaging/desktop/target/installers`
 - ADB/Tesseract files staged from `tools/`
 - custom task examples staged from root `examples/custom-tasks/`
 - template PNGs staged from `modules/vision/src/main/resources/templates`
+
+The native Windows image contains the desktop and watcher launchers plus a
+`jlink` runtime. Both launchers receive the Stable channel and workspace
+contract through packaged JVM options. The watcher and Task Scheduler launch
+the native executables when those packaged launcher paths are present, with
+the Java/JAR paths retained only as the source and transitional-ZIP fallback.
+Native packaging is opt-in through Maven profiles so the normal reactor build
+stays platform-neutral.
 
 `modules/watcher` builds a separate shaded watcher jar.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,7 +134,18 @@ FXML and CSS resources live in `modules/desktop/src/main/resources/layout` and `
 
 ## Runtime Decomposition
 
-At runtime, one process contains the JavaFX app or headless bootstrap, shared singleton services, and one task queue per enabled profile.
+At runtime, one process owns one exclusive workspace, then contains the JavaFX
+app or headless bootstrap, shared singleton services, and one task queue per
+enabled profile. `WorkspaceSession` creates and locks the workspace before
+logging or persistence initializes. All mutable state is resolved through
+`WorkspacePaths`; the installation and caller working directory are read-only
+runtime inputs.
+
+Installed defaults are `~/.frostguard/workspaces/<channel>/<name>`. Source and
+IDE launches detected inside a repository use its ignored `.frostguard-dev/`
+workspace. SQLite, logs, custom tasks, diagnostic/cache output, and Telegram
+watcher configuration and locking belong to that selected workspace. The
+watcher passes the same workspace identity to any bot process it launches.
 
 ```mermaid
 sequenceDiagram

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -121,11 +121,19 @@ Run the application from the repository root through the same Maven Wrapper:
 On Windows Command Prompt, use `mvnw.cmd javafx:run`; in PowerShell, use
 `.\mvnw.cmd javafx:run`. The JavaFX goal compiles the required reactor modules
 and starts only the desktop module; developers do not need to locate a
-versioned JAR or assemble its classpath.
+versioned JAR or assemble its classpath. It automatically uses the ignored
+`.frostguard-dev/` workspace in that clone or worktree. No runtime argument is
+required, and simultaneous production and worktree runs do not share data.
+
+Installed runs use named workspaces below
+`%USERPROFILE%\.frostguard\workspaces\<channel>\<name>\`. Each workspace owns
+its database, configuration, logs, custom tasks, cache, Telegram watcher state,
+and process lock. A workspace can be opened by only one Frostguard process at a
+time; use a different workspace for another bot instance.
 
 ## Migrating an older installation
 
-Do not overwrite a new installation with an entire old Frostguard folder.
-Migration of legacy configuration and database files is not yet automated; keep
-a backup and copy individual `database.*` files only when intentionally carrying
-existing settings forward.
+Do not overwrite a new workspace with an entire old Frostguard folder. Frostguard
+3.0 does not migrate the legacy flat `.frostguard` watcher files or a 2.x
+database. Keep a backup and recreate settings; copy only reviewed custom-task
+source files into the new workspace.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,6 +15,10 @@ Stable and Nightly are public Windows desktop bundles. They require Java 21,
 but not Git, Git LFS, or Maven. Nightly may contain unfinished changes; PR
 builds additionally contain unmerged code.
 
+The self-contained Windows installer is being introduced for Frostguard 3.0.
+Until it is published through the release workflows, the download links above
+continue to provide the existing ZIP distribution.
+
 ## Install a downloaded build
 
 1. Install a Java 21 JDK, such as [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=21).
@@ -109,6 +113,35 @@ The build writes module artifacts below their respective `target` directories
 and the transitional desktop bundle ZIP below `packaging/desktop/target`. End
 users should extract the ZIP and launch `Start Frostguard.bat`; individual
 module JARs are not standalone distributions.
+
+### Build the native Windows package
+
+Native packages must be built on Windows. Build and smoke-test the
+self-contained application image with the JDK 21 `jpackage` tool:
+
+```powershell
+.\mvnw.cmd -Pwindows-app-image package
+python build-support/verification/verify_app_image.py packaging/desktop/target/app-image/Frostguard
+powershell -ExecutionPolicy Bypass -File build-support/verification/smoke_test_app_image.ps1 -ImagePath packaging/desktop/target/app-image/Frostguard
+```
+
+This produces
+`packaging/desktop/target/app-image/Frostguard/Frostguard.exe`. The image
+contains its Java runtime, so a machine running it does not need a separate
+JDK.
+
+Building the versioned installer additionally requires WiX Toolset 3.14.1 with
+`candle.exe` and `light.exe` on `PATH`:
+
+```powershell
+.\mvnw.cmd "-Pwindows-app-image,windows-installer" package
+```
+
+The installer is written below `packaging/desktop/target/installers`. It is a
+per-user installer and defaults to
+`%LOCALAPPDATA%\Frostguard`; the installer can offer another location.
+Normal `mvn package` remains platform-neutral and does not invoke `jpackage` or
+install Frostguard.
 
 ### Run a source build
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -66,6 +66,11 @@ For a source build, run from the repository root:
 .\mvnw.cmd javafx:run
 ```
 
+This automatically creates and uses `<worktree>\.frostguard-dev\`. Each
+worktree therefore has isolated database, logs, custom tasks, cache, and
+Telegram watcher state. `git clean -xdf` intentionally removes this disposable
+development workspace.
+
 For automatic startup through scripts or Task Scheduler:
 
 ```powershell

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -14,6 +14,9 @@ building from source.
 - Java JDK 21 or newer.
 - Git and Git LFS.
 
+WiX Toolset 3.14.1 is required only when producing the native EXE installer.
+Running an installed native build does not require a separately installed JDK.
+
 Recommended installs:
 
 ```powershell
@@ -41,6 +44,27 @@ Use the checked-in Maven Wrapper:
 The wrapper only builds the reactor. It does not stop running processes, install
 Frostguard, or mutate user data.
 
+To build a self-contained Windows application image:
+
+```powershell
+.\mvnw.cmd -Pwindows-app-image package
+python build-support/verification/verify_app_image.py packaging/desktop/target/app-image/Frostguard
+powershell -ExecutionPolicy Bypass -File build-support/verification/smoke_test_app_image.ps1 -ImagePath packaging/desktop/target/app-image/Frostguard
+```
+
+To build both the application image and a versioned per-user EXE installer,
+install WiX Toolset 3.14.1, ensure `candle.exe` and `light.exe` are on `PATH`,
+then run:
+
+```powershell
+.\mvnw.cmd "-Pwindows-app-image,windows-installer" package
+```
+
+Outputs remain below `packaging/desktop/target`: the directly runnable image is
+at `app-image/Frostguard`, and the installer is under `installers`. Native
+packaging is opt-in because it is Windows-specific; ordinary `mvn package`
+continues to build and test the platform-neutral reactor.
+
 ## Runtime Requirements
 
 Configure the emulator for a stable `720x1280` display at `320 DPI`. MuMu Player is recommended.
@@ -59,6 +83,12 @@ The application currently packages Windows ADB and Tesseract assets from `tools/
 After downloading a desktop bundle, extract the complete ZIP into an empty
 folder and double-click `Start Frostguard.bat`. The launcher locates the
 versioned application JAR and reports a clear error if Java 21 is missing.
+
+For a native Frostguard 3.0 build, run the installed `Frostguard.exe` instead.
+The per-user installer defaults to `%LOCALAPPDATA%\Frostguard`, while
+all mutable databases, configuration, logs, watcher state, and custom tasks
+remain in the selected workspace below `%USERPROFILE%\.frostguard`. The
+installation directory is treated as read-only application content.
 
 For a source build, run from the repository root:
 

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/RuntimeChannel.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/RuntimeChannel.java
@@ -1,0 +1,24 @@
+package dev.frostguard.api.runtime;
+
+import java.util.Locale;
+
+public enum RuntimeChannel {
+    DEVELOPMENT,
+    NIGHTLY,
+    STABLE;
+
+    public String directoryName() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    public static RuntimeChannel from(String value) {
+        if (value == null || value.isBlank()) {
+            return STABLE;
+        }
+        try {
+            return valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            throw new IllegalArgumentException("Unsupported Frostguard channel: " + value);
+        }
+    }
+}

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspacePaths.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspacePaths.java
@@ -1,0 +1,77 @@
+package dev.frostguard.api.runtime;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public record WorkspacePaths(Path root, RuntimeChannel channel) {
+    public static final String WORKSPACE_PROPERTY = "frostguard.workspace";
+    public static final String CHANNEL_PROPERTY = "frostguard.channel";
+
+    public WorkspacePaths {
+        root = root.toAbsolutePath().normalize();
+    }
+
+    public static WorkspacePaths current() {
+        String configuredChannel = System.getProperty(CHANNEL_PROPERTY);
+        if (configuredChannel == null || configuredChannel.isBlank()) {
+            configuredChannel = System.getenv("FROSTGUARD_CHANNEL");
+        }
+        String override = System.getProperty(WORKSPACE_PROPERTY);
+        if (override == null || override.isBlank()) {
+            override = System.getenv("FROSTGUARD_WORKSPACE");
+        }
+        Path developmentRoot = findDevelopmentRoot();
+        if ((override == null || override.isBlank()) && configuredChannel == null && developmentRoot != null) {
+            configuredChannel = RuntimeChannel.DEVELOPMENT.directoryName();
+            override = developmentRoot.resolve(".frostguard-dev").toString();
+        }
+        RuntimeChannel channel = RuntimeChannel.from(configuredChannel);
+        Path root = override == null || override.isBlank()
+                ? Path.of(System.getProperty("user.home"), ".frostguard", "workspaces",
+                        channel.directoryName(), "default")
+                : Path.of(override);
+        return new WorkspacePaths(root, channel);
+    }
+
+    private static Path findDevelopmentRoot() {
+        Path candidate = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        for (int depth = 0; candidate != null && depth < 6; depth++, candidate = candidate.getParent()) {
+            if (Files.isRegularFile(candidate.resolve("pom.xml"))
+                    && Files.isDirectory(candidate.resolve("modules").resolve("desktop"))) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    public Path marker() { return root.resolve("frostguard-workspace.json"); }
+    public Path database() { return root.resolve("frostguard.db"); }
+    public Path config() { return root.resolve("config"); }
+    public Path logs() { return root.resolve("logs"); }
+    public Path customTasks() { return root.resolve("custom-tasks"); }
+    public Path cache() { return root.resolve("cache"); }
+    public Path watcher() { return root.resolve("watcher"); }
+    public Path watcherConfig() { return watcher().resolve("telegram-watcher.properties"); }
+    public Path watcherLock() { return watcher().resolve("watcher.lock"); }
+    public Path applicationLock() { return root.resolve("frostguard.lock"); }
+
+    public String identity() {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest((channel.directoryName() + "\n" + root)
+                    .getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is not available", impossible);
+        }
+    }
+
+    public int defaultLocalPort() {
+        long prefix = Long.parseUnsignedLong(identity().substring(0, 8), 16);
+        return 20_000 + (int) (prefix % 40_000);
+    }
+}

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
@@ -20,8 +20,8 @@ public final class WorkspaceSession implements AutoCloseable {
     }
 
     public static WorkspaceSession open(WorkspacePaths paths) {
+        initializeLayout(paths);
         try {
-            createLayout(paths);
             FileChannel channel = FileChannel.open(paths.applicationLock(),
                     StandardOpenOption.CREATE, StandardOpenOption.WRITE);
             FileLock lock;
@@ -37,6 +37,14 @@ public final class WorkspaceSession implements AutoCloseable {
             System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, paths.root().toString());
             System.setProperty("frostguard.log.dir", paths.logs().toString());
             return new WorkspaceSession(paths, channel, lock);
+        } catch (IOException cause) {
+            throw new IllegalStateException("Could not initialize Frostguard workspace: " + paths.root(), cause);
+        }
+    }
+
+    public static void initializeLayout(WorkspacePaths paths) {
+        try {
+            createLayout(paths);
         } catch (IOException cause) {
             throw new IllegalStateException("Could not initialize Frostguard workspace: " + paths.root(), cause);
         }

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
@@ -1,0 +1,85 @@
+package dev.frostguard.api.runtime;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+public final class WorkspaceSession implements AutoCloseable {
+    private final WorkspacePaths paths;
+    private final FileChannel lockChannel;
+    private final FileLock lock;
+
+    private WorkspaceSession(WorkspacePaths paths, FileChannel lockChannel, FileLock lock) {
+        this.paths = paths;
+        this.lockChannel = lockChannel;
+        this.lock = lock;
+    }
+
+    public static WorkspaceSession open(WorkspacePaths paths) {
+        try {
+            createLayout(paths);
+            FileChannel channel = FileChannel.open(paths.applicationLock(),
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            FileLock lock;
+            try {
+                lock = channel.tryLock();
+            } catch (OverlappingFileLockException alreadyLocked) {
+                lock = null;
+            }
+            if (lock == null) {
+                channel.close();
+                throw new IllegalStateException("Frostguard workspace is already in use: " + paths.root());
+            }
+            System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, paths.root().toString());
+            System.setProperty("frostguard.log.dir", paths.logs().toString());
+            return new WorkspaceSession(paths, channel, lock);
+        } catch (IOException cause) {
+            throw new IllegalStateException("Could not initialize Frostguard workspace: " + paths.root(), cause);
+        }
+    }
+
+    private static void createLayout(WorkspacePaths paths) throws IOException {
+        Files.createDirectories(paths.root());
+        Files.createDirectories(paths.config());
+        Files.createDirectories(paths.logs());
+        Files.createDirectories(paths.customTasks());
+        Files.createDirectories(paths.cache());
+        Files.createDirectories(paths.watcher());
+        if (Files.exists(paths.marker())) {
+            String marker = Files.readString(paths.marker(), StandardCharsets.UTF_8);
+            String expectedChannel = "\"channel\": \"" + paths.channel().directoryName() + "\"";
+            if (!marker.contains(expectedChannel)) {
+                throw new IllegalStateException("Workspace channel does not match "
+                        + paths.channel().directoryName() + ": " + paths.root());
+            }
+        } else {
+            String name = paths.root().getFileName().toString().replace("\\", "\\\\").replace("\"", "\\\"");
+            String json = "{\n"
+                    + "  \"schemaVersion\": 1,\n"
+                    + "  \"name\": \"" + name + "\",\n"
+                    + "  \"channel\": \"" + paths.channel().directoryName() + "\"\n"
+                    + "}\n";
+            Files.writeString(paths.marker(), json, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
+        }
+    }
+
+    public WorkspacePaths paths() {
+        return paths;
+    }
+
+    @Override
+    public void close() {
+        try {
+            lock.release();
+        } catch (IOException ignored) {
+        }
+        try {
+            lockChannel.close();
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
@@ -1,0 +1,106 @@
+package dev.frostguard.api.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WorkspaceSessionTest {
+    @TempDir
+    Path tempDir;
+
+    private String previousWorkspace;
+    private String previousLogDir;
+
+    @BeforeEach
+    void rememberRuntimeProperties() {
+        previousWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        previousLogDir = System.getProperty("frostguard.log.dir");
+    }
+
+    @AfterEach
+    void restoreRuntimeProperties() {
+        restore(WorkspacePaths.WORKSPACE_PROPERTY, previousWorkspace);
+        restore("frostguard.log.dir", previousLogDir);
+    }
+
+    @Test
+    void createsACompleteWorkspaceAndRejectsConcurrentUse() {
+        WorkspacePaths paths = new WorkspacePaths(tempDir.resolve("bot-1"), RuntimeChannel.STABLE);
+
+        try (WorkspaceSession ignored = WorkspaceSession.open(paths)) {
+            assertTrue(paths.marker().toFile().isFile());
+            assertTrue(paths.config().toFile().isDirectory());
+            assertTrue(paths.logs().toFile().isDirectory());
+            assertTrue(paths.customTasks().toFile().isDirectory());
+            assertTrue(paths.cache().toFile().isDirectory());
+            assertTrue(paths.watcher().toFile().isDirectory());
+            assertThrows(IllegalStateException.class, () -> WorkspaceSession.open(paths));
+        }
+    }
+
+    @Test
+    void derivesDefaultPortsAndIdentitiesFromTheWorkspace() {
+        WorkspacePaths first = new WorkspacePaths(tempDir.resolve("bot-1"), RuntimeChannel.STABLE);
+        WorkspacePaths second = new WorkspacePaths(tempDir.resolve("bot-2"), RuntimeChannel.STABLE);
+
+        assertTrue(first.defaultLocalPort() >= 20_000 && first.defaultLocalPort() < 60_000);
+        assertTrue(second.defaultLocalPort() >= 20_000 && second.defaultLocalPort() < 60_000);
+        assertNotEquals(first.identity(), second.identity());
+    }
+
+    @Test
+    void derivesIdentityIndependentlyOfJavaStringHashCollisions() {
+        WorkspacePaths first = new WorkspacePaths(tempDir.resolve("Aa"), RuntimeChannel.STABLE);
+        WorkspacePaths second = new WorkspacePaths(tempDir.resolve("BB"), RuntimeChannel.STABLE);
+
+        assertEquals(first.root().toString().hashCode(), second.root().toString().hashCode());
+        assertNotEquals(first.identity(), second.identity());
+    }
+
+    @Test
+    void rejectsOpeningAWorkspaceWithAnotherChannelIdentity() {
+        Path root = tempDir.resolve("shared");
+        try (WorkspaceSession ignored = WorkspaceSession.open(
+                new WorkspacePaths(root, RuntimeChannel.STABLE))) {
+            // Marker is persisted while the first channel owns the workspace.
+        }
+
+        assertThrows(IllegalStateException.class, () -> WorkspaceSession.open(
+                new WorkspacePaths(root, RuntimeChannel.NIGHTLY)));
+    }
+
+    @Test
+    void resolvesNamedChannelWorkspaceByDefault() {
+        String oldHome = System.getProperty("user.home");
+        String oldChannel = System.getProperty(WorkspacePaths.CHANNEL_PROPERTY);
+        String oldWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        try {
+            System.setProperty("user.home", tempDir.toString());
+            System.setProperty(WorkspacePaths.CHANNEL_PROPERTY, "nightly");
+            System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+
+            assertEquals(tempDir.resolve(".frostguard/workspaces/nightly/default").toAbsolutePath(),
+                    WorkspacePaths.current().root());
+        } finally {
+            restore("user.home", oldHome);
+            restore(WorkspacePaths.CHANNEL_PROPERTY, oldChannel);
+            restore(WorkspacePaths.WORKSPACE_PROPERTY, oldWorkspace);
+        }
+    }
+
+    private static void restore(String property, String value) {
+        if (value == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, value);
+        }
+    }
+}

--- a/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
@@ -47,6 +47,18 @@ class WorkspaceSessionTest {
     }
 
     @Test
+    void initializesACompanionWorkspaceWithoutTakingTheApplicationLock() {
+        WorkspacePaths paths = new WorkspacePaths(tempDir.resolve("watcher-only"), RuntimeChannel.STABLE);
+
+        WorkspaceSession.initializeLayout(paths);
+
+        assertTrue(paths.marker().toFile().isFile());
+        try (WorkspaceSession ignored = WorkspaceSession.open(paths)) {
+            assertTrue(paths.applicationLock().toFile().isFile());
+        }
+    }
+
+    @Test
     void derivesDefaultPortsAndIdentitiesFromTheWorkspace() {
         WorkspacePaths first = new WorkspacePaths(tempDir.resolve("bot-1"), RuntimeChannel.STABLE);
         WorkspacePaths second = new WorkspacePaths(tempDir.resolve("bot-2"), RuntimeChannel.STABLE);

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -55,6 +55,7 @@ import dev.frostguard.vision.convert.GameTimeUtils;
 public class TaskQueue {
 
     private static final Logger logger = LoggerFactory.getLogger(TaskQueue.class);
+    private static final String APP_LAUNCHER_PROPERTY = "frostguard.launcher";
     private static final long   TICK_INTERVAL_MS = 999L;
     protected static final DateTimeFormatter TS_FMT =
             DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss");
@@ -808,18 +809,16 @@ public class TaskQueue {
             if (wake.isBefore(LocalDateTime.now())) wake = LocalDateTime.now().plusMinutes(1);
             String tm = DateTimeFormatter.ofPattern("HH:mm").format(wake);
             String dt = DateTimeFormatter.ofPattern("MM/dd/yyyy").format(wake);
-            String jar = resolveDesktopJarForAutostart();
             WorkspacePaths workspace = WorkspacePaths.current();
+            java.nio.file.Path runtimeCache = workspace.cache().resolve("runtime");
+            java.nio.file.Files.createDirectories(runtimeCache);
+            String taskCommand = resolveAutostartCommand(workspace, runtimeCache);
             String scheduledTaskName = "Frostguard_AutoStart_"
                     + Integer.toUnsignedString(workspace.root().toString().hashCode(), 36);
             new ProcessBuilder("schtasks","/create","/TN",scheduledTaskName,"/TR",
-                    "javaw.exe -D" + WorkspacePaths.WORKSPACE_PROPERTY + "=\"" + workspace.root()
-                            + "\" -D" + WorkspacePaths.CHANNEL_PROPERTY + "=" + workspace.channel().directoryName()
-                            + " -jar \""+jar+"\" --autostart",
+                    taskCommand,
                     "/SC","ONCE","/ST",tm,"/SD",dt,"/RL","HIGHEST","/F")
                     .redirectErrorStream(true).start().waitFor();
-            java.nio.file.Path runtimeCache = workspace.cache().resolve("runtime");
-            java.nio.file.Files.createDirectories(runtimeCache);
             java.nio.file.Path ws = runtimeCache.resolve("fg_wake.ps1");
             java.nio.file.Files.writeString(ws,
                     "$s=New-ScheduledTaskSettingsSet -WakeToRun -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -Priority 1\n"+
@@ -837,6 +836,36 @@ public class TaskQueue {
 
     private String resolveDesktopJarForAutostart() throws java.io.IOException {
         return resolveDesktopJarForAutostart(java.nio.file.Path.of(System.getProperty("user.dir")));
+    }
+
+    private String resolveAutostartCommand(WorkspacePaths workspace, java.nio.file.Path runtimeCache)
+            throws java.io.IOException {
+        String nativeLauncher = System.getProperty(APP_LAUNCHER_PROPERTY, "").trim();
+        if (!nativeLauncher.isBlank()) {
+            java.nio.file.Path launcher = java.nio.file.Path.of(nativeLauncher).toAbsolutePath().normalize();
+            if (java.nio.file.Files.isRegularFile(launcher)) {
+                java.nio.file.Path wrapper = runtimeCache.resolve("frostguard-autostart.cmd");
+                java.nio.file.Files.writeString(wrapper,
+                        nativeAutostartLauncherContent(launcher, workspace));
+                return "\"" + wrapper + "\"";
+            }
+        }
+        String jar = resolveDesktopJarForAutostart();
+        return "javaw.exe -D" + WorkspacePaths.WORKSPACE_PROPERTY + "=\"" + workspace.root()
+                + "\" -D" + WorkspacePaths.CHANNEL_PROPERTY + "=" + workspace.channel().directoryName()
+                + " -jar \"" + jar + "\" --autostart";
+    }
+
+    static String nativeAutostartLauncherContent(java.nio.file.Path launcher, WorkspacePaths workspace) {
+        return "@echo off\r\n"
+                + "setlocal DisableDelayedExpansion\r\n"
+                + "set \"FROSTGUARD_WORKSPACE=" + escapeBatchValue(workspace.root().toString()) + "\"\r\n"
+                + "set \"FROSTGUARD_CHANNEL=" + workspace.channel().directoryName() + "\"\r\n"
+                + "start \"\" \"" + escapeBatchValue(launcher.toString()) + "\" --autostart\r\n";
+    }
+
+    private static String escapeBatchValue(String value) {
+        return value.replace("^", "^^").replace("%", "%%");
     }
 
     static String resolveDesktopJarForAutostart(java.nio.file.Path workingDirectory)

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -1,5 +1,7 @@
 package dev.frostguard.engine.schedule;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -807,16 +809,24 @@ public class TaskQueue {
             String tm = DateTimeFormatter.ofPattern("HH:mm").format(wake);
             String dt = DateTimeFormatter.ofPattern("MM/dd/yyyy").format(wake);
             String jar = resolveDesktopJarForAutostart();
-            new ProcessBuilder("schtasks","/create","/TN","Frostguard_AutoStart","/TR",
-                    "javaw.exe -jar \""+jar+"\" --autostart","/SC","ONCE","/ST",tm,"/SD",dt,"/RL","HIGHEST","/F")
+            WorkspacePaths workspace = WorkspacePaths.current();
+            String scheduledTaskName = "Frostguard_AutoStart_"
+                    + Integer.toUnsignedString(workspace.root().toString().hashCode(), 36);
+            new ProcessBuilder("schtasks","/create","/TN",scheduledTaskName,"/TR",
+                    "javaw.exe -D" + WorkspacePaths.WORKSPACE_PROPERTY + "=\"" + workspace.root()
+                            + "\" -D" + WorkspacePaths.CHANNEL_PROPERTY + "=" + workspace.channel().directoryName()
+                            + " -jar \""+jar+"\" --autostart",
+                    "/SC","ONCE","/ST",tm,"/SD",dt,"/RL","HIGHEST","/F")
                     .redirectErrorStream(true).start().waitFor();
-            java.nio.file.Path ws = java.nio.file.Paths.get(System.getProperty("user.dir"),"fg_wake.ps1");
+            java.nio.file.Path runtimeCache = workspace.cache().resolve("runtime");
+            java.nio.file.Files.createDirectories(runtimeCache);
+            java.nio.file.Path ws = runtimeCache.resolve("fg_wake.ps1");
             java.nio.file.Files.writeString(ws,
                     "$s=New-ScheduledTaskSettingsSet -WakeToRun -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -Priority 1\n"+
-                    "Set-ScheduledTask -TaskName 'Frostguard_AutoStart' -Settings $s\n");
+                    "Set-ScheduledTask -TaskName '" + scheduledTaskName + "' -Settings $s\n");
             new ProcessBuilder("powershell.exe","-NoProfile","-ExecutionPolicy","Bypass","-File",ws.toString())
                     .redirectErrorStream(true).start().waitFor();
-            java.nio.file.Path ss = java.nio.file.Paths.get(System.getProperty("user.dir"),"fg_sleep.ps1");
+            java.nio.file.Path ss = runtimeCache.resolve("fg_sleep.ps1");
             java.nio.file.Files.writeString(ss,
                     "Start-Sleep -Seconds 2\nAdd-Type -AssemblyName System.Windows.Forms\n"+
                     "[System.Windows.Forms.Application]::SetSuspendState('Suspend',$false,$false)\n");

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/CustomTaskService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/CustomTaskService.java
@@ -1,5 +1,7 @@
 package dev.frostguard.engine.service;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.engine.schedule.CustomTaskConfigurable;
@@ -155,7 +157,7 @@ public class CustomTaskService {
     // ========================================================================
 
     private CustomTaskService() {
-        compiledDir = Paths.get(System.getProperty("user.dir"), "custom_tasks");
+        compiledDir = WorkspacePaths.current().customTasks();
         jsonFile = compiledDir.resolve("custom_tasks.json");
         try {
             Files.createDirectories(compiledDir);

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
@@ -10,6 +10,7 @@ import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.AutomationBlueprint;
 import dev.frostguard.api.domain.AutomationStep;
+import dev.frostguard.api.runtime.WorkspacePaths;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -23,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Service that manages a Task Builder recording session.
@@ -52,7 +52,7 @@ public class TaskBuilderService {
 
     public TaskBuilderService() {
         this.emuManager = EmulatorController.getInstance();
-        this.customTasksDir = Paths.get(System.getProperty("user.dir"), "custom_tasks");
+        this.customTasksDir = WorkspacePaths.current().customTasks();
         this.mapper = new ObjectMapper()
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramBotService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramBotService.java
@@ -1,5 +1,7 @@
 package dev.frostguard.engine.service;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
@@ -14,7 +16,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Properties;
 
 import javax.imageio.ImageIO;
@@ -54,8 +55,6 @@ import java.util.ArrayList;
  * /status → reply with current running state
  */
 public class TelegramBotService implements BotStateListener {
-
-    static final String CURRENT_LOG_PATH = "log/frostguard.log";
 
     private static final Logger logger = LoggerFactory.getLogger(TelegramBotService.class);
     private static final String API_BASE = "https://api.telegram.org/bot";
@@ -147,17 +146,18 @@ public class TelegramBotService implements BotStateListener {
     /** Read localPort from the shared watcher properties file (default 8765). */
     private static int readLocalPort() {
         try {
-            Path cfg = Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+            Path cfg = WorkspacePaths.current().watcherConfig();
             if (Files.exists(cfg)) {
                 Properties props = new Properties();
                 try (FileInputStream fis = new FileInputStream(cfg.toFile())) { props.load(fis); }
-                return Integer.parseInt(props.getProperty("localPort", "8765").trim());
+                return Integer.parseInt(props.getProperty("localPort",
+                        String.valueOf(WorkspacePaths.current().defaultLocalPort())).trim());
             }
         } catch (Exception e) {
             LoggerFactory.getLogger(TelegramBotService.class)
                     .warn("Could not read localPort from config, defaulting to 8765: {}", e.getMessage());
         }
-        return 8765;
+        return WorkspacePaths.current().defaultLocalPort();
     }
 
     // ── public command dispatch (called by WatcherCommandServer) ─────────────
@@ -852,7 +852,7 @@ public class TelegramBotService implements BotStateListener {
                 }
                 case "log_dl" -> {
                     answerCallbackQuery(callbackId, "📥 Downloading...");
-                    sendDocument(chatId, CURRENT_LOG_PATH);
+                    sendDocument(chatId, currentLogPath().toString());
                 }
                 default -> answerCallbackQuery(callbackId, "");
             }
@@ -1208,6 +1208,10 @@ public class TelegramBotService implements BotStateListener {
         markup.set("inline_keyboard", kb);
 
         sendOrEditMessage(chatId, -1L, text, markup, "MarkdownV2");
+    }
+
+    static Path currentLogPath() {
+        return WorkspacePaths.current().logs().resolve("frostguard.log");
     }
 
     private void sendDocument(long chatId, String filePath) {

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 public class TelegramWatcherLauncher {
 
     private static final Logger logger = LoggerFactory.getLogger(TelegramWatcherLauncher.class);
+    private static final String WATCHER_LAUNCHER_PROPERTY = "frostguard.watcher.launcher";
 
     public static void startWatcherIfNotRunning() {
         if (isWatcherRunning()) {
@@ -26,19 +27,21 @@ public class TelegramWatcherLauncher {
         }
 
         logger.info("Telegram Watcher is not running. Attempting to start it...");
-        File batFile = resolveBatFile();
+        File launcher = resolveLauncher();
 
-        if (batFile != null && batFile.exists()) {
+        if (launcher != null && launcher.exists()) {
             try {
-                ProcessBuilder pb = new ProcessBuilder("cmd", "/c", "start", "\"FG-TG-Watcher\"", "/b", batFile.getName());
-                pb.directory(batFile.getParentFile());
+                ProcessBuilder pb = isNativeLauncher(launcher)
+                        ? new ProcessBuilder(launcher.getAbsolutePath())
+                        : new ProcessBuilder("cmd", "/c", "start", "\"FG-TG-Watcher\"", "/b", launcher.getName());
+                pb.directory(launcher.getParentFile());
                 pb.environment().put("FROSTGUARD_WORKSPACE", WorkspacePaths.current().root().toString());
                 pb.environment().put("FROSTGUARD_CHANNEL",
                         WorkspacePaths.current().channel().directoryName());
                 pb.start();
-                logger.info("Executed {}", batFile.getAbsolutePath());
+                logger.info("Executed {}", launcher.getAbsolutePath());
             } catch (IOException e) {
-                logger.error("Failed to start Telegram Watcher bat file", e);
+                logger.error("Failed to start Telegram Watcher launcher", e);
             }
         } else {
             logger.warn("Could not locate the Telegram Watcher launcher.");
@@ -63,7 +66,14 @@ public class TelegramWatcherLauncher {
         }
     }
 
-    private static File resolveBatFile() {
+    private static File resolveLauncher() {
+        String packagedLauncher = System.getProperty(WATCHER_LAUNCHER_PROPERTY, "").trim();
+        if (!packagedLauncher.isBlank()) {
+            File launcher = new File(packagedLauncher);
+            if (launcher.isFile()) {
+                return launcher;
+            }
+        }
         // Try to load the jar path from the active workspace.
         try {
             Path cfg = WorkspacePaths.current().watcherConfig();
@@ -99,5 +109,9 @@ public class TelegramWatcherLauncher {
         }
 
         return null;
+    }
+
+    private static boolean isNativeLauncher(File launcher) {
+        return launcher.getName().toLowerCase(java.util.Locale.ROOT).endsWith(".exe");
     }
 }

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
@@ -1,10 +1,15 @@
 package dev.frostguard.engine.service;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.StandardOpenOption;
 import java.util.Properties;
 
 import org.slf4j.Logger;
@@ -27,6 +32,9 @@ public class TelegramWatcherLauncher {
             try {
                 ProcessBuilder pb = new ProcessBuilder("cmd", "/c", "start", "\"FG-TG-Watcher\"", "/b", batFile.getName());
                 pb.directory(batFile.getParentFile());
+                pb.environment().put("FROSTGUARD_WORKSPACE", WorkspacePaths.current().root().toString());
+                pb.environment().put("FROSTGUARD_CHANNEL",
+                        WorkspacePaths.current().channel().directoryName());
                 pb.start();
                 logger.info("Executed {}", batFile.getAbsolutePath());
             } catch (IOException e) {
@@ -38,29 +46,27 @@ public class TelegramWatcherLauncher {
     }
 
     private static boolean isWatcherRunning() {
+        Path lockPath = WorkspacePaths.current().watcherLock();
         try {
-            return ProcessHandle.allProcesses()
-                    .filter(ph -> ph.info().command().map(c -> c.toLowerCase().contains("java")).orElse(false))
-                    .filter(ph -> ph.info().arguments().map(args -> {
-                        for (String a : args) {
-                            if (a.toLowerCase().contains("frostguard-watcher")) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    }).orElse(false))
-                    .findFirst()
-                    .isPresent();
+            Files.createDirectories(lockPath.getParent());
+            try (FileChannel channel = FileChannel.open(lockPath,
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+                try (FileLock lock = channel.tryLock()) {
+                    return lock == null;
+                } catch (OverlappingFileLockException lockedInThisProcess) {
+                    return true;
+                }
+            }
         } catch (Exception e) {
-            logger.error("Error checking if watcher is running", e);
+            logger.warn("Could not inspect watcher lock {}: {}", lockPath, e.getMessage());
             return false;
         }
     }
 
     private static File resolveBatFile() {
-        // Try to load the jar path from ~/.frostguard/telegram-watcher.properties
+        // Try to load the jar path from the active workspace.
         try {
-            Path cfg = Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+            Path cfg = WorkspacePaths.current().watcherConfig();
             if (Files.exists(cfg)) {
                 Properties props = new Properties();
                 try (java.io.FileInputStream fis = new java.io.FileInputStream(cfg.toFile())) {

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/WatcherCommandServer.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/WatcherCommandServer.java
@@ -7,6 +7,8 @@ import com.sun.net.httpserver.HttpServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
@@ -33,11 +35,13 @@ public class WatcherCommandServer {
     private final int               port;
     private final TelegramBotService botService;
     private final ObjectMapper       mapper = new ObjectMapper();
+    private final String             workspaceId;
     private HttpServer               server;
 
     public WatcherCommandServer(int port, TelegramBotService botService) {
         this.port       = port;
         this.botService = botService;
+        this.workspaceId = WorkspacePaths.current().identity();
     }
 
     public void start() throws IOException {
@@ -72,10 +76,20 @@ public class WatcherCommandServer {
         try {
             String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
             JsonNode req  = mapper.readTree(body);
+            if (!workspaceId.equals(req.path("workspaceId").asText())) {
+                responseBytes = "{\"ok\":false,\"error\":\"workspace mismatch\"}"
+                        .getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(409, responseBytes.length);
+                exchange.getResponseBody().write(responseBytes);
+                exchange.close();
+                return;
+            }
             String   type = req.path("type").asText("message");
             long   chatId = req.path("chatId").asLong(-1);
 
-            if ("callback".equals(type)) {
+            if ("ping".equals(type)) {
+                // Identity validation above is the complete ping operation.
+            } else if ("callback".equals(type)) {
                 String callbackId = req.path("callbackId").asText("");
                 long   messageId  = req.path("messageId").asLong(-1);
                 String data       = req.path("data").asText("noop");
@@ -110,8 +124,10 @@ public class WatcherCommandServer {
         }
 
         try {
-            long pid = ProcessHandle.current().pid();
-            String response = "{\"pid\":" + pid + "}";
+            String response = mapper.createObjectNode()
+                    .put("pid", ProcessHandle.current().pid())
+                    .put("workspaceId", workspaceId)
+                    .toString();
             byte[] responseBytes = response.getBytes(StandardCharsets.UTF_8);
             exchange.sendResponseHeaders(200, responseBytes.length);
             exchange.getResponseBody().write(responseBytes);

--- a/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueDesktopJarResolutionTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueDesktopJarResolutionTest.java
@@ -2,6 +2,7 @@ package dev.frostguard.engine.schedule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -9,6 +10,9 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 class TaskQueueDesktopJarResolutionTest {
 
@@ -38,5 +42,17 @@ class TaskQueueDesktopJarResolutionTest {
     void rejectsWorkingDirectoryWithoutDesktopArtifact() {
         assertThrows(IOException.class,
                 () -> TaskQueue.resolveDesktopJarForAutostart(tempDir));
+    }
+
+    @Test
+    void nativeAutostartWrapperPreservesTheWorkspace() {
+        Path launcher = tempDir.resolve("Frostguard.exe").toAbsolutePath();
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("Bot 1"), RuntimeChannel.STABLE);
+
+        String script = TaskQueue.nativeAutostartLauncherContent(launcher, workspace);
+
+        assertTrue(script.contains("set \"FROSTGUARD_WORKSPACE=" + workspace.root() + "\""));
+        assertTrue(script.contains("set \"FROSTGUARD_CHANNEL=stable\""));
+        assertTrue(script.contains("start \"\" \"" + launcher + "\" --autostart"));
     }
 }

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.io.TempDir;
 import dev.frostguard.api.configs.FlowStepKind;
 import dev.frostguard.api.domain.AutomationBlueprint;
 import dev.frostguard.api.domain.AutomationStep;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 class TaskBuilderServiceTest {
 
@@ -20,8 +21,8 @@ class TaskBuilderServiceTest {
 
     @Test
     void savesBuilderJsonAndGeneratedJavaBesideIt() throws Exception {
-        String originalUserDir = System.getProperty("user.dir");
-        System.setProperty("user.dir", tempDir.toString());
+        String originalWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
         try {
             TaskBuilderService service = new TaskBuilderService();
             service.startSession("Expert Idle Exploration", "0");
@@ -31,7 +32,7 @@ class TaskBuilderServiceTest {
             step.setParam("durationMs", "200");
             service.addNode(step);
 
-            Path builderFile = tempDir.resolve("custom_tasks").resolve("expert_idle_exploration.json");
+            Path builderFile = tempDir.resolve("custom-tasks").resolve("expert_idle_exploration.json");
             TaskBuilderService.CustomTaskSaveResult saved =
                     service.saveCurrentTaskToCustomTasks("Expert Idle Exploration", builderFile);
 
@@ -47,7 +48,11 @@ class TaskBuilderServiceTest {
             assertEquals("Pause before bag", loaded.getNodes().get(0).getNodeName());
             assertEquals("1", service.getActiveEmulatorNumber());
         } finally {
-            System.setProperty("user.dir", originalUserDir);
+            if (originalWorkspace == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, originalWorkspace);
+            }
         }
     }
 }

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/TelegramBotServiceTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/TelegramBotServiceTest.java
@@ -1,13 +1,20 @@
 package dev.frostguard.engine.service;
 
 import dev.frostguard.api.configs.TpDailyTaskEnum;
+import dev.frostguard.api.runtime.WorkspacePaths;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TelegramBotServiceTest {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void standardQueueExcludesCustomTaskPlaceholder() {
@@ -16,7 +23,18 @@ class TelegramBotServiceTest {
     }
 
     @Test
-    void logDownloadUsesConfiguredFrostguardLogName() {
-        assertEquals("log/frostguard.log", TelegramBotService.CURRENT_LOG_PATH);
+    void logDownloadUsesTheSelectedWorkspace() {
+        String previous = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        try {
+            System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+            assertEquals(tempDir.resolve("logs/frostguard.log").toAbsolutePath(),
+                    TelegramBotService.currentLogPath());
+        } finally {
+            if (previous == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, previous);
+            }
+        }
     }
 }

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/WatcherCommandServerTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/WatcherCommandServerTest.java
@@ -1,0 +1,72 @@
+package dev.frostguard.engine.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+class WatcherCommandServerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void rejectsCommandsFromAnotherWorkspaceAndIdentifiesItsPid() throws Exception {
+        String previous = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        WatcherCommandServer server = null;
+        try {
+            System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+            int port;
+            try (ServerSocket availablePort = new ServerSocket(0)) {
+                port = availablePort.getLocalPort();
+            }
+
+            server = new WatcherCommandServer(port, null);
+            server.start();
+            HttpClient client = HttpClient.newHttpClient();
+
+            HttpResponse<String> mismatch = client.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/command"))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(
+                            "{\"type\":\"ping\",\"workspaceId\":\"another-workspace\"}"))
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            assertEquals(409, mismatch.statusCode());
+
+            String workspaceId = WorkspacePaths.current().identity();
+            HttpResponse<String> matching = client.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/command"))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(
+                            "{\"type\":\"ping\",\"workspaceId\":\"" + workspaceId + "\"}"))
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, matching.statusCode());
+
+            HttpResponse<String> pid = client.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/pid"))
+                    .GET()
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, pid.statusCode());
+            assertTrue(pid.body().contains("\"workspaceId\":\"" + workspaceId + "\""));
+        } finally {
+            if (server != null) {
+                server.stop();
+            }
+            if (previous == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, previous);
+            }
+        }
+    }
+}

--- a/modules/desktop/pom.xml
+++ b/modules/desktop/pom.xml
@@ -131,6 +131,8 @@
 					<runtimePathOption>CLASSPATH</runtimePathOption>
 					<options>
 						<option>--enable-native-access=ALL-UNNAMED</option>
+						<option>-Dfrostguard.channel=development</option>
+						<option>-Dfrostguard.workspace=${maven.multiModuleProjectDirectory}/.frostguard-dev</option>
 					</options>
 				</configuration>
 			</plugin>

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
@@ -15,6 +15,14 @@ public class Main {
 
 	public static void main(String[] args) {
 		try {
+			if (java.util.Arrays.asList(args).contains("--frostguard-native-smoke-test")) {
+				System.out.println("Frostguard native launcher smoke test passed");
+				System.out.println("channel=" + WORKSPACE.paths().channel().directoryName());
+				System.out.println("workspace=" + WORKSPACE.paths().root());
+				System.out.println("applicationDir=" + System.getProperty("user.dir"));
+				WORKSPACE.close();
+				return;
+			}
 			boolean isHeadless = false;
 			for (String arg : args) {
 				if ("--headless".equalsIgnoreCase(arg)) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
@@ -3,11 +3,14 @@ package dev.frostguard.app.bootstrap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.api.runtime.WorkspaceSession;
 import dev.frostguard.engine.service.AnalyticsService;
 import dev.frostguard.tasks.TaskRegistrations;
 import dev.frostguard.vision.logging.ProfileContextLogger;
 
 public class Main {
+	private static final WorkspaceSession WORKSPACE = WorkspaceSession.open(WorkspacePaths.current());
 	private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
 	public static void main(String[] args) {
@@ -27,13 +30,14 @@ public class Main {
 			java.util.logging.Logger.getLogger("com.sun.javafx").setLevel(java.util.logging.Level.SEVERE);
 			java.util.logging.Logger.getLogger("javax.swing").setLevel(java.util.logging.Level.SEVERE);
 
-			logger.info("Initializing Frostguard...");
+			logger.info("Initializing Frostguard with workspace {}", WORKSPACE.paths().root());
 
 			// 2. Setup Shutdown Hook
 			Runtime.getRuntime().addShutdownHook(new Thread(() -> {
 				logger.info("Closing down subsystems.");
 				try { AnalyticsService.getInstance().trackAppShutdown(); } catch (Exception ignored) {}
 				ProfileContextLogger.shutdown();
+				WORKSPACE.close();
 			}, "frostguard-shutdown"));
 
 			// 3. Initialize Services

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/console/ConsoleLogLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/console/ConsoleLogLayoutController.java
@@ -1,5 +1,7 @@
 package dev.frostguard.app.panel.console;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.awt.Desktop;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -111,7 +113,7 @@ public class ConsoleLogLayoutController implements ProfileDataChangeListener {
 	@FXML
 	void handleButtonOpenLogFolder(ActionEvent event) {
 		try {
-			Path logsDir = Path.of("log");
+			Path logsDir = WorkspacePaths.current().logs();
 			Files.createDirectories(logsDir);
 			Desktop.getDesktop().open(logsDir.toFile());
 		} catch (IOException e) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
@@ -64,6 +64,7 @@ public class TelegramLayoutController {
 
     /** Shortcut name placed in the Windows Startup folder. */
     private static final String SHORTCUT_NAME = "Frostguard-Telegram-Watcher.lnk";
+    private static final String WATCHER_LAUNCHER_PROPERTY = "frostguard.watcher.launcher";
 
     @FXML
     public void initialize() {
@@ -283,15 +284,15 @@ public class TelegramLayoutController {
     }
 
     private void registerStartup() {
-        File batFile = resolveBatFile();
-        if (batFile == null) {
+        File watcherLauncher = resolveWatcherLauncher();
+        if (watcherLauncher == null) {
             showError("Cannot locate the Telegram Watcher launcher.");
             checkBoxAutoStart.setSelected(false);
             return;
         }
         Path shortcut = startupFolder().resolve(SHORTCUT_NAME);
         try {
-            Path workspaceLauncher = writeWorkspaceWatcherLauncher(batFile);
+            Path workspaceLauncher = writeWorkspaceWatcherLauncher(watcherLauncher);
             String vbs =
                 "Set oWS = WScript.CreateObject(\"WScript.Shell\")\n" +
                 "Set oLink = oWS.CreateShortcut(\"" + escapeVbsString(shortcut.toString()) + "\")\n" +
@@ -320,20 +321,23 @@ public class TelegramLayoutController {
         }
     }
 
-    private static Path writeWorkspaceWatcherLauncher(File batFile) throws IOException {
+    private static Path writeWorkspaceWatcherLauncher(File watcherLauncher) throws IOException {
         WorkspacePaths workspace = WorkspacePaths.current();
         Path launcher = workspace.watcher().resolve("Start-Frostguard-Watcher.cmd");
         Files.createDirectories(launcher.getParent());
-        Files.writeString(launcher, workspaceWatcherLauncherContent(batFile.toPath(), workspace));
+        Files.writeString(launcher, workspaceWatcherLauncherContent(watcherLauncher.toPath(), workspace));
         return launcher;
     }
 
-    static String workspaceWatcherLauncherContent(Path batFile, WorkspacePaths workspace) {
+    static String workspaceWatcherLauncherContent(Path watcherLauncher, WorkspacePaths workspace) {
+        String command = watcherLauncher.getFileName().toString().toLowerCase(java.util.Locale.ROOT).endsWith(".exe")
+                ? "start \"\" \"" + escapeBatchValue(watcherLauncher.toAbsolutePath().normalize().toString()) + "\""
+                : "call \"" + escapeBatchValue(watcherLauncher.toAbsolutePath().normalize().toString()) + "\"";
         return "@echo off\r\n"
                 + "setlocal DisableDelayedExpansion\r\n"
                 + "set \"FROSTGUARD_WORKSPACE=" + escapeBatchValue(workspace.root().toString()) + "\"\r\n"
                 + "set \"FROSTGUARD_CHANNEL=" + workspace.channel().directoryName() + "\"\r\n"
-                + "call \"" + escapeBatchValue(batFile.toAbsolutePath().normalize().toString()) + "\"\r\n";
+                + command + "\r\n";
     }
 
     private static String escapeBatchValue(String value) {
@@ -377,7 +381,12 @@ public class TelegramLayoutController {
      * Walks up the directory tree from several anchor points to find the watcher launcher.
      * Typical layout: frostguard/modules/desktop/target/frostguard-desktop-X.jar  →  frostguard/fg-watcher.bat
      */
-    private File resolveBatFile() {
+    private File resolveWatcherLauncher() {
+        String packagedLauncher = System.getProperty(WATCHER_LAUNCHER_PROPERTY, "").trim();
+        if (!packagedLauncher.isBlank()) {
+            File launcher = new File(packagedLauncher);
+            if (launcher.isFile()) return launcher;
+        }
         // 1. Walk up from the bot JAR path shown in the UI (most reliable)
         String jarPath = textFieldBotJarPath.getText().trim();
         if (!jarPath.isBlank()) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
@@ -1,5 +1,7 @@
 package dev.frostguard.app.panel.misc;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -189,7 +191,7 @@ public class TelegramLayoutController {
             
             // Ensure localPort exists
             if (!props.containsKey("localPort")) {
-                props.setProperty("localPort", "8765");
+                props.setProperty("localPort", String.valueOf(WorkspacePaths.current().defaultLocalPort()));
             }
             
             try (FileOutputStream fos = new FileOutputStream(cfg.toFile())) {
@@ -266,7 +268,7 @@ public class TelegramLayoutController {
 
     /** Mirrors TelegramWatcher.configFilePath() – path convention kept in sync manually. */
     private static Path watcherConfigPath() {
-        return Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+        return WorkspacePaths.current().watcherConfig();
     }
 
     // ── Startup registration ──────────────────────────────────────────────────
@@ -289,11 +291,12 @@ public class TelegramLayoutController {
         }
         Path shortcut = startupFolder().resolve(SHORTCUT_NAME);
         try {
+            Path workspaceLauncher = writeWorkspaceWatcherLauncher(batFile);
             String vbs =
                 "Set oWS = WScript.CreateObject(\"WScript.Shell\")\n" +
-                "Set oLink = oWS.CreateShortcut(\"" + shortcut.toString().replace("\\", "\\\\") + "\")\n" +
-                "oLink.TargetPath = \"" + batFile.getAbsolutePath().replace("\\", "\\\\") + "\"\n" +
-                "oLink.WorkingDirectory = \"" + batFile.getParent().replace("\\", "\\\\") + "\"\n" +
+                "Set oLink = oWS.CreateShortcut(\"" + escapeVbsString(shortcut.toString()) + "\")\n" +
+                "oLink.TargetPath = \"" + escapeVbsString(workspaceLauncher.toString()) + "\"\n" +
+                "oLink.WorkingDirectory = \"" + escapeVbsString(workspaceLauncher.getParent().toString()) + "\"\n" +
                 "oLink.Description = \"Frostguard Telegram Watcher (auto-start)\"\n" +
                 "oLink.WindowStyle = 0\n" +
                 "oLink.Save\n";
@@ -315,6 +318,30 @@ public class TelegramLayoutController {
             showError("Failed to register startup shortcut: " + e.getMessage());
             checkBoxAutoStart.setSelected(false);
         }
+    }
+
+    private static Path writeWorkspaceWatcherLauncher(File batFile) throws IOException {
+        WorkspacePaths workspace = WorkspacePaths.current();
+        Path launcher = workspace.watcher().resolve("Start-Frostguard-Watcher.cmd");
+        Files.createDirectories(launcher.getParent());
+        Files.writeString(launcher, workspaceWatcherLauncherContent(batFile.toPath(), workspace));
+        return launcher;
+    }
+
+    static String workspaceWatcherLauncherContent(Path batFile, WorkspacePaths workspace) {
+        return "@echo off\r\n"
+                + "setlocal DisableDelayedExpansion\r\n"
+                + "set \"FROSTGUARD_WORKSPACE=" + escapeBatchValue(workspace.root().toString()) + "\"\r\n"
+                + "set \"FROSTGUARD_CHANNEL=" + workspace.channel().directoryName() + "\"\r\n"
+                + "call \"" + escapeBatchValue(batFile.toAbsolutePath().normalize().toString()) + "\"\r\n";
+    }
+
+    private static String escapeBatchValue(String value) {
+        return value.replace("^", "^^").replace("%", "%%");
+    }
+
+    private static String escapeVbsString(String value) {
+        return value.replace("\"", "\"\"");
     }
 
     private void removeStartup() {

--- a/modules/desktop/src/main/resources/logback.xml
+++ b/modules/desktop/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration scan="true" scanPeriod="30 seconds">
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
-    <property name="LOG_DIR" value="log"/>
+    <property name="LOG_DIR" value="${frostguard.log.dir:-log}"/>
     <property name="LOG_FILE" value="${LOG_DIR}/frostguard.log"/>
     <property name="APP_PATTERN" value="%d{HH:mm:ss.SSS} %-5level [%thread] %logger{32} - %msg%n"/>
     <property name="FILE_PATTERN" value="%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] %logger{48} - %msg%n"/>

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/TelegramLayoutControllerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/TelegramLayoutControllerTest.java
@@ -1,0 +1,30 @@
+package dev.frostguard.app.panel.misc;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+class TelegramLayoutControllerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void startupWrapperPreservesWorkspaceIdentity() {
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("Bot 1"), RuntimeChannel.STABLE);
+        Path watcherLauncher = tempDir.resolve("install/Start-Frostguard-Watcher.bat");
+
+        String script = TelegramLayoutController.workspaceWatcherLauncherContent(
+                watcherLauncher, workspace);
+
+        assertTrue(script.contains("set \"FROSTGUARD_WORKSPACE=" + workspace.root() + "\""));
+        assertTrue(script.contains("set \"FROSTGUARD_CHANNEL=stable\""));
+        assertTrue(script.contains("call \"" + watcherLauncher.toAbsolutePath().normalize() + "\""));
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/TelegramLayoutControllerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/TelegramLayoutControllerTest.java
@@ -27,4 +27,16 @@ class TelegramLayoutControllerTest {
         assertTrue(script.contains("set \"FROSTGUARD_CHANNEL=stable\""));
         assertTrue(script.contains("call \"" + watcherLauncher.toAbsolutePath().normalize() + "\""));
     }
+
+    @Test
+    void startupWrapperStartsThePackagedNativeWatcher() {
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("Bot 1"), RuntimeChannel.STABLE);
+        Path watcherLauncher = tempDir.resolve("install/FrostguardWatcher.exe");
+
+        String script = TelegramLayoutController.workspaceWatcherLauncherContent(
+                watcherLauncher, workspace);
+
+        assertTrue(script.contains("start \"\" \""
+                + watcherLauncher.toAbsolutePath().normalize() + "\""));
+    }
 }

--- a/modules/persistence/src/main/java/dev/frostguard/data/access/DataStore.java
+++ b/modules/persistence/src/main/java/dev/frostguard/data/access/DataStore.java
@@ -1,5 +1,6 @@
 package dev.frostguard.data.access;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -13,6 +14,7 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.TypedQuery;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 /**
  * Centralized transactional gateway for all Frostguard persistence operations.
@@ -31,7 +33,10 @@ public final class DataStore implements AutoCloseable {
 
 	private DataStore(Map<String, Object> overrides) {
 		try {
-			this.emf = Persistence.createEntityManagerFactory(PERSISTENCE_UNIT, overrides);
+			Map<String, Object> effectiveOverrides = new HashMap<>(overrides);
+			effectiveOverrides.putIfAbsent("jakarta.persistence.jdbc.url",
+					"jdbc:sqlite:" + WorkspacePaths.current().database() + "?busy_timeout=1000&journal_mode=WAL");
+			this.emf = Persistence.createEntityManagerFactory(PERSISTENCE_UNIT, effectiveOverrides);
 			DataSeeder.populate(this);
 			LOG.info("Frostguard data store initialized");
 		} catch (Exception cause) {

--- a/modules/persistence/src/test/java/dev/frostguard/data/access/DataStoreWorkspaceTest.java
+++ b/modules/persistence/src/test/java/dev/frostguard/data/access/DataStoreWorkspaceTest.java
@@ -1,0 +1,32 @@
+package dev.frostguard.data.access;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+class DataStoreWorkspaceTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void opensTheDefaultDatabaseInsideTheSelectedWorkspace() {
+        String previous = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+        try (DataStore ignored = DataStore.openIsolated(Map.of("hibernate.hbm2ddl.auto", "create"))) {
+            assertTrue(Files.isRegularFile(tempDir.resolve("frostguard.db")));
+        } finally {
+            if (previous == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, previous);
+            }
+        }
+    }
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/logging/ProfileContextLogger.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/logging/ProfileContextLogger.java
@@ -3,10 +3,10 @@ package dev.frostguard.vision.logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 import java.io.*;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
@@ -62,7 +62,7 @@ public final class ProfileContextLogger {
 
     private void ensureLogDirectory() {
         try {
-            Files.createDirectories(Paths.get("logs"));
+            Files.createDirectories(WorkspacePaths.current().logs());
         } catch (IOException e) {
             rootLog.error("Base directory creation failed: {}", e.getMessage());
         }
@@ -71,8 +71,8 @@ public final class ProfileContextLogger {
     private synchronized void initWriter(AccountDescriptor acc) throws IOException {
         if (writerRegistry.containsKey(acc.getId())) return;
 
-        String path = String.format("logs/account_%s_%d.log", cleanPath(acc.getName()), acc.getId());
-        File handle = new File(path);
+        File handle = WorkspacePaths.current().logs()
+                .resolve(String.format("account_%s_%d.log", cleanPath(acc.getName()), acc.getId())).toFile();
 
         if (handle.exists() && handle.length() > MAX_BYTES) {
             rollover(handle);
@@ -186,8 +186,8 @@ public final class ProfileContextLogger {
     private void enforceSizeLimit() {
         if (profile == null) return;
         
-        String path = String.format("logs/account_%s_%d.log", cleanPath(profile.getName()), profile.getId());
-        File handle = new File(path);
+        File handle = WorkspacePaths.current().logs()
+                .resolve(String.format("account_%s_%d.log", cleanPath(profile.getName()), profile.getId())).toFile();
         
         if (handle.exists() && handle.length() > MAX_BYTES) {
             try {

--- a/modules/vision/src/main/java/dev/frostguard/vision/match/OpenCvPatternLocator.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/match/OpenCvPatternLocator.java
@@ -29,6 +29,7 @@ import dev.frostguard.api.domain.SizeData;
 import dev.frostguard.api.configs.TemplatesEnum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 /**
  * Performs normalised cross-correlation between device screen captures
@@ -1943,7 +1944,7 @@ public class OpenCvPatternLocator {
         String[] segments = resourcePath.split("/");
         String fileName = segments[segments.length - 1];
 
-        Path targetDir = Path.of("lib", "opencv");
+        Path targetDir = WorkspacePaths.current().cache().resolve("native").resolve("opencv");
         Files.createDirectories(targetDir);
         Path dest = targetDir.resolve(fileName);
 

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
@@ -21,6 +21,7 @@ import net.sourceforge.tess4j.Tesseract;
 import net.sourceforge.tess4j.TesseractException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 /**
  * Provides text recognition from captured device screens or local image
@@ -364,14 +365,14 @@ public final class TesseractOcrProvider {
     // =====================================================================
 
     /**
-     * Writes a side-by-side diagnostic PNG to {@code <cwd>/temp/}.
+     * Writes a side-by-side diagnostic PNG to the active workspace cache.
      */
     private static void exportDiagnosticImage(RawImageData capture, BufferedImage processed,
             int cx, int cy, int cw, int ch,
             TesseractSettingsData cfg, String text) {
         long t0 = System.currentTimeMillis();
         try {
-            Path tempDir = Paths.get(System.getProperty("user.dir")).resolve("temp");
+            Path tempDir = WorkspacePaths.current().cache().resolve("ocr");
             Files.createDirectories(tempDir);
 
             String summary = formatSettingsSummary(cfg, text);

--- a/modules/watcher/pom.xml
+++ b/modules/watcher/pom.xml
@@ -18,6 +18,10 @@
 
 	<!-- ─── Runtime dependencies ─── -->
 	<dependencies>
+		<dependency>
+			<groupId>dev.frostguard</groupId>
+			<artifactId>frostguard-api</artifactId>
+		</dependency>
 		<!-- JSON serialisation (version managed by parent) -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/modules/watcher/pom.xml
+++ b/modules/watcher/pom.xml
@@ -40,6 +40,11 @@
 			<artifactId>logback-classic</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<!-- ─── Build plugins ─── -->

--- a/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
+++ b/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
@@ -1,5 +1,7 @@
 package dev.frostguard.watcher;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -19,7 +21,6 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.Properties;
@@ -43,10 +44,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * Everything else is forwarded to http://127.0.0.1:{localPort}/command.
  * Callback queries (inline keyboard taps) are also forwarded to the app.
  *
- * Single-instance guarantee: a FileLock on %USERPROFILE%/.frostguard/watcher.lock
- * prevents multiple watcher processes from running simultaneously.
+ * Single-instance guarantee: a FileLock in the selected workspace's watcher
+ * directory prevents duplicate watcher processes for that workspace.
  *
- * Configuration: %USERPROFILE%\.frostguard\telegram-watcher.properties
+ * Configuration: &lt;workspace&gt;/watcher/telegram-watcher.properties
  *   token=<BotFather token>
  *   chatId=<your Telegram numeric chat-ID>
  *   botJarPath=<absolute path to frostguard-x.x.x.jar>
@@ -57,10 +58,9 @@ public class TelegramWatcher {
     private static final Logger logger = LoggerFactory.getLogger(TelegramWatcher.class);
     private static final String API_BASE         = "https://api.telegram.org/bot";
     private static final int    LONG_POLL_TIMEOUT = 30;
-    private static final int    DEFAULT_LOCAL_PORT = 8765;
 
     public static Path configFilePath() {
-        return Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+        return WorkspacePaths.current().watcherConfig();
     }
 
     // ── entry point ───────────────────────────────────────────────────────────
@@ -72,7 +72,7 @@ public class TelegramWatcher {
         System.out.println("==============================================");
 
         // ── Single-instance lock ───────────────────────────────────────────────
-        Path lockFilePath = configFilePath().resolveSibling("watcher.lock");
+        Path lockFilePath = WorkspacePaths.current().watcherLock();
         Files.createDirectories(lockFilePath.getParent());
         FileChannel lockChannel = FileChannel.open(lockFilePath,
                 StandardOpenOption.CREATE, StandardOpenOption.WRITE);
@@ -94,9 +94,10 @@ public class TelegramWatcher {
         int    localPort;
         try {
             localPort = Integer.parseInt(
-                    cfg.getProperty("localPort", String.valueOf(DEFAULT_LOCAL_PORT)).trim());
+                    cfg.getProperty("localPort",
+                            String.valueOf(WorkspacePaths.current().defaultLocalPort())).trim());
         } catch (NumberFormatException e) {
-            localPort = DEFAULT_LOCAL_PORT;
+            localPort = WorkspacePaths.current().defaultLocalPort();
         }
 
         if (token.isBlank()) {
@@ -127,6 +128,7 @@ public class TelegramWatcher {
     private final File          botJar;
     private final File          botJarDir;
     private final int           localPort;
+    private final String        workspaceId;
     private final HttpClient    httpClient;
     private final ObjectMapper  mapper = new ObjectMapper();
 
@@ -144,6 +146,7 @@ public class TelegramWatcher {
         this.botJar        = new File(jarPath);
         this.botJarDir     = botJar.getParentFile();
         this.localPort     = localPort;
+        this.workspaceId   = WorkspacePaths.current().identity();
         this.httpClient    = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
@@ -271,9 +274,15 @@ public class TelegramWatcher {
             }
             try {
                 String javaExe = ProcessHandle.current().info().command().orElse("java");
-                ProcessBuilder pb = headless
-                        ? new ProcessBuilder(javaExe, "-jar", botJar.getName(), "--headless")
-                        : new ProcessBuilder(javaExe, "-jar", botJar.getName());
+                java.util.List<String> command = new java.util.ArrayList<>();
+                command.add(javaExe);
+                command.add("-D" + WorkspacePaths.WORKSPACE_PROPERTY + "=" + WorkspacePaths.current().root());
+                command.add("-D" + WorkspacePaths.CHANNEL_PROPERTY + "="
+                        + WorkspacePaths.current().channel().directoryName());
+                command.add("-jar");
+                command.add(botJar.getAbsolutePath());
+                if (headless) command.add("--headless");
+                ProcessBuilder pb = new ProcessBuilder(command);
                 
                 // Use the parent of the bot jar as the working directory, unless it's in a 'target' dir
                 // (to support Maven multi-module dev workflows where the root is one level up).
@@ -283,9 +292,6 @@ public class TelegramWatcher {
                     workDir = botJarDir.getParentFile().getParentFile().getParentFile();
                 }
                 pb.directory(workDir);
-
-                // When changing workDir, we must execute the jar using a path relative to workDir or absolute path.
-                pb.command().set(2, botJar.getAbsolutePath());
 
                 pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
                 pb.redirectError(ProcessBuilder.Redirect.DISCARD);
@@ -319,22 +325,7 @@ public class TelegramWatcher {
         }
         
         // Try to get the PID from the bot's command server
-        Long remotePid = null;
-        try {
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create("http://127.0.0.1:" + localPort + "/pid"))
-                    .timeout(Duration.ofSeconds(2))
-                    .GET()
-                    .build();
-            HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            if (resp.statusCode() == 200) {
-                JsonNode json = mapper.readTree(resp.body());
-                remotePid = json.path("pid").asLong(-1);
-                if (remotePid == -1) remotePid = null;
-            }
-        } catch (Exception e) {
-            logger.debug("Could not get PID from /pid endpoint: {}", e.getMessage());
-        }
+        Long remotePid = fetchWorkspacePid();
         
         // If we got a PID from the server, kill that process
         if (remotePid != null) {
@@ -367,6 +358,7 @@ public class TelegramWatcher {
                         || cmdLine.contains("dev.frostguard.app.bootstrap.Main")
                         || cmdLine.contains("dev.frostguard.app.bootstrap.FXApp")
                         || cmdLine.contains("dev.frostguard.app.bootstrap.HeadlessApp");
+                    matches = matches && cmdLine.contains(WorkspacePaths.current().root().toString());
                     
                     if (matches) {
                         logger.debug("Found matching process PID {}: {}", ph.pid(), cmdLine);
@@ -412,6 +404,7 @@ public class TelegramWatcher {
             body.put("type",   "message");
             body.put("chatId", chatId);
             body.put("text",   text);
+            body.put("workspaceId", workspaceId);
 
             HttpRequest req = HttpRequest.newBuilder()
                     .uri(URI.create("http://127.0.0.1:" + localPort + "/command"))
@@ -441,6 +434,7 @@ public class TelegramWatcher {
             body.put("messageId",  messageId);
             body.put("callbackId", callbackId);
             body.put("data",       data);
+            body.put("workspaceId", workspaceId);
 
             HttpRequest req = HttpRequest.newBuilder()
                     .uri(URI.create("http://127.0.0.1:" + localPort + "/command"))
@@ -469,27 +463,8 @@ public class TelegramWatcher {
             botProcess = null; // clear stale reference
         }
         
-        // Try to connect to the bot's command server as a reliable check
-        // If the server responds (even with an error), the bot is definitely running
-        try {
-            ObjectNode testBody = mapper.createObjectNode();
-            testBody.put("type", "ping");
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create("http://127.0.0.1:" + localPort + "/command"))
-                    .timeout(Duration.ofSeconds(1))
-                    .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(testBody.toString()))
-                    .build();
-            httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            // If we get ANY response (success or error), the server is up
+        if (fetchWorkspacePid() != null) {
             logger.debug("Bot process alive via network check on port {}", localPort);
-            return true;
-        } catch (ConnectException e) {
-            // Connection refused = server not running, continue to process search
-            logger.debug("Network check failed (connection refused), trying process search");
-        } catch (Exception e) {
-            // Any other response (including errors) means the server is up
-            logger.debug("Bot process alive via network check (got response: {})", e.getClass().getSimpleName());
             return true;
         }
         
@@ -498,10 +473,11 @@ public class TelegramWatcher {
                 .filter(ph -> ph.info().command().map(c -> c.toLowerCase().contains("java")).orElse(false))
                 .filter(ph -> {
                     String cmd = ph.info().commandLine().orElse("");
-                    return cmd.contains(botJar.getName())
+                    boolean matchesApp = cmd.contains(botJar.getName())
                         || cmd.contains("dev.frostguard.app.bootstrap.Main")
                         || cmd.contains("dev.frostguard.app.bootstrap.FXApp")
                         || cmd.contains("dev.frostguard.app.bootstrap.HeadlessApp");
+                    return matchesApp && cmd.contains(WorkspacePaths.current().root().toString());
                 })
                 .findFirst()
                 .isPresent();
@@ -512,6 +488,34 @@ public class TelegramWatcher {
             logger.debug("Bot process not found via any method");
         }
         return found;
+    }
+
+    private Long fetchWorkspacePid() {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + localPort + "/pid"))
+                    .timeout(Duration.ofSeconds(2))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                logger.debug("PID endpoint on port {} replied HTTP {}", localPort, response.statusCode());
+                return null;
+            }
+            JsonNode json = mapper.readTree(response.body());
+            if (!workspaceId.equals(json.path("workspaceId").asText())) {
+                logger.warn("Ignoring command server on port {} because it belongs to another workspace", localPort);
+                return null;
+            }
+            long pid = json.path("pid").asLong(-1);
+            return pid > 0 ? pid : null;
+        } catch (ConnectException connectionRefused) {
+            logger.debug("No command server listening on port {}", localPort);
+            return null;
+        } catch (Exception failure) {
+            logger.debug("Could not read matching PID from port {}: {}", localPort, failure.getMessage());
+            return null;
+        }
     }
 
     private static String buildHelpMessage() {
@@ -616,7 +620,7 @@ public class TelegramWatcher {
                   + "token=\n"
                   + "chatId=\n"
                   + "botJarPath=\n"
-                  + "localPort=8765\n");
+                  + "localPort=" + WorkspacePaths.current().defaultLocalPort() + "\n");
             System.out.println("[INFO] Created config template at: " + cfg);
         }
         Properties props = new Properties();

--- a/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
+++ b/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
@@ -1,6 +1,7 @@
 package dev.frostguard.watcher;
 
 import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.api.runtime.WorkspaceSession;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,6 +20,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -58,6 +60,9 @@ public class TelegramWatcher {
     private static final Logger logger = LoggerFactory.getLogger(TelegramWatcher.class);
     private static final String API_BASE         = "https://api.telegram.org/bot";
     private static final int    LONG_POLL_TIMEOUT = 30;
+    private static final String APP_LAUNCHER_PROPERTY = "frostguard.launcher";
+    private static final String WATCHER_LAUNCHER_PROPERTY = "frostguard.watcher.launcher";
+    private static final String NATIVE_SMOKE_ARGUMENT = "--frostguard-native-smoke-test";
 
     public static Path configFilePath() {
         return WorkspacePaths.current().watcherConfig();
@@ -66,6 +71,19 @@ public class TelegramWatcher {
     // ── entry point ───────────────────────────────────────────────────────────
 
     public static void main(String[] args) throws Exception {
+        WorkspacePaths workspace = WorkspacePaths.current();
+        WorkspaceSession.initializeLayout(workspace);
+        if (java.util.Arrays.asList(args).contains(NATIVE_SMOKE_ARGUMENT)) {
+            loadConfig();
+            Files.writeString(workspace.cache().resolve("native-watcher-smoke.properties"),
+                    "channel=" + workspace.channel().directoryName() + "\n"
+                            + "workspace=" + workspace.root() + "\n"
+                            + "applicationDir=" + System.getProperty("user.dir") + "\n"
+                            + "appLauncher=" + System.getProperty(APP_LAUNCHER_PROPERTY, "") + "\n"
+                            + "watcherLauncher=" + System.getProperty(WATCHER_LAUNCHER_PROPERTY, "") + "\n",
+                    StandardCharsets.UTF_8);
+            return;
+        }
         System.out.println("==============================================");
         System.out.println("  Frostguard – Telegram Watcher");
         System.out.println("  Config: " + configFilePath());
@@ -127,6 +145,7 @@ public class TelegramWatcher {
     private final long          allowedChatId;
     private final File          botJar;
     private final File          botJarDir;
+    private final File          botLauncher;
     private final int           localPort;
     private final String        workspaceId;
     private final HttpClient    httpClient;
@@ -145,6 +164,8 @@ public class TelegramWatcher {
         this.allowedChatId = allowedChatId;
         this.botJar        = new File(jarPath);
         this.botJarDir     = botJar.getParentFile();
+        String launcherPath = System.getProperty(APP_LAUNCHER_PROPERTY, "").trim();
+        this.botLauncher   = launcherPath.isBlank() ? null : new File(launcherPath);
         this.localPort     = localPort;
         this.workspaceId   = WorkspacePaths.current().identity();
         this.httpClient    = HttpClient.newBuilder()
@@ -267,29 +288,32 @@ public class TelegramWatcher {
                 sendMessage(chatId, "ℹ️ Bot app is already running.");
                 return;
             }
-            if (!botJar.exists()) {
+            if ((botLauncher == null || !botLauncher.isFile()) && !botJar.exists()) {
                 sendMessage(chatId, "❌ JAR not found at:\n`" + botJar.getAbsolutePath()
                         + "`\nCheck the path in the Telegram config panel.");
                 return;
             }
             try {
                 String javaExe = ProcessHandle.current().info().command().orElse("java");
-                java.util.List<String> command = new java.util.ArrayList<>();
-                command.add(javaExe);
-                command.add("-D" + WorkspacePaths.WORKSPACE_PROPERTY + "=" + WorkspacePaths.current().root());
-                command.add("-D" + WorkspacePaths.CHANNEL_PROPERTY + "="
-                        + WorkspacePaths.current().channel().directoryName());
-                command.add("-jar");
-                command.add(botJar.getAbsolutePath());
-                if (headless) command.add("--headless");
+                java.util.List<String> command = botLaunchCommand(
+                        botLauncher == null ? null : botLauncher.toPath(),
+                        Path.of(javaExe), botJar.toPath(), WorkspacePaths.current(), headless);
                 ProcessBuilder pb = new ProcessBuilder(command);
                 
                 // Use the parent of the bot jar as the working directory, unless it's in a 'target' dir
                 // (to support Maven multi-module dev workflows where the root is one level up).
-                File workDir = botJarDir;
-                if ("target".equalsIgnoreCase(botJarDir.getName())
-                        && botJarDir.toPath().endsWith(Path.of("modules", "desktop", "target"))) {
-                    workDir = botJarDir.getParentFile().getParentFile().getParentFile();
+                File workDir;
+                if (botLauncher != null && botLauncher.isFile()) {
+                    workDir = botLauncher.getParentFile();
+                    pb.environment().put("FROSTGUARD_WORKSPACE", WorkspacePaths.current().root().toString());
+                    pb.environment().put("FROSTGUARD_CHANNEL",
+                            WorkspacePaths.current().channel().directoryName());
+                } else {
+                    workDir = botJarDir;
+                    if ("target".equalsIgnoreCase(botJarDir.getName())
+                            && botJarDir.toPath().endsWith(Path.of("modules", "desktop", "target"))) {
+                        workDir = botJarDir.getParentFile().getParentFile().getParentFile();
+                    }
                 }
                 pb.directory(workDir);
 
@@ -306,6 +330,25 @@ public class TelegramWatcher {
         } finally {
             launchLock.unlock();
         }
+    }
+
+    static java.util.List<String> botLaunchCommand(Path nativeLauncher, Path javaExecutable,
+            Path botJar, WorkspacePaths workspace, boolean headless) {
+        java.util.List<String> command = new java.util.ArrayList<>();
+        if (nativeLauncher != null) {
+            command.add(nativeLauncher.toAbsolutePath().normalize().toString());
+        } else {
+            command.add(javaExecutable.toString());
+            command.add("-D" + WorkspacePaths.WORKSPACE_PROPERTY + "=" + workspace.root());
+            command.add("-D" + WorkspacePaths.CHANNEL_PROPERTY + "="
+                    + workspace.channel().directoryName());
+            command.add("-jar");
+            command.add(botJar.toAbsolutePath().normalize().toString());
+        }
+        if (headless) {
+            command.add("--headless");
+        }
+        return command;
     }
 
     private void handleKill(long chatId) {

--- a/modules/watcher/src/test/java/dev/frostguard/watcher/TelegramWatcherTest.java
+++ b/modules/watcher/src/test/java/dev/frostguard/watcher/TelegramWatcherTest.java
@@ -1,0 +1,42 @@
+package dev.frostguard.watcher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+class TelegramWatcherTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void packagedWatcherLaunchesTheNativeApplication() {
+        Path launcher = tempDir.resolve("Frostguard.exe");
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("Bot 1"), RuntimeChannel.STABLE);
+
+        assertEquals(List.of(launcher.toAbsolutePath().toString(), "--headless"),
+                TelegramWatcher.botLaunchCommand(launcher, Path.of("java"),
+                        tempDir.resolve("frostguard.jar"), workspace, true));
+    }
+
+    @Test
+    void sourceWatcherPreservesWorkspaceThroughJvmOptions() {
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("Bot 1"), RuntimeChannel.DEVELOPMENT);
+        Path jar = tempDir.resolve("frostguard.jar");
+
+        assertEquals(List.of(
+                "java",
+                "-Dfrostguard.workspace=" + workspace.root(),
+                "-Dfrostguard.channel=development",
+                "-jar",
+                jar.toAbsolutePath().toString()),
+                TelegramWatcher.botLaunchCommand(null, Path.of("java"), jar, workspace, false));
+    }
+}

--- a/packaging/desktop/pom.xml
+++ b/packaging/desktop/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>frostguard-desktop-package</artifactId>
     <name>Frostguard Desktop Packaging</name>
-    <description>Platform packaging inputs and transitional desktop bundle</description>
+    <description>Platform packaging inputs, native application images, and installers</description>
     <packaging>pom</packaging>
 
     <dependencies>
@@ -114,6 +114,59 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>stage-template-browser-assets</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/input/templates</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.parent.basedir}/modules/vision/src/main/resources/templates</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stage-custom-task-examples</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/input/custom_tasks</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.parent.basedir}/examples/custom-tasks</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>prepare-jpackage-launchers</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/jpackage</outputDirectory>
+                            <encoding>UTF-8</encoding>
+                            <propertiesEncoding>UTF-8</propertiesEncoding>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/src/main/windows</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>Frostguard-Watcher.properties</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -138,4 +191,155 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>windows-app-image</id>
+            <activation>
+                <property>
+                    <name>windows.app.image</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-windows-app-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <condition property="jpackage.executable"
+                                                value="${java.home}/bin/jpackage.exe"
+                                                else="${java.home}/bin/jpackage">
+                                            <os family="windows" />
+                                        </condition>
+                                        <delete dir="${project.build.directory}/app-image/Frostguard" />
+                                        <mkdir dir="${project.build.directory}/app-image" />
+                                        <exec executable="powershell.exe" failonerror="true">
+                                            <arg value="-NoProfile" />
+                                            <arg value="-NonInteractive" />
+                                            <arg value="-ExecutionPolicy" />
+                                            <arg value="Bypass" />
+                                            <arg value="-File" />
+                                            <arg path="${maven.multiModuleProjectDirectory}/build-support/packaging/write_windows_icon.ps1" />
+                                            <arg value="-InputPath" />
+                                            <arg path="${maven.multiModuleProjectDirectory}/modules/desktop/src/main/resources/icons/appIcon.png" />
+                                            <arg value="-OutputPath" />
+                                            <arg path="${project.build.directory}/jpackage/Frostguard.ico" />
+                                        </exec>
+                                        <exec executable="${jpackage.executable}" failonerror="true">
+                                            <arg value="--type" />
+                                            <arg value="app-image" />
+                                            <arg value="--dest" />
+                                            <arg path="${project.build.directory}/app-image" />
+                                            <arg value="--input" />
+                                            <arg path="${project.build.directory}/input" />
+                                            <arg value="--name" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--app-version" />
+                                            <arg value="${project.version}" />
+                                            <arg value="--vendor" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--description" />
+                                            <arg value="Frostguard automation desktop application" />
+                                            <arg value="--icon" />
+                                            <arg path="${project.build.directory}/jpackage/Frostguard.ico" />
+                                            <arg value="--main-jar" />
+                                            <arg value="frostguard-desktop-${project.version}.jar" />
+                                            <arg value="--main-class" />
+                                            <arg value="dev.frostguard.app.bootstrap.Main" />
+                                            <arg value="--java-options" />
+                                            <arg value="--enable-native-access=ALL-UNNAMED" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Dfrostguard.channel=stable" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Duser.dir=$APPDIR" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Dfrostguard.launcher=$APPDIR/../Frostguard.exe" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe" />
+                                            <arg value="--add-launcher" />
+                                            <arg value="FrostguardWatcher=${project.build.directory}/jpackage/Frostguard-Watcher.properties" />
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>windows-installer</id>
+            <activation>
+                <property>
+                    <name>windows.installer</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-windows-installer</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <condition property="jpackage.executable"
+                                                value="${java.home}/bin/jpackage.exe"
+                                                else="${java.home}/bin/jpackage">
+                                            <os family="windows" />
+                                        </condition>
+                                        <delete dir="${project.build.directory}/installers" />
+                                        <mkdir dir="${project.build.directory}/installers" />
+                                        <exec executable="${jpackage.executable}" failonerror="true">
+                                            <arg value="--verbose" />
+                                            <arg value="--type" />
+                                            <arg value="exe" />
+                                            <arg value="--dest" />
+                                            <arg path="${project.build.directory}/installers" />
+                                            <arg value="--name" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--app-version" />
+                                            <arg value="${project.version}" />
+                                            <arg value="--vendor" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--description" />
+                                            <arg value="Frostguard automation desktop application" />
+                                            <arg value="--app-image" />
+                                            <arg path="${project.build.directory}/app-image/Frostguard" />
+                                            <!-- Nested per-user install paths can trigger inconsistent WiX
+                                                 directory validation (JDK-8226534). -->
+                                            <arg value="--install-dir" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--win-per-user-install" />
+                                            <arg value="--win-dir-chooser" />
+                                            <arg value="--win-menu" />
+                                            <arg value="--win-menu-group" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--win-shortcut-prompt" />
+                                            <arg value="--win-upgrade-uuid" />
+                                            <arg value="fa0d66f6-1f7d-4da8-9701-88f7b4570797" />
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/packaging/desktop/src/main/common/zip.xml
+++ b/packaging/desktop/src/main/common/zip.xml
@@ -11,9 +11,5 @@
     <fileSets>
         <fileSet><directory>${project.build.directory}/input</directory><outputDirectory>.</outputDirectory><useDefaultExcludes>true</useDefaultExcludes><fileMode>0644</fileMode><directoryMode>0755</directoryMode><includes><include>**/*</include></includes><excludes><exclude>**/*.lastUpdated</exclude><exclude>**/_remote.repositories</exclude><exclude>lib/adb/**</exclude></excludes></fileSet>
         <fileSet><directory>${project.build.directory}/input/lib/adb</directory><outputDirectory>lib/adb</outputDirectory><useDefaultExcludes>true</useDefaultExcludes><fileMode>0755</fileMode><directoryMode>0755</directoryMode><includes><include>**/*</include></includes><excludes><exclude>**/*.tmp</exclude></excludes></fileSet>
-        <fileSet><directory>${project.parent.basedir}/examples/custom-tasks</directory><outputDirectory>custom_tasks</outputDirectory><useDefaultExcludes>true</useDefaultExcludes><fileMode>0644</fileMode><directoryMode>0755</directoryMode><includes><include>**/*</include></includes></fileSet>
-        <!-- pernerch/2026-07-02: Include 361 template PNG files in distribution ZIP for Debugging UI template search -->
-        <!-- Templates are used for image pattern matching in the Image Recognition debugging tool -->
-        <fileSet><directory>${project.parent.basedir}/modules/vision/src/main/resources/templates</directory><outputDirectory>templates</outputDirectory><useDefaultExcludes>true</useDefaultExcludes><fileMode>0644</fileMode><directoryMode>0755</directoryMode><includes><include>**/*</include></includes></fileSet>
     </fileSets>
 </assembly>

--- a/packaging/desktop/src/main/windows/Frostguard-Watcher.properties
+++ b/packaging/desktop/src/main/windows/Frostguard-Watcher.properties
@@ -1,0 +1,4 @@
+main-jar=frostguard-watcher-${project.version}.jar
+main-class=dev.frostguard.watcher.TelegramWatcher
+description=Frostguard Telegram Watcher
+java-options=--enable-native-access=ALL-UNNAMED -Dfrostguard.channel=stable "-Duser.dir=$APPDIR" "-Dfrostguard.launcher=$APPDIR/../Frostguard.exe" "-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe"

--- a/packaging/desktop/src/main/windows/Start-Frostguard-Watcher.bat
+++ b/packaging/desktop/src/main/windows/Start-Frostguard-Watcher.bat
@@ -45,6 +45,5 @@ exit /b 1
 :found
 echo Starting Frostguard Telegram Watcher (background)...
 echo JAR: %JAR%
-echo Log: %USERPROFILE%\.frostguard\tg-watcher.log
 start "FG-TG-Watcher" /b javaw -jar "%JAR%"
 exit /b 0

--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,12 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven.surefire.plugin.version}</version>
+					<configuration>
+						<systemPropertyVariables>
+							<frostguard.channel>development</frostguard.channel>
+							<frostguard.workspace>${project.build.directory}/test-workspace</frostguard.workspace>
+						</systemPropertyVariables>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Closes #152
Parent: #130
Depends on #145 / #147 and #150 / #151.

## Summary

- build a self-contained Windows `jpackage` application image with Frostguard and Telegram watcher launchers, a bundled Java runtime, Windows metadata, the application icon, and all required runtime assets
- build a versioned per-user EXE installer with a stable upgrade identity and `%LOCALAPPDATA%\Frostguard` as its default installation directory
- make watcher startup, Telegram `/launch`, and Task Scheduler autostart use the packaged native launchers while retaining the Java/JAR fallback for source and transitional ZIP runs
- add structural verification, no-system-Java launcher smoke coverage, and a native Windows CI job that installs pinned WiX 3 and uploads both artifacts
- document the native developer/release commands without changing the behavior of ordinary `mvn package`

## Why

This is the packaging child of the Frostguard 3.0 delivery plan in #130. It turns the modular desktop artifacts and isolated runtime workspaces from the preceding stack into an installable Windows application that does not require users to install Java and does not write mutable state into its installation directory.

This PR is intentionally stacked on #151, which is itself stacked on #147. GitHub cannot use a branch from this fork as an upstream base branch, so the PR targets `main` and its displayed diff includes the preceding stack. Review and test it independently, but do not merge it ahead of #147 and #151; the three PRs are intended to land in dependency order as one coordinated #130 merge batch.

## Validation

- `.\mvnw.cmd package`: passed; the normal reactor build did not activate either native packaging goal
- `.\mvnw.cmd -pl modules/automation,modules/desktop,modules/watcher -am test`: passed
- `.\mvnw.cmd -pl modules/watcher -am test`: passed after the final watcher smoke-contract change
- `.\mvnw.cmd -pl packaging/desktop -am -Pwindows-app-image package -DskipTests`: built `packaging/desktop/target/app-image/Frostguard`
- `python build-support/verification/test_verify_app_image.py`: 5 tests passed
- `python build-support/verification/verify_app_image.py packaging/desktop/target/app-image/Frostguard`: passed against the real application image
- `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File build-support/verification/smoke_test_app_image.ps1 -ImagePath packaging/desktop/target/app-image/Frostguard`: Frostguard and the watcher both exited 0 with `JAVA_HOME` removed and system Java absent from `PATH`; Stable channel, workspace, application directory, icon, metadata, and native launcher paths were verified
- [Native Windows Package CI](https://github.com/Shederator/wosbot/actions/runs/31353756304): passed on GitHub Windows; WiX built the EXE installer, all verification and smoke steps passed, and both native artifacts were uploaded
- [Daily Windows Bundle CI](https://github.com/Shederator/wosbot/actions/runs/31353756358): passed on Linux

Evidence level: automated tests, local native application-image startup, and GitHub Windows installer build/smoke confirmation.

## Risks

- The generated installer has not yet been interactively installed and exercised on a fresh user desktop; CI verifies its build boundary and the exact app image it contains.
- Authenticode signing, release publication, update handoff, and portable packaging are intentionally excluded from #152.
