### PR TITLE
feat(formations): make Quick Deploy optional

### DIFF
--- a/docs/task/arena.md
+++ b/docs/task/arena.md
@@ -1,0 +1,13 @@
+# Arena Routine Constraints
+
+`ArenaRoutine` automates challenge attacks only. It does not open, replace, or
+otherwise manage the Arena defense formation.
+
+Attack Quick Deploy is enabled by default for backward compatibility. Profiles
+may disable it to keep the saved attack formation when starting a challenge.
+This setting has no effect on defense because the routine never enters that
+flow.
+
+Quick Deploy, Fight, Pause, and Retreat still use fixed tap points. Those taps
+assume the corresponding Arena screen state and are not direct detection of the
+individual controls.

--- a/docs/task/do-exploration.md
+++ b/docs/task/do-exploration.md
@@ -5,6 +5,10 @@ battle results, but quick deploy, fight, and victory continuation still use
 fixed tap regions. Those taps are not confirmation that the requested state
 transition succeeded.
 
+Quick Deploy is enabled by default for backward compatibility. Profiles may
+disable it to preserve their saved exploration formation; the routine then
+taps Fight without changing the selected heroes.
+
 The routine therefore treats an unreadable result as an unknown or locked
 battle and exits conservatively. Both the overall fighting loop and result
 polling are time-bounded so a missed victory or defeat cannot trap the task.

--- a/modules/api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
+++ b/modules/api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
@@ -100,6 +100,7 @@ public enum ConfigurationKeyEnum {
     ARENA_TASK_ACTIVATION_TIME_STRING   ("23:50",   String.class,   ConfigCategory.DAILIES),
     ARENA_TASK_BOOL                     ("false",   Boolean.class,  ConfigCategory.DAILIES),
     ARENA_TASK_EXTRA_ATTEMPTS_INT       ("0",       Integer.class,  ConfigCategory.DAILIES),
+    ARENA_TASK_ATTACK_QUICK_DEPLOY_BOOL ("true",    Boolean.class,  ConfigCategory.DAILIES),
     /** Legacy arena state filter key retained only so existing persisted profiles can still be read. */
     ARENA_TASK_PLAYER_STATE_INT         ("0",       Integer.class,  ConfigCategory.DAILIES, true),
     ARENA_TASK_SERVER_POLICY_STRING     ("Any server", String.class, ConfigCategory.DAILIES),
@@ -248,6 +249,7 @@ public enum ConfigurationKeyEnum {
     BOOL_CRYSTAL_LAB_DAILY_DISCOUNTED_RFC   ("false",   Boolean.class,  ConfigCategory.SHOPS),
     BOOL_CRYSTAL_LAB_FC                     ("false",   Boolean.class,  ConfigCategory.SHOPS),
     BOOL_DO_EXPLORATION                     ("false",   Boolean.class,  ConfigCategory.SHOPS),
+    DO_EXPLORATION_QUICK_DEPLOY_BOOL        ("true",    Boolean.class,  ConfigCategory.SHOPS),
     BOOL_EXPLORATION_CHEST                  ("false",   Boolean.class,  ConfigCategory.SHOPS),
     BOOL_HERO_RECRUITMENT                   ("false",   Boolean.class,  ConfigCategory.SHOPS),
     BOOL_MYSTERY_SHOP                       ("false",   Boolean.class,  ConfigCategory.SHOPS),

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsExtraLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsExtraLayoutController.java
@@ -54,6 +54,8 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
     @FXML
     private CheckBox checkBoxArenaRefreshWithGems;
     @FXML
+    private CheckBox checkBoxArenaAttackQuickDeploy;
+    @FXML
     private TextField textFieldArenaActivationHour;
     @FXML
     private Label labelArenaProfileAlliance;
@@ -96,6 +98,7 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
             new ToggleBinding(checkBoxTrekSupplies, ConfigurationKeyEnum.TUNDRA_TREK_SUPPLIES_BOOL),
             new ToggleBinding(checkBoxTrekAutomation, ConfigurationKeyEnum.TUNDRA_TREK_AUTOMATION_BOOL),
             new ToggleBinding(checkBoxArena, ConfigurationKeyEnum.ARENA_TASK_BOOL),
+            new ToggleBinding(checkBoxArenaAttackQuickDeploy, ConfigurationKeyEnum.ARENA_TASK_ATTACK_QUICK_DEPLOY_BOOL),
             new ToggleBinding(checkBoxArenaRefreshWithGems, ConfigurationKeyEnum.ARENA_TASK_REFRESH_WITH_GEMS_BOOL)
         );
     }
@@ -156,7 +159,8 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
 
     private final class ArenaSection {
         private void install() {
-            List.of(checkBoxArenaRefreshWithGems, textFieldArenaActivationHour, comboBoxArenaExtraAttempts)
+            List.of(checkBoxArenaAttackQuickDeploy, checkBoxArenaRefreshWithGems,
+                    textFieldArenaActivationHour, comboBoxArenaExtraAttempts)
                 .forEach(CityEventsExtraLayoutController.this::disableWhenArenaOff);
             comboBoxArenaAlliancePolicy.disableProperty().bind(
                 checkBoxArena.selectedProperty().not()

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsLayoutController.java
@@ -16,7 +16,7 @@ public class CityEventsLayoutController extends AbstractProfileController {
 	@FXML
 	private CheckBox checkBoxCrystalLabFC, checkBoxDailyDiscountedRFC, checkBoxExplorationChest, checkBoxMailRewards,
 			checkBoxLifeEssence, checkBoxWeeklyScroll, checkBoxDailyMission, checkBoxAutoScheduleDailyMission,
-			checkBoxWarAcademyShards, checkBoxDoExploration;
+			checkBoxWarAcademyShards, checkBoxDoExploration, checkBoxExplorationQuickDeploy;
 
 	@FXML
 	private TextField textfieldExplorationOffset, textfieldMailOffset, textfieldLifeEssenceOffset,
@@ -31,6 +31,7 @@ public class CityEventsLayoutController extends AbstractProfileController {
 		offsetFields().forEach(binding -> textFieldMappings.put(binding.control(), binding.configKey()));
 		comboBoxMondayRefinements.getItems().setAll(WEEKLY_REFINEMENT_WINDOWS);
 		comboBoxMappings.put(comboBoxMondayRefinements, ConfigurationKeyEnum.INT_WEEKLY_RFC);
+		checkBoxExplorationQuickDeploy.disableProperty().bind(checkBoxDoExploration.selectedProperty().not());
 		initializeChangeEvents();
 	}
 
@@ -40,6 +41,7 @@ public class CityEventsLayoutController extends AbstractProfileController {
 			new CitySwitch(checkBoxDailyDiscountedRFC, ConfigurationKeyEnum.BOOL_CRYSTAL_LAB_DAILY_DISCOUNTED_RFC),
 			new CitySwitch(checkBoxExplorationChest, ConfigurationKeyEnum.BOOL_EXPLORATION_CHEST),
 			new CitySwitch(checkBoxDoExploration, ConfigurationKeyEnum.BOOL_DO_EXPLORATION),
+			new CitySwitch(checkBoxExplorationQuickDeploy, ConfigurationKeyEnum.DO_EXPLORATION_QUICK_DEPLOY_BOOL),
 			new CitySwitch(checkBoxWarAcademyShards, ConfigurationKeyEnum.WAR_ACADEMY_TASK_BOOL),
 			new CitySwitch(checkBoxMailRewards, ConfigurationKeyEnum.MAIL_REWARDS_BOOL),
 			new CitySwitch(checkBoxLifeEssence, ConfigurationKeyEnum.LIFE_ESSENCE_BOOL),

--- a/modules/desktop/src/main/resources/layout/CityEventsExtraLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/CityEventsExtraLayout.fxml
@@ -50,6 +50,11 @@
                                 <CheckBox fx:id="checkBoxArenaRefreshWithGems" mnemonicParsing="false"
                                           text="Allow paid list refreshes"
                                           GridPane.columnIndex="1" GridPane.rowIndex="3" />
+
+                                <Label styleClass="task-field-label" text="Attack formation" GridPane.columnIndex="0" GridPane.rowIndex="4" />
+                                <CheckBox fx:id="checkBoxArenaAttackQuickDeploy" mnemonicParsing="false"
+                                          text="Use Quick Deploy for attacks"
+                                          GridPane.columnIndex="1" GridPane.rowIndex="4" />
                             </GridPane>
 
                             <Separator style="-fx-opacity: 0.15;" />

--- a/modules/desktop/src/main/resources/layout/CityEventsLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/CityEventsLayout.fxml
@@ -39,6 +39,8 @@
                     <!-- Exploration row -->
                     <CheckBox fx:id="checkBoxDoExploration" graphicTextGap="6.0"
                               mnemonicParsing="false" text="Do Exploration" />
+                    <CheckBox fx:id="checkBoxExplorationQuickDeploy" graphicTextGap="6.0"
+                              mnemonicParsing="false" text="Use Quick Deploy before each fight" />
 
                     <HBox alignment="CENTER_LEFT" spacing="14">
                         <CheckBox fx:id="checkBoxExplorationChest" graphicTextGap="6.0"

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/ArenaRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/ArenaRoutine.java
@@ -1032,11 +1032,18 @@ public class ArenaRoutine extends DelayedTask {
         return saturatedBluePixels > scaleSampledThreshold(250) && saturatedBluePixels > greyPixels;
     }
 
-    private void executeBattleSequence() {
+    void executeBattleSequence() {
         logInfo("Executing battle sequence (with animation skip)");
 
-        tapNear(QUICK_DEPLOY_BUTTON);
-        sleepTask(500);
+        boolean useQuickDeploy = profile.getConfig(
+                ConfigurationKeyEnum.ARENA_TASK_ATTACK_QUICK_DEPLOY_BOOL, Boolean.class);
+        if (useQuickDeploy) {
+            logInfo("Tapping Quick Deploy for the Arena attack.");
+            tapNear(QUICK_DEPLOY_BUTTON);
+            sleepTask(500);
+        } else {
+            logInfo("Arena attack Quick Deploy is disabled. Keeping the saved attack formation.");
+        }
 
         tapNear(BATTLE_START_BUTTON);
         sleepTask(3000);

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/exploration/DoExplorationRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/exploration/DoExplorationRoutine.java
@@ -1,5 +1,6 @@
 package dev.frostguard.tasks.exploration;
 
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import dev.frostguard.api.configs.TemplatesEnum;
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
@@ -115,10 +116,16 @@ public class DoExplorationRoutine extends DelayedTask {
         return true;
     }
 
-    private void startBattle() {
-        logInfo("Tapping quick deploy...");
-        tapInside(QUICK_DEPLOY_TOP_LEFT, QUICK_DEPLOY_BOTTOM_RIGHT);
-        sleepTask(QUICK_DEPLOY_DELAY_MS);
+    void startBattle() {
+        boolean useQuickDeploy = profile.getConfig(
+                ConfigurationKeyEnum.DO_EXPLORATION_QUICK_DEPLOY_BOOL, Boolean.class);
+        if (useQuickDeploy) {
+            logInfo("Tapping quick deploy...");
+            tapInside(QUICK_DEPLOY_TOP_LEFT, QUICK_DEPLOY_BOTTOM_RIGHT);
+            sleepTask(QUICK_DEPLOY_DELAY_MS);
+        } else {
+            logInfo("Quick Deploy is disabled. Keeping the saved exploration formation.");
+        }
         logInfo("Tapping fight button...");
         tapInside(FIGHT_BUTTON_TOP_LEFT, FIGHT_BUTTON_BOTTOM_RIGHT);
     }

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/combat/ArenaRoutineQuickDeployTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/combat/ArenaRoutineQuickDeployTest.java
@@ -1,0 +1,86 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.configs.TpDailyTaskEnum;
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.PointData;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArenaRoutineQuickDeployTest {
+
+    @BeforeAll
+    static void createsRuntimeWorkspaceBeforeRoutineConstruction() throws IOException {
+        Files.createDirectories(WorkspacePaths.current().root());
+    }
+
+    @Test
+    void usesQuickDeployForAttacksWhenEnabled() {
+        TestableArenaRoutine routine = routineWithAttackQuickDeploy(true);
+
+        routine.executeBattleSequence();
+
+        assertEquals(List.of(
+                new PointData(180, 1200),
+                new PointData(530, 1200),
+                new PointData(60, 962),
+                new PointData(252, 635)), routine.taps);
+        assertEquals(List.of(500L, 3000L, 500L, 1000L), routine.sleepDurations);
+    }
+
+    @Test
+    void keepsSavedAttackFormationWhenQuickDeployIsDisabled() {
+        TestableArenaRoutine routine = routineWithAttackQuickDeploy(false);
+
+        routine.executeBattleSequence();
+
+        assertEquals(List.of(
+                new PointData(530, 1200),
+                new PointData(60, 962),
+                new PointData(252, 635)), routine.taps);
+        assertEquals(List.of(3000L, 500L, 1000L), routine.sleepDurations);
+    }
+
+    @Test
+    void attackQuickDeployRemainsEnabledByDefault() {
+        assertTrue(profile().getConfig(ConfigurationKeyEnum.ARENA_TASK_ATTACK_QUICK_DEPLOY_BOOL, Boolean.class));
+    }
+
+    private TestableArenaRoutine routineWithAttackQuickDeploy(boolean enabled) {
+        AccountDescriptor profile = profile();
+        profile.setConfig(ConfigurationKeyEnum.ARENA_TASK_ATTACK_QUICK_DEPLOY_BOOL, enabled);
+        return new TestableArenaRoutine(profile);
+    }
+
+    private AccountDescriptor profile() {
+        return new AccountDescriptor(1L, "Test", "1", true, 1L, 30L);
+    }
+
+    private static final class TestableArenaRoutine extends ArenaRoutine {
+        private final List<PointData> taps = new ArrayList<>();
+        private final List<Long> sleepDurations = new ArrayList<>();
+
+        private TestableArenaRoutine(AccountDescriptor profile) {
+            super(profile, TpDailyTaskEnum.ARENA);
+        }
+
+        @Override
+        public void tapNear(PointData point) {
+            taps.add(point);
+        }
+
+        @Override
+        protected void sleepTask(long millis) {
+            sleepDurations.add(millis);
+        }
+    }
+}

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/exploration/DoExplorationRoutineTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/exploration/DoExplorationRoutineTest.java
@@ -1,0 +1,83 @@
+package dev.frostguard.tasks.exploration;
+
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.configs.TpDailyTaskEnum;
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.PointData;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DoExplorationRoutineTest {
+
+    @BeforeAll
+    static void createsRuntimeWorkspaceBeforeRoutineConstruction() throws IOException {
+        Files.createDirectories(WorkspacePaths.current().root());
+    }
+
+    @Test
+    void usesQuickDeployWhenEnabled() {
+        TestableDoExplorationRoutine routine = routineWithQuickDeploy(true);
+
+        routine.startBattle();
+
+        assertEquals(List.of(
+                new PointData(55, 1170),
+                new PointData(390, 1170)), routine.tapTopLefts);
+        assertEquals(List.of(300L), routine.sleepDurations);
+    }
+
+    @Test
+    void keepsSavedFormationWhenQuickDeployIsDisabled() {
+        TestableDoExplorationRoutine routine = routineWithQuickDeploy(false);
+
+        routine.startBattle();
+
+        assertEquals(List.of(new PointData(390, 1170)), routine.tapTopLefts);
+        assertEquals(List.of(), routine.sleepDurations);
+    }
+
+    @Test
+    void quickDeployRemainsEnabledByDefault() {
+        AccountDescriptor profile = profile();
+
+        assertTrue(profile.getConfig(ConfigurationKeyEnum.DO_EXPLORATION_QUICK_DEPLOY_BOOL, Boolean.class));
+    }
+
+    private TestableDoExplorationRoutine routineWithQuickDeploy(boolean enabled) {
+        AccountDescriptor profile = profile();
+        profile.setConfig(ConfigurationKeyEnum.DO_EXPLORATION_QUICK_DEPLOY_BOOL, enabled);
+        return new TestableDoExplorationRoutine(profile);
+    }
+
+    private AccountDescriptor profile() {
+        return new AccountDescriptor(1L, "Test", "1", true, 1L, 30L);
+    }
+
+    private static final class TestableDoExplorationRoutine extends DoExplorationRoutine {
+        private final List<PointData> tapTopLefts = new ArrayList<>();
+        private final List<Long> sleepDurations = new ArrayList<>();
+
+        private TestableDoExplorationRoutine(AccountDescriptor profile) {
+            super(profile, TpDailyTaskEnum.DO_EXPLORATION);
+        }
+
+        @Override
+        public void tapInside(PointData topLeft, PointData bottomRight) {
+            tapTopLefts.add(topLeft);
+        }
+
+        @Override
+        protected void sleepTask(long millis) {
+            sleepDurations.add(millis);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add separate per-profile Quick Deploy options for Exploration fights and Arena attacks
- skip Quick Deploy when disabled so each activity's saved attack formation remains selected
- keep both options enabled by default for backward compatibility
- document that `ArenaRoutine` never opens or changes the Arena defense formation

## Why

Exploration and Arena attacks previously pressed Quick Deploy unconditionally. The game can replace intentionally saved heroes with its suggested strongest heroes, even when those heroes are not the player's preferred formation for that activity.

Arena defense does not need a separate setting: repository inspection confirms that Frostguard only automates challenge attacks and never enters the defense-formation flow.

Closes #159.

## Validation

- rebased onto current `main` after #179 / Frostguard 3.0.0
- `mvnw.cmd -pl modules/desktop -am test` — passed 368 tests with 0 failures, errors, or skips
- focused Quick Deploy tests cover enabled, disabled, and default-enabled behavior for Exploration and Arena attacks
- both affected settings FXML files parsed successfully and expose their new control IDs
- build-support verification: 39 verification, 47 release, and 61 notification tests passed; all inline workflow Python snippets compile
- repository scan found no Arena defense interaction in `ArenaRoutine`
- `git diff --check origin/main...HEAD` — passed
- live PR-build test by **cLaimAngeL [NERD]**: Arena and Exploration both retained their previously saved formations; testing both in the same run produced no errors

## Risks

- Live behavior is user-confirmed, but no account logs or screenshots were supplied with the report. Future game UI changes can still affect the fixed-coordinate Arena and Exploration fight controls.

## Credits

- Tested-by: **cLaimAngeL [NERD]**
