### PR TITLE
type(scope): implement profile and settings export/import with safe merge

### DIFF
--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerActionController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerActionController.java
@@ -151,7 +151,7 @@ public class ProfileManagerActionController implements ProfileStatusChangeListen
 						}
 					}
 				} catch (Exception ex) {
-					// Ignore invalid global configs
+					log(TpMessageSeverityEnum.WARNING, "Failed to apply global configuration " + gCfg.name() + ": " + ex.getMessage());
 				}
 			}
 		}

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerActionController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerActionController.java
@@ -119,9 +119,17 @@ public class ProfileManagerActionController implements ProfileStatusChangeListen
 					globalConfigs.addAll(transfer.globalConfigs());
 				}
 				for (AccountDescriptor descriptor : transfer.profiles()) {
-					String name = availableName(descriptor.getName(), occupiedNames);
-					descriptor.setName(name);
-					occupiedNames.add(name);
+					java.util.Optional<ProfileAux> existing = existingProfiles.stream()
+							.filter(p -> p.getName() != null && p.getName().equalsIgnoreCase(descriptor.getName()))
+							.findFirst();
+
+					if (existing.isPresent()) {
+						descriptor.setId(existing.get().getId());
+					} else {
+						String name = availableName(descriptor.getName(), occupiedNames);
+						descriptor.setName(name);
+						occupiedNames.add(name);
+					}
 					prepared.add(descriptor);
 				}
 			} catch (Exception ex) {
@@ -136,7 +144,13 @@ public class ProfileManagerActionController implements ProfileStatusChangeListen
 		int imported = 0;
 		int failed = 0;
 		for (AccountDescriptor descriptor : profiles) {
-			if (iModel.addProfile(descriptor)) imported++; else failed++;
+			boolean success;
+			if (descriptor.getId() != null) {
+				success = iModel.saveProfile(descriptor);
+			} else {
+				success = iModel.addProfile(descriptor);
+			}
+			if (success) imported++; else failed++;
 		}
 		
 		int globalUpdated = 0;

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerActionController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerActionController.java
@@ -87,24 +87,38 @@ public class ProfileManagerActionController implements ProfileStatusChangeListen
 		}
 	}
 
-	public void exportProfiles(Path destination, List<ProfileAux> selectedProfiles) throws IOException {
-		transferService.write(destination, selectedProfiles);
-		log(TpMessageSeverityEnum.INFO, "Exported " + selectedProfiles.size() + " profiles to " + destination);
+	public void exportProfiles(Path destination, List<ProfileAux> selectedProfiles, boolean excludeTelegram) throws IOException {
+		transferService.write(destination, selectedProfiles, excludeTelegram);
+		log(TpMessageSeverityEnum.INFO, "Exported " + selectedProfiles.size() + " profiles and global configs to " + destination);
+	}
+
+	public void resetProfileConfigs(List<ProfileAux> selectedProfiles) {
+		if (selectedProfiles == null || selectedProfiles.isEmpty()) return;
+		for (ProfileAux profile : selectedProfiles) {
+			profile.getConfigs().clear();
+			saveProfile(profile);
+		}
+		log(TpMessageSeverityEnum.INFO, "Reset configurations for " + selectedProfiles.size() + " profiles");
 	}
 
 	public ImportResult importProfiles(List<Path> sources, List<ProfileAux> existingProfiles) {
 		ImportPreview preview = prepareImport(sources, existingProfiles);
-		ImportResult imported = importPrepared(preview.profiles());
-		return new ImportResult(imported.imported(), imported.failed() + preview.errors().size());
+		ImportResult imported = importPrepared(preview.profiles(), preview.globalConfigs());
+		return new ImportResult(imported.imported(), imported.failed() + preview.errors().size(), imported.globalUpdated());
 	}
 
 	public ImportPreview prepareImport(List<Path> sources, List<ProfileAux> existingProfiles) {
 		List<String> occupiedNames = new ArrayList<>(existingProfiles.stream().map(ProfileAux::getName).toList());
 		List<AccountDescriptor> prepared = new ArrayList<>();
 		List<String> errors = new ArrayList<>();
+		List<ProfileTransferService.TransferredConfig> globalConfigs = new ArrayList<>();
 		for (Path source : sources) {
 			try {
-				for (AccountDescriptor descriptor : transferService.read(source)) {
+				ProfileTransferService.TransferResult transfer = transferService.read(source);
+				if (transfer.globalConfigs() != null) {
+					globalConfigs.addAll(transfer.globalConfigs());
+				}
+				for (AccountDescriptor descriptor : transfer.profiles()) {
 					String name = availableName(descriptor.getName(), occupiedNames);
 					descriptor.setName(name);
 					occupiedNames.add(name);
@@ -115,16 +129,33 @@ public class ProfileManagerActionController implements ProfileStatusChangeListen
 				log(TpMessageSeverityEnum.ERROR, "Failed to import " + source + ": " + ex.getMessage());
 			}
 		}
-		return new ImportPreview(prepared, errors);
+		return new ImportPreview(prepared, errors, globalConfigs);
 	}
 
-	public ImportResult importPrepared(List<AccountDescriptor> profiles) {
+	public ImportResult importPrepared(List<AccountDescriptor> profiles, List<ProfileTransferService.TransferredConfig> globalConfigs) {
 		int imported = 0;
 		int failed = 0;
 		for (AccountDescriptor descriptor : profiles) {
 			if (iModel.addProfile(descriptor)) imported++; else failed++;
 		}
-		return new ImportResult(imported, failed);
+		
+		int globalUpdated = 0;
+		if (globalConfigs != null) {
+			dev.frostguard.engine.service.ConfigService configService = dev.frostguard.engine.service.ConfigService.obtain();
+			for (ProfileTransferService.TransferredConfig gCfg : globalConfigs) {
+				try {
+					ConfigurationKeyEnum key = ConfigurationKeyEnum.fromName(gCfg.name());
+					if (key != null) {
+						if (configService.writeGlobalSetting(key, gCfg.value())) {
+							globalUpdated++;
+						}
+					}
+				} catch (Exception ex) {
+					// Ignore invalid global configs
+				}
+			}
+		}
+		return new ImportResult(imported, failed, globalUpdated);
 	}
 
 	private String availableName(String requested, List<String> occupiedNames) {
@@ -141,11 +172,11 @@ public class ProfileManagerActionController implements ProfileStatusChangeListen
 		return names.stream().anyMatch(name -> name != null && name.equalsIgnoreCase(candidate));
 	}
 
-	public record ImportResult(int imported, int failed) {
+	public record ImportResult(int imported, int failed, int globalUpdated) {
 		public boolean successful() { return failed == 0; }
 	}
 
-	public record ImportPreview(List<AccountDescriptor> profiles, List<String> errors) {
+	public record ImportPreview(List<AccountDescriptor> profiles, List<String> errors, List<ProfileTransferService.TransferredConfig> globalConfigs) {
 	}
 
 	public boolean saveProfile(ProfileAux currentProfile) {

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerLayoutController.java
@@ -831,9 +831,12 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 		loadProfiles();
 		int failed = result.failed() + preview.errors().size();
 		Alert.AlertType type = failed == 0 ? Alert.AlertType.INFORMATION : Alert.AlertType.WARNING;
+		
+		String restartNote = result.globalUpdated() > 0 ? "\n\nPlease restart the application to apply global settings changes." : "";
 		showAlert(type, "Profile import complete",
 				result.imported() + " imported; " + failed + " failed.\n"
 						+ result.globalUpdated() + " global settings updated."
+						+ restartNote
 						+ (preview.errors().isEmpty() ? "" : "\n" + String.join("\n", preview.errors())));
 	}
 

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerLayoutController.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerLayoutController.java
@@ -134,6 +134,8 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	@FXML
 	private Button btnTagsSelected;
 	@FXML
+	private Button btnResetSelected;
+	@FXML
 	private Label lblSelectionCount;
 	@FXML
 	private Separator selectionSeparator;
@@ -624,6 +626,9 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 		setVisibleAndManaged(btnEnableSelected, hasSelection);
 		setVisibleAndManaged(btnDisableSelected, hasSelection);
 		setVisibleAndManaged(btnTagsSelected, hasSelection);
+		if (btnResetSelected != null) {
+			setVisibleAndManaged(btnResetSelected, hasSelection);
+		}
 		setVisibleAndManaged(selectionSeparator, hasSelection);
 
 		long visibleCount = sortedProfiles.stream().filter(profile -> profile.getId() != null).count();
@@ -762,6 +767,23 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	}
 
 	@FXML
+	private void handleResetSelectedProfiles(ActionEvent event) {
+		List<ProfileAux> selected = selectedProfiles();
+		if (selected.isEmpty()) {
+			return;
+		}
+		Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+				"Are you sure you want to reset all configurations for the " + selected.size() + " selected profile(s)?",
+				ButtonType.YES, ButtonType.CANCEL);
+		if (confirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.YES) {
+			profileManagerActionController.resetProfileConfigs(selected);
+			loadProfiles();
+			showAlert(Alert.AlertType.INFORMATION, "Profiles Reset",
+					"Successfully reset configs for " + selected.size() + " profile(s).");
+		}
+	}
+
+	@FXML
 	private void handleExportProfiles(ActionEvent event) {
 		List<ProfileAux> selected = selectedProfiles();
 		if (selected.isEmpty()) {
@@ -769,13 +791,26 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 					"Select one or more profiles to export.");
 			return;
 		}
+		
+		ButtonType withTelegram = new ButtonType("Yes (Include Telegram)");
+		ButtonType withoutTelegram = new ButtonType("No (Safe Export)");
+		ButtonType cancel = new ButtonType("Cancel", javafx.scene.control.ButtonBar.ButtonData.CANCEL_CLOSE);
+		
+		Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+				"Do you want to include Telegram settings in this backup?",
+				withTelegram, withoutTelegram, cancel);
+		
+		ButtonType choice = confirm.showAndWait().orElse(cancel);
+		if (choice == cancel) return;
+		boolean excludeTelegram = choice == withoutTelegram;
+
 		FileChooser chooser = profileJsonChooser("Export Profiles");
 		chooser.setInitialFileName(selected.size() == 1
 				? safeFileName(selected.get(0).getName()) + ".json" : "frostguard-profiles.json");
 		File destination = chooser.showSaveDialog(btnExportProfiles.getScene().getWindow());
 		if (destination == null) return;
 		try {
-			profileManagerActionController.exportProfiles(destination.toPath(), selected);
+			profileManagerActionController.exportProfiles(destination.toPath(), selected, excludeTelegram);
 			showAlert(Alert.AlertType.INFORMATION, "Profiles exported",
 					selected.size() + (selected.size() == 1 ? " profile exported." : " profiles exported."));
 		} catch (Exception ex) {
@@ -792,12 +827,13 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 				sources.stream().map(File::toPath).toList(), new ArrayList<>(profiles));
 		List<AccountDescriptor> selected = showImportPreview(preview);
 		if (selected == null) return;
-		var result = profileManagerActionController.importPrepared(selected);
+		var result = profileManagerActionController.importPrepared(selected, preview.globalConfigs());
 		loadProfiles();
 		int failed = result.failed() + preview.errors().size();
 		Alert.AlertType type = failed == 0 ? Alert.AlertType.INFORMATION : Alert.AlertType.WARNING;
 		showAlert(type, "Profile import complete",
-				result.imported() + " imported; " + failed + " failed."
+				result.imported() + " imported; " + failed + " failed.\n"
+						+ result.globalUpdated() + " global settings updated."
 						+ (preview.errors().isEmpty() ? "" : "\n" + String.join("\n", preview.errors())));
 	}
 

--- a/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileTransferService.java
+++ b/fg-app/src/main/java/dev/frostguard/app/panel/profile/ProfileTransferService.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.ConfigData;
@@ -22,15 +23,29 @@ final class ProfileTransferService {
 	private final ObjectMapper mapper;
 
 	ProfileTransferService() {
-		mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+		mapper = new ObjectMapper()
+			.enable(SerializationFeature.INDENT_OUTPUT)
+			.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 	}
 
-	void write(Path destination, List<ProfileAux> profiles) throws IOException {
+	void write(Path destination, List<ProfileAux> profiles, boolean excludeTelegram) throws IOException {
 		List<TransferredProfile> exported = profiles.stream().map(this::fromProfile).toList();
-		mapper.writeValue(destination.toFile(), new TransferFile(FORMAT_VERSION, exported));
+		
+		List<TransferredConfig> globalConfigs = new ArrayList<>();
+		java.util.LinkedHashMap<String, String> settings = dev.frostguard.engine.service.ConfigService.obtain().loadGlobalSettings();
+		if (settings != null) {
+			for (java.util.Map.Entry<String, String> entry : settings.entrySet()) {
+				if (excludeTelegram && entry.getKey() != null && entry.getKey().toUpperCase().startsWith("TELEGRAM_")) {
+					continue;
+				}
+				globalConfigs.add(new TransferredConfig(entry.getKey(), entry.getValue()));
+			}
+		}
+
+		mapper.writeValue(destination.toFile(), new TransferFile(FORMAT_VERSION, exported, globalConfigs));
 	}
 
-	List<AccountDescriptor> read(Path source) throws IOException {
+	TransferResult read(Path source) throws IOException {
 		if (!Files.isRegularFile(source) || Files.size(source) > MAX_FILE_SIZE_BYTES) {
 			throw new IOException("Profile file must be a regular JSON file no larger than 5 MB");
 		}
@@ -45,7 +60,7 @@ final class ProfileTransferService {
 		for (TransferredProfile imported : transfer.profiles()) {
 			profiles.add(toDescriptor(imported));
 		}
-		return profiles;
+		return new TransferResult(profiles, transfer.globalConfigs() != null ? transfer.globalConfigs() : new ArrayList<>());
 	}
 
 	AccountDescriptor duplicate(ProfileAux source, String newName) throws IOException {
@@ -124,7 +139,10 @@ final class ProfileTransferService {
 		return value == null || value.isBlank() ? null : value.trim();
 	}
 
-	record TransferFile(int formatVersion, List<TransferredProfile> profiles) {
+	record TransferFile(int formatVersion, List<TransferredProfile> profiles, List<TransferredConfig> globalConfigs) {
+	}
+
+	record TransferResult(List<AccountDescriptor> profiles, List<TransferredConfig> globalConfigs) {
 	}
 
 	record TransferredProfile(String name, String emulatorNumber, Boolean enabled, Long priority,

--- a/fg-app/src/main/resources/layout/ProfileManagerLayout.fxml
+++ b/fg-app/src/main/resources/layout/ProfileManagerLayout.fxml
@@ -92,6 +92,9 @@
             <Button fx:id="btnTagsSelected" mnemonicParsing="false"
                     onAction="#handleTagsSelected" text="Tags ▾"
                     visible="false" managed="false" styleClass="action-button-tags" />
+            <Button fx:id="btnResetSelected" mnemonicParsing="false"
+                    onAction="#handleResetSelectedProfiles" text="Reset"
+                    visible="false" managed="false" styleClass="action-button-disable" />
             <Separator fx:id="selectionSeparator" orientation="VERTICAL"
                        visible="false" managed="false" prefHeight="24" />
             <Button fx:id="btnImportProfiles" mnemonicParsing="false"

--- a/fg-app/src/test/java/dev/frostguard/app/panel/profile/ProfileTransferServiceTest.java
+++ b/fg-app/src/test/java/dev/frostguard/app/panel/profile/ProfileTransferServiceTest.java
@@ -23,16 +23,16 @@ class ProfileTransferServiceTest {
 		ProfileAux second = profile(8L, "Farm Two");
 		Path export = tempDirectory.resolve("profiles.json");
 
-		service.write(export, List.of(first, second));
+		service.write(export, List.of(first, second), true);
 		var imported = service.read(export);
 
-		assertEquals(2, imported.size());
-		assertNull(imported.get(0).getId());
-		assertEquals("Farm One", imported.get(0).getName());
-		assertEquals("1234", imported.get(0).getCharacterServer());
-		assertEquals(List.of("Farm", "SVS"), imported.get(0).getTags());
-		assertEquals(1, imported.get(0).getConfigs().size());
-		assertEquals("GATHER_TASK_BOOL", imported.get(0).getConfigs().get(0).getConfigurationName());
+		assertEquals(2, imported.profiles().size());
+		assertNull(imported.profiles().get(0).getId());
+		assertEquals("Farm One", imported.profiles().get(0).getName());
+		assertEquals("1234", imported.profiles().get(0).getCharacterServer());
+		assertEquals(List.of("Farm", "SVS"), imported.profiles().get(0).getTags());
+		assertEquals(1, imported.profiles().get(0).getConfigs().size());
+		assertEquals("GATHER_TASK_BOOL", imported.profiles().get(0).getConfigs().get(0).getConfigurationName());
 	}
 
 	@Test


### PR DESCRIPTION
### type(scope): implement profile and settings export/import with safe merge

**Summary**
This PR implements full configuration export, import, and reset functionality for user profiles and global settings in the `ProfileManagerActionController` and `ProfileTransferService`.

**Changes:**
- Added robust Profile Export/Import using Jackson JSON serialization, packaging both `AccountDescriptor` profiles and active global settings.
- Implemented a "Safe Export" mode that automatically strips sensitive `TELEGRAM_` configuration keys from the payload to prevent accidental leakage of Bot Tokens and Chat IDs.
- Introduced ID-based merging on import: instead of generating duplicates, importing a profile that already exists locally will merge and override its settings gracefully.
- Added a "Reset Config" action to selectively wipe configurations of an existing profile back to default states without removing the profile entry itself.
- Updated the Import Success UI alert to prompt users to restart their application so that imported global settings correctly populate in the `LauncherLayoutController` panes.

**Evidence:**
- Automated tests pass on reactor build (`mvn package`).
- Verified live account-log confirmation for successful database persistence of imported settings and correct exclusion of Telegram tokens during "Safe Export".