### PR TITLE
refactor(vision): introduce provider-neutral OCR interface (step 1 of 3)

### DIFF
--- a/modules/api/src/main/java/dev/frostguard/api/domain/OcrSettingsData.java
+++ b/modules/api/src/main/java/dev/frostguard/api/domain/OcrSettingsData.java
@@ -4,67 +4,42 @@ import java.awt.Color;
 import java.util.Objects;
 
 /**
- * Encapsulates the full set of parameters passed to the Tesseract
- * OCR recognition engine. Instances are assembled exclusively
- * through the {@link Configurator} fluent builder.
+ * Encapsulates the full set of parameters passed to the OCR recognition engine.
+ * Instances are assembled exclusively through the {@link Configurator} fluent builder.
  *
  * <p>Pre-configured factories like {@link #forNumberRecognition()}
  * and {@link #forTextBlock()} cover the most common use cases.</p>
  */
-public class TesseractSettingsData {
+public class OcrSettingsData {
 
     /**
-     * Backends supported by the Tesseract recognition engine.
+     * Generic layout hints to inform the OCR engine about the expected
+     * structure of the text to be recognized.
      */
-    public enum RecognitionEngine {
-        LEGACY_ONLY(0), LSTM_ONLY(1), COMBINED(2), AUTO(3);
-
-        private final int code;
-
-        RecognitionEngine(int code) { this.code = code; }
-
-        /** Numeric identifier passed to the native engine. */
-        public int code() { return code; }
-    }
-
-    /**
-     * Page segmentation strategies that control how Tesseract
-     * identifies text regions within an image.
-     */
-    public enum PageAnalysis {
-        OSD_ONLY(0), AUTO_WITH_OSD(1), AUTO_NO_OSD(2), FULLY_AUTO(3),
-        SINGLE_COLUMN(4), VERTICAL_BLOCK(5), UNIFORM_BLOCK(6),
-        SINGLE_LINE(7), SINGLE_WORD(8), CIRCULAR_WORD(9),
-        SINGLE_GLYPH(10), SPARSE(11), SPARSE_WITH_OSD(12), RAW_LINE(13);
-
-        private final int code;
-
-        PageAnalysis(int code) { this.code = code; }
-
-        /** Numeric identifier passed to the native engine. */
-        public int code() { return code; }
+    public enum TextLayout {
+        SINGLE_LINE,
+        SINGLE_WORD,
+        TEXT_BLOCK,
+        SPARSE,
+        AUTO
     }
 
     /* ---- immutable configuration fields ---- */
 
-    private final PageAnalysis pageAnalysis;
-    private final RecognitionEngine recognitionEngine;
+    private final TextLayout textLayout;
     private final boolean isolateForeground;
     private final Color targetColor;
     private final boolean diagnosticMode;
     private final String allowedGlyphs;
-    private final boolean reuseFrame;
 
     /* ---- private: construction via Configurator only ---- */
 
-    private TesseractSettingsData(Configurator cfg) {
-        this.pageAnalysis      = cfg.pageAnalysis;
-        this.recognitionEngine = cfg.recognitionEngine;
+    private OcrSettingsData(Configurator cfg) {
+        this.textLayout        = cfg.textLayout;
         this.isolateForeground = cfg.isolateForeground;
         this.targetColor       = cfg.targetColor;
         this.diagnosticMode    = cfg.diagnosticMode;
         this.allowedGlyphs    = cfg.allowedGlyphs;
-        this.reuseFrame        = cfg.reuseFrame;
     }
 
     /* ---- pre-configured presets ---- */
@@ -73,10 +48,9 @@ public class TesseractSettingsData {
      * Settings optimised for recognising numeric strings
      * (digits, commas, and decimal points only).
      */
-    public static TesseractSettingsData forNumberRecognition() {
+    public static OcrSettingsData forNumberRecognition() {
         return configurator()
-                .pageAnalysis(PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(RecognitionEngine.LSTM_ONLY)
+                .textLayout(TextLayout.SINGLE_LINE)
                 .allowedGlyphs("0123456789,.")
                 .build();
     }
@@ -84,10 +58,9 @@ public class TesseractSettingsData {
     /**
      * Settings suitable for reading a uniform block of mixed text.
      */
-    public static TesseractSettingsData forTextBlock() {
+    public static OcrSettingsData forTextBlock() {
         return configurator()
-                .pageAnalysis(PageAnalysis.UNIFORM_BLOCK)
-                .recognitionEngine(RecognitionEngine.LSTM_ONLY)
+                .textLayout(TextLayout.TEXT_BLOCK)
                 .build();
     }
 
@@ -95,10 +68,9 @@ public class TesseractSettingsData {
      * Settings for recognising isolated single words, such as
      * button labels or short status indicators.
      */
-    public static TesseractSettingsData forSingleWord() {
+    public static OcrSettingsData forSingleWord() {
         return configurator()
-                .pageAnalysis(PageAnalysis.SINGLE_WORD)
-                .recognitionEngine(RecognitionEngine.LSTM_ONLY)
+                .textLayout(TextLayout.SINGLE_WORD)
                 .build();
     }
 
@@ -106,10 +78,9 @@ public class TesseractSettingsData {
      * Settings for reading white text on dark game backgrounds,
      * with foreground isolation enabled.
      */
-    public static TesseractSettingsData forWhiteTextOnDark() {
+    public static OcrSettingsData forWhiteTextOnDark() {
         return configurator()
-                .pageAnalysis(PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(RecognitionEngine.LSTM_ONLY)
+                .textLayout(TextLayout.SINGLE_LINE)
                 .isolateForeground(true)
                 .targetColor(Color.WHITE)
                 .build();
@@ -117,17 +88,15 @@ public class TesseractSettingsData {
 
     /**
      * Returns {@code true} when this settings instance uses all
-     * default (unset) values — no page analysis, no engine, no
+     * default (unset) values — no layout hint, no
      * foreground isolation, and no glyph filter.
      */
     public boolean isDefaultConfiguration() {
-        return pageAnalysis == null
-                && recognitionEngine == null
+        return textLayout == null
                 && !isolateForeground
                 && targetColor == null
                 && !diagnosticMode
-                && (allowedGlyphs == null || allowedGlyphs.isEmpty())
-                && !reuseFrame;
+                && (allowedGlyphs == null || allowedGlyphs.isEmpty());
     }
 
     /**
@@ -138,22 +107,17 @@ public class TesseractSettingsData {
      */
     public Configurator toConfigurator() {
         return new Configurator()
-                .pageAnalysis(this.pageAnalysis)
-                .recognitionEngine(this.recognitionEngine)
+                .textLayout(this.textLayout)
                 .isolateForeground(this.isolateForeground)
                 .targetColor(this.targetColor)
                 .diagnosticMode(this.diagnosticMode)
-                .allowedGlyphs(this.allowedGlyphs)
-                .reuseFrame(this.reuseFrame);
+                .allowedGlyphs(this.allowedGlyphs);
     }
 
     /* ---- primary accessors ---- */
 
-    /** Active page segmentation strategy. */
-    public PageAnalysis pageAnalysis()           { return pageAnalysis; }
-
-    /** Active recognition backend. */
-    public RecognitionEngine recognitionEngine()  { return recognitionEngine; }
+    /** Expected layout of the text. */
+    public TextLayout textLayout()               { return textLayout; }
 
     /** Whether background removal is applied before recognition. */
     public boolean isolateForeground()           { return isolateForeground; }
@@ -167,51 +131,26 @@ public class TesseractSettingsData {
     /** Restricted character set for recognition (whitelist). */
     public String allowedGlyphs()                { return allowedGlyphs; }
 
-    /** Whether the previous screen capture should be recycled. */
-    public boolean reuseFrame()                  { return reuseFrame; }
-
     /* ---- presence checks ---- */
 
-    public boolean hasPageAnalysis() { return pageAnalysis != null; }
-    public boolean hasEngine()       { return recognitionEngine != null; }
+    public boolean hasTextLayout() { return textLayout != null; }
 
     public boolean hasGlyphFilter() {
         return allowedGlyphs != null && !allowedGlyphs.isEmpty();
     }
 
-    /** Returns the numeric code of the page analysis mode, or {@code null}. */
-    public Integer pageAnalysisCode() {
-        return pageAnalysis != null ? pageAnalysis.code() : null;
-    }
-
-    /** Returns the numeric code of the engine backend, or {@code null}. */
-    public Integer engineCode() {
-        return recognitionEngine != null ? recognitionEngine.code() : null;
-    }
-
     /* ---------- backward-compatible accessor shims ---------- */
 
-    public Integer segmentationCode()       { return pageAnalysisCode(); }
-    public Integer backendCode()            { return engineCode(); }
     public boolean shouldStripBackground()  { return isolateForeground; }
     public Color getForegroundHint()        { return targetColor; }
     public boolean isVerbose()              { return diagnosticMode; }
-    public boolean hasSegmentation()        { return hasPageAnalysis(); }
-    public boolean hasBackend()             { return hasEngine(); }
     public String getCharWhitelist()        { return allowedGlyphs; }
     public boolean hasCharWhitelist()       { return hasGlyphFilter(); }
-    public boolean shouldRecycleCapture()   { return reuseFrame; }
-    public Integer getPageSegMode()         { return pageAnalysisCode(); }
-    public Integer getOcrEngineMode()       { return engineCode(); }
     public boolean isRemoveBackground()     { return isolateForeground; }
     public Color getTextColor()             { return targetColor; }
     public boolean isDebug()                { return diagnosticMode; }
-    public boolean hasPageSegMode()         { return hasPageAnalysis(); }
-    public boolean hasOcrEngineMode()       { return hasEngine(); }
     public String getAllowedChars()         { return allowedGlyphs; }
     public boolean hasAllowedChars()        { return hasGlyphFilter(); }
-    public boolean isReuseLastImage()       { return reuseFrame; }
-
     /* ---- factory entry points ---- */
 
     /** Creates a fresh configurator for building settings instances. */
@@ -224,12 +163,10 @@ public class TesseractSettingsData {
     @Override
     public boolean equals(Object other) {
         if (this == other) return true;
-        if (!(other instanceof TesseractSettingsData that)) return false;
+        if (!(other instanceof OcrSettingsData that)) return false;
         return isolateForeground == that.isolateForeground
             && diagnosticMode    == that.diagnosticMode
-            && reuseFrame        == that.reuseFrame
-            && pageAnalysis      == that.pageAnalysis
-            && recognitionEngine == that.recognitionEngine
+            && textLayout        == that.textLayout
             && Objects.equals(targetColor,   that.targetColor)
             && Objects.equals(allowedGlyphs, that.allowedGlyphs);
     }
@@ -237,41 +174,33 @@ public class TesseractSettingsData {
     @Override
     public int hashCode() {
         return Objects.hash(
-                pageAnalysis, recognitionEngine, isolateForeground,
-                targetColor, diagnosticMode, allowedGlyphs, reuseFrame);
+                textLayout, isolateForeground,
+                targetColor, diagnosticMode, allowedGlyphs);
     }
 
     @Override
     public String toString() {
-        return "OCR{page=" + pageAnalysis
-                + ", engine=" + recognitionEngine
+        return "OCR{layout=" + textLayout
                 + ", fgIsolation=" + isolateForeground
                 + ", glyphs=" + allowedGlyphs + "}";
     }
 
     /**
-     * Step-by-step builder for assembling {@link TesseractSettingsData}
+     * Step-by-step builder for assembling {@link OcrSettingsData}
      * instances with a fluent API.
      */
     public static class Configurator {
 
-        private PageAnalysis pageAnalysis;
-        private RecognitionEngine recognitionEngine;
+        private TextLayout textLayout;
         private boolean isolateForeground;
         private Color targetColor;
         private boolean diagnosticMode;
         private String allowedGlyphs;
-        private boolean reuseFrame = false;
 
         /* ---- primary setters ---- */
 
-        public Configurator pageAnalysis(PageAnalysis mode) {
-            this.pageAnalysis = mode;
-            return this;
-        }
-
-        public Configurator recognitionEngine(RecognitionEngine engine) {
-            this.recognitionEngine = engine;
+        public Configurator textLayout(TextLayout layout) {
+            this.textLayout = layout;
             return this;
         }
 
@@ -295,31 +224,20 @@ public class TesseractSettingsData {
             return this;
         }
 
-        public Configurator reuseFrame(boolean reuse) {
-            this.reuseFrame = reuse;
-            return this;
-        }
-
         /* ---- backward-compatible setter aliases ---- */
 
-        public Configurator segmentation(PageAnalysis m)      { return pageAnalysis(m); }
-        public Configurator backend(RecognitionEngine b)      { return recognitionEngine(b); }
         public Configurator stripBackground(boolean s)        { return isolateForeground(s); }
         public Configurator foregroundHint(Color c)           { return targetColor(c); }
         public Configurator verbose(boolean v)                { return diagnosticMode(v); }
         public Configurator charWhitelist(String c)           { return allowedGlyphs(c); }
-        public Configurator recycleCapture(boolean r)         { return reuseFrame(r); }
-        public Configurator setPageSegMode(PageAnalysis m)    { return pageAnalysis(m); }
-        public Configurator setOcrEngineMode(RecognitionEngine b) { return recognitionEngine(b); }
         public Configurator setRemoveBackground(boolean r)    { return isolateForeground(r); }
         public Configurator setTextColor(Color c)             { return targetColor(c); }
         public Configurator setDebug(boolean d)               { return diagnosticMode(d); }
         public Configurator setAllowedChars(String c)         { return allowedGlyphs(c); }
-        public Configurator setReuseLastImage(boolean r)      { return reuseFrame(r); }
 
         /** Freezes the current configuration into an immutable instance. */
-        public TesseractSettingsData build() {
-            return new TesseractSettingsData(this);
+        public OcrSettingsData build() {
+            return new OcrSettingsData(this);
         }
     }
 }

--- a/modules/automation/src/main/java/dev/frostguard/engine/emulator/EmulatorController.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/emulator/EmulatorController.java
@@ -16,7 +16,7 @@ import dev.frostguard.engine.input.TapInteractionService;
 import dev.frostguard.engine.schedule.QueuedEmulatorTask;
 import dev.frostguard.engine.service.ConfigService;
 import dev.frostguard.engine.service.ProfileService;
-import net.sourceforge.tess4j.TesseractException;
+import dev.frostguard.vision.ocr.OcrException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -176,12 +176,16 @@ public class EmulatorController {
 
     // --- OCR ---
 
-    public String readText(String idx, PointData a, PointData b) throws IOException, TesseractException {
+    public String readText(String idx, PointData a, PointData b) throws IOException, OcrException {
         requireBackend(); return backend.readText(idx, a, b);
     }
-    public String readText(String idx, PointData a, PointData b, TesseractSettingsData c)
-            throws IOException, TesseractException {
+    public String readText(String idx, PointData a, PointData b, OcrSettingsData c)
+            throws IOException, OcrException {
         requireBackend(); return backend.readText(idx, a, b, c);
+    }
+    public String readText(String idx, PointData a, PointData b, OcrSettingsData c, boolean reuseFrame)
+            throws IOException, OcrException {
+        requireBackend(); return backend.readText(idx, a, b, c, reuseFrame);
     }
 
     // --- template matching ---

--- a/modules/automation/src/main/java/dev/frostguard/engine/emulator/EmulatorInstance.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/emulator/EmulatorInstance.java
@@ -6,13 +6,14 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 import dev.frostguard.api.configs.GameVersionEnum;
 import dev.frostguard.engine.error.ADBConnectionException;
 import dev.frostguard.api.domain.*;
 import com.android.ddmlib.*;
-import net.sourceforge.tess4j.TesseractException;
+import dev.frostguard.vision.ocr.OcrException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -408,17 +409,28 @@ public abstract class EmulatorInstance {
 
     // --- OCR ---
 
-    public String readText(String idx, PointData a, PointData b) throws IOException, TesseractException {
-        RawImageData scr = captureScreenshot(idx);
-        if (scr == null) throw new IOException("Capture null");
-        String lang = (EmulatorController.GAME == GameVersionEnum.CHINA) ? "eng+chi_sim" : "eng";
-        return TesseractOcrProvider.recognizeText(scr, a, b, lang);
+    public String readText(String idx, PointData a, PointData b) throws IOException, OcrException {
+        return readText(idx, a, b, null, false);
     }
 
-    public String readText(String idx, PointData a, PointData b, TesseractSettingsData cfg) throws IOException, TesseractException {
-        RawImageData scr = (cfg != null && cfg.isReuseLastImage()) ? lastFrame.getOrDefault(idx, captureScreenshot(idx)) : captureScreenshot(idx);
+    public String readText(String idx, PointData a, PointData b, OcrSettingsData cfg) throws IOException, OcrException {
+        return readText(idx, a, b, cfg, false);
+    }
+
+    public String readText(String idx, PointData a, PointData b, OcrSettingsData cfg, boolean reuseFrame) throws IOException, OcrException {
+        RawImageData scr = selectFrame(lastFrame, idx, reuseFrame, () -> captureScreenshot(idx));
         if (scr == null) throw new IOException("Capture null");
-        return TesseractOcrProvider.recognizeText(scr, a, b, cfg);
+        String lang = (EmulatorController.GAME == GameVersionEnum.CHINA) ? "eng+chi_sim" : "eng";
+        if (cfg == null) {
+            return OcrEngine.recognizeText(scr, a, b, lang);
+        }
+        return OcrEngine.recognizeText(scr, a, b, cfg);
+    }
+
+    static RawImageData selectFrame(Map<String, RawImageData> frames, String idx,
+            boolean reuseFrame, Supplier<RawImageData> capture) {
+        RawImageData cached = reuseFrame ? frames.get(idx) : null;
+        return cached != null ? cached : capture.get();
     }
 
     protected int getColorComponent(RawImage img, int base, int bit) {

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/CharacterSwitchHelper.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/CharacterSwitchHelper.java
@@ -9,7 +9,7 @@ import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.emulator.EmulatorController;
 import dev.frostguard.engine.input.TapInteractionService;
 import dev.frostguard.engine.nav.CommonGameAreas;
@@ -177,7 +177,7 @@ public class CharacterSwitchHelper {
         return Pattern.compile(Pattern.quote(b), Pattern.CASE_INSENSITIVE).matcher(a).find();
     }
 
-    private String ocrRead(AreaData area, TesseractSettingsData cfg) {
+    private String ocrRead(AreaData area, OcrSettingsData cfg) {
         return ocr.attemptRecognition(area, 3, 300L, cfg, t -> t != null && !t.trim().isEmpty(), String::trim);
     }
 
@@ -192,19 +192,18 @@ public class CharacterSwitchHelper {
         if (src != null) dst.addAll(src);
     }
 
-    private TesseractSettingsData idOcrCfg() {
-        return TesseractSettingsData.builder()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
-                .allowedGlyphs("0123456789").isolateForeground(true).build();
+    private OcrSettingsData idOcrCfg() {
+        return OcrSettingsData.builder()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+                .setAllowedChars("0123456789")
+                .setRemoveBackground(true).build();
     }
 
-    private TesseractSettingsData nameOcrCfg() {
-        return TesseractSettingsData.builder()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
-                .allowedGlyphs("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ")
-                .isolateForeground(true).build();
+    private OcrSettingsData nameOcrCfg() {
+        return OcrSettingsData.builder()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+                .setAllowedChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ")
+                .setRemoveBackground(true).build();
     }
 
     private void sleep(long ms) {

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/DeploymentHelper.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/DeploymentHelper.java
@@ -15,7 +15,7 @@ import dev.frostguard.vision.convert.GameTimeUtils;
 import dev.frostguard.vision.logging.ProfileContextLogger;
 import dev.frostguard.vision.convert.RegexNumberParser;
 import dev.frostguard.vision.ocr.ResilientOcrExecutor;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 
 import java.awt.image.BufferedImage;
 import java.time.Duration;
@@ -201,7 +201,7 @@ public class DeploymentHelper {
 
     private BufferedImage captureImage() {
         RawImageData frame = emu.captureScreen(device);
-        return TesseractOcrProvider.toBufferedImage(frame);
+        return dev.frostguard.vision.convert.ImageConverter.toBufferedImage(frame);
     }
 
     private static TemplateSearchHelper.SearchConfig search(

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/IntelScreenHelper.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/IntelScreenHelper.java
@@ -10,7 +10,7 @@ import dev.frostguard.engine.input.TapInteractionService;
 import dev.frostguard.engine.nav.SearchConfigConstants;
 import dev.frostguard.engine.schedule.LaunchPoint;
 import dev.frostguard.vision.logging.ProfileContextLogger;
-import net.sourceforge.tess4j.TesseractException;
+import dev.frostguard.vision.ocr.OcrException;
 
 import java.io.IOException;
 import java.util.function.BooleanSupplier;
@@ -90,7 +90,7 @@ public class IntelScreenHelper {
         try {
             String txt = emu.readText(dev, new PointData(85, 15), new PointData(171, 62));
             return txt != null && txt.toLowerCase().contains("intel");
-        } catch (IOException | TesseractException e) {
+        } catch (IOException | OcrException e) {
             log.warn("OCR check failed: " + e.getMessage());
             return false;
         }

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/MarchHelper.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/MarchHelper.java
@@ -20,7 +20,7 @@ import dev.frostguard.vision.color.PixelStats;
 import dev.frostguard.vision.convert.GameTimeUtils;
 import dev.frostguard.vision.logging.ProfileContextLogger;
 import dev.frostguard.vision.ocr.ResilientOcrExecutor;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 
 import java.awt.image.BufferedImage;
 import java.time.Duration;
@@ -109,7 +109,7 @@ public class MarchHelper {
     public List<MarchSlotState> readVisibleMarchQueue() {
         try {
             RawImageData frame = emu.captureScreen(device);
-            BufferedImage image = TesseractOcrProvider.toBufferedImage(frame);
+            BufferedImage image = dev.frostguard.vision.convert.ImageConverter.toBufferedImage(frame);
 
             List<MarchSlotState> slots = new ArrayList<>(SLOT_COUNT);
             for (int index = 0; index < SLOT_COUNT; index++) {
@@ -250,7 +250,7 @@ public class MarchHelper {
     private FormationFrame captureFormationFrame(int flagNumber) {
         try {
             RawImageData raw = emu.captureScreen(device);
-            return new FormationFrame(raw, TesseractOcrProvider.toBufferedImage(raw));
+            return new FormationFrame(raw, dev.frostguard.vision.convert.ImageConverter.toBufferedImage(raw));
         } catch (Exception ex) {
             log.warn("Could not inspect formation #" + flagNumber + ": " + ex.getMessage());
             return null;

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/StaminaHelper.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/StaminaHelper.java
@@ -196,7 +196,7 @@ public class StaminaHelper {
     }
 
     private Integer readDialogNumber(dev.frostguard.api.domain.AreaData area,
-                                     dev.frostguard.api.domain.TesseractSettingsData settings, String label) {
+                                     dev.frostguard.api.domain.OcrSettingsData settings, String label) {
         Integer value = numberReader.attemptRecognition(area.topLeft(), area.bottomRight(), 3, 100L, settings,
                 txt -> RegexNumberParser.conformsTo(txt, CommonOCRSettings.NUMBER_PATTERN),
                 txt -> RegexNumberParser.extractByPattern(txt, CommonOCRSettings.NUMBER_PATTERN));

--- a/modules/automation/src/main/java/dev/frostguard/engine/nav/CommonOCRSettings.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/nav/CommonOCRSettings.java
@@ -1,76 +1,73 @@
 package dev.frostguard.engine.nav;
 
-import dev.frostguard.api.domain.TesseractSettingsData;
-import dev.frostguard.api.domain.TesseractSettingsData.PageAnalysis;
-import dev.frostguard.api.domain.TesseractSettingsData.RecognitionEngine;
+import dev.frostguard.api.domain.OcrSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData.TextLayout;
 
 import java.awt.Color;
 import java.util.regex.Pattern;
 
-// Shared Tesseract presets and regex helpers for OCR-based game-state readers.
+// Shared OCR presets and regex helpers for OCR-based game-state readers.
 public final class CommonOCRSettings {
 
     private CommonOCRSettings() {}
 
     // stamina fraction: "123/500" style
-    public static final TesseractSettingsData STAMINA_FRACTION_SETTINGS =
-            buildLstmConfig("0123456789/", true, 255, 255, 255, PageAnalysis.SINGLE_LINE);
+    public static final OcrSettingsData STAMINA_FRACTION_SETTINGS =
+            buildConfig("0123456789/", true, 255, 255, 255, TextLayout.SINGLE_LINE);
 
     // spent stamina: digits only, near-white foreground
-    public static final TesseractSettingsData SPENT_STAMINA_SETTINGS =
+    public static final OcrSettingsData SPENT_STAMINA_SETTINGS =
             buildSpentStaminaConfig();
 
     // travel time: "12:34:56" in white, next to a clock icon that has no white pixel at all
-    public static final TesseractSettingsData TRAVEL_TIME_SETTINGS =
-            buildLstmConfig("0123456789:", true, 255, 255, 255, PageAnalysis.SINGLE_LINE);
+    public static final OcrSettingsData TRAVEL_TIME_SETTINGS =
+            buildConfig("0123456789:", true, 255, 255, 255, TextLayout.SINGLE_LINE);
 
     // march queue countdown: "00:01:53" in white on top of the progress bar
-    public static final TesseractSettingsData MARCH_QUEUE_TIMER_SETTINGS =
-            buildLstmConfig("0123456789:", true, 255, 255, 255, PageAnalysis.SINGLE_LINE);
+    public static final OcrSettingsData MARCH_QUEUE_TIMER_SETTINGS =
+            buildConfig("0123456789:", true, 255, 255, 255, TextLayout.SINGLE_LINE);
 
-    public static final TesseractSettingsData INTEL_COOLDOWN_SETTINGS =
-            buildLstmConfig("0123456789:", true, 255, 255, 255, PageAnalysis.SINGLE_LINE);
+    public static final OcrSettingsData INTEL_COOLDOWN_SETTINGS =
+            buildConfig("0123456789:", true, 255, 255, 255, TextLayout.SINGLE_LINE);
 
     // red cooldown clock, isolated from illustrated skill backgrounds
-    public static final TesseractSettingsData RED_DURATION_SETTINGS =
-            buildLstmConfig("0123456789:", true, 243, 59, 59, PageAnalysis.SINGLE_LINE);
+    public static final OcrSettingsData RED_DURATION_SETTINGS =
+            buildConfig("0123456789:", true, 243, 59, 59, TextLayout.SINGLE_LINE);
 
     // Keep raw anti-aliased glyphs: colour isolation drops the slender "1" in wrapped "1d" timers.
-    public static final TesseractSettingsData RED_MULTILINE_DURATION_SETTINGS =
-            buildLstmConfig("0123456789d:", false, 0, 0, 0, PageAnalysis.SPARSE);
+    public static final OcrSettingsData RED_MULTILINE_DURATION_SETTINGS =
+            buildConfig("0123456789d:", false, 0, 0, 0, TextLayout.SPARSE);
 
     // polar terror level: dark slate digits inside a pale pill
-    public static final TesseractSettingsData POLAR_LEVEL_SETTINGS =
-            TesseractSettingsData.assembler()
+    public static final OcrSettingsData POLAR_LEVEL_SETTINGS =
+            OcrSettingsData.assembler()
                     .charWhitelist("0123456789")
-                    .pageAnalysis(PageAnalysis.SINGLE_LINE)
+                    .textLayout(TextLayout.SINGLE_LINE)
                     .stripBackground(true)
                     .setTextColor(new Color(66, 84, 108))
                     .build();
 
     // special rewards heading: "Special Rewards (8 left)" in white on a blue section bar
-    public static final TesseractSettingsData POLAR_SPECIAL_REWARDS_SETTINGS =
-            buildLstmConfig("SpecialRewardsleft0123456789() ", true,
-                    255, 255, 255, PageAnalysis.SINGLE_LINE);
+    public static final OcrSettingsData POLAR_SPECIAL_REWARDS_SETTINGS =
+            buildConfig("SpecialRewardsleft0123456789() ", true,
+                    255, 255, 255, TextLayout.SINGLE_LINE);
 
     // extraction pattern for pulling first integer from noisy OCR text
     public static final Pattern NUMBER_PATTERN = Pattern.compile(".*?(\\d+).*");
 
-    private static TesseractSettingsData buildLstmConfig(String glyphs, boolean isolate,
-                                                          int r, int g, int b,
-                                                          PageAnalysis pageMode) {
-        TesseractSettingsData.Configurator builder = TesseractSettingsData.builder()
+    private static OcrSettingsData buildConfig(String glyphs, boolean isolate,
+                                               int r, int g, int b,
+                                               TextLayout layout) {
+        OcrSettingsData.Configurator builder = OcrSettingsData.builder()
                 .allowedGlyphs(glyphs)
-                .pageAnalysis(pageMode)
-                .recognitionEngine(RecognitionEngine.LSTM_ONLY);
+                .textLayout(layout);
         if (isolate) builder.isolateForeground(true).targetColor(new Color(r, g, b));
         return builder.build();
     }
 
-    private static TesseractSettingsData buildSpentStaminaConfig() {
-        return TesseractSettingsData.builder()
-                .pageAnalysis(PageAnalysis.SINGLE_WORD)
-                .recognitionEngine(RecognitionEngine.LSTM_ONLY)
+    private static OcrSettingsData buildSpentStaminaConfig() {
+        return OcrSettingsData.builder()
+                .textLayout(TextLayout.SINGLE_WORD)
                 .isolateForeground(true)
                 .targetColor(new Color(254, 254, 254))
                 .allowedGlyphs("0123456789")

--- a/modules/automation/src/main/java/dev/frostguard/engine/nav/LeftMenuTextSettings.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/nav/LeftMenuTextSettings.java
@@ -1,12 +1,12 @@
 package dev.frostguard.engine.nav;
 
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 
 import java.awt.Color;
 
 // Tesseract presets tuned for reading the left slide-out menu overlay.
-// Each configuration targets a specific text colour while reusing the
-// previously captured screen image.
+// Each configuration targets a specific text colour. Caller must reuse
+// frames explicitly if reading multiple regions in one pass.
 public final class LeftMenuTextSettings {
 
     private LeftMenuTextSettings() {}
@@ -15,46 +15,43 @@ public final class LeftMenuTextSettings {
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
     // alphabetic readers
-    public static final TesseractSettingsData WHITE_SETTINGS =
+    public static final OcrSettingsData WHITE_SETTINGS =
             alphabeticPreset(255, 255, 255);
 
-    public static final TesseractSettingsData GREEN_TEXT_SETTINGS =
+    public static final OcrSettingsData GREEN_TEXT_SETTINGS =
             alphabeticPreset(0, 193, 0);
 
-    public static final TesseractSettingsData ORANGE_SETTINGS =
+    public static final OcrSettingsData ORANGE_SETTINGS =
             alphabeticPreset(237, 138, 33);
 
-    public static final TesseractSettingsData RED_SETTINGS =
-            TesseractSettingsData.builder()
+    public static final OcrSettingsData RED_SETTINGS =
+            OcrSettingsData.builder()
                     .setRemoveBackground(true)
                     .setTextColor(new Color(243, 59, 59))
-                    .setReuseLastImage(true)
                     .build();
 
     // numeric readers
-    public static final TesseractSettingsData WHITE_DURATION =
+    public static final OcrSettingsData WHITE_DURATION =
             numericPreset("0123456789:d");
 
-    public static final TesseractSettingsData WHITE_NUMBERS =
+    public static final OcrSettingsData WHITE_NUMBERS =
             numericPreset("0123456789d");
 
-    public static final TesseractSettingsData WHITE_ONLY_NUMBERS =
+    public static final OcrSettingsData WHITE_ONLY_NUMBERS =
             numericPreset("0123456789");
 
-    private static TesseractSettingsData alphabeticPreset(int r, int g, int b) {
-        return TesseractSettingsData.builder()
+    private static OcrSettingsData alphabeticPreset(int r, int g, int b) {
+        return OcrSettingsData.builder()
                 .setRemoveBackground(true)
                 .setTextColor(new Color(r, g, b))
-                .setReuseLastImage(true)
                 .setAllowedChars(LETTERS)
                 .build();
     }
 
-    private static TesseractSettingsData numericPreset(String allowedChars) {
-        return TesseractSettingsData.builder()
+    private static OcrSettingsData numericPreset(String allowedChars) {
+        return OcrSettingsData.builder()
                 .setRemoveBackground(true)
                 .setTextColor(new Color(255, 255, 255))
-                .setReuseLastImage(true)
                 .setAllowedChars(allowedChars)
                 .build();
     }

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/DelayedTask.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/DelayedTask.java
@@ -13,7 +13,7 @@ import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.input.TapInteractionService;
 import dev.frostguard.engine.input.TapJitterPolicy;
 import dev.frostguard.engine.service.LoggingService;
@@ -290,7 +290,7 @@ public abstract class DelayedTask implements Runnable, Delayed, StaminaWaitSched
 
     // ── OCR convenience ─────────────────────────────────────────────
 
-    protected Integer readNumberValue(PointData tl, PointData br, TesseractSettingsData cfg) {
+    protected Integer readNumberValue(PointData tl, PointData br, OcrSettingsData cfg) {
         Integer val = integerHelper.attemptRecognition(tl, br, 5, 200L, cfg,
                 text -> RegexNumberParser.conformsTo(text, CommonOCRSettings.NUMBER_PATTERN),
                 text -> RegexNumberParser.extractByPattern(text, CommonOCRSettings.NUMBER_PATTERN));
@@ -298,7 +298,7 @@ public abstract class DelayedTask implements Runnable, Delayed, StaminaWaitSched
         return val;
     }
 
-    protected String readStringValue(PointData tl, PointData br, TesseractSettingsData cfg) {
+    protected String readStringValue(PointData tl, PointData br, OcrSettingsData cfg) {
         String val = stringHelper.attemptRecognition(tl, br, 5, 200L, cfg,
                 Objects::nonNull, text -> text);
         logDebug("String OCR result: " + (val != null ? val : "null"));

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/BotOcrEngine.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/BotOcrEngine.java
@@ -1,13 +1,13 @@
 package dev.frostguard.engine.service;
 
 import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.emulator.EmulatorController;
 import dev.frostguard.vision.ocr.ResilientOcrExecutor;
 
 import java.io.IOException;
 import java.util.Objects;
-import net.sourceforge.tess4j.TesseractException;
+import dev.frostguard.vision.ocr.OcrException;
 
 /**
  * Bridges the Frostguard OCR pipeline to a specific emulator instance
@@ -22,6 +22,7 @@ public final class BotOcrEngine implements ResilientOcrExecutor.TextExtractor {
 
     private final EmulatorController controller;
     private final String boundDevice;
+    private final boolean reuseLastFrame;
 
     /**
      * Constructs a bridge for the given controller and device.
@@ -30,15 +31,23 @@ public final class BotOcrEngine implements ResilientOcrExecutor.TextExtractor {
      * @param deviceId    emulator instance identifier used in ADB commands
      */
     public BotOcrEngine(EmulatorController controller, String deviceId) {
+        this(controller, deviceId, false);
+    }
+
+    private BotOcrEngine(EmulatorController controller, String deviceId, boolean reuseLastFrame) {
         this.controller = Objects.requireNonNull(controller, "controller");
         this.boundDevice = Objects.requireNonNull(deviceId, "deviceId");
+        this.reuseLastFrame = reuseLastFrame;
     }
 
     @Override
-    public String extractText(TesseractSettingsData tessConfig, PointData topLeft, PointData bottomRight)
-            throws IOException, TesseractException {
-        return hasCustomConfig(tessConfig)
-                ? controller.readText(boundDevice, topLeft, bottomRight, tessConfig)
+    public String extractText(OcrSettingsData config, PointData topLeft, PointData bottomRight)
+            throws IOException, OcrException {
+        if (reuseLastFrame) {
+            return controller.readText(boundDevice, topLeft, bottomRight, config, true);
+        }
+        return config != null
+                ? controller.readText(boundDevice, topLeft, bottomRight, config)
                 : controller.readText(boundDevice, topLeft, bottomRight);
     }
 
@@ -47,7 +56,11 @@ public final class BotOcrEngine implements ResilientOcrExecutor.TextExtractor {
         return boundDevice;
     }
 
-    private static boolean hasCustomConfig(TesseractSettingsData cfg) {
-        return cfg != null;
+    /**
+     * Returns an extractor that reads the controller's most recently captured frame.
+     * Capture reuse is an automation concern and intentionally does not live in OCR settings.
+     */
+    public BotOcrEngine reusingLastFrame() {
+        return new BotOcrEngine(controller, boundDevice, true);
     }
 }

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
@@ -1,6 +1,6 @@
 package dev.frostguard.engine.service;
 
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 import dev.frostguard.api.configs.FlowStepKind;
 import dev.frostguard.api.configs.TemplatesEnum;
 import dev.frostguard.engine.emulator.EmulatorController;
@@ -171,7 +171,7 @@ public class TaskBuilderService {
         try {
             RawImageData rawImage = emuManager.captureScreen(activeEmulatorNumber);
             if (rawImage != null) {
-                return TesseractOcrProvider.toBufferedImage(rawImage);
+                return dev.frostguard.vision.convert.ImageConverter.toBufferedImage(rawImage);
             }
         } catch (Exception e) {
             logger.error("Failed to capture screenshot for task builder", e);
@@ -346,7 +346,7 @@ public class TaskBuilderService {
                 node.setLastOcrResult("[no screenshot]");
                 return false;
             }
-            String ocrText = TesseractOcrProvider.recognizeText(rawImage,
+            String ocrText = OcrEngine.recognizeText(rawImage,
                     new PointData(tlX, tlY), new PointData(brX, brY), "eng");
             node.setLastOcrResult(ocrText != null ? ocrText.trim() : "");
             logger.info("OCR result: '{}'", node.getLastOcrResult());

--- a/modules/automation/src/test/java/dev/frostguard/engine/emulator/EmulatorInstanceFrameReuseTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/emulator/EmulatorInstanceFrameReuseTest.java
@@ -1,0 +1,43 @@
+package dev.frostguard.engine.emulator;
+
+import dev.frostguard.api.domain.RawImageData;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EmulatorInstanceFrameReuseTest {
+
+    @Test
+    void reusesCachedFrameWithoutCapturingEagerly() {
+        RawImageData cached = RawImageData.capture(new byte[4], 1, 1, 4);
+        AtomicInteger captures = new AtomicInteger();
+
+        RawImageData selected = EmulatorInstance.selectFrame(Map.of("device", cached), "device", true, () -> {
+            captures.incrementAndGet();
+            return RawImageData.capture(new byte[4], 1, 1, 4);
+        });
+
+        assertSame(cached, selected);
+        assertEquals(0, captures.get());
+    }
+
+    @Test
+    void capturesWhenReuseIsDisabledOrNoFrameExists() {
+        RawImageData fresh = RawImageData.capture(new byte[4], 1, 1, 4);
+        AtomicInteger captures = new AtomicInteger();
+
+        assertSame(fresh, EmulatorInstance.selectFrame(Map.of(), "device", true, () -> {
+            captures.incrementAndGet();
+            return fresh;
+        }));
+        assertSame(fresh, EmulatorInstance.selectFrame(Map.of("device", fresh), "device", false, () -> {
+            captures.incrementAndGet();
+            return fresh;
+        }));
+        assertEquals(2, captures.get());
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/helper/DeploymentCostOcrFrameTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/helper/DeploymentCostOcrFrameTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.engine.nav.CommonGameAreas;
 import dev.frostguard.engine.nav.CommonOCRSettings;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 
 class DeploymentCostOcrFrameTest {
 
@@ -22,7 +22,7 @@ class DeploymentCostOcrFrameTest {
                 .getResourceAsStream("/deployment/polar-after-equalize-20260709.png")));
         RawImageData frame = rgbaFrame(image);
 
-        String text = TesseractOcrProvider.recognizeText(
+        String text = OcrEngine.recognizeText(
                 frame,
                 CommonGameAreas.SPENT_STAMINA_OCR_AREA.topLeft(),
                 CommonGameAreas.SPENT_STAMINA_OCR_AREA.bottomRight(),

--- a/modules/automation/src/test/java/dev/frostguard/engine/helper/DeploymentHelperTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/helper/DeploymentHelperTest.java
@@ -9,7 +9,7 @@ import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 import dev.frostguard.api.domain.AccountDescriptor;
-import dev.frostguard.api.domain.TesseractSettingsData.PageAnalysis;
+import dev.frostguard.api.domain.OcrSettingsData.TextLayout;
 import dev.frostguard.engine.nav.CommonOCRSettings;
 import dev.frostguard.vision.ocr.ResilientOcrExecutor;
 
@@ -24,7 +24,7 @@ class DeploymentHelperTest {
         assertEquals(36, read.travelTimeSeconds());
         assertEquals(9, read.staminaCost());
         assertFalse(read.staminaCostFallback());
-        assertEquals(PageAnalysis.SINGLE_WORD, CommonOCRSettings.SPENT_STAMINA_SETTINGS.pageAnalysis());
+        assertEquals(TextLayout.SINGLE_WORD, CommonOCRSettings.SPENT_STAMINA_SETTINGS.textLayout());
     }
 
     @Test

--- a/modules/automation/src/test/java/dev/frostguard/engine/helper/IntelCooldownOcrFrameTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/helper/IntelCooldownOcrFrameTest.java
@@ -15,7 +15,7 @@ import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.engine.nav.CommonGameAreas;
 import dev.frostguard.engine.nav.CommonOCRSettings;
 import dev.frostguard.vision.convert.GameTimeUtils;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 
 class IntelCooldownOcrFrameTest {
 
@@ -39,7 +39,7 @@ class IntelCooldownOcrFrameTest {
         BufferedImage image = ImageIO.read(Objects.requireNonNull(getClass().getResourceAsStream(resource)));
         RawImageData frame = rgbaFrame(image);
 
-        String text = TesseractOcrProvider.recognizeText(
+        String text = OcrEngine.recognizeText(
                 frame,
                 area.topLeft(),
                 area.bottomRight(),

--- a/modules/automation/src/test/java/dev/frostguard/engine/helper/ResearchBadgeReaderFrameTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/helper/ResearchBadgeReaderFrameTest.java
@@ -7,16 +7,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.api.domain.ResearchBadgeData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.vision.match.OpenCvPatternLocator;
 import dev.frostguard.vision.ocr.ResearchBadgeReader;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import javax.imageio.ImageIO;
-import net.sourceforge.tess4j.TesseractException;
+import dev.frostguard.vision.ocr.OcrException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +32,7 @@ class ResearchBadgeReaderFrameTest {
     }
 
     @Test
-    void readsProgressFromARealResearchBadge() throws IOException, TesseractException {
+    void readsProgressFromARealResearchBadge() throws IOException, OcrException {
         BufferedImage image = ImageIO.read(Objects.requireNonNull(getClass()
                 .getResourceAsStream("/research/resource-shortfall-20260717.png")));
 
@@ -45,7 +45,7 @@ class ResearchBadgeReaderFrameTest {
     }
 
     @Test
-    void readsEveryIncompleteBadgeFromARealBattleTree() throws IOException, TesseractException {
+    void readsEveryIncompleteBadgeFromARealBattleTree() throws IOException, OcrException {
         BufferedImage image = ImageIO.read(Objects.requireNonNull(getClass()
                 .getResourceAsStream("/research/battle-progress-badges-20260718.png")));
 
@@ -66,7 +66,7 @@ class ResearchBadgeReaderFrameTest {
     }
 
     @Test
-    void readsOneOfThreeBadgesAfterCompletedResearch() throws IOException, TesseractException {
+    void readsOneOfThreeBadgesAfterCompletedResearch() throws IOException, OcrException {
         var badges = readTreeFrame("/research/help-completed-20260716.png");
 
         assertEquals(3, badges.size());
@@ -79,7 +79,7 @@ class ResearchBadgeReaderFrameTest {
     }
 
     @Test
-    void readsMixedBadgesWhileResearchHelpIsVisible() throws IOException, TesseractException {
+    void readsMixedBadgesWhileResearchHelpIsVisible() throws IOException, OcrException {
         var badges = readTreeFrame("/research/help-short-20260716.png");
 
         assertEquals(3, badges.size());
@@ -93,7 +93,7 @@ class ResearchBadgeReaderFrameTest {
 
     @Test
     void recoversEveryOneOfFiveBadgeFromTheLiveBattleTree()
-            throws IOException, TesseractException {
+            throws IOException, OcrException {
         var badges = readTreeFrame("/research/battle-progress-badges-5-20260718.png");
 
         assertEquals(4, badges.size());
@@ -107,7 +107,7 @@ class ResearchBadgeReaderFrameTest {
 
     @Test
     void readsEverySixLevelBadgeFromTheLiveBattleTree()
-            throws IOException, TesseractException {
+            throws IOException, OcrException {
         var badges = readTreeFrame("/research/battle-progress-badges-6-20260720.png");
 
         assertEquals(7, badges.size());
@@ -124,7 +124,7 @@ class ResearchBadgeReaderFrameTest {
 
     @Test
     void doesNotInventResearchBadgesOnAnUnrelatedGameScreen()
-            throws IOException, TesseractException {
+            throws IOException, OcrException {
         var badges = readTreeFrame("/dailymission/selected-daily-claims-20260716.png");
 
         assertTrue(badges.isEmpty());
@@ -132,10 +132,9 @@ class ResearchBadgeReaderFrameTest {
 
     @Test
     void researchTitleOcrVerifiesTheTreeAndRejectsAnUnrelatedScreen()
-            throws IOException, TesseractException {
-        TesseractSettingsData settings = TesseractSettingsData.assembler()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+            throws IOException, OcrException {
+        OcrSettingsData settings = OcrSettingsData.assembler()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
                 .build();
 
         String researchTitle = readTitle("/research/battle-progress-badges-6-20260720.png", settings);
@@ -147,16 +146,16 @@ class ResearchBadgeReaderFrameTest {
                 "An unrelated screen must not pass the Research tree gate: " + unrelatedTitle);
     }
 
-    private static String readTitle(String resource, TesseractSettingsData settings)
-            throws IOException, TesseractException {
+    private static String readTitle(String resource, OcrSettingsData settings)
+            throws IOException, OcrException {
         BufferedImage image = ImageIO.read(Objects.requireNonNull(
                 ResearchBadgeReaderFrameTest.class.getResourceAsStream(resource)));
-        return TesseractOcrProvider.recognizeText(
+        return OcrEngine.recognizeText(
                 rgbaFrame(image), new PointData(80, 0), new PointData(360, 80), settings).trim();
     }
 
     private static List<ResearchBadgeData> readTreeFrame(
-            String resource) throws IOException, TesseractException {
+            String resource) throws IOException, OcrException {
         BufferedImage image = ImageIO.read(Objects.requireNonNull(
                 ResearchBadgeReaderFrameTest.class.getResourceAsStream(resource)));
         return ResearchBadgeReader.read(

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/DebuggingLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/DebuggingLayoutController.java
@@ -12,7 +12,7 @@ import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.engine.service.ProfileService;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 
 import javafx.collections.FXCollections;
 import javafx.event.ActionEvent;
@@ -654,7 +654,7 @@ public class DebuggingLayoutController {
                 imgEndX, imgEndY));
 
         try {
-            String result = dev.frostguard.vision.ocr.TesseractOcrProvider.readFromFile(currentScreenshotFile, imgStartX, imgStartY,
+            String result = OcrEngine.readFromFile(currentScreenshotFile, imgStartX, imgStartY,
                     width, height, "eng");
             log("OCR Output:\n" + result);
         } catch (Exception e) {
@@ -693,7 +693,7 @@ public class DebuggingLayoutController {
                         .captureScreen(selected.getEmulatorNumber());
 
                 if (rawImage != null) {
-                    java.awt.image.BufferedImage bImg = TesseractOcrProvider.toBufferedImage(rawImage);
+                    java.awt.image.BufferedImage bImg = dev.frostguard.vision.convert.ImageConverter.toBufferedImage(rawImage);
 
                     File tempFile = File.createTempFile("adb_screenshot", ".png");
                     javax.imageio.ImageIO.write(bImg, "png", tempFile);

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/taskbuilder/TaskBuilderLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/taskbuilder/TaskBuilderLayoutController.java
@@ -1,6 +1,6 @@
 package dev.frostguard.app.panel.taskbuilder;
 
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 import dev.frostguard.api.configs.FlowStepKind;
 import dev.frostguard.api.configs.TemplatesEnum;
 import dev.frostguard.engine.emulator.EmulatorController;
@@ -446,7 +446,7 @@ public class TaskBuilderLayoutController {
             if (sel == null) return;
             RawImageData raw = EmulatorController.getInstance().captureScreen(sel.getEmulatorNumber());
             if (raw != null) {
-                BufferedImage bi = TesseractOcrProvider.toBufferedImage(raw);
+                BufferedImage bi = dev.frostguard.vision.convert.ImageConverter.toBufferedImage(raw);
                 Image fx = toFxImage(bi);
                 Platform.runLater(() -> { previewImageView.setImage(fx); previewHint.setVisible(false); hasPreviewImage=true; setStatus("📷 Preview updated"); });
             } else { Platform.runLater(() -> setStatus("❌ Capture failed")); }

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/alliance/AllianceMobilizationRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/alliance/AllianceMobilizationRoutine.java
@@ -7,7 +7,7 @@ import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.helper.TemplateSearchHelper.SearchConfig;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
@@ -277,9 +277,9 @@ private int scanRefreshCooldownFromMission(PointData bonusLocation) {
         sleepTask(500);
 
 
-        TesseractSettingsData timeSettings = TesseractSettingsData.assembler()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+        OcrSettingsData timeSettings = OcrSettingsData.assembler()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
                 .stripBackground(true)
                 .setTextColor(new Color(158, 14, 14))
                 .charWhitelist("0123456789d:")
@@ -1148,9 +1148,9 @@ private TaskPassResult handle200PercentTask(
     }
 
 private int scanTimerFromRegion(PointData topLeft, PointData bottomRight, String timerName) {
-        TesseractSettingsData timeSettings = TesseractSettingsData.assembler()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+        OcrSettingsData timeSettings = OcrSettingsData.assembler()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
                 .charWhitelist("0123456789d:")
                 .build();
 

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/alliance/AllianceShopRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/alliance/AllianceShopRoutine.java
@@ -315,7 +315,7 @@ private Integer scanAvailableQuantity(int cardIndex, AllianceShopItemEnum shopIt
                 RETRIES_OCR_VALUE,
                 1000L,
 
-                TesseractSettingsData.assembler()
+                OcrSettingsData.assembler()
                         .charWhitelist("0123456789")
                         .setTextColor(Color.white)
                         .stripBackground(true)
@@ -512,9 +512,9 @@ private Integer scanCurrentCoins() {
                 RETRIES_OCR_VALUE,
                 200L,
 
-                TesseractSettingsData.assembler()
+                OcrSettingsData.assembler()
                         .charWhitelist("0123456789")
-                        .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
+                        .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
                         .build(),
                 text -> RegexNumberParser.conformsTo(text, Pattern.compile(".*?(\\d+).*")),
                 text -> RegexNumberParser.extractByPattern(text, Pattern.compile(".*?(\\d+).*")));
@@ -702,7 +702,7 @@ private Integer scanItemPrice(int cardIndex, AllianceShopItemEnum shopItem) {
                 RETRIES_OCR_VALUE,
                 1000L,
 
-                TesseractSettingsData.assembler()
+                OcrSettingsData.assembler()
                         .charWhitelist("0123456789")
                         .build(),
                 text -> RegexNumberParser.conformsTo(text, Pattern.compile(".*?(\\d+).*")),

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/alliance/AllianceTechRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/alliance/AllianceTechRoutine.java
@@ -7,7 +7,7 @@ import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.helper.NavigationHelper;
 import dev.frostguard.engine.helper.TemplateSearchHelper.SearchConfig;
 import dev.frostguard.engine.nav.SearchConfigConstants;
@@ -57,9 +57,9 @@ private static final int DEFAULT_OFFSET_MINUTES_VALUE = Integer.parseInt(
 
 private static final int ERROR_RETRY_MINUTES_VALUE = 10;
 
-private static final TesseractSettingsData COIN_COUNT_OCR_SETTINGS_VALUE = TesseractSettingsData.assembler()
+private static final OcrSettingsData COIN_COUNT_OCR_SETTINGS_VALUE = OcrSettingsData.assembler()
 			.charWhitelist("0123456789")
-			.pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
+			.textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
 			.build();
 
 private int offsetMinutes;

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/city/PrioritiseFurnaceRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/city/PrioritiseFurnaceRoutine.java
@@ -5,7 +5,7 @@ import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.nav.SearchConfigConstants;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
@@ -120,7 +120,7 @@ public PrioritiseFurnaceRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDai
                         try {
                             emuManager.captureScreen(EMULATOR_NUMBER);
 
-                            TesseractSettingsData[] settingsToTry = {
+                            OcrSettingsData[] settingsToTry = {
                                     WHITE_SETTINGS,
                                     WHITE_NUMBERS,
                                     RED_SETTINGS,
@@ -130,12 +130,13 @@ public PrioritiseFurnaceRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDai
                             AreaData timeArea = new AreaData(new PointData(490, 1209), new PointData(605, 1239));
                             boolean timeFound = false;
 
-                            for (TesseractSettingsData ocrPreset : settingsToTry) {
+                            for (OcrSettingsData ocrPreset : settingsToTry) {
                                 String ocrText = emuManager.readText(
                                         EMULATOR_NUMBER,
                                         timeArea.topLeft(),
                                         timeArea.bottomRight(),
-                                        ocrPreset).trim();
+                                        ocrPreset,
+                                        true).trim();
 
                                 logDebug(routineLogPrioritiseFurnaceLine("OCR result with ocrPreset " + ocrPreset.getClass().getSimpleName() + ": '"
                                         + ocrText + "'"));
@@ -247,7 +248,7 @@ public PrioritiseFurnaceRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDai
                 try {
                     emuManager.captureScreen(EMULATOR_NUMBER);
 
-                    TesseractSettingsData[] settingsToTry = {
+                    OcrSettingsData[] settingsToTry = {
                             WHITE_SETTINGS,
                             WHITE_NUMBERS,
                             RED_SETTINGS,
@@ -257,12 +258,13 @@ public PrioritiseFurnaceRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDai
                     AreaData timeArea = new AreaData(new PointData(480, 1045), new PointData(596, 1070));
                     boolean timeFound = false;
 
-                    for (TesseractSettingsData ocrPreset : settingsToTry) {
+                    for (OcrSettingsData ocrPreset : settingsToTry) {
                         String ocrText = emuManager.readText(
                                 EMULATOR_NUMBER,
                                 timeArea.topLeft(),
                                 timeArea.bottomRight(),
-                                ocrPreset).trim();
+                                ocrPreset,
+                                true).trim();
 
                         logDebug(routineLogPrioritiseFurnaceLine("OCR result with ocrPreset " + ocrPreset.getClass().getSimpleName() + ": '" + ocrText
                                 + "'"));
@@ -552,19 +554,20 @@ private QueueSnapshot inspectQueueState(AreaData queueArea) {
         try {
 
 
-            TesseractSettingsData[] settingsToTry = {
+            OcrSettingsData[] settingsToTry = {
                     WHITE_SETTINGS,
                     WHITE_NUMBERS,
                     RED_SETTINGS,
                     ORANGE_SETTINGS,
             };
 
-            for (TesseractSettingsData ocrPreset : settingsToTry) {
+            for (OcrSettingsData ocrPreset : settingsToTry) {
                 String ocrText = emuManager.readText(
                         EMULATOR_NUMBER,
                         queueArea.topLeft(),
                         queueArea.bottomRight(),
-                        ocrPreset).trim();
+                        ocrPreset,
+                        true).trim();
 
                 logDebug(routineLogPrioritiseFurnaceLine("OCR result with ocrPreset " + ocrPreset.getClass().getSimpleName() + ": '" + ocrText + "'"));
 

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
@@ -10,7 +10,7 @@ import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.PriorityItemData;
 import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.api.domain.ResearchBadgeData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.config.PriorityConfigResolver;
 import dev.frostguard.engine.helper.TemplateSearchHelper.SearchConfig;
 import dev.frostguard.engine.nav.SearchConfigConstants;
@@ -21,13 +21,13 @@ import dev.frostguard.tasks.city.ResearchNodeSelectionPolicy.ResearchNode;
 import dev.frostguard.tasks.city.ResearchNodeSelectionPolicy.ResearchRow;
 import dev.frostguard.vision.convert.GameTimeUtils;
 import dev.frostguard.vision.ocr.ResearchBadgeReader;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import net.sourceforge.tess4j.TesseractException;
+import dev.frostguard.vision.ocr.OcrException;
 
 public class ResearchRoutine extends DelayedTask {
 
@@ -86,9 +86,9 @@ private static final SearchConfig REPLENISH_BUTTON_RECHECK = SearchConfig.builde
         .withCoordinates(new PointData(180, 1070), new PointData(535, 1195))
         .build();
 
-private static final TesseractSettingsData RESEARCH_TITLE_OCR = TesseractSettingsData.assembler()
-        .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-        .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+private static final OcrSettingsData RESEARCH_TITLE_OCR = OcrSettingsData.assembler()
+        .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
         .build();
 
 private static final PointData REPLENISH_CONFIRM_POINT = new PointData(511, 1056);
@@ -175,7 +175,7 @@ public ResearchRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask) {
                 }
                 return;
             }
-        } catch (IOException | TesseractException | RuntimeException e) {
+        } catch (IOException | OcrException | RuntimeException e) {
             logError(routineLogResearchLine("Issue while research status OCR: " + e.getMessage()));
             this.reschedule(LocalDateTime.now().plusHours(1));
             return;
@@ -409,7 +409,7 @@ private boolean isResearchTreeVisible() {
                 if (title.toLowerCase().contains("research")) {
                     return true;
                 }
-            } catch (IOException | TesseractException | RuntimeException e) {
+            } catch (IOException | OcrException | RuntimeException e) {
                 logDebug(routineLogResearchLine("Research tree title OCR attempt "
                         + attempt + " failed: " + e.getMessage()));
             }
@@ -607,10 +607,10 @@ private ResearchDialogInspection inspectResearchDialog() {
                 RESEARCH_GO_TOP_LEFT, RESEARCH_GO_BOTTOM_RIGHT, 85.0, 4).size();
         String requirements = "";
         try {
-            requirements = TesseractOcrProvider.recognizeText(
+            requirements = OcrEngine.recognizeText(
                     screenshot, RESEARCH_REQUIREMENTS_TOP_LEFT, RESEARCH_REQUIREMENTS_BOTTOM_RIGHT,
-                    TesseractSettingsData.forTextBlock());
-        } catch (TesseractException | RuntimeException exception) {
+                    OcrSettingsData.forTextBlock());
+        } catch (OcrException | RuntimeException exception) {
             logWarning(routineLogResearchLine("Research requirement OCR failed: " + exception.getMessage()));
         }
         ResearchDialogState state = ResearchDialogClassifier.classify(

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/city/TrainingRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/city/TrainingRoutine.java
@@ -354,7 +354,7 @@ private void capturePromotionCompletionTimeFlow() {
                     PROMOTION_TIME_BOTTOM_RIGHT_MS,
                     3,
                     200L,
-                    TesseractSettingsData.assembler()
+                    OcrSettingsData.assembler()
                             .charWhitelist("0123456789")
                             .build(),
                     GameTimeUtils::isAcceptedFormat,
@@ -388,7 +388,7 @@ private LocalDateTime extractTrainingCompletionTimeFlow() {
                     TRAIN_TIME_STARTED_BOTTOM_RIGHT_MS,
                     3,
                     200L,
-                    TesseractSettingsData.assembler()
+                    OcrSettingsData.assembler()
                             .charWhitelist("0123456789")
                             .build(),
                     GameTimeUtils::isAcceptedFormat,
@@ -526,7 +526,7 @@ private void scanAndUpdateAppointmentTime() {
                 MINISTRY_TIME_BOTTOM_RIGHT_MS,
                 5,
                 200L,
-                TesseractSettingsData.assembler()
+                OcrSettingsData.assembler()
                         .stripBackground(true)
                         .setTextColor(new Color(121, 136, 155))
                         .charWhitelist("0123456789:d")
@@ -634,7 +634,7 @@ private Duration extractMaxTrainingTimeFlow() {
                 TRAIN_TIME_BOTTOM_RIGHT_MS,
                 3,
                 200L,
-                TesseractSettingsData.assembler()
+                OcrSettingsData.assembler()
                         .charWhitelist("0123456789")
                         .stripBackground(true)
                         .setTextColor(new Color(254, 254, 254))
@@ -767,7 +767,7 @@ private Integer extractMaxTroopCountFlow() {
                 TROOP_COUNT_INPUT_MAX_VALUE,
                 5,
                 200L,
-                TesseractSettingsData.assembler()
+                OcrSettingsData.assembler()
                         .charWhitelist("0123456789")
                         .stripBackground(true)
                         .setTextColor(new Color(254, 254, 254))
@@ -921,11 +921,13 @@ private void logUnresolvedQueuesFlow(List<Integer> unknownIndices) {
 private QueueSlot inspectForStateKeywords(
             AreaData queueArea,
             TroopTypeShape troopType,
-            TesseractSettingsData[] settingsToTry) {
+            OcrSettingsData[] settingsToTry) {
 
-        for (TesseractSettingsData ocrPreset : settingsToTry) {
+        ResilientOcrExecutor<String> frameReader =
+                new ResilientOcrExecutor<>(provider.reusingLastFrame());
+        for (OcrSettingsData ocrPreset : settingsToTry) {
             try {
-                String text = stringHelper.attemptRecognition(
+                String text = frameReader.attemptRecognition(
                         queueArea.topLeft(),
                         queueArea.bottomRight(),
                         1,
@@ -1116,11 +1118,13 @@ private void manageNoQueuesSelected() {
 private QueueSlot inspectForTrainingTime(
             AreaData queueArea,
             TroopTypeShape troopType,
-            TesseractSettingsData[] settingsToTry) {
+            OcrSettingsData[] settingsToTry) {
 
-        for (TesseractSettingsData ocrPreset : settingsToTry) {
+        ResilientOcrExecutor<LocalDateTime> frameReader =
+                new ResilientOcrExecutor<>(provider.reusingLastFrame());
+        for (OcrSettingsData ocrPreset : settingsToTry) {
             try {
-                LocalDateTime readyAt = trainingTimeHelper.attemptRecognition(
+                LocalDateTime readyAt = frameReader.attemptRecognition(
                         queueArea,
                         3,
                         10,
@@ -1371,7 +1375,7 @@ private boolean pressEventsButton() {
     }
 
 private QueueSlot inspectQueueState(AreaData queueArea, TroopTypeShape troopType) {
-        TesseractSettingsData[] settingsToTry = {
+        OcrSettingsData[] settingsToTry = {
                 WHITE_SETTINGS,
                 WHITE_NUMBERS,
                 ORANGE_SETTINGS,

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/city/UpgradeBuildingsRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/city/UpgradeBuildingsRoutine.java
@@ -422,7 +422,8 @@ private String readSelectedBuildingName() {
                     EMULATOR_NUMBER,
                     BUILDING_NAME_AREA_VALUE.topLeft(),
                     BUILDING_NAME_AREA_VALUE.bottomRight(),
-                    WHITE_SETTINGS).trim();
+                    WHITE_SETTINGS,
+                    true).trim();
             logInfo(routineLogUpgradeBuildingsLine("Selected building name OCR: '" + text + "'"));
             return text;
         } catch (Exception e) {
@@ -648,7 +649,8 @@ private boolean isBuildButtonVisible() {
                     EMULATOR_NUMBER,
                     BUILDING_ACTION_BUTTON_AREA_VALUE.topLeft(),
                     BUILDING_ACTION_BUTTON_AREA_VALUE.bottomRight(),
-                    WHITE_SETTINGS);
+                    WHITE_SETTINGS,
+                    true);
             String normalized = buttonText == null ? "" : buttonText.toLowerCase().replaceAll("[^a-z]", "");
             logDebug(routineLogUpgradeBuildingsLine("Build button OCR result: '" + buttonText + "'"));
             boolean detected = normalized.contains("build") || normalized.contains("bui");
@@ -686,19 +688,20 @@ private UpgradeBuildingsRoutine.QueueSnapshot inspectQueueState(AreaData queueAr
         try {
 
 
-            TesseractSettingsData[] settingsToTry = {
+            OcrSettingsData[] settingsToTry = {
                     WHITE_SETTINGS,
                     WHITE_NUMBERS,
                     RED_SETTINGS,
                     ORANGE_SETTINGS,
             };
 
-            for (TesseractSettingsData ocrPreset : settingsToTry) {
+            for (OcrSettingsData ocrPreset : settingsToTry) {
                 String ocrText = emuManager.readText(
                         EMULATOR_NUMBER,
                         queueArea.topLeft(),
                         queueArea.bottomRight(),
-                        ocrPreset).trim();
+                        ocrPreset,
+                        true).trim();
 
                 logDebug(routineLogUpgradeBuildingsLine("OCR result with ocrPreset " + ocrPreset.getClass().getSimpleName() + ": '" + ocrText + "'"));
 

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/city/WarAcademyRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/city/WarAcademyRoutine.java
@@ -5,7 +5,7 @@ import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.nav.SearchConfigConstants;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
@@ -46,9 +46,9 @@ private static final int RETRY_DELAY_MINUTES_MS = 5;
 
 private static final int ADDITIONAL_SHARDS_DELAY_HOURS_MS = 2;
 
-private static final TesseractSettingsData SHARDS_OCR_SETTINGS_VALUE = TesseractSettingsData.assembler()
-            .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-            .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+private static final OcrSettingsData SHARDS_OCR_SETTINGS_VALUE = OcrSettingsData.assembler()
+            .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
             .charWhitelist("0123456789")
             .build();
 

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/ArenaRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/ArenaRoutine.java
@@ -24,7 +24,7 @@ import dev.frostguard.api.domain.ConfigData;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.RawImageData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.helper.TemplateSearchHelper.SearchConfig;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
@@ -32,7 +32,7 @@ import dev.frostguard.engine.service.StatisticsService;
 import dev.frostguard.vision.color.GameColors;
 import dev.frostguard.vision.color.PixelStats;
 import dev.frostguard.vision.convert.GameTimeUtils;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 
 /**
  * Task responsible for managing arena challenges.
@@ -341,7 +341,7 @@ public class ArenaRoutine extends DelayedTask {
     private boolean detectFirstRun() {
         logDebug("Checking if this is first arena run");
 
-        TesseractSettingsData configMap = TesseractSettingsData.assembler()
+        OcrSettingsData configMap = OcrSettingsData.assembler()
                 .stripBackground(true)
                 .setTextColor(new Color(255, 255, 255))
                 .charWhitelist("0123456789")
@@ -388,9 +388,9 @@ public class ArenaRoutine extends DelayedTask {
     private boolean readInitialAttempts() {
         logDebug("Reading initial challenge attempts");
 
-        TesseractSettingsData strictSettings = TesseractSettingsData.assembler()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+        OcrSettingsData strictSettings = OcrSettingsData.assembler()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
                 .stripBackground(true)
                 .setTextColor(new Color(91, 112, 147))
                 .charWhitelist("0123456789")
@@ -404,9 +404,9 @@ public class ArenaRoutine extends DelayedTask {
         if (attemptsRead == null) {
             logDebug("Attempt count strict OCR did not produce a value. Retrying with relaxed settings.");
 
-            TesseractSettingsData relaxedSettings = TesseractSettingsData.assembler()
-                    .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                    .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+            OcrSettingsData relaxedSettings = OcrSettingsData.assembler()
+                    .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
                     .stripBackground(true)
                     .charWhitelist("0123456789")
                     .build();
@@ -703,7 +703,7 @@ public class ArenaRoutine extends DelayedTask {
         PointData topLeft = powerArea.topLeft();
         PointData bottomRight = powerArea.bottomRight();
 
-        TesseractSettingsData powerSettings = powerOcrSettings();
+        OcrSettingsData powerSettings = powerOcrSettings();
 
         String text = stringHelper.attemptRecognition(
                 topLeft,
@@ -724,10 +724,9 @@ public class ArenaRoutine extends DelayedTask {
         return new PowerRead(colorRead.relation(), powerValue, text);
     }
 
-    static TesseractSettingsData powerOcrSettings() {
-        return TesseractSettingsData.assembler()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+    static OcrSettingsData powerOcrSettings() {
+        return OcrSettingsData.assembler()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
                 .stripBackground(true)
                 .setTextColor(ARENA_POWER_GREEN_TEXT)
                 .charWhitelist("0123456789.,KMBkmb")
@@ -907,9 +906,9 @@ public class ArenaRoutine extends DelayedTask {
 
     private String readOpponentText(PointData topLeft, PointData bottomRight, String whitelist, Color textColor,
                                     String label, int opponentNumber) {
-        TesseractSettingsData settings = TesseractSettingsData.assembler()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+        OcrSettingsData settings = OcrSettingsData.assembler()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
                 .stripBackground(true)
                 .setTextColor(textColor)
                 .charWhitelist(whitelist)
@@ -924,7 +923,7 @@ public class ArenaRoutine extends DelayedTask {
     private BufferedImage captureFrameForPixelScan(String context) {
         try {
             RawImageData frame = emuManager.captureScreen(EMULATOR_NUMBER);
-            return TesseractOcrProvider.toBufferedImage(frame);
+            return dev.frostguard.vision.convert.ImageConverter.toBufferedImage(frame);
         } catch (Exception ex) {
             logError(String.format("%s color analysis failed: %s", context, ex.getMessage()));
             return null;
@@ -1163,7 +1162,7 @@ public class ArenaRoutine extends DelayedTask {
     private int detectCurrentAttemptPosition() {
         logDebug("Detecting current attempt position via price");
 
-        TesseractSettingsData configMap = TesseractSettingsData.assembler()
+        OcrSettingsData configMap = OcrSettingsData.assembler()
                 .stripBackground(true)
                 .setTextColor(new Color(255, 255, 255))
                 .charWhitelist("0123456789")

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearTrapRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearTrapRoutine.java
@@ -7,7 +7,7 @@ import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.FormationSlots;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.helper.BearTrapHelper;
 import dev.frostguard.engine.helper.TemplateSearchHelper.SearchConfig;
 import dev.frostguard.engine.schedule.DelayedTask;
@@ -161,11 +161,10 @@ private LocalDateTime referenceTrapTime;
 
 private boolean isVisuallyTriggered = false;
 
-private static final TesseractSettingsData FREE_MARCHES_OCR_SETTINGS_VALUE = TesseractSettingsData.assembler()
+private static final OcrSettingsData FREE_MARCHES_OCR_SETTINGS_VALUE = OcrSettingsData.assembler()
             .charWhitelist("0123456789/")
             .stripBackground(true)
             .setTextColor(new Color(253, 253, 253))
-            .setReuseLastImage(true)
             .build();
 
 public BearTrapRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask) {
@@ -688,8 +687,10 @@ private int inspectFreeMarches() {
         checkPreemption();
 
         emuManager.captureScreen(EMULATOR_NUMBER);
+        ResilientOcrExecutor<Integer> frameReader =
+                new ResilientOcrExecutor<>(provider.reusingLastFrame());
 
-        Integer used = integerHelper.attemptRecognition(
+        Integer used = frameReader.attemptRecognition(
                 FREE_MARCHES_OCR_TL_VALUE,
                 FREE_MARCHES_OCR_BR_VALUE,
                 5,
@@ -701,7 +702,7 @@ private int inspectFreeMarches() {
         checkPreemption();
 
 
-        Integer total = integerHelper.attemptRecognition(
+        Integer total = frameReader.attemptRecognition(
                 FREE_MARCHES_OCR_TL_VALUE,
                 FREE_MARCHES_OCR_BR_VALUE,
                 5,

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/ManualRallyJoinRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/ManualRallyJoinRoutine.java
@@ -13,7 +13,7 @@ import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
 import dev.frostguard.engine.schedule.preempt.ManualRallyJoinPreemptionRule;
 import dev.frostguard.vision.color.PixelStats;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.time.LocalDateTime;
@@ -249,7 +249,7 @@ private TemplatesEnum resolveTargetTemplateFlow(String key) {
 private boolean hasJoinButtonGreen(PointData center) {
         try {
             RawImageData rawImage = emuManager.captureScreen(EMULATOR_NUMBER);
-            BufferedImage img = TesseractOcrProvider.toBufferedImage(rawImage);
+            BufferedImage img = dev.frostguard.vision.convert.ImageConverter.toBufferedImage(rawImage);
 
             AreaData joinButton = new AreaData(
                     new PointData(center.getX() - 20, center.getY() - 10),

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/VipRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/VipRoutine.java
@@ -6,7 +6,7 @@ import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.nav.SearchConfigConstants;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
@@ -82,9 +82,9 @@ public VipRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDailyTask) {
 private void scanAndStoreVipExpirationTime() {
 		logDebug(routineLogVipLine("Reading VIP expiration time from screen"));
 
-		TesseractSettingsData timeSettings = TesseractSettingsData.assembler()
-				.pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-				.recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+		OcrSettingsData timeSettings = OcrSettingsData.assembler()
+				.textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
 				.charWhitelist("0123456789d")
 				.build();
 

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/economy/BankRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/economy/BankRoutine.java
@@ -12,7 +12,7 @@ import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
 import dev.frostguard.engine.nav.SearchConfigConstants;
@@ -568,7 +568,7 @@ public class BankRoutine extends DelayedTask {
 				TIME_OCR_BOTTOM_RIGHT,
 				MAX_OCR_RETRIES,
 				OCR_RETRY_DELAY_MS,
-				TesseractSettingsData.assembler()
+				OcrSettingsData.assembler()
                         .stripBackground(true)
                         .setTextColor(new Color(255, 255, 255))
                         .charWhitelist("0123456789:d")

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
@@ -34,7 +34,7 @@ import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.api.runtime.WorkspacePaths;
 import dev.frostguard.engine.helper.MarchSlotAvailabilityEstimator;
@@ -44,7 +44,6 @@ import dev.frostguard.engine.schedule.LaunchPoint;
 import dev.frostguard.engine.schedule.TaskQueue;
 import dev.frostguard.engine.helper.TemplateSearchHelper.SearchConfig;
 import dev.frostguard.engine.service.StatisticsService;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
 
 import javax.imageio.ImageIO;
 
@@ -630,7 +629,7 @@ public class GatherRoutine extends DelayedTask {
             Path output = outputDirectory.resolve(
                     "gather-recall-controls-missing-" + safeProfileName + "-latest.png");
             RawImageData frame = emuManager.captureScreen(EMULATOR_NUMBER);
-            BufferedImage image = TesseractOcrProvider.toBufferedImage(frame);
+            BufferedImage image = dev.frostguard.vision.convert.ImageConverter.toBufferedImage(frame);
             if (!ImageIO.write(image, "png", output.toFile())) {
                 throw new IOException("PNG writer unavailable");
             }
@@ -822,7 +821,7 @@ public class GatherRoutine extends DelayedTask {
     // ================= HELPERS (UI/OCR) =================
 
     private Integer readLevel() {
-        TesseractSettingsData s = TesseractSettingsData.assembler().charWhitelist("0123456789")
+        OcrSettingsData s = OcrSettingsData.assembler().charWhitelist("0123456789")
                 .stripBackground(true).setTextColor(new Color(255, 255, 255)).build();
         return readNumberValue(LEVEL_DISPLAY_TL, LEVEL_DISPLAY_BR, s);
     }

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/economy/StorehouseChestRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/economy/StorehouseChestRoutine.java
@@ -17,7 +17,7 @@ import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.service.StaminaService;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
@@ -74,12 +74,12 @@ public class StorehouseChestRoutine extends DelayedTask {
     private static final int SCROLL_REPEAT_DELAY = 300;
 
     // ========== OCR Settings ==========
-    private static final TesseractSettingsData STAMINA_OCR_SETTINGS = TesseractSettingsData.assembler()
+    private static final OcrSettingsData STAMINA_OCR_SETTINGS = OcrSettingsData.assembler()
             .setTextColor(new Color(248, 247, 234))
             .stripBackground(true)
             .charWhitelist("0123456789")
-            .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-            .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+            .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
             .build();
 
     // ========== Configuration (loaded in loadConfiguration()) ==========
@@ -228,9 +228,9 @@ public class StorehouseChestRoutine extends DelayedTask {
     private LocalDateTime readChestTimer() {
         logDebug("Reading chest timer via OCR");
 
-        TesseractSettingsData configs = TesseractSettingsData.assembler()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+        OcrSettingsData configs = OcrSettingsData.assembler()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
                 .stripBackground(true)
                 .setTextColor(new Color(255, 95, 95))
                 .charWhitelist("0123456789:")
@@ -403,9 +403,9 @@ public class StorehouseChestRoutine extends DelayedTask {
     private LocalDateTime readFallbackTimer() {
         logDebug("Attempting fallback timer reading.");
 
-        TesseractSettingsData configs = TesseractSettingsData.assembler()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+        OcrSettingsData configs = OcrSettingsData.assembler()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
                 .stripBackground(true)
                 .setTextColor(new Color(255, 255, 255))
                 .charWhitelist("0123456789:")

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/events/HeroMissionEventRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/events/HeroMissionEventRoutine.java
@@ -15,7 +15,7 @@ import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.service.TaskManagementService;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
@@ -286,8 +286,8 @@ public class HeroMissionEventRoutine extends DelayedTask {
     }
 
     private ReaperAvailabilityResult reapersAvailable() {
-        TesseractSettingsData settingsRallied = TesseractSettingsData.assembler()
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+        OcrSettingsData settingsRallied = OcrSettingsData.assembler()
+
                 .stripBackground(true)
                 .setTextColor(new Color(254, 254, 254)) // White text
                 .charWhitelist("0123456789") // Only allow digits

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/events/JourneyofLightRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/events/JourneyofLightRoutine.java
@@ -12,7 +12,7 @@ import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.nav.SearchConfigConstants;
 
@@ -77,9 +77,9 @@ public class JourneyofLightRoutine extends DelayedTask {
                 { new PointData(560, 1036), new PointData(664, 1058) },
         };
 
-        TesseractSettingsData configs = TesseractSettingsData.assembler()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+        OcrSettingsData configs = OcrSettingsData.assembler()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
                 .charWhitelist("0123456789:")
                 .build();
 

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/events/MercenaryEventRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/events/MercenaryEventRoutine.java
@@ -10,7 +10,7 @@ import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.service.TaskManagementService;
 import dev.frostguard.engine.service.StaminaService;
 import dev.frostguard.engine.schedule.DelayedTask;
@@ -122,9 +122,9 @@ public class MercenaryEventRoutine extends DelayedTask {
     }
 
     private Integer checkMercenaryLevel() {
-        TesseractSettingsData configs = TesseractSettingsData.assembler()
-                .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-                .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+        OcrSettingsData configs = OcrSettingsData.assembler()
+                .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
                 .stripBackground(true)
                 .setTextColor(new Color(255, 255, 255)) // White text
                 .charWhitelist("0123456789") // Only allow digits and '/'

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/heroes/HeroRecruitmentRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/heroes/HeroRecruitmentRoutine.java
@@ -9,7 +9,7 @@ import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
 import dev.frostguard.engine.helper.TemplateSearchHelper;
@@ -314,7 +314,7 @@ public class HeroRecruitmentRoutine extends DelayedTask {
                 bottomRight,
                 MAX_OCR_RETRIES,
                 OCR_RETRY_DELAY_MS,
-                TesseractSettingsData.assembler()
+                OcrSettingsData.assembler()
                         .charWhitelist("0123456789d")
                         .build(),
                 GameTimeUtils::isAcceptedFormat,

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/lifecycle/CreateCharacterRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/lifecycle/CreateCharacterRoutine.java
@@ -9,7 +9,7 @@ import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.service.ScheduleService;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
@@ -42,16 +42,16 @@ public class CreateCharacterRoutine extends DelayedTask {
     private static final PointData CROSS_BUTTON = new PointData(631, 158);// FIXXX ITTT <----------
 
     // --- OCR ---
-    private static final TesseractSettingsData TIPS_OCR_SETTINGS = TesseractSettingsData.assembler()
-            .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-            .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+    private static final OcrSettingsData TIPS_OCR_SETTINGS = OcrSettingsData.assembler()
+            .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
             .charWhitelist("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
             .stripBackground(true)
             .build();
 
-    private static final TesseractSettingsData AGE_OCR_SETTINGS = TesseractSettingsData.assembler()
-            .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
-            .recognitionEngine(TesseractSettingsData.RecognitionEngine.LSTM_ONLY)
+    private static final OcrSettingsData AGE_OCR_SETTINGS = OcrSettingsData.assembler()
+            .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
+
             .charWhitelist("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789() ")
             .stripBackground(true)
             .build();

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/pets/PetSkillsRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/pets/PetSkillsRoutine.java
@@ -15,7 +15,8 @@ import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.nav.CommonOCRSettings;
 import dev.frostguard.engine.nav.SearchConfigConstants;
 import dev.frostguard.engine.schedule.DelayedTask;
@@ -24,7 +25,6 @@ import dev.frostguard.engine.service.StaminaService;
 import dev.frostguard.vision.color.PixelStats;
 import dev.frostguard.vision.convert.GameTimeUtils;
 import dev.frostguard.vision.convert.RegexNumberParser;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
 
 /**
  * Unified Pet Skills task that processes all enabled pet skills in a single
@@ -115,18 +115,16 @@ public class PetSkillsRoutine extends DelayedTask {
     private static final int STAMINA_PER_LEVEL = 5;
     private static final int STAMINA_FALLBACK_VALUE = 35; // Level 1 equivalent
 
-    // ========== OCR Settings ==========
-    private static final TesseractSettingsData COOLDOWN_OCR_SETTINGS =
-            CommonOCRSettings.RED_DURATION_SETTINGS;
+    private static final OcrSettingsData COOLDOWN_OCR_SETTINGS = CommonOCRSettings.RED_DURATION_SETTINGS;
 
-    private static final TesseractSettingsData SKILL_LEVEL_OCR_SETTINGS = TesseractSettingsData.assembler()
+    private static final OcrSettingsData SKILL_LEVEL_OCR_SETTINGS = OcrSettingsData.assembler()
             .charWhitelist("0123456789")
-            .pageAnalysis(TesseractSettingsData.PageAnalysis.SINGLE_LINE)
+            .textLayout(OcrSettingsData.TextLayout.SINGLE_LINE)
             .stripBackground(true)
             .setTextColor(new Color(69, 88, 110))
             .build();
 
-    private static final TesseractSettingsData GATHERING_SKILL_OCR_SETTINGS = TesseractSettingsData.assembler()
+    private static final OcrSettingsData GATHERING_SKILL_OCR_SETTINGS = OcrSettingsData.assembler()
             .charWhitelist("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
             .stripBackground(true)
             .setTextColor(new Color(0, 187, 0))
@@ -486,7 +484,7 @@ public class PetSkillsRoutine extends DelayedTask {
 
     private boolean isSkillPresent(PetSkill skill) {
         try {
-            BufferedImage image = TesseractOcrProvider.toBufferedImage(
+            BufferedImage image = dev.frostguard.vision.convert.ImageConverter.toBufferedImage(
                     emuManager.captureScreen(EMULATOR_NUMBER));
             return hasDistinctiveSkillTilePixels(image, skill.area);
         } catch (Exception ex) {
@@ -655,7 +653,7 @@ public class PetSkillsRoutine extends DelayedTask {
         return readSkillCooldown(area, COOLDOWN_OCR_SETTINGS);
     }
 
-    private Duration readSkillCooldown(AreaData area, TesseractSettingsData settings) {
+    private Duration readSkillCooldown(AreaData area, OcrSettingsData settings) {
         return durationHelper.attemptRecognition(
                 area.topLeft(),
                 area.bottomRight(),
@@ -1127,7 +1125,7 @@ public class PetSkillsRoutine extends DelayedTask {
                 new PointData(78, 991),
                 new PointData(474, 1028));
 
-        TesseractSettingsData configs = TesseractSettingsData.assembler()
+        OcrSettingsData configs = OcrSettingsData.assembler()
                 .charWhitelist("0123456789")
                 .stripBackground(true)
                 .setTextColor(new Color(255, 255, 255))

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/combat/ArenaRoutinePowerFrameTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/combat/ArenaRoutinePowerFrameTest.java
@@ -4,7 +4,7 @@ import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.vision.color.GameColors;
 import dev.frostguard.vision.color.PixelStats;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 import org.junit.jupiter.api.Test;
 
 import javax.imageio.ImageIO;
@@ -68,7 +68,7 @@ class ArenaRoutinePowerFrameTest {
 
     private Double readPower(RawImageData frame, int opponentNumber) throws Exception {
         AreaData area = ArenaRoutine.serverPowerTextArea(opponentY(opponentNumber));
-        String text = TesseractOcrProvider.recognizeText(
+        String text = OcrEngine.recognizeText(
                 frame, area.topLeft(), area.bottomRight(), ArenaRoutine.powerOcrSettings());
         return ArenaRoutine.parsePowerValue(text);
     }

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/pets/PetSkillsCooldownOcrFrameTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/pets/PetSkillsCooldownOcrFrameTest.java
@@ -16,7 +16,7 @@ import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.engine.nav.CommonOCRSettings;
 import dev.frostguard.vision.convert.GameTimeUtils;
-import dev.frostguard.vision.ocr.TesseractOcrProvider;
+import dev.frostguard.vision.ocr.OcrEngine;
 
 class PetSkillsCooldownOcrFrameTest {
 
@@ -24,7 +24,7 @@ class PetSkillsCooldownOcrFrameTest {
     void readsSingleLineStaminaCooldown() throws Exception {
         BufferedImage image = loadFrame();
 
-        String clock = TesseractOcrProvider.recognizeText(
+        String clock = OcrEngine.recognizeText(
                 rgbaFrame(image),
                 PetSkillsRoutine.STAMINA_COOLDOWN_OCR_AREA.topLeft(),
                 PetSkillsRoutine.STAMINA_COOLDOWN_OCR_AREA.bottomRight(),
@@ -40,7 +40,7 @@ class PetSkillsCooldownOcrFrameTest {
         BufferedImage image = loadFrame();
 
         RawImageData frame = rgbaFrame(image);
-        String timer = TesseractOcrProvider.recognizeText(
+        String timer = OcrEngine.recognizeText(
                 frame,
                 PetSkillsRoutine.GATHERING_COOLDOWN_OCR_AREA.topLeft(),
                 PetSkillsRoutine.GATHERING_COOLDOWN_OCR_AREA.bottomRight(),

--- a/modules/vision/src/main/java/dev/frostguard/vision/convert/ImageConverter.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/convert/ImageConverter.java
@@ -1,0 +1,56 @@
+package dev.frostguard.vision.convert;
+
+import dev.frostguard.api.domain.RawImageData;
+import java.awt.image.BufferedImage;
+
+public final class ImageConverter {
+
+    private ImageConverter() {
+        // static utility
+    }
+
+    /**
+     * Converts a raw byte array capture from the emulator into a standard
+     * {@link BufferedImage}. Useful for diagnostic dumps or when an image
+     * processing library requires AWT images.
+     */
+    public static BufferedImage toBufferedImage(RawImageData capture) {
+        if (capture == null) {
+            throw new IllegalArgumentException("Capture must not be null.");
+        }
+        int w = capture.getWidth();
+        int h = capture.getHeight();
+        byte[] raw = capture.getData();
+        int bpp = capture.getBpp();
+        int bytesPerPixel = switch (bpp) {
+            case 2, 16 -> 2;
+            case 4, 32 -> 4;
+            default -> throw new IllegalArgumentException("Unsupported capture depth: " + bpp);
+        };
+        int requiredBytes = Math.multiplyExact(Math.multiplyExact(w, h), bytesPerPixel);
+        if (w <= 0 || h <= 0 || raw == null || raw.length < requiredBytes) {
+            throw new IllegalArgumentException("Capture has invalid dimensions or pixel data.");
+        }
+
+        int[] pixels = new int[w * h];
+        for (int index = 0; index < pixels.length; index++) {
+            int offset = index * bytesPerPixel;
+            if (bytesPerPixel == 2) {
+                int packed = ((raw[offset + 1] & 0xFF) << 8) | (raw[offset] & 0xFF);
+                int red = ((packed >> 11) & 0x1F) << 3;
+                int green = ((packed >> 5) & 0x3F) << 2;
+                int blue = (packed & 0x1F) << 3;
+                pixels[index] = (red << 16) | (green << 8) | blue;
+            } else {
+                int red = raw[offset] & 0xFF;
+                int green = raw[offset + 1] & 0xFF;
+                int blue = raw[offset + 2] & 0xFF;
+                pixels[index] = (red << 16) | (green << 8) | blue;
+            }
+        }
+
+        BufferedImage image = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
+        image.setRGB(0, 0, w, h, pixels, 0, w);
+        return image;
+    }
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/convert/ImagePreprocessor.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/convert/ImagePreprocessor.java
@@ -1,0 +1,94 @@
+package dev.frostguard.vision.convert;
+
+import dev.frostguard.api.domain.RawImageData;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+
+/**
+ * Prepares raw screen captures for OCR by applying cropping, background
+ * isolation, and smooth upscaling.
+ */
+public final class ImagePreprocessor {
+
+    /** Magnification applied before recognition. */
+    private static final int MAGNIFICATION = 4;
+
+    /** Per-channel distance used when isolating text pixels. */
+    private static final int CHANNEL_TOLERANCE = 50;
+
+    private ImagePreprocessor() {}
+
+    /**
+     * Extracts a rectangular region and magnifies it for OCR. When isolating
+     * text ({@code stripBackground} + {@code textColour}), the region is turned
+     * into a soft distance-to-target grayscale rather than a hard black/white mask,
+     * then upscaled bilinearly.
+     */
+    public static BufferedImage prepareForOcr(RawImageData capture,
+            int cx, int cy, int cw, int ch,
+            boolean stripBackground, Color textColour) {
+
+        byte[] raw = capture.getData();
+        int bpp = capture.getBpp();
+        int srcStride = capture.getWidth();
+        boolean isolate = stripBackground && textColour != null;
+
+        int tR = 0, tG = 0, tB = 0;
+        if (isolate) {
+            tR = textColour.getRed();
+            tG = textColour.getGreen();
+            tB = textColour.getBlue();
+        }
+
+        int[] px = new int[cw * ch];
+        for (int y = 0; y < ch; y++) {
+            for (int x = 0; x < cw; x++) {
+                int rgb = decodePixel(raw, bpp, srcStride, cx + x, cy + y);
+                if (isolate) {
+                    int pr = (rgb >> 16) & 0xFF, pg = (rgb >> 8) & 0xFF, pb = rgb & 0xFF;
+                    int dist = Math.max(Math.abs(pr - tR), Math.max(Math.abs(pg - tG), Math.abs(pb - tB)));
+                    int v = Math.min(255, dist * 255 / CHANNEL_TOLERANCE);
+                    px[y * cw + x] = (v << 16) | (v << 8) | v;
+                } else {
+                    px[y * cw + x] = rgb;
+                }
+            }
+        }
+        BufferedImage base = new BufferedImage(cw, ch, BufferedImage.TYPE_INT_RGB);
+        base.setRGB(0, 0, cw, ch, px, 0, cw);
+
+        int outW = cw * MAGNIFICATION;
+        int outH = ch * MAGNIFICATION;
+        BufferedImage result = new BufferedImage(outW, outH, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = result.createGraphics();
+        // Bilinear interpolation is intentional. Nearest-neighbour scaling caused real
+        // recognition regressions in small game glyphs (notably 2 -> 7 and 5 -> 3).
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g.drawImage(base, 0, 0, outW, outH, null);
+        g.dispose();
+        return result;
+    }
+
+    private static int decodePixel(byte[] data, int bpp, int stride, int px, int py) {
+        if (bpp == 2 || bpp == 16) {
+            int off = (py * stride + px) * 2;
+            int packed = ((data[off + 1] & 0xFF) << 8) | (data[off] & 0xFF);
+            int r = ((packed >> 11) & 0x1F) << 3;
+            int g = ((packed >> 5)  & 0x3F) << 2;
+            int b = (packed & 0x1F) << 3;
+            return (r << 16) | (g << 8) | b;
+        }
+        if (bpp != 4 && bpp != 32) {
+            throw new IllegalArgumentException("Unsupported capture depth: " + bpp);
+        }
+        // 32-bit RGBA
+        int off = (py * stride + px) * 4;
+        int r = data[off]     & 0xFF;
+        int g = data[off + 1] & 0xFF;
+        int b = data[off + 2] & 0xFF;
+        return (r << 16) | (g << 8) | b;
+    }
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/OcrDiagnosticWriter.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/OcrDiagnosticWriter.java
@@ -1,0 +1,119 @@
+package dev.frostguard.vision.ocr;
+
+import dev.frostguard.api.domain.OcrSettingsData;
+import dev.frostguard.api.domain.RawImageData;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.vision.convert.ImageConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.imageio.ImageIO;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+final class OcrDiagnosticWriter {
+
+    private static final Logger log = LoggerFactory.getLogger(OcrDiagnosticWriter.class);
+
+    private OcrDiagnosticWriter() {}
+
+    static Path write(RawImageData capture, BufferedImage processed,
+            int x, int y, int width, int height, OcrSettingsData settings, String text) throws IOException {
+        Path directory = WorkspacePaths.current().cache().resolve("ocr");
+        Files.createDirectories(directory);
+        Path output = Files.createTempFile(directory, "ocr-", "-debug.png");
+        BufferedImage full = ImageConverter.toBufferedImage(capture);
+        ImageIO.write(composePanel(full, processed, x, y, width, height, settings, text), "png", output.toFile());
+        log.debug("OCR diagnostic image saved to {}", output);
+        return output;
+    }
+
+    private static BufferedImage composePanel(BufferedImage full, BufferedImage processed,
+            int x, int y, int width, int height, OcrSettingsData settings, String text) {
+        final int gap = 20;
+        final int header = 40;
+        final int infoHeight = 180;
+        int rightWidth = Math.max(processed.getWidth(), 500);
+        int totalWidth = full.getWidth() + gap + rightWidth;
+        int totalHeight = Math.max(full.getHeight() + header,
+                processed.getHeight() + header + infoHeight + gap);
+
+        BufferedImage canvas = new BufferedImage(totalWidth, totalHeight, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = canvas.createGraphics();
+        enableSmoothing(graphics);
+        graphics.setColor(Color.WHITE);
+        graphics.fillRect(0, 0, totalWidth, totalHeight);
+
+        graphics.setColor(Color.BLACK);
+        graphics.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 16));
+        graphics.drawString("Full image with region", 10, 20);
+        graphics.drawImage(annotateRegion(full, x, y, width, height, text), 0, header, null);
+
+        int rightX = full.getWidth() + gap;
+        graphics.drawString("Processed region", rightX + 10, 20);
+        graphics.drawImage(processed, rightX, header, null);
+
+        int infoY = header + processed.getHeight() + gap;
+        graphics.setColor(new Color(240, 240, 240));
+        graphics.fillRect(rightX, infoY, rightWidth, infoHeight);
+        graphics.setColor(Color.GRAY);
+        graphics.drawRect(rightX, infoY, rightWidth, infoHeight);
+        graphics.setColor(Color.BLACK);
+        graphics.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+        int lineY = infoY + 20;
+        for (String line : settingsSummary(settings, text).split("\n")) {
+            graphics.drawString(line, rightX + 10, lineY);
+            lineY += 18;
+        }
+        graphics.dispose();
+        return canvas;
+    }
+
+    private static BufferedImage annotateRegion(BufferedImage full,
+            int x, int y, int width, int height, String text) {
+        BufferedImage copy = new BufferedImage(full.getWidth(), full.getHeight(), BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = copy.createGraphics();
+        enableSmoothing(graphics);
+        graphics.drawImage(full, 0, 0, null);
+        graphics.setColor(Color.RED);
+        graphics.setStroke(new BasicStroke(3));
+        graphics.drawRect(x, y, width, height);
+
+        String label = text == null ? "" : text;
+        graphics.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 20));
+        FontMetrics metrics = graphics.getFontMetrics();
+        int labelX = x + 5;
+        int labelY = y > metrics.getHeight() + 10 ? y - 10 : y + height + metrics.getHeight();
+        graphics.setColor(new Color(0, 0, 0, 180));
+        graphics.fillRect(labelX - 5, labelY - metrics.getHeight() + 5,
+                metrics.stringWidth(label) + 10, metrics.getHeight());
+        graphics.setColor(Color.RED);
+        graphics.drawString(label, labelX, labelY);
+        graphics.dispose();
+        return copy;
+    }
+
+    private static String settingsSummary(OcrSettingsData settings, String text) {
+        return "OCR settings:"
+                + "\n  Layout: " + (settings.hasTextLayout() ? settings.textLayout() : "provider default")
+                + "\n  Allowed glyphs: " + (settings.hasGlyphFilter() ? settings.allowedGlyphs() : "all")
+                + "\n  Isolate foreground: " + settings.isolateForeground()
+                + "\n  Target color: " + (settings.targetColor() == null ? "automatic" : settings.targetColor())
+                + "\n\nRecognized: \"" + text + "\"";
+    }
+
+    private static void enableSmoothing(Graphics2D graphics) {
+        graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                RenderingHints.VALUE_ANTIALIAS_ON);
+    }
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/OcrEngine.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/OcrEngine.java
@@ -1,0 +1,160 @@
+package dev.frostguard.vision.ocr;
+
+import dev.frostguard.api.domain.PointData;
+import dev.frostguard.api.domain.RawImageData;
+import dev.frostguard.api.domain.OcrSettingsData;
+import dev.frostguard.vision.convert.ImagePreprocessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Provider-neutral OCR facade.
+ *
+ * <p>All call sites use this class rather than a concrete provider directly.
+ * Tesseract is the sole provider in this step; additional providers will be
+ * added opt-in in a subsequent step once their behavior is validated against
+ * real saved frames.
+ *
+ * <p>The shared provider instance is created lazily.
+ */
+public final class OcrEngine {
+
+    private static final Logger log = LoggerFactory.getLogger(OcrEngine.class);
+
+    private static volatile OcrProvider provider;
+
+    private OcrEngine() {}
+
+    private static OcrProvider getProvider() {
+        OcrProvider p = provider;
+        if (p == null) {
+            synchronized (OcrEngine.class) {
+                p = provider;
+                if (p == null) {
+                    log.debug("Initializing Tesseract OCR provider");
+                    p = new TesseractOcrProvider();
+                    provider = p;
+                }
+            }
+        }
+        return p;
+    }
+
+    /**
+     * Recognizes text within the specified region using the default language.
+     *
+     * @param capture raw RGBA frame from the emulator
+     * @param c1      top-left corner of the crop region
+     * @param c2      bottom-right corner of the crop region
+     * @param lang    OCR language code (e.g. {@code "eng"})
+     * @return trimmed recognized text, never {@code null}
+     */
+    public static String recognizeText(RawImageData capture, PointData c1, PointData c2, String lang)
+            throws OcrException {
+        requireValidCapture(capture);
+        int[] clip = computeClipRect(c1, c2, capture);
+        BufferedImage prepared = ImagePreprocessor.prepareForOcr(
+                capture, clip[0], clip[1], clip[2], clip[3],
+                false, null);
+        return getProvider().recognizeText(prepared, lang);
+    }
+
+    /**
+     * Recognizes text within the specified region using explicit OCR presets.
+     *
+     * @param capture raw RGBA frame from the emulator
+     * @param c1      top-left corner of the crop region
+     * @param c2      bottom-right corner of the crop region
+     * @param cfg     tuning parameters (page segmentation, whitelist, scaling, etc.)
+     * @return trimmed recognized text, never {@code null}
+     */
+    public static String recognizeText(RawImageData capture, PointData c1, PointData c2, OcrSettingsData cfg)
+            throws OcrException {
+        requireValidCapture(capture);
+        int[] clip = computeClipRect(c1, c2, capture);
+        int cx = clip[0], cy = clip[1], cw = clip[2], ch = clip[3];
+        log.debug("Clip rect: x={}, y={}, w={}, h={}", cx, cy, cw, ch);
+        log.debug("Config: stripBackground={}, targetColour={}",
+                cfg.isolateForeground(), cfg.targetColor());
+
+        long step = System.currentTimeMillis();
+        BufferedImage prepared = ImagePreprocessor.prepareForOcr(
+                capture, cx, cy, cw, ch,
+                cfg.isolateForeground(), cfg.targetColor());
+        log.debug("Crop + preprocess: {} ms", System.currentTimeMillis() - step);
+
+        String recognized = getProvider().recognizeText(prepared, cfg);
+        if (cfg.diagnosticMode()) {
+            try {
+                OcrDiagnosticWriter.write(capture, prepared, cx, cy, cw, ch, cfg, recognized);
+            } catch (IOException | RuntimeException exception) {
+                log.error("OCR diagnostic image export failed: {}", exception.getMessage());
+            }
+        }
+        return recognized;
+    }
+
+    /**
+     * Reads text from a sub-region of an image file.
+     *
+     * @param file image file on disk
+     * @param x    left edge of the crop region in pixels
+     * @param y    top edge of the crop region in pixels
+     * @param w    width of the crop region in pixels
+     * @param h    height of the crop region in pixels
+     * @param lang OCR language code
+     * @return trimmed recognized text, never {@code null}
+     */
+    public static String readFromFile(File file, int x, int y, int w, int h, String lang) throws OcrException {
+        BufferedImage full;
+        try {
+            full = ImageIO.read(file);
+        } catch (IOException e) {
+            throw new OcrException("Failed to read file", e);
+        }
+        if (full == null) {
+            throw new IllegalArgumentException("Unreadable image: " + file);
+        }
+        x = Math.max(0, Math.min(x, full.getWidth() - 1));
+        y = Math.max(0, Math.min(y, full.getHeight() - 1));
+        w = Math.max(1, Math.min(w, full.getWidth() - x));
+        h = Math.max(1, Math.min(h, full.getHeight() - y));
+
+        // Use a basic zoom for files (no foreground isolation logic needed)
+        BufferedImage cropped = full.getSubimage(x, y, w, h);
+        int outW = w * 4; // MAGNIFICATION = 4
+        int outH = h * 4;
+        BufferedImage magnified = new BufferedImage(outW, outH, BufferedImage.TYPE_INT_RGB);
+        java.awt.Graphics2D g = magnified.createGraphics();
+        g.setRenderingHint(java.awt.RenderingHints.KEY_INTERPOLATION, java.awt.RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g.drawImage(cropped, 0, 0, outW, outH, null);
+        g.dispose();
+
+        return getProvider().recognizeText(magnified, lang);
+    }
+
+    private static void requireValidCapture(RawImageData capture) {
+        if (capture == null) {
+            throw new IllegalArgumentException("Screen capture must not be null.");
+        }
+    }
+
+    /**
+     * Converts two corners into a clamped {@code [x, y, w, h]} clip rect.
+     */
+    private static int[] computeClipRect(PointData c1, PointData c2, RawImageData capture) {
+        int x = (int) Math.min(c1.getX(), c2.getX());
+        int y = (int) Math.min(c1.getY(), c2.getY());
+        int w = (int) Math.abs(c1.getX() - c2.getX());
+        int h = (int) Math.abs(c1.getY() - c2.getY());
+        if (x + w > capture.getWidth() || y + h > capture.getHeight()) {
+            throw new IllegalArgumentException("Clip rect exceeds capture dimensions.");
+        }
+        return new int[]{ x, y, w, h };
+    }
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/OcrException.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/OcrException.java
@@ -1,0 +1,16 @@
+package dev.frostguard.vision.ocr;
+
+/**
+ * Thrown when an OCR operation fails. This is a generic exception that wraps
+ * provider-specific failures such as Tesseract exceptions.
+ */
+public class OcrException extends Exception {
+
+    public OcrException(String message) {
+        super(message);
+    }
+
+    public OcrException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/OcrProvider.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/OcrProvider.java
@@ -1,0 +1,29 @@
+package dev.frostguard.vision.ocr;
+
+import dev.frostguard.api.domain.OcrSettingsData;
+
+import java.awt.image.BufferedImage;
+
+/**
+ * Abstraction over the OCR backend used for in-game text extraction.
+ */
+public interface OcrProvider {
+
+    /**
+     * Recognizes text from a pre-processed image.
+     *
+     * @param preparedImage pre-processed, cropped, and scaled image
+     * @param lang          OCR language code (e.g. {@code "eng"})
+     * @return trimmed recognized text, never {@code null}
+     */
+    String recognizeText(BufferedImage preparedImage, String lang) throws OcrException;
+
+    /**
+     * Recognizes text from a pre-processed image using explicit OCR presets.
+     *
+     * @param preparedImage pre-processed, cropped, and scaled image
+     * @param cfg           tuning parameters (layout, whitelist, etc.)
+     * @return trimmed recognized text, never {@code null}
+     */
+    String recognizeText(BufferedImage preparedImage, OcrSettingsData cfg) throws OcrException;
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/ResilientOcrExecutor.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/ResilientOcrExecutor.java
@@ -2,14 +2,14 @@ package dev.frostguard.vision.ocr;
 
 import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
 
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import net.sourceforge.tess4j.TesseractException;
+import dev.frostguard.vision.ocr.OcrException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,10 +41,10 @@ public class ResilientOcrExecutor<R> {
          * @param bottomRight lower-right corner
          * @return recognized text, never null
          * @throws IOException        if capture fails
-         * @throws TesseractException if recognition fails
+         * @throws OcrException if recognition fails
          */
-        String extractText(TesseractSettingsData config, PointData topLeft, PointData bottomRight)
-                throws IOException, TesseractException;
+        String extractText(OcrSettingsData config, PointData topLeft, PointData bottomRight)
+                throws IOException, OcrException;
     }
 
     private final TextExtractor textExtractor;
@@ -74,7 +74,7 @@ public class ResilientOcrExecutor<R> {
                                 PointData lowerRight,
                                 int maxAttempts,
                                 long pauseMillis,
-                                TesseractSettingsData config,
+                                OcrSettingsData config,
                                 Predicate<String> acceptor,
                                 Function<String, R> transformer) {
 
@@ -100,7 +100,7 @@ public class ResilientOcrExecutor<R> {
                 }
             } catch (CancellationException exception) {
                 throw exception;
-            } catch (IOException | TesseractException | RuntimeException ex) {
+            } catch (IOException | OcrException | RuntimeException ex) {
                 log.warn("OCR trial {} failed: {}", trial + 1, ex.getMessage());
             }
 
@@ -129,7 +129,7 @@ public class ResilientOcrExecutor<R> {
     public R attemptRecognition(AreaData area,
                                 int maxAttempts,
                                 long pauseMillis,
-                                TesseractSettingsData config,
+                                OcrSettingsData config,
                                 Predicate<String> acceptor,
                                 Function<String, R> transformer) {
         return attemptRecognition(

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
@@ -1,45 +1,30 @@
 package dev.frostguard.vision.ocr;
 
-import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.imageio.ImageIO;
-
-import dev.frostguard.api.domain.RawImageData;
-import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.TesseractSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData;
+import dev.frostguard.api.domain.OcrSettingsData.TextLayout;
 import net.sourceforge.tess4j.Tesseract;
 import net.sourceforge.tess4j.TesseractException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import dev.frostguard.api.runtime.WorkspacePaths;
 
 /**
- * Provides text recognition from captured device screens or local image
- * files.  Handles sub-region extraction, upscaling, optional background
- * removal, and Tesseract engine configuration.
+ * Provides text recognition from pre-processed images using Tesseract.
  *
- * <p>All public entry points are thread-safe.  The tessdata directory is
- * located once and then cached for the lifetime of the JVM.
+ * <p>The tessdata directory is located once and then cached for the lifetime
+ * of the JVM.
  */
-public final class TesseractOcrProvider {
+public final class TesseractOcrProvider implements OcrProvider {
 
     private static final Logger log = LoggerFactory.getLogger(TesseractOcrProvider.class);
-
-    /** Nearest-neighbour magnification applied before recognition. */
-    private static final int MAGNIFICATION = 4;
-
-    /** Per-channel distance used when isolating text pixels. */
-    private static final int CHANNEL_TOLERANCE = 50;
 
     /** Lazily resolved, then reused for every subsequent call. */
     private static volatile String resolvedTessdataDir;
@@ -48,154 +33,100 @@ public final class TesseractOcrProvider {
     //  Public entry points
     // =====================================================================
 
-    /**
-     * Recognises text inside the rectangle described by two corners,
-     * using the specified Tesseract language pack.
-     *
-     * @param capture  device screen snapshot
-     * @param corner1  one corner of the target rectangle
-     * @param corner2  opposite corner
-     * @param lang     Tesseract language code (e.g. {@code "eng"})
-     * @return trimmed text, never {@code null}
-     */
-    public static String recognizeText(RawImageData capture, PointData corner1,
-                                       PointData corner2, String lang)
-            throws TesseractException {
-        requireValidCapture(capture);
-        int[] clip = computeClipRect(corner1, corner2, capture);
-        BufferedImage prepared = cropAndPreprocess(
-                capture, clip[0], clip[1], clip[2], clip[3],
-                MAGNIFICATION, false, null);
-        return executeRecognition(configureTesseract(lang), prepared);
-    }
-
-    /**
-     * Recognises text inside the rectangle described by two corners,
-     * driven by a full {@link TesseractSettingsData}.
-     *
-     * @param capture  device screen snapshot
-     * @param corner1  one corner of the target rectangle
-     * @param corner2  opposite corner
-     * @param cfg      Tesseract tuning parameters
-     * @return trimmed text, never {@code null}
-     */
-    public static String recognizeText(RawImageData capture, PointData corner1,
-                                       PointData corner2, TesseractSettingsData cfg)
-            throws TesseractException {
+    @Override
+    public String recognizeText(BufferedImage preparedImage, String lang) throws OcrException {
         long t0 = System.currentTimeMillis();
         log.debug("=== Recognition Started ===");
 
-        requireValidCapture(capture);
-        int[] clip = computeClipRect(corner1, corner2, capture);
-        int cx = clip[0], cy = clip[1], cw = clip[2], ch = clip[3];
-        log.debug("Clip rect: x={}, y={}, w={}, h={}", cx, cy, cw, ch);
-        log.debug("Config: stripBackground={}, targetColour={}",
-                cfg.isRemoveBackground(), cfg.getTextColor());
+        requireValidCapture(preparedImage);
 
         long step = System.currentTimeMillis();
-        BufferedImage prepared = cropAndPreprocess(
-                capture, cx, cy, cw, ch, MAGNIFICATION,
-                cfg.isRemoveBackground(), cfg.getTextColor());
-        log.debug("Crop + preprocess: {} ms", System.currentTimeMillis() - step);
-
-        step = System.currentTimeMillis();
-        Tesseract engine = configureTesseract(cfg);
+        Tesseract engine = configureTesseract(lang);
         log.debug("Engine config: {} ms", System.currentTimeMillis() - step);
 
         step = System.currentTimeMillis();
-        String recognised = executeRecognition(engine, prepared);
+        String recognised = executeRecognition(engine, preparedImage);
         log.debug("Engine execution: {} ms", System.currentTimeMillis() - step);
-
-        if (cfg.isDebug()) {
-            exportDiagnosticImage(capture, prepared, cx, cy, cw, ch, cfg, recognised);
-        }
 
         log.debug("=== Recognition Finished === elapsed={} ms, text='{}'",
                 System.currentTimeMillis() - t0, recognised);
         return recognised;
     }
 
-    /**
-     * Reads text from a region of a local image file on disk.
-     *
-     * @param file    source image (PNG, JPEG, etc.)
-     * @param x       left edge of the region
-     * @param y       top edge
-     * @param w       width
-     * @param h       height
-     * @param lang    Tesseract language code
-     * @return trimmed text, never {@code null}
-     */
-    public static String readFromFile(File file, int x, int y, int w, int h, String lang)
-            throws Exception {
-        BufferedImage full = ImageIO.read(file);
-        if (full == null) {
-            throw new IllegalArgumentException("Unreadable image: " + file);
-        }
-        x = Math.max(0, Math.min(x, full.getWidth() - 1));
-        y = Math.max(0, Math.min(y, full.getHeight() - 1));
-        w = Math.max(1, Math.min(w, full.getWidth() - x));
-        h = Math.max(1, Math.min(h, full.getHeight() - y));
+    @Override
+    public String recognizeText(BufferedImage preparedImage, OcrSettingsData cfg) throws OcrException {
+        long t0 = System.currentTimeMillis();
+        log.debug("=== Recognition Started ===");
 
-        BufferedImage magnified = enlargeViaGraphics(
-                full.getSubimage(x, y, w, h), MAGNIFICATION);
-        return executeRecognition(configureTesseract(lang), magnified);
-    }
+        requireValidCapture(preparedImage);
 
-    /**
-     * Converts a full {@link RawImageData} to a standard
-     * {@link BufferedImage}.  Useful for diagnostic dumps only — not
-     * invoked on the hot path.
-     */
-    public static BufferedImage toBufferedImage(RawImageData capture) {
-        int w = capture.getWidth();
-        int h = capture.getHeight();
-        byte[] raw = capture.getData();
-        int bpp = capture.getBpp();
-        int[] pixels = new int[w * h];
+        long step = System.currentTimeMillis();
+        Tesseract engine = configureTesseract(cfg);
+        log.debug("Engine config: {} ms", System.currentTimeMillis() - step);
 
-        for (int row = 0; row < h; row++) {
-            for (int col = 0; col < w; col++) {
-                pixels[row * w + col] = decodePixel(raw, bpp, w, col, row);
-            }
-        }
+        step = System.currentTimeMillis();
+        String recognised = executeRecognition(engine, preparedImage);
+        log.debug("Engine execution: {} ms", System.currentTimeMillis() - step);
 
-        BufferedImage img = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
-        img.setRGB(0, 0, w, h, pixels, 0, w);
-        return img;
+        log.debug("=== Recognition Finished === elapsed={} ms, text='{}'",
+                System.currentTimeMillis() - t0, recognised);
+        return recognised;
     }
 
     // =====================================================================
     //  Tesseract factory
     // =====================================================================
 
-    /** Builds a single-line LSTM engine for the given language. */
     private static Tesseract configureTesseract(String lang) {
         Tesseract t = new Tesseract();
         t.setDatapath(locateTessdata());
         t.setLanguage(lang);
         t.setConfigs(Collections.singletonList("quiet"));
-        t.setPageSegMode(7);
-        t.setOcrEngineMode(1);
+        t.setPageSegMode(7); // SINGLE_LINE, matching the established default path
+        t.setOcrEngineMode(1); // LSTM_ONLY
         return t;
     }
 
     /** Builds an engine whose behaviour is controlled by {@code cfg}. */
-    private static Tesseract configureTesseract(TesseractSettingsData cfg) {
+    private static Tesseract configureTesseract(OcrSettingsData cfg) {
         Tesseract t = new Tesseract();
         t.setDatapath(locateTessdata());
         t.setLanguage("eng");
         t.setConfigs(Collections.singletonList("quiet"));
-        if (cfg.hasPageSegMode())   t.setPageSegMode(cfg.getPageSegMode());
-        if (cfg.hasOcrEngineMode()) t.setOcrEngineMode(cfg.getOcrEngineMode());
-        if (cfg.hasAllowedChars())  t.setVariable("tessedit_char_whitelist", cfg.getAllowedChars());
+
+        if (cfg.hasTextLayout()) {
+            t.setPageSegMode(mapTextLayout(cfg.textLayout()));
+        } else {
+            t.setPageSegMode(3); // AUTO
+        }
+
+        t.setOcrEngineMode(1); // Default to LSTM_ONLY for our use cases
+
+        if (cfg.hasAllowedChars()) {
+            t.setVariable("tessedit_char_whitelist", cfg.getAllowedChars());
+        }
         return t;
+    }
+
+    private static int mapTextLayout(TextLayout layout) {
+        return switch (layout) {
+            case SINGLE_LINE -> 7; // PSM_SINGLE_LINE
+            case SINGLE_WORD -> 8; // PSM_SINGLE_WORD
+            case TEXT_BLOCK  -> 6; // PSM_UNIFORM_BLOCK
+            case SPARSE      -> 11; // PSM_SPARSE
+            case AUTO        -> 3; // PSM_AUTO
+            default          -> 3;
+        };
     }
 
     /** Runs the engine and strips whitespace / line breaks. */
     private static String executeRecognition(Tesseract engine, BufferedImage img)
-            throws TesseractException {
-        return engine.doOCR(img).replace("\n", "").replace("\r", "").trim();
+            throws OcrException {
+        try {
+            return engine.doOCR(img).replace("\n", "").replace("\r", "").trim();
+        } catch (TesseractException e) {
+            throw new OcrException("Tesseract OCR failed", e);
+        }
     }
 
     // =====================================================================
@@ -241,248 +172,12 @@ public final class TesseractOcrProvider {
     }
 
     // =====================================================================
-    //  Pixel decoding
-    // =====================================================================
-
-    /**
-     * Reads one pixel from the raw byte buffer and returns packed
-     * {@code 0x00RRGGBB}.  Handles both 16-bit RGB565 and 32-bit RGBA.
-     */
-    private static int decodePixel(byte[] data, int bpp, int stride, int px, int py) {
-        if (bpp == 16) {
-            int off = (py * stride + px) * 2;
-            int packed = ((data[off + 1] & 0xFF) << 8) | (data[off] & 0xFF);
-            int r = ((packed >> 11) & 0x1F) << 3;
-            int g = ((packed >> 5)  & 0x3F) << 2;
-            int b = (packed & 0x1F) << 3;
-            return (r << 16) | (g << 8) | b;
-        }
-        // 32 bpp RGBA
-        int off = (py * stride + px) * 4;
-        int r = data[off]     & 0xFF;
-        int g = data[off + 1] & 0xFF;
-        int b = data[off + 2] & 0xFF;
-        return (r << 16) | (g << 8) | b;
-    }
-
-    // =====================================================================
-    //  Image processing
-    // =====================================================================
-
-    /**
-     * Extracts a rectangular region and magnifies it for OCR. When isolating
-     * text ({@code stripBackground} + {@code textColour}), the region is turned
-     * into a <em>soft</em> distance-to-target grayscale (anti-aliased) rather
-     * than a hard black/white mask, then upscaled <em>bilinearly</em>.
-     *
-     * <p>The previous approach — hard per-pixel binarisation blown up by
-     * nearest-neighbour — produced blocky, stair-stepped glyph edges that made
-     * the LSTM flip borderline digits on clean input (verified: 2->7, 5->3).
-     * A smooth grayscale keeps the "background removed" benefit while giving
-     * Tesseract the anti-aliased edges its model was trained on.
-     */
-    private static BufferedImage cropAndPreprocess(RawImageData capture,
-            int cx, int cy, int cw, int ch, int scale,
-            boolean stripBackground, Color textColour) {
-
-        byte[] raw = capture.getData();
-        int bpp = capture.getBpp();
-        int srcStride = capture.getWidth();
-        boolean isolate = stripBackground && textColour != null;
-
-        int tR = 0, tG = 0, tB = 0;
-        if (isolate) {
-            tR = textColour.getRed();
-            tG = textColour.getGreen();
-            tB = textColour.getBlue();
-        }
-
-        // Native-resolution intermediate: soft grayscale when isolating text
-        // (0 = exact text colour -> dark, >= tolerance -> light), else raw colour.
-        int[] px = new int[cw * ch];
-        for (int y = 0; y < ch; y++) {
-            for (int x = 0; x < cw; x++) {
-                int rgb = decodePixel(raw, bpp, srcStride, cx + x, cy + y);
-                if (isolate) {
-                    int pr = (rgb >> 16) & 0xFF, pg = (rgb >> 8) & 0xFF, pb = rgb & 0xFF;
-                    int dist = Math.max(Math.abs(pr - tR), Math.max(Math.abs(pg - tG), Math.abs(pb - tB)));
-                    int v = Math.min(255, dist * 255 / CHANNEL_TOLERANCE);
-                    px[y * cw + x] = (v << 16) | (v << 8) | v;
-                } else {
-                    px[y * cw + x] = rgb;
-                }
-            }
-        }
-        BufferedImage base = new BufferedImage(cw, ch, BufferedImage.TYPE_INT_RGB);
-        base.setRGB(0, 0, cw, ch, px, 0, cw);
-
-        // Smooth (bilinear) upscale — replaces the old nearest-neighbour blow-up.
-        int outW = cw * scale, outH = ch * scale;
-        BufferedImage result = new BufferedImage(outW, outH, BufferedImage.TYPE_INT_RGB);
-        Graphics2D g = result.createGraphics();
-        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-        g.drawImage(base, 0, 0, outW, outH, null);
-        g.dispose();
-        return result;
-    }
-
-    /** Bilinear upscale via {@link Graphics2D} — used for file-based path. */
-    private static BufferedImage enlargeViaGraphics(BufferedImage src, int factor) {
-        int w = src.getWidth()  * factor;
-        int h = src.getHeight() * factor;
-        BufferedImage out = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
-        Graphics2D g = out.createGraphics();
-        g.drawImage(src, 0, 0, w, h, null);
-        g.dispose();
-        return out;
-    }
-
-    // =====================================================================
     //  Validation
     // =====================================================================
 
-    private static void requireValidCapture(RawImageData capture) {
+    private static void requireValidCapture(BufferedImage capture) {
         if (capture == null) {
-            throw new IllegalArgumentException("Screen capture must not be null.");
+            throw new IllegalArgumentException("Prepared image must not be null.");
         }
-    }
-
-    /**
-     * Converts two corners into a clamped {@code [x, y, w, h]} clip rect.
-     */
-    private static int[] computeClipRect(PointData c1, PointData c2, RawImageData capture) {
-        int x = (int) Math.min(c1.getX(), c2.getX());
-        int y = (int) Math.min(c1.getY(), c2.getY());
-        int w = (int) Math.abs(c1.getX() - c2.getX());
-        int h = (int) Math.abs(c1.getY() - c2.getY());
-        if (x + w > capture.getWidth() || y + h > capture.getHeight()) {
-            throw new IllegalArgumentException("Clip rect exceeds capture dimensions.");
-        }
-        return new int[]{ x, y, w, h };
-    }
-
-    // =====================================================================
-    //  Debug / diagnostic output
-    // =====================================================================
-
-    /**
-     * Writes a side-by-side diagnostic PNG to the active workspace cache.
-     */
-    private static void exportDiagnosticImage(RawImageData capture, BufferedImage processed,
-            int cx, int cy, int cw, int ch,
-            TesseractSettingsData cfg, String text) {
-        long t0 = System.currentTimeMillis();
-        try {
-            Path tempDir = WorkspacePaths.current().cache().resolve("ocr");
-            Files.createDirectories(tempDir);
-
-            String summary = formatSettingsSummary(cfg, text);
-            BufferedImage full = toBufferedImage(capture);
-            BufferedImage composite = composeDiagnosticPanel(
-                    full, processed, cx, cy, cw, ch, summary, text);
-
-            ByteArrayOutputStream buf = new ByteArrayOutputStream();
-            ImageIO.write(composite, "png", buf);
-            Files.write(tempDir.resolve(System.currentTimeMillis() + "_debug.png"), buf.toByteArray());
-
-            log.debug("Diagnostic image saved: {} ms", System.currentTimeMillis() - t0);
-        } catch (IOException ex) {
-            log.error("Diagnostic image export failed: {}", ex.getMessage());
-        }
-    }
-
-    private static String formatSettingsSummary(TesseractSettingsData cfg, String text) {
-        return "Engine Settings:"
-                + "\n  Language: eng"
-                + "\n  Seg Mode: " + (cfg.hasPageSegMode() ? cfg.getPageSegMode() : "Default")
-                + "\n  Engine Mode: " + (cfg.hasOcrEngineMode() ? cfg.getOcrEngineMode() : "Default")
-                + "\n  Whitelist: " + (cfg.hasAllowedChars() ? cfg.getAllowedChars() : "All")
-                + "\n  Strip BG: " + cfg.isRemoveBackground()
-                + "\n  Text Colour: " + (cfg.getTextColor() != null ? cfg.getTextColor() : "Auto")
-                + "\n  Magnification: " + MAGNIFICATION + "x"
-                + "\n\nRecognised: \"" + text + "\"";
-    }
-
-    private static BufferedImage composeDiagnosticPanel(BufferedImage full, BufferedImage processed,
-            int cx, int cy, int cw, int ch, String summary, String detectedText) {
-        final int GAP = 20;
-        final int HEADER = 40;
-        final int INFO_BLOCK = 200;
-        int rightW = Math.max(processed.getWidth(), 500);
-        int totalW = full.getWidth() + GAP + rightW;
-        int totalH = Math.max(full.getHeight() + HEADER,
-                processed.getHeight() + HEADER + INFO_BLOCK + GAP);
-
-        BufferedImage canvas = new BufferedImage(totalW, totalH, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g = canvas.createGraphics();
-        enableSmoothing(g);
-
-        g.setColor(Color.WHITE);
-        g.fillRect(0, 0, totalW, totalH);
-
-        // Left panel — full image with annotation
-        g.setColor(Color.BLACK);
-        g.setFont(new Font("Arial", Font.BOLD, 16));
-        g.drawString("Full Image with Region", 10, 20);
-        g.drawImage(annotateWithRegion(full, cx, cy, cw, ch, detectedText), 0, HEADER, null);
-
-        // Right panel — processed crop + info
-        int rx = full.getWidth() + GAP;
-        g.drawString("Processed Region", rx + 10, 20);
-        g.drawImage(processed, rx, HEADER, null);
-
-        int infoY = HEADER + processed.getHeight() + GAP;
-        g.setColor(new Color(240, 240, 240));
-        g.fillRect(rx, infoY, rightW, INFO_BLOCK);
-        g.setColor(Color.GRAY);
-        g.setStroke(new BasicStroke(1));
-        g.drawRect(rx, infoY, rightW, INFO_BLOCK);
-        g.setColor(Color.BLACK);
-        g.setFont(new Font("Monospaced", Font.PLAIN, 12));
-        int lineY = infoY + 20;
-        for (String line : summary.split("\n")) {
-            g.drawString(line, rx + 10, lineY);
-            lineY += 18;
-        }
-
-        g.setColor(Color.GRAY);
-        g.setStroke(new BasicStroke(2));
-        g.drawLine(full.getWidth() + GAP / 2, 0, full.getWidth() + GAP / 2, totalH);
-
-        g.dispose();
-        return canvas;
-    }
-
-    private static BufferedImage annotateWithRegion(BufferedImage full,
-            int cx, int cy, int cw, int ch, String label) {
-        BufferedImage copy = new BufferedImage(
-                full.getWidth(), full.getHeight(), BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g = copy.createGraphics();
-        enableSmoothing(g);
-        g.drawImage(full, 0, 0, null);
-
-        g.setColor(Color.RED);
-        g.setStroke(new BasicStroke(3));
-        g.drawRect(cx, cy, cw, ch);
-
-        g.setFont(new Font("Arial", Font.BOLD, 20));
-        FontMetrics fm = g.getFontMetrics();
-        int tw = fm.stringWidth(label);
-        int th = fm.getHeight();
-        int tx = cx + 5;
-        int ty = (cy > th + 10) ? (cy - 10) : (cy + ch + th);
-
-        g.setColor(new Color(0, 0, 0, 180));
-        g.fillRect(tx - 5, ty - th + 5, tw + 10, th);
-        g.setColor(Color.RED);
-        g.drawString(label, tx, ty);
-
-        g.dispose();
-        return copy;
-    }
-
-    private static void enableSmoothing(Graphics2D g) {
-        g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING,      RenderingHints.VALUE_ANTIALIAS_ON);
     }
 }

--- a/modules/vision/src/test/java/dev/frostguard/vision/convert/ImageConverterTest.java
+++ b/modules/vision/src/test/java/dev/frostguard/vision/convert/ImageConverterTest.java
@@ -1,0 +1,37 @@
+package dev.frostguard.vision.convert;
+
+import dev.frostguard.api.domain.RawImageData;
+import org.junit.jupiter.api.Test;
+
+import java.awt.image.BufferedImage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ImageConverterTest {
+
+    @Test
+    void convertsRgbaWithoutSwappingChannels() {
+        RawImageData capture = RawImageData.capture(new byte[] {
+                (byte) 0x12, (byte) 0x34, (byte) 0x56, (byte) 0x78
+        }, 1, 1, 4);
+
+        BufferedImage image = ImageConverter.toBufferedImage(capture);
+
+        assertEquals(0x123456, image.getRGB(0, 0) & 0xFFFFFF);
+    }
+
+    @Test
+    void convertsLittleEndianRgb565Pixels() {
+        RawImageData capture = RawImageData.capture(new byte[] {
+                0x00, (byte) 0xF8,
+                (byte) 0xE0, 0x07,
+                0x1F, 0x00
+        }, 3, 1, 2);
+
+        BufferedImage image = ImageConverter.toBufferedImage(capture);
+
+        assertEquals(0xF80000, image.getRGB(0, 0) & 0xFFFFFF);
+        assertEquals(0x00FC00, image.getRGB(1, 0) & 0xFFFFFF);
+        assertEquals(0x0000F8, image.getRGB(2, 0) & 0xFFFFFF);
+    }
+}

--- a/modules/vision/src/test/java/dev/frostguard/vision/convert/ImagePreprocessorTest.java
+++ b/modules/vision/src/test/java/dev/frostguard/vision/convert/ImagePreprocessorTest.java
@@ -1,0 +1,26 @@
+package dev.frostguard.vision.convert;
+
+import dev.frostguard.api.domain.RawImageData;
+import org.junit.jupiter.api.Test;
+
+import java.awt.image.BufferedImage;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ImagePreprocessorTest {
+
+    @Test
+    void usesSmoothInterpolationForMagnifiedGlyphs() {
+        RawImageData capture = RawImageData.capture(new byte[] {
+                0, 0, 0, (byte) 255,
+                (byte) 255, (byte) 255, (byte) 255, (byte) 255
+        }, 2, 1, 4);
+
+        BufferedImage prepared = ImagePreprocessor.prepareForOcr(capture, 0, 0, 2, 1, false, null);
+
+        assertTrue(IntStream.range(0, prepared.getWidth())
+                .map(x -> prepared.getRGB(x, 0) & 0xFF)
+                .anyMatch(value -> value > 0 && value < 255));
+    }
+}

--- a/modules/vision/src/test/java/dev/frostguard/vision/ocr/OcrDiagnosticWriterTest.java
+++ b/modules/vision/src/test/java/dev/frostguard/vision/ocr/OcrDiagnosticWriterTest.java
@@ -1,0 +1,43 @@
+package dev.frostguard.vision.ocr;
+
+import dev.frostguard.api.domain.OcrSettingsData;
+import dev.frostguard.api.domain.RawImageData;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OcrDiagnosticWriterTest {
+
+    @Test
+    void writesReadableDiagnosticImageToWorkspaceCache(@TempDir Path workspace) throws Exception {
+        String previousWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        try {
+            System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, workspace.toString());
+            RawImageData capture = RawImageData.capture(new byte[] {
+                    (byte) 255, 0, 0, (byte) 255
+            }, 1, 1, 4);
+            BufferedImage processed = new BufferedImage(4, 4, BufferedImage.TYPE_INT_RGB);
+
+            Path output = OcrDiagnosticWriter.write(capture, processed, 0, 0, 1, 1,
+                    OcrSettingsData.configurator().diagnosticMode(true).build(), "test");
+
+            assertTrue(output.startsWith(workspace.resolve("cache").resolve("ocr")));
+            assertTrue(Files.isRegularFile(output));
+            assertNotNull(ImageIO.read(output.toFile()));
+        } finally {
+            if (previousWorkspace == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, previousWorkspace);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Introduces a provider-neutral OCR boundary while keeping Tesseract as the sole provider and default. This is Step 1 of the staged OCR work tracked in #212; it does not add Paddle/RapidOCR or runtime provider selection.

## Why

A second provider should be evaluated behind a stable boundary without changing existing capture, preprocessing, diagnostics, or Tesseract recognition behavior first.

## Changes

- replaces the shared Tesseract-specific settings and exception contracts with `OcrSettingsData`, `OcrProvider`, and `OcrException`;
- moves crop conversion and preprocessing in front of the provider boundary;
- retains the established Tesseract single-line default, LSTM mode, glyph/layout mapping, and bilinear magnification;
- preserves diagnostic PNG export in the active workspace cache through a provider-neutral writer;
- keeps frame reuse out of recognition settings and models it explicitly at the emulator capture bridge;
- preserves reuse for left-menu multi-region reads and the Bear Trap march-counter read;
- correctly decodes both 32-bit RGBA and 16-bit RGB565 captures;
- removes the unrelated desktop Maven configuration change from the PR.

## Verification

- `mvnw.cmd -pl modules/vision,modules/automation -am test`
- `mvnw.cmd package`
- 428 tests passed, 0 failures, 0 errors
- existing saved-frame OCR tests passed, including deployment cost and both Intel cooldown layouts
- new regression tests cover RGBA channel order, RGB565 conversion, bilinear scaling, diagnostic export, and lazy frame reuse

## Remaining evidence / risk

- No live account-log validation was performed for this maintainer follow-up. Before merging, the updated CI should pass and the affected left-menu/Bear Trap OCR paths should ideally receive a live smoke check.
- This PR does not establish that Paddle is better than Tesseract. That comparison remains Step 2 in #212 and requires ground-truth accuracy and operational measurements on identical prepared inputs.