### PR TITLE
fix(autojoin): defer redundant activation

### DIFF
--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -131,6 +131,24 @@ public class TaskQueue {
                 .anyMatch(t -> t.getDelay(TimeUnit.SECONDS) <= withinSec);
     }
 
+    public synchronized List<TpDailyTaskEnum> getNextQueuedTaskTypes(int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+
+        Comparator<DelayedTask> priorityOrder = Comparator
+                .comparingInt(rankingStrategy::getPriority)
+                .reversed();
+        Comparator<DelayedTask> queueOrder = Comparator
+                .comparing(DelayedTask::getScheduled, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(priorityOrder);
+        return taskBacklog.stream()
+                .sorted(queueOrder)
+                .limit(limit)
+                .map(DelayedTask::getTpTask)
+                .toList();
+    }
+
     public synchronized boolean scheduleOrRescheduleQueuedTask(
             TpDailyTaskEnum kind,
             AccountDescriptor updatedProfile,

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/alliance/AllianceAutojoinRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/alliance/AllianceAutojoinRoutine.java
@@ -8,7 +8,10 @@ import dev.frostguard.api.domain.PointData;
 import dev.frostguard.engine.helper.NavigationHelper;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
+import dev.frostguard.engine.schedule.TaskQueue;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public class AllianceAutojoinRoutine extends DelayedTask {
 
@@ -46,6 +49,8 @@ private static final int SCHEDULE_HOURS_VALUE = 7;
 
 private static final int SCHEDULE_MINUTES_VALUE = 50;
 
+private static final int LOOKAHEAD_RETRY_MINUTES_VALUE = 5;
+
 private boolean useAllTroops;
 
 private int queueCount;
@@ -58,6 +63,10 @@ public AllianceAutojoinRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask
 	protected void execute() {
 
 		hydrateConfiguration();
+
+		if (deferForUpcomingAutoJoinReset()) {
+			return;
+		}
 
 		if (!openUpAllianceWarMenu()) {
 			manageTaskFailure("Failed to open Alliance War menu");
@@ -74,6 +83,27 @@ public AllianceAutojoinRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask
 		enableAutoJoinFlow();
 
 		queueNextRun();
+	}
+
+private boolean deferForUpcomingAutoJoinReset() {
+		TaskQueue queue = scheduleService.getCoordinator().getQueue(profile.getId());
+		if (queue == null) {
+			return false;
+		}
+
+		List<TpDailyTaskEnum> queuedTasks = queue.getNextQueuedTaskTypes(
+				AutojoinActivationPolicy.LOOKAHEAD_TASK_COUNT);
+		Optional<TpDailyTaskEnum> resetTask = AutojoinActivationPolicy.findUpcomingResetTask(queuedTasks);
+		if (resetTask.isEmpty()) {
+			return false;
+		}
+
+		reschedule(LocalDateTime.now().plusMinutes(LOOKAHEAD_RETRY_MINUTES_VALUE));
+		logInfo(routineLogAllianceAutojoinLine("Deferring activation because "
+				+ resetTask.get().getName() + " is within the next "
+				+ AutojoinActivationPolicy.LOOKAHEAD_TASK_COUNT
+				+ " queued tasks and will restore auto-join afterwards"));
+		return true;
 	}
 
 @Override

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/alliance/AutojoinActivationPolicy.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/alliance/AutojoinActivationPolicy.java
@@ -1,0 +1,26 @@
+package dev.frostguard.tasks.alliance;
+
+import dev.frostguard.api.configs.TpDailyTaskEnum;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+final class AutojoinActivationPolicy {
+
+    static final int LOOKAHEAD_TASK_COUNT = 5;
+
+    private static final Set<TpDailyTaskEnum> AUTOJOIN_RESET_TASKS = Set.of(
+            TpDailyTaskEnum.INTEL,
+            TpDailyTaskEnum.BEAR_TRAP);
+
+    private AutojoinActivationPolicy() {
+    }
+
+    static Optional<TpDailyTaskEnum> findUpcomingResetTask(List<TpDailyTaskEnum> queuedTasks) {
+        return queuedTasks.stream()
+                .limit(LOOKAHEAD_TASK_COUNT)
+                .filter(AUTOJOIN_RESET_TASKS::contains)
+                .findFirst();
+    }
+}

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/alliance/AutojoinActivationPolicyTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/alliance/AutojoinActivationPolicyTest.java
@@ -1,0 +1,52 @@
+package dev.frostguard.tasks.alliance;
+
+import dev.frostguard.api.configs.TpDailyTaskEnum;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AutojoinActivationPolicyTest {
+
+    @Test
+    void defersForIntelWithinNextFiveTasks() {
+        List<TpDailyTaskEnum> queuedTasks = List.of(
+                TpDailyTaskEnum.ALLIANCE_CHESTS,
+                TpDailyTaskEnum.GATHER_RESOURCES,
+                TpDailyTaskEnum.INTEL,
+                TpDailyTaskEnum.DAILY_MISSIONS,
+                TpDailyTaskEnum.ALLIANCE_SHOP);
+
+        assertEquals(TpDailyTaskEnum.INTEL,
+                AutojoinActivationPolicy.findUpcomingResetTask(queuedTasks).orElseThrow());
+    }
+
+    @Test
+    void defersForBearTrapWithinNextFiveTasks() {
+        assertEquals(TpDailyTaskEnum.BEAR_TRAP,
+                AutojoinActivationPolicy.findUpcomingResetTask(List.of(TpDailyTaskEnum.BEAR_TRAP))
+                        .orElseThrow());
+    }
+
+    @Test
+    void doesNotDeferForResetTaskAfterLookaheadWindow() {
+        List<TpDailyTaskEnum> queuedTasks = List.of(
+                TpDailyTaskEnum.ALLIANCE_CHESTS,
+                TpDailyTaskEnum.GATHER_RESOURCES,
+                TpDailyTaskEnum.DAILY_MISSIONS,
+                TpDailyTaskEnum.ALLIANCE_SHOP,
+                TpDailyTaskEnum.ALLIANCE_TECH,
+                TpDailyTaskEnum.INTEL);
+
+        assertTrue(AutojoinActivationPolicy.findUpcomingResetTask(queuedTasks).isEmpty());
+    }
+
+    @Test
+    void doesNotDeferWhenUpcomingTasksLeaveAutojoinUntouched() {
+        assertTrue(AutojoinActivationPolicy.findUpcomingResetTask(List.of(
+                TpDailyTaskEnum.ALLIANCE_CHESTS,
+                TpDailyTaskEnum.GATHER_RESOURCES)).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary

- inspect the next five queued tasks before Alliance Autojoin enables rally joining
- defer activation when Intel or Bear Trap will disable and restore Autojoin shortly afterward
- retain the existing queued Autojoin instance with a five-minute fallback, so restoration is neither duplicated nor lost

## Why

Alliance Autojoin could enable rally joining immediately before Intel or Bear Trap disabled it again. Those routines already restore Autojoin with `runNow`, so the extra activation caused unnecessary UI churn.

## Validation

- `mvn -pl fg-tasks -am test` on the original feature layout ? passed 157 tests with 0 failures, errors, or skips
- combined staging `mvn package` before the repository layout recut ? passed 251 tests with 0 failures, errors, or skips and built the desktop bundle
- policy tests cover Intel, Bear Trap, the five-task boundary, and queues without reset tasks
- live account log: Autojoin deferred at 17:55:08 because Intel was within the next five tasks; no activation occurred before Intel; Intel restored the task at 18:04:14; exactly one activation followed at 18:04:57; no errors or exceptions occurred during the staging session
- recut onto current `main`: the two new policy/test files are byte-identical and the complete semantic diff remains 126 additions across the same four files, relocated under `modules/`; no additional test run was requested after this path-only recut

## Risks

Bear Trap uses the same tested policy branch but was not the event observed in the live account log. The five-minute fallback intentionally retries if the expected restore path does not run.
