### PR TITLE
feat(update): implement signed release updates

### DIFF
--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -64,7 +64,8 @@ jobs:
         shell: pwsh
         run: |
           $mavenArgs = $env:MAVEN_ARGS -split " "
-          & .\mvnw.cmd @mavenArgs "-Pwindows-app-image,windows-installer" package
+          & .\mvnw.cmd @mavenArgs "-Dfrostguard.pull-request-build=true" `
+              "-Pwindows-app-image,windows-installer" package
 
       - name: Test the application-image verifier
         run: python build-support/verification/test_verify_app_image.py

--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -1,0 +1,114 @@
+name: Native Windows Package
+
+on:
+  pull_request:
+    paths:
+      - "**/pom.xml"
+      - "modules/**/src/**"
+      - "packaging/desktop/**"
+      - "build-support/packaging/**"
+      - "build-support/verification/*app_image*"
+      - "build-support/verification/smoke_test_app_image.ps1"
+      - "tools/**"
+      - "examples/custom-tasks/**"
+      - ".github/workflows/windows-native-package.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-native-package-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MAVEN_ARGS: "-B --no-transfer-progress -Dstyle.color=never"
+
+jobs:
+  package:
+    name: Build and verify native Windows package
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Verify Git LFS assets are real binaries
+        shell: bash
+        run: build-support/verification/check_lfs_assets.sh
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      # JDK 21 jpackage invokes the WiX 3 candle/light toolchain for an EXE.
+      # Pinning the Chocolatey package prevents an incompatible WiX major from
+      # silently changing the installer build underneath this workflow.
+      - name: Install WiX Toolset 3
+        shell: pwsh
+        run: |
+          choco install wixtoolset --version=3.14.1.20250415 --no-progress -y
+          $wixBin = "${env:ProgramFiles(x86)}\WiX Toolset v3.14\bin"
+          if (-not (Test-Path -LiteralPath (Join-Path $wixBin "candle.exe"))) {
+              throw "WiX candle.exe was not installed below $wixBin"
+          }
+          $wixBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Build application image and installer
+        shell: pwsh
+        run: |
+          $mavenArgs = $env:MAVEN_ARGS -split " "
+          & .\mvnw.cmd @mavenArgs "-Pwindows-app-image,windows-installer" package
+
+      - name: Test the application-image verifier
+        run: python build-support/verification/test_verify_app_image.py
+
+      - name: Verify application image
+        run: >-
+          python build-support/verification/verify_app_image.py
+          packaging/desktop/target/app-image/Frostguard
+
+      - name: Smoke test native launchers and workspace isolation
+        shell: pwsh
+        run: |
+          powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+              -File build-support/verification/smoke_test_app_image.ps1 `
+              -ImagePath packaging/desktop/target/app-image/Frostguard
+
+      - name: Verify installer boundary
+        id: installer
+        shell: pwsh
+        run: |
+          $installers = @(Get-ChildItem -LiteralPath packaging/desktop/target/installers `
+              -Filter "Frostguard-*.exe" -File)
+          if ($installers.Count -ne 1) {
+              throw "Expected exactly one versioned installer, found $($installers.Count)"
+          }
+          if ($installers[0].Length -lt 1MB) {
+              throw "Installer is unexpectedly small: $($installers[0].Length) bytes"
+          }
+          "path=$($installers[0].FullName)" | Out-File `
+              -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Upload native application image
+        uses: actions/upload-artifact@v4
+        with:
+          name: frostguard-windows-app-image
+          path: packaging/desktop/target/app-image/Frostguard
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: frostguard-windows-installer
+          path: ${{ steps.installer.outputs.path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ── Maven build output ──
 target/
+.frostguard-dev/
 **/target/
 dependency-reduced-pom.xml
 

--- a/build-support/packaging/write_windows_icon.ps1
+++ b/build-support/packaging/write_windows_icon.ps1
@@ -1,0 +1,50 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$InputPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = "Stop"
+$png = [System.IO.File]::ReadAllBytes((Resolve-Path -LiteralPath $InputPath))
+$signature = [byte[]](137, 80, 78, 71, 13, 10, 26, 10)
+if ($png.Length -lt 24) {
+    throw "The Windows icon source must be a PNG file"
+}
+for ($index = 0; $index -lt $signature.Length; $index++) {
+    if ($png[$index] -ne $signature[$index]) {
+        throw "The Windows icon source must be a PNG file"
+    }
+}
+
+# PNG stores the IHDR dimensions in big-endian order. ICO uses a zero byte for
+# a 256-pixel dimension and can embed the original PNG payload without lossy
+# conversion on supported Windows versions.
+$width = [System.Net.IPAddress]::NetworkToHostOrder([BitConverter]::ToInt32($png, 16))
+$height = [System.Net.IPAddress]::NetworkToHostOrder([BitConverter]::ToInt32($png, 20))
+if ($width -lt 1 -or $width -gt 256 -or $height -lt 1 -or $height -gt 256) {
+    throw "The PNG dimensions must be between 1 and 256 pixels"
+}
+
+$outputDirectory = Split-Path -Parent $OutputPath
+New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+$stream = [System.IO.File]::Open($OutputPath, [System.IO.FileMode]::Create)
+$writer = [System.IO.BinaryWriter]::new($stream)
+try {
+    $writer.Write([uint16]0)
+    $writer.Write([uint16]1)
+    $writer.Write([uint16]1)
+    $writer.Write([byte]($(if ($width -eq 256) { 0 } else { $width })))
+    $writer.Write([byte]($(if ($height -eq 256) { 0 } else { $height })))
+    $writer.Write([byte]0)
+    $writer.Write([byte]0)
+    $writer.Write([uint16]1)
+    $writer.Write([uint16]32)
+    $writer.Write([uint32]$png.Length)
+    $writer.Write([uint32]22)
+    $writer.Write($png)
+}
+finally {
+    $writer.Dispose()
+}

--- a/build-support/verification/smoke_test_app_image.ps1
+++ b/build-support/verification/smoke_test_app_image.ps1
@@ -1,0 +1,106 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ImagePath
+)
+
+$ErrorActionPreference = "Stop"
+$image = (Resolve-Path -LiteralPath $ImagePath).Path
+$appLauncher = Join-Path $image "Frostguard.exe"
+$watcherLauncher = Join-Path $image "FrostguardWatcher.exe"
+if (-not (Test-Path -LiteralPath $appLauncher -PathType Leaf)) {
+    throw "Frostguard.exe is missing from $image"
+}
+if (-not (Test-Path -LiteralPath $watcherLauncher -PathType Leaf)) {
+    throw "FrostguardWatcher.exe is missing from $image"
+}
+
+$versionInfo = (Get-Item -LiteralPath $appLauncher).VersionInfo
+if ($versionInfo.ProductName -ne "Frostguard" -or
+        $versionInfo.CompanyName -ne "Frostguard" -or
+        $versionInfo.FileDescription -ne "Frostguard automation desktop application") {
+    throw "Frostguard.exe has incomplete Windows application metadata"
+}
+Add-Type -AssemblyName System.Drawing
+$icon = [System.Drawing.Icon]::ExtractAssociatedIcon($appLauncher)
+if ($null -eq $icon -or $icon.Width -lt 16 -or $icon.Height -lt 16) {
+    throw "Frostguard.exe has no usable Windows application icon"
+}
+$icon.Dispose()
+
+$smokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("frostguard-native-smoke-" + [guid]::NewGuid().ToString("N"))
+$appWorkspace = Join-Path $smokeRoot "app-workspace"
+$watcherWorkspace = Join-Path $smokeRoot "watcher-workspace"
+New-Item -ItemType Directory -Path $appWorkspace, $watcherWorkspace | Out-Null
+$originalPath = $env:PATH
+$hadJavaHome = Test-Path Env:JAVA_HOME
+$originalJavaHome = $env:JAVA_HOME
+
+try {
+    Remove-Item Env:JAVA_HOME -ErrorAction SilentlyContinue
+    $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
+    $env:FROSTGUARD_WORKSPACE = $appWorkspace
+    $app = Start-Process -FilePath $appLauncher -ArgumentList "--frostguard-native-smoke-test" -Wait -PassThru
+    if ($app.ExitCode -ne 0) {
+        throw "Native Frostguard launcher exited with $($app.ExitCode)"
+    }
+    $marker = Join-Path $appWorkspace "frostguard-workspace.json"
+    if (-not (Test-Path -LiteralPath $marker)) {
+        throw "Native launcher did not create its isolated workspace marker"
+    }
+    $workspaceMetadata = Get-Content -Raw -LiteralPath $marker | ConvertFrom-Json
+    if ($workspaceMetadata.channel -ne "stable") {
+        throw "Native launcher selected '$($workspaceMetadata.channel)' instead of Stable"
+    }
+
+    $env:FROSTGUARD_WORKSPACE = $watcherWorkspace
+    $watcher = Start-Process -FilePath $watcherLauncher `
+        -ArgumentList "--frostguard-native-smoke-test" -Wait -PassThru
+    if ($watcher.ExitCode -ne 0) {
+        throw "Native Frostguard watcher launcher exited with $($watcher.ExitCode)"
+    }
+    $watcherConfig = Join-Path $watcherWorkspace "watcher/telegram-watcher.properties"
+    if (-not (Test-Path -LiteralPath $watcherConfig)) {
+        throw "Native watcher launcher did not reach workspace configuration"
+    }
+    $watcherMarker = Join-Path $watcherWorkspace "frostguard-workspace.json"
+    if (-not (Test-Path -LiteralPath $watcherMarker)) {
+        throw "Native watcher launcher did not create its workspace marker"
+    }
+    $watcherMetadata = Get-Content -Raw -LiteralPath $watcherMarker | ConvertFrom-Json
+    if ($watcherMetadata.channel -ne "stable") {
+        throw "Native watcher launcher selected '$($watcherMetadata.channel)' instead of Stable"
+    }
+    $watcherEvidencePath = Join-Path $watcherWorkspace "cache/native-watcher-smoke.properties"
+    if (-not (Test-Path -LiteralPath $watcherEvidencePath)) {
+        throw "Native watcher launcher did not write smoke-test evidence"
+    }
+    $watcherEvidence = @{}
+    Get-Content -LiteralPath $watcherEvidencePath | ForEach-Object {
+        if ($_ -match '^([^=]+)=(.*)$') {
+            $watcherEvidence[$matches[1]] = $matches[2]
+        }
+    }
+    if ($watcherEvidence["channel"] -ne "stable" -or
+            [System.IO.Path]::GetFullPath($watcherEvidence["workspace"]) -ne $watcherWorkspace -or
+            [System.IO.Path]::GetFullPath($watcherEvidence["applicationDir"]) -ne (Join-Path $image "app") -or
+            [System.IO.Path]::GetFullPath($watcherEvidence["appLauncher"]) -ne $appLauncher -or
+            [System.IO.Path]::GetFullPath($watcherEvidence["watcherLauncher"]) -ne $watcherLauncher) {
+        throw "Native watcher launcher did not receive its packaged runtime contract"
+    }
+    Write-Host "Native app-image smoke test passed (app and watcher exit 0 without system Java)."
+}
+finally {
+    Remove-Item Env:FROSTGUARD_WORKSPACE -ErrorAction SilentlyContinue
+    $env:PATH = $originalPath
+    if ($hadJavaHome) {
+        $env:JAVA_HOME = $originalJavaHome
+    } else {
+        Remove-Item Env:JAVA_HOME -ErrorAction SilentlyContinue
+    }
+    $resolvedSmokeRoot = [System.IO.Path]::GetFullPath($smokeRoot)
+    $resolvedTempRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+    if ($resolvedSmokeRoot.StartsWith($resolvedTempRoot, [System.StringComparison]::OrdinalIgnoreCase) -and
+            (Split-Path -Leaf $resolvedSmokeRoot).StartsWith("frostguard-native-smoke-")) {
+        Remove-Item -LiteralPath $resolvedSmokeRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/build-support/verification/smoke_test_bundle.sh
+++ b/build-support/verification/smoke_test_bundle.sh
@@ -120,12 +120,14 @@ echo "  no classpath resolution errors from java -jar"
 echo "Booting the Telegram watcher from the bundle..."
 watcher_log="${workdir}/watcher.log"
 watcher_home="${workdir}/watcher-home"
+watcher_workspace="${workdir}/.frostguard-dev"
 mkdir -p "${watcher_home}"
 set +e
-# -Duser.home: the watcher derives its config path from user.home, which the JVM
-# reads from the OS account rather than $HOME. Redirect it so the smoke test
-# never touches a real developer profile.
-timeout 90s java -Duser.home="${watcher_home}" -jar "${watcher_jar}" \
+# Keep both user.home and the explicit workspace inside the disposable smoke
+# directory. The override makes the test deterministic even when a host Java
+# process does not inherit the shell's changed working directory.
+timeout 90s java -Duser.home="${watcher_home}" \
+  -Dfrostguard.workspace="${watcher_workspace}" -jar "${watcher_jar}" \
   > "${watcher_log}" 2>&1
 watcher_status=$?
 set -e
@@ -154,8 +156,8 @@ if ! grep -q "telegram-watcher.properties" "${watcher_log}" \
   exit 1
 fi
 
-if [[ ! -f "${watcher_home}/.frostguard/telegram-watcher.properties" ]]; then
-  echo "::error::The watcher did not create its config template under user.home."
+if [[ ! -f "${watcher_workspace}/watcher/telegram-watcher.properties" ]]; then
+  echo "::error::The watcher did not create its config template in the development workspace."
   sed 's/^/    /' "${watcher_log}" | head -n 30
   exit 1
 fi

--- a/build-support/verification/test_project_layout.py
+++ b/build-support/verification/test_project_layout.py
@@ -18,6 +18,7 @@ MODULES = {
     "modules/automation": "frostguard-automation",
     "modules/tasks": "frostguard-tasks",
     "modules/watcher": "frostguard-watcher",
+    "modules/update": "frostguard-update",
     "modules/desktop": "frostguard-desktop",
     "packaging/desktop": "frostguard-desktop-package",
 }

--- a/build-support/verification/test_verify_app_image.py
+++ b/build-support/verification/test_verify_app_image.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -20,6 +21,7 @@ class VerifyAppImageTest(unittest.TestCase):
         files = list(verify_app_image.REQUIRED_FILES) + [
             "app/frostguard-desktop-3.0.0.jar",
             "app/frostguard-watcher-3.0.0.jar",
+            "app/lib/frostguard-update-3.0.0.jar",
             "app/lib/opencv-4.9.0.jar",
             "app/lib/tess4j-5.14.0.jar",
             "app/lib/javafx-graphics-23.0.1-win.jar",
@@ -30,9 +32,17 @@ class VerifyAppImageTest(unittest.TestCase):
             path = self.image / relative
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_bytes(b"payload")
-        common_options = "\n".join(verify_app_image.COMMON_JAVA_OPTIONS) + "\n"
+        with zipfile.ZipFile(self.image / "app/frostguard-desktop-3.0.0.jar", "w") as desktop_jar:
+            desktop_jar.writestr(
+                verify_app_image.BUILD_METADATA,
+                "pullRequestBuild=false\nauthenticodePublisher=CN=Frostguard Project, O=Frostguard\n",
+            )
+        common_options = "\n".join(verify_app_image.COMMON_JAVA_OPTIONS) + (
+            "\njava-options=-Dfrostguard.update.pullRequestBuild=false\n"
+        )
         (self.image / "app/Frostguard.cfg").write_text(
-            "app.mainclass=dev.frostguard.app.bootstrap.Main\n" + common_options,
+            "app.mainclass=dev.frostguard.app.bootstrap.Main\n"
+            "java-options=-Dfrostguard.update.manifest.stable=\n" + common_options,
             encoding="utf-8")
         (self.image / "app/FrostguardWatcher.cfg").write_text(
             "app.mainclass=dev.frostguard.watcher.TelegramWatcher\n" + common_options,
@@ -57,6 +67,26 @@ class VerifyAppImageTest(unittest.TestCase):
         config = self.image / "app/FrostguardWatcher.cfg"
         config.write_text(config.read_text().replace("channel=stable", "channel=development"))
         self.assertTrue(any("FrostguardWatcher.cfg" in item for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_launcher_without_pr_build_identity(self):
+        config = self.image / "app/Frostguard.cfg"
+        config.write_text(config.read_text().replace(
+            "java-options=-Dfrostguard.update.pullRequestBuild=false\n", ""))
+        self.assertTrue(any("PR-build update identity" in item
+                            for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_launcher_identity_that_disagrees_with_desktop_jar(self):
+        config = self.image / "app/Frostguard.cfg"
+        config.write_text(config.read_text().replace(
+            "frostguard.update.pullRequestBuild=false",
+            "frostguard.update.pullRequestBuild=true"))
+        self.assertTrue(any("does not match the desktop JAR" in item
+                            for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_desktop_jar_without_embedded_identity(self):
+        (self.image / "app/frostguard-desktop-3.0.0.jar").write_bytes(b"not a jar")
+        self.assertTrue(any("no valid embedded PR-build" in item
+                            for item in verify_app_image.inspect_image(self.image)))
 
     def test_rejects_runtime_data(self):
         leaked = self.image / "app/logs/frostguard.log"

--- a/build-support/verification/test_verify_app_image.py
+++ b/build-support/verification/test_verify_app_image.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import verify_app_image  # noqa: E402
+
+
+class VerifyAppImageTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.image = Path(self.temp.name) / "Frostguard"
+        files = list(verify_app_image.REQUIRED_FILES) + [
+            "app/frostguard-desktop-3.0.0.jar",
+            "app/frostguard-watcher-3.0.0.jar",
+            "app/lib/opencv-4.9.0.jar",
+            "app/lib/tess4j-5.14.0.jar",
+            "app/lib/javafx-graphics-23.0.1-win.jar",
+            "app/templates/home/world.png",
+            "app/custom_tasks/shield.java",
+        ] + [f"app/lib/runtime-{index}.jar" for index in range(60)]
+        for relative in files:
+            path = self.image / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"payload")
+        common_options = "\n".join(verify_app_image.COMMON_JAVA_OPTIONS) + "\n"
+        (self.image / "app/Frostguard.cfg").write_text(
+            "app.mainclass=dev.frostguard.app.bootstrap.Main\n" + common_options,
+            encoding="utf-8")
+        (self.image / "app/FrostguardWatcher.cfg").write_text(
+            "app.mainclass=dev.frostguard.watcher.TelegramWatcher\n" + common_options,
+            encoding="utf-8")
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_accepts_complete_image(self):
+        self.assertEqual([], verify_app_image.inspect_image(self.image))
+
+    def test_rejects_missing_bundled_runtime(self):
+        (self.image / "runtime/bin/server/jvm.dll").unlink()
+        self.assertTrue(any("jvm.dll" in item for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_development_channel_launcher(self):
+        config = self.image / "app/Frostguard.cfg"
+        config.write_text(config.read_text().replace("channel=stable", "channel=development"))
+        self.assertTrue(any("channel=stable" in item for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_watcher_without_stable_channel(self):
+        config = self.image / "app/FrostguardWatcher.cfg"
+        config.write_text(config.read_text().replace("channel=stable", "channel=development"))
+        self.assertTrue(any("FrostguardWatcher.cfg" in item for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_runtime_data(self):
+        leaked = self.image / "app/logs/frostguard.log"
+        leaked.parent.mkdir(parents=True)
+        leaked.write_text("private runtime log")
+        self.assertTrue(any("leaked" in item for item in verify_app_image.inspect_image(self.image)))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/build-support/verification/verify_app_image.py
+++ b/build-support/verification/verify_app_image.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import zipfile
 from pathlib import Path
 
 MINIMUM_RUNTIME_JARS = 50
@@ -26,6 +27,7 @@ FORBIDDEN_NAMES = {
     "frostguard.db",
     "telegram-watcher.properties",
 }
+BUILD_METADATA = "dev/frostguard/app/frostguard-build.properties"
 COMMON_JAVA_OPTIONS = (
     "java-options=-Dfrostguard.channel=stable",
     "java-options=-Duser.dir=$APPDIR",
@@ -35,6 +37,7 @@ COMMON_JAVA_OPTIONS = (
 CONFIG_SETTINGS = {
     "app/Frostguard.cfg": (
         "app.mainclass=dev.frostguard.app.bootstrap.Main",
+        "java-options=-Dfrostguard.update.manifest.stable=",
         *COMMON_JAVA_OPTIONS,
     ),
     "app/FrostguardWatcher.cfg": (
@@ -67,6 +70,7 @@ def inspect_image(image: Path) -> list[str]:
     for pattern, description in (
         (r"^app/frostguard-desktop-[^/]+\.jar$", "desktop JAR"),
         (r"^app/frostguard-watcher-[^/]+\.jar$", "watcher JAR"),
+        (r"^app/lib/frostguard-update-[^/]+\.jar$", "update module"),
         (r"^app/lib/opencv-[^/]+\.jar$", "OpenCV runtime"),
         (r"^app/lib/tess4j-[^/]+\.jar$", "Tess4J runtime"),
         (r"^app/lib/javafx-graphics-[^/]+-win\.jar$", "Windows JavaFX runtime"),
@@ -76,6 +80,7 @@ def inspect_image(image: Path) -> list[str]:
         if not any(re.match(pattern, name) for name in files):
             problems.append(f"Application image has no {description}")
 
+    config_identities: dict[str, str] = {}
     for config_path, settings in CONFIG_SETTINGS.items():
         if config_path not in files:
             continue
@@ -83,6 +88,43 @@ def inspect_image(image: Path) -> list[str]:
         for setting in settings:
             if setting not in config:
                 problems.append(f"{Path(config_path).name} is missing: {setting}")
+        identity = re.search(
+            r"-Dfrostguard\.update\.pullRequestBuild=(true|false)", config
+        )
+        if identity is None:
+            problems.append(
+                f"{Path(config_path).name} is missing its PR-build update identity"
+            )
+        else:
+            config_identities[config_path] = identity.group(1)
+
+    desktop_jars = [
+        path for name, path in files.items()
+        if re.match(r"^app/frostguard-desktop-[^/]+\.jar$", name)
+    ]
+    if len(desktop_jars) == 1:
+        try:
+            with zipfile.ZipFile(desktop_jars[0]) as desktop_jar:
+                metadata = desktop_jar.read(BUILD_METADATA).decode("utf-8")
+            metadata_values = {}
+            for line in metadata.splitlines():
+                key, separator, value = line.partition("=")
+                if not separator or key in metadata_values:
+                    metadata_values = {}
+                    break
+                metadata_values[key] = value
+            if (set(metadata_values) != {"pullRequestBuild", "authenticodePublisher"}
+                    or metadata_values["pullRequestBuild"] not in {"true", "false"}):
+                problems.append("Desktop JAR has an invalid PR-build update identity")
+            else:
+                embedded_identity = metadata_values["pullRequestBuild"]
+                for config_path, config_identity in config_identities.items():
+                    if config_identity != embedded_identity:
+                        problems.append(
+                            f"{Path(config_path).name} PR-build identity does not match the desktop JAR"
+                        )
+        except (KeyError, UnicodeDecodeError, zipfile.BadZipFile):
+            problems.append("Desktop JAR has no valid embedded PR-build update identity")
 
     for relative in files:
         path = Path(relative)

--- a/build-support/verification/verify_app_image.py
+++ b/build-support/verification/verify_app_image.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Verify a native Frostguard jpackage application image."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+MINIMUM_RUNTIME_JARS = 50
+REQUIRED_FILES = (
+    "Frostguard.exe",
+    "FrostguardWatcher.exe",
+    "runtime/bin/server/jvm.dll",
+    "app/Frostguard.cfg",
+    "app/FrostguardWatcher.cfg",
+    "app/lib/adb/adb.exe",
+    "app/lib/adb/AdbWinApi.dll",
+    "app/lib/adb/AdbWinUsbApi.dll",
+    "app/lib/tesseract/eng.traineddata",
+    "app/lib/tesseract/osd.traineddata",
+    "app/lib/tesseract/chi_sim.traineddata",
+)
+FORBIDDEN_NAMES = {
+    "frostguard-workspace.json",
+    "frostguard.db",
+    "telegram-watcher.properties",
+}
+COMMON_JAVA_OPTIONS = (
+    "java-options=-Dfrostguard.channel=stable",
+    "java-options=-Duser.dir=$APPDIR",
+    "java-options=-Dfrostguard.launcher=$APPDIR/../Frostguard.exe",
+    "java-options=-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe",
+)
+CONFIG_SETTINGS = {
+    "app/Frostguard.cfg": (
+        "app.mainclass=dev.frostguard.app.bootstrap.Main",
+        *COMMON_JAVA_OPTIONS,
+    ),
+    "app/FrostguardWatcher.cfg": (
+        "app.mainclass=dev.frostguard.watcher.TelegramWatcher",
+        *COMMON_JAVA_OPTIONS,
+    ),
+}
+
+
+def inspect_image(image: Path) -> list[str]:
+    problems: list[str] = []
+    if not image.is_dir():
+        return [f"Application image does not exist: {image}"]
+
+    files = {
+        path.relative_to(image).as_posix(): path
+        for path in image.rglob("*")
+        if path.is_file()
+    }
+    for required in REQUIRED_FILES:
+        if required not in files:
+            problems.append(f"Application image is missing {required}")
+
+    runtime_jars = [name for name in files if re.match(r"^app/lib/[^/]+\.jar$", name)]
+    if len(runtime_jars) < MINIMUM_RUNTIME_JARS:
+        problems.append(
+            f"Only {len(runtime_jars)} runtime JARs found; expected at least "
+            f"{MINIMUM_RUNTIME_JARS}"
+        )
+    for pattern, description in (
+        (r"^app/frostguard-desktop-[^/]+\.jar$", "desktop JAR"),
+        (r"^app/frostguard-watcher-[^/]+\.jar$", "watcher JAR"),
+        (r"^app/lib/opencv-[^/]+\.jar$", "OpenCV runtime"),
+        (r"^app/lib/tess4j-[^/]+\.jar$", "Tess4J runtime"),
+        (r"^app/lib/javafx-graphics-[^/]+-win\.jar$", "Windows JavaFX runtime"),
+        (r"^app/templates/.+\.png$", "template browser assets"),
+        (r"^app/custom_tasks/.+$", "custom task examples"),
+    ):
+        if not any(re.match(pattern, name) for name in files):
+            problems.append(f"Application image has no {description}")
+
+    for config_path, settings in CONFIG_SETTINGS.items():
+        if config_path not in files:
+            continue
+        config = files[config_path].read_text(encoding="utf-8")
+        for setting in settings:
+            if setting not in config:
+                problems.append(f"{Path(config_path).name} is missing: {setting}")
+
+    for relative in files:
+        path = Path(relative)
+        lower_name = path.name.lower()
+        if lower_name in FORBIDDEN_NAMES or lower_name.endswith((".db-wal", ".db-shm", ".log")):
+            problems.append(f"Runtime/user data leaked into the application image: {relative}")
+        if any(part.lower() in {".frostguard", ".frostguard-dev", "logs"} for part in path.parts):
+            problems.append(f"Runtime/user-data directory leaked into the application image: {relative}")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("image", type=Path)
+    args = parser.parse_args(argv)
+    problems = inspect_image(args.image)
+    if problems:
+        for problem in problems:
+            print(f"::error::{problem}")
+        return 1
+    print(f"Native application image verification passed: {args.image}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ flowchart TD
     App --> Engine[modules/automation<br/>services, scheduler, helpers]
     App --> Tasks[modules/tasks<br/>built-in routines]
     App --> Watcher[modules/watcher<br/>Telegram watcher jar]
-    App -. future update module .-> Update[platform-neutral update contracts and policy]
+    App --> Update[modules/update<br/>manifest, policy, verified download, handoff]
 
     Engine --> Data[modules/persistence<br/>SQLite and repositories]
     Engine --> Vision[modules/vision<br/>OCR and template matching]
@@ -36,6 +36,7 @@ flowchart LR
     fg_app --> fg_tasks[modules/tasks]
     fg_app --> fg_vision[modules/vision]
     fg_app --> fg_api[modules/api]
+    fg_app --> fg_update[modules/update]
 
     fg_tasks --> fg_engine
     fg_tasks --> fg_api
@@ -46,6 +47,7 @@ flowchart LR
 
     fg_data --> fg_api
     fg_vision --> fg_api
+    fg_update --> fg_api
     fg_watcher[modules/watcher] -. standalone .-> watcher_runtime[Telegram runtime]
 ```
 
@@ -60,10 +62,22 @@ Do not put game task business logic in `modules/desktop`; do not put UI concepts
 | `modules/tasks` | `frostguard-tasks` | Game-specific automation routines |
 | `modules/desktop` | `frostguard-desktop` | JavaFX UI and desktop entry points |
 | `modules/watcher` | `frostguard-watcher` | Companion watcher process |
+| `modules/update` | `frostguard-update` | Release manifest, version/channel policy, verified download, and installer handoff |
 | `packaging/desktop` | `frostguard-desktop-package` | Platform packaging inputs and output verification |
 
-The platform-neutral update module is introduced with its implementation rather
-than as an empty project-layout placeholder.
+### Update Layer
+
+`modules/update` owns the platform-neutral update trust boundary:
+
+- strict schema-versioned manifest parsing;
+- semantic-version, channel, operating-system, and architecture selection;
+- restart-safe downloads below the selected workspace cache;
+- byte-size and SHA-256 verification;
+- a build-pinned Windows Authenticode identity and token-authorized external handoff.
+
+The desktop module owns presentation and runtime shutdown. Update code does not
+depend on JavaFX, persistence, scheduling, or GitHub APIs. Development and
+PR-test identities are rejected before manifest discovery.
 
 ## Logical Decomposition
 
@@ -217,6 +231,7 @@ flowchart TD
     RootPom --> EngineJar[modules/automation jar]
     RootPom --> TasksJar[modules/tasks jar]
     RootPom --> WatcherJar[modules/watcher shaded jar]
+    RootPom --> UpdateJar[modules/update jar]
     RootPom --> AppJar[modules/desktop executable jar]
 
     ApiJar --> AppBundle[desktop bundle zip]
@@ -225,6 +240,7 @@ flowchart TD
     EngineJar --> AppBundle
     TasksJar --> AppBundle
     WatcherJar --> AppBundle
+    UpdateJar --> AppBundle
     AppJar --> AppBundle
 
     Tools[tools/adb and tools/tesseract] --> AppBundle
@@ -253,6 +269,16 @@ the Java/JAR paths retained only as the source and transitional-ZIP fallback.
 Native packaging is opt-in through Maven profiles so the normal reactor build
 stays platform-neutral.
 
+The installed desktop exposes update controls only for eligible Stable or
+Nightly builds. A selected installer is downloaded to
+`<workspace>/cache/updates/<channel>/<version>`, verified, and passed to a
+hidden PowerShell waiter. The waiter requires a one-time authorization token
+and waits for the Frostguard PID to disappear before starting the installer.
+Frostguard authorizes the staged waiter, stops queues and workspace-owned
+services, closes SQLite and the workspace lock, and exits. A failed shutdown
+cancels the authorization, and the waiter cannot start the installer while the
+Frostguard PID is alive. Frostguard never replaces its own running files.
+
 `modules/watcher` builds a separate shaded watcher jar.
 
 ## Where To Change Things
@@ -265,3 +291,4 @@ stays platform-neutral.
 - Change persisted config/profile/task state: `modules/persistence` entities/repositories and engine services.
 - Change UI controls or panels: `modules/desktop/src/main/java/dev/frostguard/app/panel/*` plus matching FXML/CSS.
 - Change runtime packaging: `packaging/desktop/pom.xml` or its platform sources.
+- Change update manifests, selection, download, or trust policy: `modules/update`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,9 +239,19 @@ with `./mvnw javafx:run`; its versioned JAR is not a standalone distribution.
 - executable jar: `modules/desktop/target/frostguard-desktop-<version>.jar`
 - transitional desktop zip: `packaging/desktop/target/frostguard-<version>-desktop-bundle.zip`
 - packaging inputs staged under `packaging/desktop/target/input`
+- Windows application image: `packaging/desktop/target/app-image/Frostguard`
+- Windows installer: versioned EXE under `packaging/desktop/target/installers`
 - ADB/Tesseract files staged from `tools/`
 - custom task examples staged from root `examples/custom-tasks/`
 - template PNGs staged from `modules/vision/src/main/resources/templates`
+
+The native Windows image contains the desktop and watcher launchers plus a
+`jlink` runtime. Both launchers receive the Stable channel and workspace
+contract through packaged JVM options. The watcher and Task Scheduler launch
+the native executables when those packaged launcher paths are present, with
+the Java/JAR paths retained only as the source and transitional-ZIP fallback.
+Native packaging is opt-in through Maven profiles so the normal reactor build
+stays platform-neutral.
 
 `modules/watcher` builds a separate shaded watcher jar.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,7 +134,18 @@ FXML and CSS resources live in `modules/desktop/src/main/resources/layout` and `
 
 ## Runtime Decomposition
 
-At runtime, one process contains the JavaFX app or headless bootstrap, shared singleton services, and one task queue per enabled profile.
+At runtime, one process owns one exclusive workspace, then contains the JavaFX
+app or headless bootstrap, shared singleton services, and one task queue per
+enabled profile. `WorkspaceSession` creates and locks the workspace before
+logging or persistence initializes. All mutable state is resolved through
+`WorkspacePaths`; the installation and caller working directory are read-only
+runtime inputs.
+
+Installed defaults are `~/.frostguard/workspaces/<channel>/<name>`. Source and
+IDE launches detected inside a repository use its ignored `.frostguard-dev/`
+workspace. SQLite, logs, custom tasks, diagnostic/cache output, and Telegram
+watcher configuration and locking belong to that selected workspace. The
+watcher passes the same workspace identity to any bot process it launches.
 
 ```mermaid
 sequenceDiagram

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -121,11 +121,19 @@ Run the application from the repository root through the same Maven Wrapper:
 On Windows Command Prompt, use `mvnw.cmd javafx:run`; in PowerShell, use
 `.\mvnw.cmd javafx:run`. The JavaFX goal compiles the required reactor modules
 and starts only the desktop module; developers do not need to locate a
-versioned JAR or assemble its classpath.
+versioned JAR or assemble its classpath. It automatically uses the ignored
+`.frostguard-dev/` workspace in that clone or worktree. No runtime argument is
+required, and simultaneous production and worktree runs do not share data.
+
+Installed runs use named workspaces below
+`%USERPROFILE%\.frostguard\workspaces\<channel>\<name>\`. Each workspace owns
+its database, configuration, logs, custom tasks, cache, Telegram watcher state,
+and process lock. A workspace can be opened by only one Frostguard process at a
+time; use a different workspace for another bot instance.
 
 ## Migrating an older installation
 
-Do not overwrite a new installation with an entire old Frostguard folder.
-Migration of legacy configuration and database files is not yet automated; keep
-a backup and copy individual `database.*` files only when intentionally carrying
-existing settings forward.
+Do not overwrite a new workspace with an entire old Frostguard folder. Frostguard
+3.0 does not migrate the legacy flat `.frostguard` watcher files or a 2.x
+database. Keep a backup and recreate settings; copy only reviewed custom-task
+source files into the new workspace.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -143,6 +143,13 @@ per-user installer and defaults to
 Normal `mvn package` remains platform-neutral and does not invoke `jpackage` or
 install Frostguard.
 
+Native Stable and Nightly builds can expose a channel-specific update feed in
+**Config > Updates**. Development and pull-request builds cannot install from
+release feeds. Frostguard accepts an update only after the manifest identity,
+download size, SHA-256, and Windows Authenticode signer all match. The current
+public ZIP feeds are not used by this updater; automatic installer updates stay
+disabled until signed Frostguard 3.0 release manifests are published.
+
 ### Run a source build
 
 Run the application from the repository root through the same Maven Wrapper:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,6 +15,10 @@ Stable and Nightly are public Windows desktop bundles. They require Java 21,
 but not Git, Git LFS, or Maven. Nightly may contain unfinished changes; PR
 builds additionally contain unmerged code.
 
+The self-contained Windows installer is being introduced for Frostguard 3.0.
+Until it is published through the release workflows, the download links above
+continue to provide the existing ZIP distribution.
+
 ## Install a downloaded build
 
 1. Install a Java 21 JDK, such as [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=21).
@@ -109,6 +113,35 @@ The build writes module artifacts below their respective `target` directories
 and the transitional desktop bundle ZIP below `packaging/desktop/target`. End
 users should extract the ZIP and launch `Start Frostguard.bat`; individual
 module JARs are not standalone distributions.
+
+### Build the native Windows package
+
+Native packages must be built on Windows. Build and smoke-test the
+self-contained application image with the JDK 21 `jpackage` tool:
+
+```powershell
+.\mvnw.cmd -Pwindows-app-image package
+python build-support/verification/verify_app_image.py packaging/desktop/target/app-image/Frostguard
+powershell -ExecutionPolicy Bypass -File build-support/verification/smoke_test_app_image.ps1 -ImagePath packaging/desktop/target/app-image/Frostguard
+```
+
+This produces
+`packaging/desktop/target/app-image/Frostguard/Frostguard.exe`. The image
+contains its Java runtime, so a machine running it does not need a separate
+JDK.
+
+Building the versioned installer additionally requires WiX Toolset 3.14.1 with
+`candle.exe` and `light.exe` on `PATH`:
+
+```powershell
+.\mvnw.cmd "-Pwindows-app-image,windows-installer" package
+```
+
+The installer is written below `packaging/desktop/target/installers`. It is a
+per-user installer and defaults to
+`%LOCALAPPDATA%\Frostguard`; the installer can offer another location.
+Normal `mvn package` remains platform-neutral and does not invoke `jpackage` or
+install Frostguard.
 
 ### Run a source build
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -86,3 +86,84 @@ public download.
 3. Store both maintained webhook message IDs as repository variables.
 4. Move `/build-pr` results to `#request-a-build`.
 5. Archive redundant legacy release channels after their links are replaced.
+
+## Native installer update contract
+
+The Frostguard 3.0 updater uses one immutable HTTPS manifest per channel. Do
+not publish a manifest until its installer has been built, Authenticode-signed,
+uploaded, and smoke-tested. Signing credentials remain outside the repository.
+
+### Manifest schema 1
+
+```json
+{
+  "schemaVersion": 1,
+  "channel": "stable",
+  "version": "3.0.1",
+  "publishedAt": "2026-08-10T04:00:00Z",
+  "minimumUpdaterVersion": "3.0.0",
+  "releaseNotesUrl": "https://example.invalid/releases/3.0.1",
+  "artifacts": {
+    "windows-x64": {
+      "operatingSystem": "windows",
+      "architecture": "x64",
+      "fileName": "Frostguard-3.0.1-windows-x64.exe",
+      "url": "https://example.invalid/releases/3.0.1/Frostguard-3.0.1-windows-x64.exe",
+      "sha256": "<64 lowercase hexadecimal characters>",
+      "size": 123456789,
+      "signature": {
+        "type": "authenticode",
+        "publisher": "<exact certificate subject>"
+      }
+    }
+  }
+}
+```
+
+Unknown fields, unsupported schemas, mutable filenames, insecure URLs, and
+Windows artifacts without an Authenticode publisher are rejected. Calculate
+the hash and size after signing because Authenticode changes the file.
+
+### Build inputs
+
+Embed the Stable endpoint and exact trusted certificate subject at packaging
+time:
+
+```powershell
+.\mvnw.cmd -Dfrostguard.update.manifest.stable=https://updates.example.invalid/stable.json `
+  "-Dfrostguard.update.authenticode-publisher=CN=Frostguard Project, O=Frostguard" `
+  "-Pwindows-app-image,windows-installer" package
+```
+
+The checked-in endpoint and publisher defaults are empty, so ordinary local
+builds cannot contact or trust a release feed accidentally. PR packaging also
+embeds `frostguard.update.pullRequestBuild=true`. Development builds, PR builds,
+and builds without a pinned publisher cannot update even if someone supplies a
+manifest URL manually. The manifest publisher must match the value embedded in
+the application JAR before its installer can be downloaded or executed.
+
+### Publication order
+
+1. Build and smoke-test the native application image.
+2. Build the channel-specific installer with its stable upgrade identity.
+3. Authenticode-sign the final installer outside the repository.
+4. Verify the signature and exact certificate subject on Windows.
+5. Calculate the final byte size and SHA-256.
+6. Upload the installer to an immutable versioned HTTPS URL.
+7. Publish the manifest atomically as the final step.
+
+Never publish a PR artifact, unsigned installer, mutable rolling filename, or
+manifest whose artifact has not completed the same verification sequence.
+
+### Runtime and recovery
+
+Downloads belong to the selected workspace under
+`cache/updates/<channel>/<version>`. Incomplete data uses a `.part` suffix and
+is never exposed as a completed installer. Completion requires an atomic rename
+after size and hash verification.
+
+The external Windows handoff receives the Frostguard PID plus a one-time token.
+Frostguard authorizes the staged waiter immediately before coordinated
+shutdown. The waiter cannot start the installer while the Frostguard PID is
+alive, and a failed shutdown deletes the token so a later unrelated application
+exit cannot launch the staged installer.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -17,6 +17,28 @@ building from source.
 WiX Toolset 3.14.1 is required only when producing the native EXE installer.
 Running an installed native build does not require a separately installed JDK.
 
+## Native application updates
+
+Installed Frostguard builds provide **Config > Updates** when their product
+identity has a configured release manifest. The update flow:
+
+1. selects only a newer artifact for the running channel, Windows, and x64;
+2. shows the version, release notes, channel, and size before confirmation;
+3. downloads below the selected workspace's `cache\updates` directory;
+4. verifies the declared size, SHA-256, and exact Authenticode signer;
+5. stops scheduling and workspace services, closes SQLite, and releases the
+   workspace lock;
+6. exits before an external waiter launches the installer.
+
+Development and PR-test packages cannot use automatic release updates. An
+unsigned installer is never handed off. Public automatic updates remain
+disabled until the release workflow can provide signed Frostguard 3.0
+installers and atomically promoted manifests.
+
+Interrupted downloads remain `.part` files and resume when the server supports
+byte ranges. A failed size, hash, or signature check prevents installer handoff
+and leaves the current installation untouched.
+
 Recommended installs:
 
 ```powershell

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -66,6 +66,11 @@ For a source build, run from the repository root:
 .\mvnw.cmd javafx:run
 ```
 
+This automatically creates and uses `<worktree>\.frostguard-dev\`. Each
+worktree therefore has isolated database, logs, custom tasks, cache, and
+Telegram watcher state. `git clean -xdf` intentionally removes this disposable
+development workspace.
+
 For automatic startup through scripts or Task Scheduler:
 
 ```powershell

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -14,6 +14,9 @@ building from source.
 - Java JDK 21 or newer.
 - Git and Git LFS.
 
+WiX Toolset 3.14.1 is required only when producing the native EXE installer.
+Running an installed native build does not require a separately installed JDK.
+
 Recommended installs:
 
 ```powershell
@@ -41,6 +44,27 @@ Use the checked-in Maven Wrapper:
 The wrapper only builds the reactor. It does not stop running processes, install
 Frostguard, or mutate user data.
 
+To build a self-contained Windows application image:
+
+```powershell
+.\mvnw.cmd -Pwindows-app-image package
+python build-support/verification/verify_app_image.py packaging/desktop/target/app-image/Frostguard
+powershell -ExecutionPolicy Bypass -File build-support/verification/smoke_test_app_image.ps1 -ImagePath packaging/desktop/target/app-image/Frostguard
+```
+
+To build both the application image and a versioned per-user EXE installer,
+install WiX Toolset 3.14.1, ensure `candle.exe` and `light.exe` are on `PATH`,
+then run:
+
+```powershell
+.\mvnw.cmd "-Pwindows-app-image,windows-installer" package
+```
+
+Outputs remain below `packaging/desktop/target`: the directly runnable image is
+at `app-image/Frostguard`, and the installer is under `installers`. Native
+packaging is opt-in because it is Windows-specific; ordinary `mvn package`
+continues to build and test the platform-neutral reactor.
+
 ## Runtime Requirements
 
 Configure the emulator for a stable `720x1280` display at `320 DPI`. MuMu Player is recommended.
@@ -59,6 +83,12 @@ The application currently packages Windows ADB and Tesseract assets from `tools/
 After downloading a desktop bundle, extract the complete ZIP into an empty
 folder and double-click `Start Frostguard.bat`. The launcher locates the
 versioned application JAR and reports a clear error if Java 21 is missing.
+
+For a native Frostguard 3.0 build, run the installed `Frostguard.exe` instead.
+The per-user installer defaults to `%LOCALAPPDATA%\Frostguard`, while
+all mutable databases, configuration, logs, watcher state, and custom tasks
+remain in the selected workspace below `%USERPROFILE%\.frostguard`. The
+installation directory is treated as read-only application content.
 
 For a source build, run from the repository root:
 

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/RuntimeChannel.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/RuntimeChannel.java
@@ -1,0 +1,24 @@
+package dev.frostguard.api.runtime;
+
+import java.util.Locale;
+
+public enum RuntimeChannel {
+    DEVELOPMENT,
+    NIGHTLY,
+    STABLE;
+
+    public String directoryName() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    public static RuntimeChannel from(String value) {
+        if (value == null || value.isBlank()) {
+            return STABLE;
+        }
+        try {
+            return valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            throw new IllegalArgumentException("Unsupported Frostguard channel: " + value);
+        }
+    }
+}

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspacePaths.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspacePaths.java
@@ -1,0 +1,77 @@
+package dev.frostguard.api.runtime;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public record WorkspacePaths(Path root, RuntimeChannel channel) {
+    public static final String WORKSPACE_PROPERTY = "frostguard.workspace";
+    public static final String CHANNEL_PROPERTY = "frostguard.channel";
+
+    public WorkspacePaths {
+        root = root.toAbsolutePath().normalize();
+    }
+
+    public static WorkspacePaths current() {
+        String configuredChannel = System.getProperty(CHANNEL_PROPERTY);
+        if (configuredChannel == null || configuredChannel.isBlank()) {
+            configuredChannel = System.getenv("FROSTGUARD_CHANNEL");
+        }
+        String override = System.getProperty(WORKSPACE_PROPERTY);
+        if (override == null || override.isBlank()) {
+            override = System.getenv("FROSTGUARD_WORKSPACE");
+        }
+        Path developmentRoot = findDevelopmentRoot();
+        if ((override == null || override.isBlank()) && configuredChannel == null && developmentRoot != null) {
+            configuredChannel = RuntimeChannel.DEVELOPMENT.directoryName();
+            override = developmentRoot.resolve(".frostguard-dev").toString();
+        }
+        RuntimeChannel channel = RuntimeChannel.from(configuredChannel);
+        Path root = override == null || override.isBlank()
+                ? Path.of(System.getProperty("user.home"), ".frostguard", "workspaces",
+                        channel.directoryName(), "default")
+                : Path.of(override);
+        return new WorkspacePaths(root, channel);
+    }
+
+    private static Path findDevelopmentRoot() {
+        Path candidate = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        for (int depth = 0; candidate != null && depth < 6; depth++, candidate = candidate.getParent()) {
+            if (Files.isRegularFile(candidate.resolve("pom.xml"))
+                    && Files.isDirectory(candidate.resolve("modules").resolve("desktop"))) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    public Path marker() { return root.resolve("frostguard-workspace.json"); }
+    public Path database() { return root.resolve("frostguard.db"); }
+    public Path config() { return root.resolve("config"); }
+    public Path logs() { return root.resolve("logs"); }
+    public Path customTasks() { return root.resolve("custom-tasks"); }
+    public Path cache() { return root.resolve("cache"); }
+    public Path watcher() { return root.resolve("watcher"); }
+    public Path watcherConfig() { return watcher().resolve("telegram-watcher.properties"); }
+    public Path watcherLock() { return watcher().resolve("watcher.lock"); }
+    public Path applicationLock() { return root.resolve("frostguard.lock"); }
+
+    public String identity() {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest((channel.directoryName() + "\n" + root)
+                    .getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is not available", impossible);
+        }
+    }
+
+    public int defaultLocalPort() {
+        long prefix = Long.parseUnsignedLong(identity().substring(0, 8), 16);
+        return 20_000 + (int) (prefix % 40_000);
+    }
+}

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
@@ -20,8 +20,8 @@ public final class WorkspaceSession implements AutoCloseable {
     }
 
     public static WorkspaceSession open(WorkspacePaths paths) {
+        initializeLayout(paths);
         try {
-            createLayout(paths);
             FileChannel channel = FileChannel.open(paths.applicationLock(),
                     StandardOpenOption.CREATE, StandardOpenOption.WRITE);
             FileLock lock;
@@ -37,6 +37,14 @@ public final class WorkspaceSession implements AutoCloseable {
             System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, paths.root().toString());
             System.setProperty("frostguard.log.dir", paths.logs().toString());
             return new WorkspaceSession(paths, channel, lock);
+        } catch (IOException cause) {
+            throw new IllegalStateException("Could not initialize Frostguard workspace: " + paths.root(), cause);
+        }
+    }
+
+    public static void initializeLayout(WorkspacePaths paths) {
+        try {
+            createLayout(paths);
         } catch (IOException cause) {
             throw new IllegalStateException("Could not initialize Frostguard workspace: " + paths.root(), cause);
         }

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
@@ -1,0 +1,85 @@
+package dev.frostguard.api.runtime;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+public final class WorkspaceSession implements AutoCloseable {
+    private final WorkspacePaths paths;
+    private final FileChannel lockChannel;
+    private final FileLock lock;
+
+    private WorkspaceSession(WorkspacePaths paths, FileChannel lockChannel, FileLock lock) {
+        this.paths = paths;
+        this.lockChannel = lockChannel;
+        this.lock = lock;
+    }
+
+    public static WorkspaceSession open(WorkspacePaths paths) {
+        try {
+            createLayout(paths);
+            FileChannel channel = FileChannel.open(paths.applicationLock(),
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            FileLock lock;
+            try {
+                lock = channel.tryLock();
+            } catch (OverlappingFileLockException alreadyLocked) {
+                lock = null;
+            }
+            if (lock == null) {
+                channel.close();
+                throw new IllegalStateException("Frostguard workspace is already in use: " + paths.root());
+            }
+            System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, paths.root().toString());
+            System.setProperty("frostguard.log.dir", paths.logs().toString());
+            return new WorkspaceSession(paths, channel, lock);
+        } catch (IOException cause) {
+            throw new IllegalStateException("Could not initialize Frostguard workspace: " + paths.root(), cause);
+        }
+    }
+
+    private static void createLayout(WorkspacePaths paths) throws IOException {
+        Files.createDirectories(paths.root());
+        Files.createDirectories(paths.config());
+        Files.createDirectories(paths.logs());
+        Files.createDirectories(paths.customTasks());
+        Files.createDirectories(paths.cache());
+        Files.createDirectories(paths.watcher());
+        if (Files.exists(paths.marker())) {
+            String marker = Files.readString(paths.marker(), StandardCharsets.UTF_8);
+            String expectedChannel = "\"channel\": \"" + paths.channel().directoryName() + "\"";
+            if (!marker.contains(expectedChannel)) {
+                throw new IllegalStateException("Workspace channel does not match "
+                        + paths.channel().directoryName() + ": " + paths.root());
+            }
+        } else {
+            String name = paths.root().getFileName().toString().replace("\\", "\\\\").replace("\"", "\\\"");
+            String json = "{\n"
+                    + "  \"schemaVersion\": 1,\n"
+                    + "  \"name\": \"" + name + "\",\n"
+                    + "  \"channel\": \"" + paths.channel().directoryName() + "\"\n"
+                    + "}\n";
+            Files.writeString(paths.marker(), json, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
+        }
+    }
+
+    public WorkspacePaths paths() {
+        return paths;
+    }
+
+    @Override
+    public void close() {
+        try {
+            lock.release();
+        } catch (IOException ignored) {
+        }
+        try {
+            lockChannel.close();
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
@@ -1,0 +1,106 @@
+package dev.frostguard.api.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WorkspaceSessionTest {
+    @TempDir
+    Path tempDir;
+
+    private String previousWorkspace;
+    private String previousLogDir;
+
+    @BeforeEach
+    void rememberRuntimeProperties() {
+        previousWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        previousLogDir = System.getProperty("frostguard.log.dir");
+    }
+
+    @AfterEach
+    void restoreRuntimeProperties() {
+        restore(WorkspacePaths.WORKSPACE_PROPERTY, previousWorkspace);
+        restore("frostguard.log.dir", previousLogDir);
+    }
+
+    @Test
+    void createsACompleteWorkspaceAndRejectsConcurrentUse() {
+        WorkspacePaths paths = new WorkspacePaths(tempDir.resolve("bot-1"), RuntimeChannel.STABLE);
+
+        try (WorkspaceSession ignored = WorkspaceSession.open(paths)) {
+            assertTrue(paths.marker().toFile().isFile());
+            assertTrue(paths.config().toFile().isDirectory());
+            assertTrue(paths.logs().toFile().isDirectory());
+            assertTrue(paths.customTasks().toFile().isDirectory());
+            assertTrue(paths.cache().toFile().isDirectory());
+            assertTrue(paths.watcher().toFile().isDirectory());
+            assertThrows(IllegalStateException.class, () -> WorkspaceSession.open(paths));
+        }
+    }
+
+    @Test
+    void derivesDefaultPortsAndIdentitiesFromTheWorkspace() {
+        WorkspacePaths first = new WorkspacePaths(tempDir.resolve("bot-1"), RuntimeChannel.STABLE);
+        WorkspacePaths second = new WorkspacePaths(tempDir.resolve("bot-2"), RuntimeChannel.STABLE);
+
+        assertTrue(first.defaultLocalPort() >= 20_000 && first.defaultLocalPort() < 60_000);
+        assertTrue(second.defaultLocalPort() >= 20_000 && second.defaultLocalPort() < 60_000);
+        assertNotEquals(first.identity(), second.identity());
+    }
+
+    @Test
+    void derivesIdentityIndependentlyOfJavaStringHashCollisions() {
+        WorkspacePaths first = new WorkspacePaths(tempDir.resolve("Aa"), RuntimeChannel.STABLE);
+        WorkspacePaths second = new WorkspacePaths(tempDir.resolve("BB"), RuntimeChannel.STABLE);
+
+        assertEquals(first.root().toString().hashCode(), second.root().toString().hashCode());
+        assertNotEquals(first.identity(), second.identity());
+    }
+
+    @Test
+    void rejectsOpeningAWorkspaceWithAnotherChannelIdentity() {
+        Path root = tempDir.resolve("shared");
+        try (WorkspaceSession ignored = WorkspaceSession.open(
+                new WorkspacePaths(root, RuntimeChannel.STABLE))) {
+            // Marker is persisted while the first channel owns the workspace.
+        }
+
+        assertThrows(IllegalStateException.class, () -> WorkspaceSession.open(
+                new WorkspacePaths(root, RuntimeChannel.NIGHTLY)));
+    }
+
+    @Test
+    void resolvesNamedChannelWorkspaceByDefault() {
+        String oldHome = System.getProperty("user.home");
+        String oldChannel = System.getProperty(WorkspacePaths.CHANNEL_PROPERTY);
+        String oldWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        try {
+            System.setProperty("user.home", tempDir.toString());
+            System.setProperty(WorkspacePaths.CHANNEL_PROPERTY, "nightly");
+            System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+
+            assertEquals(tempDir.resolve(".frostguard/workspaces/nightly/default").toAbsolutePath(),
+                    WorkspacePaths.current().root());
+        } finally {
+            restore("user.home", oldHome);
+            restore(WorkspacePaths.CHANNEL_PROPERTY, oldChannel);
+            restore(WorkspacePaths.WORKSPACE_PROPERTY, oldWorkspace);
+        }
+    }
+
+    private static void restore(String property, String value) {
+        if (value == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, value);
+        }
+    }
+}

--- a/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
@@ -47,6 +47,18 @@ class WorkspaceSessionTest {
     }
 
     @Test
+    void initializesACompanionWorkspaceWithoutTakingTheApplicationLock() {
+        WorkspacePaths paths = new WorkspacePaths(tempDir.resolve("watcher-only"), RuntimeChannel.STABLE);
+
+        WorkspaceSession.initializeLayout(paths);
+
+        assertTrue(paths.marker().toFile().isFile());
+        try (WorkspaceSession ignored = WorkspaceSession.open(paths)) {
+            assertTrue(paths.applicationLock().toFile().isFile());
+        }
+    }
+
+    @Test
     void derivesDefaultPortsAndIdentitiesFromTheWorkspace() {
         WorkspacePaths first = new WorkspacePaths(tempDir.resolve("bot-1"), RuntimeChannel.STABLE);
         WorkspacePaths second = new WorkspacePaths(tempDir.resolve("bot-2"), RuntimeChannel.STABLE);

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -55,6 +55,7 @@ import dev.frostguard.vision.convert.GameTimeUtils;
 public class TaskQueue {
 
     private static final Logger logger = LoggerFactory.getLogger(TaskQueue.class);
+    private static final String APP_LAUNCHER_PROPERTY = "frostguard.launcher";
     private static final long   TICK_INTERVAL_MS = 999L;
     protected static final DateTimeFormatter TS_FMT =
             DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss");
@@ -808,18 +809,16 @@ public class TaskQueue {
             if (wake.isBefore(LocalDateTime.now())) wake = LocalDateTime.now().plusMinutes(1);
             String tm = DateTimeFormatter.ofPattern("HH:mm").format(wake);
             String dt = DateTimeFormatter.ofPattern("MM/dd/yyyy").format(wake);
-            String jar = resolveDesktopJarForAutostart();
             WorkspacePaths workspace = WorkspacePaths.current();
+            java.nio.file.Path runtimeCache = workspace.cache().resolve("runtime");
+            java.nio.file.Files.createDirectories(runtimeCache);
+            String taskCommand = resolveAutostartCommand(workspace, runtimeCache);
             String scheduledTaskName = "Frostguard_AutoStart_"
                     + Integer.toUnsignedString(workspace.root().toString().hashCode(), 36);
             new ProcessBuilder("schtasks","/create","/TN",scheduledTaskName,"/TR",
-                    "javaw.exe -D" + WorkspacePaths.WORKSPACE_PROPERTY + "=\"" + workspace.root()
-                            + "\" -D" + WorkspacePaths.CHANNEL_PROPERTY + "=" + workspace.channel().directoryName()
-                            + " -jar \""+jar+"\" --autostart",
+                    taskCommand,
                     "/SC","ONCE","/ST",tm,"/SD",dt,"/RL","HIGHEST","/F")
                     .redirectErrorStream(true).start().waitFor();
-            java.nio.file.Path runtimeCache = workspace.cache().resolve("runtime");
-            java.nio.file.Files.createDirectories(runtimeCache);
             java.nio.file.Path ws = runtimeCache.resolve("fg_wake.ps1");
             java.nio.file.Files.writeString(ws,
                     "$s=New-ScheduledTaskSettingsSet -WakeToRun -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -Priority 1\n"+
@@ -837,6 +836,36 @@ public class TaskQueue {
 
     private String resolveDesktopJarForAutostart() throws java.io.IOException {
         return resolveDesktopJarForAutostart(java.nio.file.Path.of(System.getProperty("user.dir")));
+    }
+
+    private String resolveAutostartCommand(WorkspacePaths workspace, java.nio.file.Path runtimeCache)
+            throws java.io.IOException {
+        String nativeLauncher = System.getProperty(APP_LAUNCHER_PROPERTY, "").trim();
+        if (!nativeLauncher.isBlank()) {
+            java.nio.file.Path launcher = java.nio.file.Path.of(nativeLauncher).toAbsolutePath().normalize();
+            if (java.nio.file.Files.isRegularFile(launcher)) {
+                java.nio.file.Path wrapper = runtimeCache.resolve("frostguard-autostart.cmd");
+                java.nio.file.Files.writeString(wrapper,
+                        nativeAutostartLauncherContent(launcher, workspace));
+                return "\"" + wrapper + "\"";
+            }
+        }
+        String jar = resolveDesktopJarForAutostart();
+        return "javaw.exe -D" + WorkspacePaths.WORKSPACE_PROPERTY + "=\"" + workspace.root()
+                + "\" -D" + WorkspacePaths.CHANNEL_PROPERTY + "=" + workspace.channel().directoryName()
+                + " -jar \"" + jar + "\" --autostart";
+    }
+
+    static String nativeAutostartLauncherContent(java.nio.file.Path launcher, WorkspacePaths workspace) {
+        return "@echo off\r\n"
+                + "setlocal DisableDelayedExpansion\r\n"
+                + "set \"FROSTGUARD_WORKSPACE=" + escapeBatchValue(workspace.root().toString()) + "\"\r\n"
+                + "set \"FROSTGUARD_CHANNEL=" + workspace.channel().directoryName() + "\"\r\n"
+                + "start \"\" \"" + escapeBatchValue(launcher.toString()) + "\" --autostart\r\n";
+    }
+
+    private static String escapeBatchValue(String value) {
+        return value.replace("^", "^^").replace("%", "%%");
     }
 
     static String resolveDesktopJarForAutostart(java.nio.file.Path workingDirectory)

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -1,5 +1,7 @@
 package dev.frostguard.engine.schedule;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -807,16 +809,24 @@ public class TaskQueue {
             String tm = DateTimeFormatter.ofPattern("HH:mm").format(wake);
             String dt = DateTimeFormatter.ofPattern("MM/dd/yyyy").format(wake);
             String jar = resolveDesktopJarForAutostart();
-            new ProcessBuilder("schtasks","/create","/TN","Frostguard_AutoStart","/TR",
-                    "javaw.exe -jar \""+jar+"\" --autostart","/SC","ONCE","/ST",tm,"/SD",dt,"/RL","HIGHEST","/F")
+            WorkspacePaths workspace = WorkspacePaths.current();
+            String scheduledTaskName = "Frostguard_AutoStart_"
+                    + Integer.toUnsignedString(workspace.root().toString().hashCode(), 36);
+            new ProcessBuilder("schtasks","/create","/TN",scheduledTaskName,"/TR",
+                    "javaw.exe -D" + WorkspacePaths.WORKSPACE_PROPERTY + "=\"" + workspace.root()
+                            + "\" -D" + WorkspacePaths.CHANNEL_PROPERTY + "=" + workspace.channel().directoryName()
+                            + " -jar \""+jar+"\" --autostart",
+                    "/SC","ONCE","/ST",tm,"/SD",dt,"/RL","HIGHEST","/F")
                     .redirectErrorStream(true).start().waitFor();
-            java.nio.file.Path ws = java.nio.file.Paths.get(System.getProperty("user.dir"),"fg_wake.ps1");
+            java.nio.file.Path runtimeCache = workspace.cache().resolve("runtime");
+            java.nio.file.Files.createDirectories(runtimeCache);
+            java.nio.file.Path ws = runtimeCache.resolve("fg_wake.ps1");
             java.nio.file.Files.writeString(ws,
                     "$s=New-ScheduledTaskSettingsSet -WakeToRun -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -Priority 1\n"+
-                    "Set-ScheduledTask -TaskName 'Frostguard_AutoStart' -Settings $s\n");
+                    "Set-ScheduledTask -TaskName '" + scheduledTaskName + "' -Settings $s\n");
             new ProcessBuilder("powershell.exe","-NoProfile","-ExecutionPolicy","Bypass","-File",ws.toString())
                     .redirectErrorStream(true).start().waitFor();
-            java.nio.file.Path ss = java.nio.file.Paths.get(System.getProperty("user.dir"),"fg_sleep.ps1");
+            java.nio.file.Path ss = runtimeCache.resolve("fg_sleep.ps1");
             java.nio.file.Files.writeString(ss,
                     "Start-Sleep -Seconds 2\nAdd-Type -AssemblyName System.Windows.Forms\n"+
                     "[System.Windows.Forms.Application]::SetSuspendState('Suspend',$false,$false)\n");

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/CustomTaskService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/CustomTaskService.java
@@ -171,6 +171,20 @@ public class CustomTaskService {
         return INSTANCE;
     }
 
+    public synchronized void shutdown() {
+        if (taskClassLoader != null) {
+            try {
+                taskClassLoader.close();
+            } catch (IOException exception) {
+                logger.warn("Could not close custom task class loader: {}", exception.getMessage());
+            }
+            taskClassLoader = null;
+        }
+        loadedClasses.clear();
+        sourceFiles.clear();
+        logger.info("Custom task service stopped");
+    }
+
     // ========================================================================
     // Compile & Load
     // ========================================================================

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/CustomTaskService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/CustomTaskService.java
@@ -1,5 +1,7 @@
 package dev.frostguard.engine.service;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.engine.schedule.CustomTaskConfigurable;
@@ -155,7 +157,7 @@ public class CustomTaskService {
     // ========================================================================
 
     private CustomTaskService() {
-        compiledDir = Paths.get(System.getProperty("user.dir"), "custom_tasks");
+        compiledDir = WorkspacePaths.current().customTasks();
         jsonFile = compiledDir.resolve("custom_tasks.json");
         try {
             Files.createDirectories(compiledDir);

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
@@ -10,6 +10,7 @@ import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.AutomationBlueprint;
 import dev.frostguard.api.domain.AutomationStep;
+import dev.frostguard.api.runtime.WorkspacePaths;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -23,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Service that manages a Task Builder recording session.
@@ -52,7 +52,7 @@ public class TaskBuilderService {
 
     public TaskBuilderService() {
         this.emuManager = EmulatorController.getInstance();
-        this.customTasksDir = Paths.get(System.getProperty("user.dir"), "custom_tasks");
+        this.customTasksDir = WorkspacePaths.current().customTasks();
         this.mapper = new ObjectMapper()
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramBotService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramBotService.java
@@ -1,5 +1,7 @@
 package dev.frostguard.engine.service;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
@@ -14,7 +16,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Properties;
 
 import javax.imageio.ImageIO;
@@ -54,8 +55,6 @@ import java.util.ArrayList;
  * /status → reply with current running state
  */
 public class TelegramBotService implements BotStateListener {
-
-    static final String CURRENT_LOG_PATH = "log/frostguard.log";
 
     private static final Logger logger = LoggerFactory.getLogger(TelegramBotService.class);
     private static final String API_BASE = "https://api.telegram.org/bot";
@@ -147,17 +146,18 @@ public class TelegramBotService implements BotStateListener {
     /** Read localPort from the shared watcher properties file (default 8765). */
     private static int readLocalPort() {
         try {
-            Path cfg = Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+            Path cfg = WorkspacePaths.current().watcherConfig();
             if (Files.exists(cfg)) {
                 Properties props = new Properties();
                 try (FileInputStream fis = new FileInputStream(cfg.toFile())) { props.load(fis); }
-                return Integer.parseInt(props.getProperty("localPort", "8765").trim());
+                return Integer.parseInt(props.getProperty("localPort",
+                        String.valueOf(WorkspacePaths.current().defaultLocalPort())).trim());
             }
         } catch (Exception e) {
             LoggerFactory.getLogger(TelegramBotService.class)
                     .warn("Could not read localPort from config, defaulting to 8765: {}", e.getMessage());
         }
-        return 8765;
+        return WorkspacePaths.current().defaultLocalPort();
     }
 
     // ── public command dispatch (called by WatcherCommandServer) ─────────────
@@ -852,7 +852,7 @@ public class TelegramBotService implements BotStateListener {
                 }
                 case "log_dl" -> {
                     answerCallbackQuery(callbackId, "📥 Downloading...");
-                    sendDocument(chatId, CURRENT_LOG_PATH);
+                    sendDocument(chatId, currentLogPath().toString());
                 }
                 default -> answerCallbackQuery(callbackId, "");
             }
@@ -1208,6 +1208,10 @@ public class TelegramBotService implements BotStateListener {
         markup.set("inline_keyboard", kb);
 
         sendOrEditMessage(chatId, -1L, text, markup, "MarkdownV2");
+    }
+
+    static Path currentLogPath() {
+        return WorkspacePaths.current().logs().resolve("frostguard.log");
     }
 
     private void sendDocument(long chatId, String filePath) {

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 public class TelegramWatcherLauncher {
 
     private static final Logger logger = LoggerFactory.getLogger(TelegramWatcherLauncher.class);
+    private static final String WATCHER_LAUNCHER_PROPERTY = "frostguard.watcher.launcher";
 
     public static void startWatcherIfNotRunning() {
         if (isWatcherRunning()) {
@@ -26,19 +27,21 @@ public class TelegramWatcherLauncher {
         }
 
         logger.info("Telegram Watcher is not running. Attempting to start it...");
-        File batFile = resolveBatFile();
+        File launcher = resolveLauncher();
 
-        if (batFile != null && batFile.exists()) {
+        if (launcher != null && launcher.exists()) {
             try {
-                ProcessBuilder pb = new ProcessBuilder("cmd", "/c", "start", "\"FG-TG-Watcher\"", "/b", batFile.getName());
-                pb.directory(batFile.getParentFile());
+                ProcessBuilder pb = isNativeLauncher(launcher)
+                        ? new ProcessBuilder(launcher.getAbsolutePath())
+                        : new ProcessBuilder("cmd", "/c", "start", "\"FG-TG-Watcher\"", "/b", launcher.getName());
+                pb.directory(launcher.getParentFile());
                 pb.environment().put("FROSTGUARD_WORKSPACE", WorkspacePaths.current().root().toString());
                 pb.environment().put("FROSTGUARD_CHANNEL",
                         WorkspacePaths.current().channel().directoryName());
                 pb.start();
-                logger.info("Executed {}", batFile.getAbsolutePath());
+                logger.info("Executed {}", launcher.getAbsolutePath());
             } catch (IOException e) {
-                logger.error("Failed to start Telegram Watcher bat file", e);
+                logger.error("Failed to start Telegram Watcher launcher", e);
             }
         } else {
             logger.warn("Could not locate the Telegram Watcher launcher.");
@@ -63,7 +66,14 @@ public class TelegramWatcherLauncher {
         }
     }
 
-    private static File resolveBatFile() {
+    private static File resolveLauncher() {
+        String packagedLauncher = System.getProperty(WATCHER_LAUNCHER_PROPERTY, "").trim();
+        if (!packagedLauncher.isBlank()) {
+            File launcher = new File(packagedLauncher);
+            if (launcher.isFile()) {
+                return launcher;
+            }
+        }
         // Try to load the jar path from the active workspace.
         try {
             Path cfg = WorkspacePaths.current().watcherConfig();
@@ -99,5 +109,9 @@ public class TelegramWatcherLauncher {
         }
 
         return null;
+    }
+
+    private static boolean isNativeLauncher(File launcher) {
+        return launcher.getName().toLowerCase(java.util.Locale.ROOT).endsWith(".exe");
     }
 }

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramWatcherLauncher.java
@@ -1,10 +1,15 @@
 package dev.frostguard.engine.service;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.StandardOpenOption;
 import java.util.Properties;
 
 import org.slf4j.Logger;
@@ -27,6 +32,9 @@ public class TelegramWatcherLauncher {
             try {
                 ProcessBuilder pb = new ProcessBuilder("cmd", "/c", "start", "\"FG-TG-Watcher\"", "/b", batFile.getName());
                 pb.directory(batFile.getParentFile());
+                pb.environment().put("FROSTGUARD_WORKSPACE", WorkspacePaths.current().root().toString());
+                pb.environment().put("FROSTGUARD_CHANNEL",
+                        WorkspacePaths.current().channel().directoryName());
                 pb.start();
                 logger.info("Executed {}", batFile.getAbsolutePath());
             } catch (IOException e) {
@@ -38,29 +46,27 @@ public class TelegramWatcherLauncher {
     }
 
     private static boolean isWatcherRunning() {
+        Path lockPath = WorkspacePaths.current().watcherLock();
         try {
-            return ProcessHandle.allProcesses()
-                    .filter(ph -> ph.info().command().map(c -> c.toLowerCase().contains("java")).orElse(false))
-                    .filter(ph -> ph.info().arguments().map(args -> {
-                        for (String a : args) {
-                            if (a.toLowerCase().contains("frostguard-watcher")) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    }).orElse(false))
-                    .findFirst()
-                    .isPresent();
+            Files.createDirectories(lockPath.getParent());
+            try (FileChannel channel = FileChannel.open(lockPath,
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+                try (FileLock lock = channel.tryLock()) {
+                    return lock == null;
+                } catch (OverlappingFileLockException lockedInThisProcess) {
+                    return true;
+                }
+            }
         } catch (Exception e) {
-            logger.error("Error checking if watcher is running", e);
+            logger.warn("Could not inspect watcher lock {}: {}", lockPath, e.getMessage());
             return false;
         }
     }
 
     private static File resolveBatFile() {
-        // Try to load the jar path from ~/.frostguard/telegram-watcher.properties
+        // Try to load the jar path from the active workspace.
         try {
-            Path cfg = Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+            Path cfg = WorkspacePaths.current().watcherConfig();
             if (Files.exists(cfg)) {
                 Properties props = new Properties();
                 try (java.io.FileInputStream fis = new java.io.FileInputStream(cfg.toFile())) {

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/WatcherCommandServer.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/WatcherCommandServer.java
@@ -7,6 +7,8 @@ import com.sun.net.httpserver.HttpServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
@@ -33,11 +35,13 @@ public class WatcherCommandServer {
     private final int               port;
     private final TelegramBotService botService;
     private final ObjectMapper       mapper = new ObjectMapper();
+    private final String             workspaceId;
     private HttpServer               server;
 
     public WatcherCommandServer(int port, TelegramBotService botService) {
         this.port       = port;
         this.botService = botService;
+        this.workspaceId = WorkspacePaths.current().identity();
     }
 
     public void start() throws IOException {
@@ -72,10 +76,20 @@ public class WatcherCommandServer {
         try {
             String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
             JsonNode req  = mapper.readTree(body);
+            if (!workspaceId.equals(req.path("workspaceId").asText())) {
+                responseBytes = "{\"ok\":false,\"error\":\"workspace mismatch\"}"
+                        .getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(409, responseBytes.length);
+                exchange.getResponseBody().write(responseBytes);
+                exchange.close();
+                return;
+            }
             String   type = req.path("type").asText("message");
             long   chatId = req.path("chatId").asLong(-1);
 
-            if ("callback".equals(type)) {
+            if ("ping".equals(type)) {
+                // Identity validation above is the complete ping operation.
+            } else if ("callback".equals(type)) {
                 String callbackId = req.path("callbackId").asText("");
                 long   messageId  = req.path("messageId").asLong(-1);
                 String data       = req.path("data").asText("noop");
@@ -110,8 +124,10 @@ public class WatcherCommandServer {
         }
 
         try {
-            long pid = ProcessHandle.current().pid();
-            String response = "{\"pid\":" + pid + "}";
+            String response = mapper.createObjectNode()
+                    .put("pid", ProcessHandle.current().pid())
+                    .put("workspaceId", workspaceId)
+                    .toString();
             byte[] responseBytes = response.getBytes(StandardCharsets.UTF_8);
             exchange.sendResponseHeaders(200, responseBytes.length);
             exchange.getResponseBody().write(responseBytes);

--- a/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueDesktopJarResolutionTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueDesktopJarResolutionTest.java
@@ -2,6 +2,7 @@ package dev.frostguard.engine.schedule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -9,6 +10,9 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 class TaskQueueDesktopJarResolutionTest {
 
@@ -38,5 +42,17 @@ class TaskQueueDesktopJarResolutionTest {
     void rejectsWorkingDirectoryWithoutDesktopArtifact() {
         assertThrows(IOException.class,
                 () -> TaskQueue.resolveDesktopJarForAutostart(tempDir));
+    }
+
+    @Test
+    void nativeAutostartWrapperPreservesTheWorkspace() {
+        Path launcher = tempDir.resolve("Frostguard.exe").toAbsolutePath();
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("Bot 1"), RuntimeChannel.STABLE);
+
+        String script = TaskQueue.nativeAutostartLauncherContent(launcher, workspace);
+
+        assertTrue(script.contains("set \"FROSTGUARD_WORKSPACE=" + workspace.root() + "\""));
+        assertTrue(script.contains("set \"FROSTGUARD_CHANNEL=stable\""));
+        assertTrue(script.contains("start \"\" \"" + launcher + "\" --autostart"));
     }
 }

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.io.TempDir;
 import dev.frostguard.api.configs.FlowStepKind;
 import dev.frostguard.api.domain.AutomationBlueprint;
 import dev.frostguard.api.domain.AutomationStep;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 class TaskBuilderServiceTest {
 
@@ -20,8 +21,8 @@ class TaskBuilderServiceTest {
 
     @Test
     void savesBuilderJsonAndGeneratedJavaBesideIt() throws Exception {
-        String originalUserDir = System.getProperty("user.dir");
-        System.setProperty("user.dir", tempDir.toString());
+        String originalWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
         try {
             TaskBuilderService service = new TaskBuilderService();
             service.startSession("Expert Idle Exploration", "0");
@@ -31,7 +32,7 @@ class TaskBuilderServiceTest {
             step.setParam("durationMs", "200");
             service.addNode(step);
 
-            Path builderFile = tempDir.resolve("custom_tasks").resolve("expert_idle_exploration.json");
+            Path builderFile = tempDir.resolve("custom-tasks").resolve("expert_idle_exploration.json");
             TaskBuilderService.CustomTaskSaveResult saved =
                     service.saveCurrentTaskToCustomTasks("Expert Idle Exploration", builderFile);
 
@@ -47,7 +48,11 @@ class TaskBuilderServiceTest {
             assertEquals("Pause before bag", loaded.getNodes().get(0).getNodeName());
             assertEquals("1", service.getActiveEmulatorNumber());
         } finally {
-            System.setProperty("user.dir", originalUserDir);
+            if (originalWorkspace == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, originalWorkspace);
+            }
         }
     }
 }

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/TelegramBotServiceTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/TelegramBotServiceTest.java
@@ -1,13 +1,20 @@
 package dev.frostguard.engine.service;
 
 import dev.frostguard.api.configs.TpDailyTaskEnum;
+import dev.frostguard.api.runtime.WorkspacePaths;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TelegramBotServiceTest {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void standardQueueExcludesCustomTaskPlaceholder() {
@@ -16,7 +23,18 @@ class TelegramBotServiceTest {
     }
 
     @Test
-    void logDownloadUsesConfiguredFrostguardLogName() {
-        assertEquals("log/frostguard.log", TelegramBotService.CURRENT_LOG_PATH);
+    void logDownloadUsesTheSelectedWorkspace() {
+        String previous = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        try {
+            System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+            assertEquals(tempDir.resolve("logs/frostguard.log").toAbsolutePath(),
+                    TelegramBotService.currentLogPath());
+        } finally {
+            if (previous == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, previous);
+            }
+        }
     }
 }

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/WatcherCommandServerTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/WatcherCommandServerTest.java
@@ -1,0 +1,72 @@
+package dev.frostguard.engine.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+class WatcherCommandServerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void rejectsCommandsFromAnotherWorkspaceAndIdentifiesItsPid() throws Exception {
+        String previous = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        WatcherCommandServer server = null;
+        try {
+            System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+            int port;
+            try (ServerSocket availablePort = new ServerSocket(0)) {
+                port = availablePort.getLocalPort();
+            }
+
+            server = new WatcherCommandServer(port, null);
+            server.start();
+            HttpClient client = HttpClient.newHttpClient();
+
+            HttpResponse<String> mismatch = client.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/command"))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(
+                            "{\"type\":\"ping\",\"workspaceId\":\"another-workspace\"}"))
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            assertEquals(409, mismatch.statusCode());
+
+            String workspaceId = WorkspacePaths.current().identity();
+            HttpResponse<String> matching = client.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/command"))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(
+                            "{\"type\":\"ping\",\"workspaceId\":\"" + workspaceId + "\"}"))
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, matching.statusCode());
+
+            HttpResponse<String> pid = client.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/pid"))
+                    .GET()
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, pid.statusCode());
+            assertTrue(pid.body().contains("\"workspaceId\":\"" + workspaceId + "\""));
+        } finally {
+            if (server != null) {
+                server.stop();
+            }
+            if (previous == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, previous);
+            }
+        }
+    }
+}

--- a/modules/desktop/pom.xml
+++ b/modules/desktop/pom.xml
@@ -131,6 +131,8 @@
 					<runtimePathOption>CLASSPATH</runtimePathOption>
 					<options>
 						<option>--enable-native-access=ALL-UNNAMED</option>
+						<option>-Dfrostguard.channel=development</option>
+						<option>-Dfrostguard.workspace=${maven.multiModuleProjectDirectory}/.frostguard-dev</option>
 					</options>
 				</configuration>
 			</plugin>

--- a/modules/desktop/pom.xml
+++ b/modules/desktop/pom.xml
@@ -93,6 +93,10 @@
 			<groupId>dev.frostguard</groupId>
 			<artifactId>frostguard-vision</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>dev.frostguard</groupId>
+			<artifactId>frostguard-update</artifactId>
+		</dependency>
 
 		<!-- Logging -->
 		<dependency>
@@ -120,6 +124,22 @@
 
 	<!-- ─── Build configuration ─── -->
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>dev/frostguard/app/frostguard-build.properties</exclude>
+				</excludes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>dev/frostguard/app/frostguard-build.properties</include>
+				</includes>
+			</resource>
+		</resources>
 		<plugins>
 			<!-- Root-level javafx:run skips every reactor module except this one. -->
 			<plugin>

--- a/modules/desktop/src/main/java/dev/frostguard/app/BuildMetadata.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/BuildMetadata.java
@@ -1,0 +1,35 @@
+package dev.frostguard.app;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public record BuildMetadata(boolean pullRequestBuild, String authenticodePublisher) {
+    private static final String RESOURCE = "/dev/frostguard/app/frostguard-build.properties";
+
+    public static BuildMetadata current() {
+        return Holder.INSTANCE;
+    }
+
+    static BuildMetadata read(InputStream input) {
+        if (input == null) {
+            return new BuildMetadata(true, "");
+        }
+        Properties properties = new Properties();
+        try (input) {
+            properties.load(input);
+        } catch (IOException exception) {
+            return new BuildMetadata(true, "");
+        }
+        String value = properties.getProperty("pullRequestBuild", "").trim();
+        if (!value.equals("true") && !value.equals("false")) {
+            return new BuildMetadata(true, "");
+        }
+        return new BuildMetadata(Boolean.parseBoolean(value),
+                properties.getProperty("authenticodePublisher", "").trim());
+    }
+
+    private static final class Holder {
+        private static final BuildMetadata INSTANCE = read(BuildMetadata.class.getResourceAsStream(RESOURCE));
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/ApplicationLifecycle.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/ApplicationLifecycle.java
@@ -1,0 +1,95 @@
+package dev.frostguard.app.bootstrap;
+
+import dev.frostguard.app.panel.misc.GiftCodeAutomationService;
+import dev.frostguard.data.access.DataStore;
+import dev.frostguard.engine.service.AnalyticsService;
+import dev.frostguard.engine.service.CustomTaskService;
+import dev.frostguard.engine.service.ScheduleService;
+import dev.frostguard.engine.service.TelegramBotService;
+import dev.frostguard.vision.logging.ProfileContextLogger;
+import javafx.application.Platform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class ApplicationLifecycle {
+    private static final Logger LOG = LoggerFactory.getLogger(ApplicationLifecycle.class);
+    private static final AtomicBoolean SHUTDOWN_ACTIVE = new AtomicBoolean();
+    private static final RuntimeShutdownCoordinator COORDINATOR = new RuntimeShutdownCoordinator(List.of(
+            new RuntimeShutdownCoordinator.Step("scheduler", () -> ScheduleService.obtain().haltEngine()),
+            new RuntimeShutdownCoordinator.Step("gift code automation",
+                    () -> GiftCodeAutomationService.getInstance().shutdown()),
+            new RuntimeShutdownCoordinator.Step("Telegram command server",
+                    () -> TelegramBotService.getInstance().stop()),
+            new RuntimeShutdownCoordinator.Step("custom task loader", () -> CustomTaskService.getInstance().shutdown()),
+            new RuntimeShutdownCoordinator.Step("analytics", () -> AnalyticsService.getInstance().trackAppShutdown()),
+            new RuntimeShutdownCoordinator.Step("persistence", () -> DataStore.getInstance().close()),
+            new RuntimeShutdownCoordinator.Step("ADB", ApplicationLifecycle::terminateAdbProcess),
+            new RuntimeShutdownCoordinator.Step("profile logging", ProfileContextLogger::shutdown),
+            new RuntimeShutdownCoordinator.Step("workspace", Main::closeWorkspace)
+    ));
+
+    private ApplicationLifecycle() {
+    }
+
+    public static void stopForUpdate() throws LifecycleException {
+        if (!SHUTDOWN_ACTIVE.compareAndSet(false, true)) {
+            throw new LifecycleException("Another shutdown is already active");
+        }
+        try {
+            COORDINATOR.shutdown();
+        } catch (RuntimeShutdownCoordinator.ShutdownException exception) {
+            SHUTDOWN_ACTIVE.set(false);
+            throw new LifecycleException(exception.getMessage(), exception);
+        }
+    }
+
+    public static void exitNormally(int status) {
+        if (SHUTDOWN_ACTIVE.compareAndSet(false, true)) {
+            try {
+                COORDINATOR.shutdown();
+            } catch (RuntimeShutdownCoordinator.ShutdownException exception) {
+                LOG.warn("Runtime shutdown completed with errors: {}", exception.getMessage());
+            }
+        }
+        Platform.exit();
+        System.exit(status);
+    }
+
+    public static void exitAfterUpdateHandoff() {
+        Platform.exit();
+        System.exit(0);
+    }
+
+    static void runShutdownHook() {
+        if (!SHUTDOWN_ACTIVE.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            COORDINATOR.shutdown();
+        } catch (RuntimeShutdownCoordinator.ShutdownException exception) {
+            LOG.warn("Shutdown hook completed with errors: {}", exception.getMessage());
+        }
+    }
+
+    private static void terminateAdbProcess() throws IOException {
+        if (!System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("win")) {
+            return;
+        }
+        new ProcessBuilder("taskkill", "/F", "/IM", "adb.exe").start();
+        LOG.info("adb.exe shutdown requested");
+    }
+
+    public static final class LifecycleException extends Exception {
+        LifecycleException(String message) {
+            super(message);
+        }
+
+        LifecycleException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/FXApp.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/FXApp.java
@@ -113,8 +113,7 @@ public class FXApp extends Application {
 
     private void shutdownFromUi(Stage stage) {
         rememberWindowBounds(stage);
-        terminateAdbProcess();
-        System.exit(0);
+        ApplicationLifecycle.exitNormally(0);
     }
 
     private void rememberWindowBounds(Stage stage) {
@@ -149,12 +148,4 @@ public class FXApp extends Application {
         logger.info("Window restored to the primary display");
     }
 
-    private void terminateAdbProcess() {
-        try {
-            new ProcessBuilder("taskkill", "/F", "/IM", "adb.exe").start();
-            logger.info("adb.exe shutdown requested");
-        } catch (IOException e) {
-            logger.warn("Unable to stop adb.exe cleanly", e);
-        }
-    }
 }

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
@@ -7,7 +7,6 @@ import dev.frostguard.api.runtime.WorkspacePaths;
 import dev.frostguard.api.runtime.WorkspaceSession;
 import dev.frostguard.engine.service.AnalyticsService;
 import dev.frostguard.tasks.TaskRegistrations;
-import dev.frostguard.vision.logging.ProfileContextLogger;
 
 public class Main {
 	private static final WorkspaceSession WORKSPACE = WorkspaceSession.open(WorkspacePaths.current());
@@ -20,6 +19,8 @@ public class Main {
 				System.out.println("channel=" + WORKSPACE.paths().channel().directoryName());
 				System.out.println("workspace=" + WORKSPACE.paths().root());
 				System.out.println("applicationDir=" + System.getProperty("user.dir"));
+				System.out.println("pullRequestBuild="
+						+ System.getProperty("frostguard.update.pullRequestBuild", "false"));
 				WORKSPACE.close();
 				return;
 			}
@@ -43,9 +44,7 @@ public class Main {
 			// 2. Setup Shutdown Hook
 			Runtime.getRuntime().addShutdownHook(new Thread(() -> {
 				logger.info("Closing down subsystems.");
-				try { AnalyticsService.getInstance().trackAppShutdown(); } catch (Exception ignored) {}
-				ProfileContextLogger.shutdown();
-				WORKSPACE.close();
+				ApplicationLifecycle.runShutdownHook();
 			}, "frostguard-shutdown"));
 
 			// 3. Initialize Services
@@ -64,8 +63,11 @@ public class Main {
 
 		} catch (Exception e) {
 			logger.error("Startup failure: ", e);
-			ProfileContextLogger.shutdown();
-			System.exit(1);
+			ApplicationLifecycle.exitNormally(1);
 		}
+	}
+
+	static void closeWorkspace() {
+		WORKSPACE.close();
 	}
 }

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
@@ -15,6 +15,14 @@ public class Main {
 
 	public static void main(String[] args) {
 		try {
+			if (java.util.Arrays.asList(args).contains("--frostguard-native-smoke-test")) {
+				System.out.println("Frostguard native launcher smoke test passed");
+				System.out.println("channel=" + WORKSPACE.paths().channel().directoryName());
+				System.out.println("workspace=" + WORKSPACE.paths().root());
+				System.out.println("applicationDir=" + System.getProperty("user.dir"));
+				WORKSPACE.close();
+				return;
+			}
 			boolean isHeadless = false;
 			for (String arg : args) {
 				if ("--headless".equalsIgnoreCase(arg)) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
@@ -3,11 +3,14 @@ package dev.frostguard.app.bootstrap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.api.runtime.WorkspaceSession;
 import dev.frostguard.engine.service.AnalyticsService;
 import dev.frostguard.tasks.TaskRegistrations;
 import dev.frostguard.vision.logging.ProfileContextLogger;
 
 public class Main {
+	private static final WorkspaceSession WORKSPACE = WorkspaceSession.open(WorkspacePaths.current());
 	private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
 	public static void main(String[] args) {
@@ -27,13 +30,14 @@ public class Main {
 			java.util.logging.Logger.getLogger("com.sun.javafx").setLevel(java.util.logging.Level.SEVERE);
 			java.util.logging.Logger.getLogger("javax.swing").setLevel(java.util.logging.Level.SEVERE);
 
-			logger.info("Initializing Frostguard...");
+			logger.info("Initializing Frostguard with workspace {}", WORKSPACE.paths().root());
 
 			// 2. Setup Shutdown Hook
 			Runtime.getRuntime().addShutdownHook(new Thread(() -> {
 				logger.info("Closing down subsystems.");
 				try { AnalyticsService.getInstance().trackAppShutdown(); } catch (Exception ignored) {}
 				ProfileContextLogger.shutdown();
+				WORKSPACE.close();
 			}, "frostguard-shutdown"));
 
 			// 3. Initialize Services

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/RuntimeShutdownCoordinator.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/RuntimeShutdownCoordinator.java
@@ -1,0 +1,55 @@
+package dev.frostguard.app.bootstrap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class RuntimeShutdownCoordinator {
+    private final List<Step> steps;
+
+    RuntimeShutdownCoordinator(List<Step> steps) {
+        this.steps = List.copyOf(steps);
+    }
+
+    void shutdown() throws ShutdownException {
+        List<String> failures = new ArrayList<>();
+        for (Step step : steps) {
+            try {
+                step.action().run();
+            } catch (Exception exception) {
+                String message = exception.getMessage() == null
+                        ? exception.getClass().getSimpleName()
+                        : exception.getMessage();
+                failures.add(step.name() + ": " + message);
+            }
+        }
+        if (!failures.isEmpty()) {
+            throw new ShutdownException(failures);
+        }
+    }
+
+    record Step(String name, ShutdownAction action) {
+        Step {
+            if (name == null || name.isBlank() || action == null) {
+                throw new IllegalArgumentException("Shutdown steps require a name and action");
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface ShutdownAction {
+        void run() throws Exception;
+    }
+
+    static final class ShutdownException extends Exception {
+        private final List<String> failures;
+
+        ShutdownException(List<String> failures) {
+            super("Runtime shutdown was incomplete: " + String.join("; ", failures));
+            this.failures = List.copyOf(failures);
+        }
+
+        List<String> failures() {
+            return failures;
+        }
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/console/ConsoleLogLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/console/ConsoleLogLayoutController.java
@@ -1,5 +1,7 @@
 package dev.frostguard.app.panel.console;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.awt.Desktop;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -111,7 +113,7 @@ public class ConsoleLogLayoutController implements ProfileDataChangeListener {
 	@FXML
 	void handleButtonOpenLogFolder(ActionEvent event) {
 		try {
-			Path logsDir = Path.of("log");
+			Path logsDir = WorkspacePaths.current().logs();
 			Files.createDirectories(logsDir);
 			Desktop.getDesktop().open(logsDir.toFile());
 		} catch (IOException e) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
@@ -82,6 +82,8 @@ import javafx.animation.*;
 import javafx.util.Duration;
 import dev.frostguard.app.panel.alliance.AllianceShopController;
 import dev.frostguard.app.panel.misc.TelegramLayoutController;
+import dev.frostguard.app.bootstrap.ApplicationLifecycle;
+import dev.frostguard.app.panel.update.UpdateLayoutController;
 import dev.frostguard.engine.service.TelegramBotService;
 import org.kordamp.ikonli.javafx.FontIcon;
 import org.kordamp.ikonli.materialdesign2.MaterialDesignT;
@@ -479,7 +481,7 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
         alert.setHeaderText(null);
         alert.setContentText(message);
         alert.showAndWait();
-        System.exit(0);
+        ApplicationLifecycle.exitNormally(0);
     }
 
     private void initializeDiscordBot() { /* internal */
@@ -526,18 +528,22 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
 
         addPinnedButton("Control", MaterialDesignC.CONTROLLER_CLASSIC, controlTabs);
 
-        // Config pinned button — TabPane with Emulators + Telegram
+        // Config pinned button with application-wide settings tabs.
         EmuConfigLayoutController configCtrl = new EmuConfigLayoutController();
         Parent configPane = loadNode("EmuConfigLayout", configCtrl);
 
         TelegramLayoutController telegramCtrl = new TelegramLayoutController();
         Parent telegramPane = loadNode("TelegramLayout", telegramCtrl);
 
+        UpdateLayoutController updateCtrl = new UpdateLayoutController();
+        Parent updatePane = loadNode("UpdateLayout", updateCtrl);
+
         TabPane configTabs = new TabPane();
         configTabs.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
         configTabs.getTabs().addAll(
                 makeTab("Emulators", configPane),
-                makeTab("Telegram", telegramPane)
+                makeTab("Telegram", telegramPane),
+                makeTab("Updates", updatePane)
         );
         configTabs.setMaxWidth(Double.MAX_VALUE);
         configTabs.setMaxHeight(Double.MAX_VALUE);

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/GiftCodeAutomationService.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/GiftCodeAutomationService.java
@@ -82,6 +82,13 @@ public final class GiftCodeAutomationService {
         }
     }
 
+    public synchronized void shutdown() {
+        manualStopRequested.set(true);
+        executor.shutdownNow();
+        started = false;
+        LOG.info("Gift code automation stopped");
+    }
+
     public GiftCodeState snapshot() {
         List<AccountDescriptor> accounts = profiles();
         List<GiftCodeProfile> giftProfiles = accounts.stream().map(this::toGiftCodeProfile).toList();

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
@@ -64,6 +64,7 @@ public class TelegramLayoutController {
 
     /** Shortcut name placed in the Windows Startup folder. */
     private static final String SHORTCUT_NAME = "Frostguard-Telegram-Watcher.lnk";
+    private static final String WATCHER_LAUNCHER_PROPERTY = "frostguard.watcher.launcher";
 
     @FXML
     public void initialize() {
@@ -283,15 +284,15 @@ public class TelegramLayoutController {
     }
 
     private void registerStartup() {
-        File batFile = resolveBatFile();
-        if (batFile == null) {
+        File watcherLauncher = resolveWatcherLauncher();
+        if (watcherLauncher == null) {
             showError("Cannot locate the Telegram Watcher launcher.");
             checkBoxAutoStart.setSelected(false);
             return;
         }
         Path shortcut = startupFolder().resolve(SHORTCUT_NAME);
         try {
-            Path workspaceLauncher = writeWorkspaceWatcherLauncher(batFile);
+            Path workspaceLauncher = writeWorkspaceWatcherLauncher(watcherLauncher);
             String vbs =
                 "Set oWS = WScript.CreateObject(\"WScript.Shell\")\n" +
                 "Set oLink = oWS.CreateShortcut(\"" + escapeVbsString(shortcut.toString()) + "\")\n" +
@@ -320,20 +321,23 @@ public class TelegramLayoutController {
         }
     }
 
-    private static Path writeWorkspaceWatcherLauncher(File batFile) throws IOException {
+    private static Path writeWorkspaceWatcherLauncher(File watcherLauncher) throws IOException {
         WorkspacePaths workspace = WorkspacePaths.current();
         Path launcher = workspace.watcher().resolve("Start-Frostguard-Watcher.cmd");
         Files.createDirectories(launcher.getParent());
-        Files.writeString(launcher, workspaceWatcherLauncherContent(batFile.toPath(), workspace));
+        Files.writeString(launcher, workspaceWatcherLauncherContent(watcherLauncher.toPath(), workspace));
         return launcher;
     }
 
-    static String workspaceWatcherLauncherContent(Path batFile, WorkspacePaths workspace) {
+    static String workspaceWatcherLauncherContent(Path watcherLauncher, WorkspacePaths workspace) {
+        String command = watcherLauncher.getFileName().toString().toLowerCase(java.util.Locale.ROOT).endsWith(".exe")
+                ? "start \"\" \"" + escapeBatchValue(watcherLauncher.toAbsolutePath().normalize().toString()) + "\""
+                : "call \"" + escapeBatchValue(watcherLauncher.toAbsolutePath().normalize().toString()) + "\"";
         return "@echo off\r\n"
                 + "setlocal DisableDelayedExpansion\r\n"
                 + "set \"FROSTGUARD_WORKSPACE=" + escapeBatchValue(workspace.root().toString()) + "\"\r\n"
                 + "set \"FROSTGUARD_CHANNEL=" + workspace.channel().directoryName() + "\"\r\n"
-                + "call \"" + escapeBatchValue(batFile.toAbsolutePath().normalize().toString()) + "\"\r\n";
+                + command + "\r\n";
     }
 
     private static String escapeBatchValue(String value) {
@@ -377,7 +381,12 @@ public class TelegramLayoutController {
      * Walks up the directory tree from several anchor points to find the watcher launcher.
      * Typical layout: frostguard/modules/desktop/target/frostguard-desktop-X.jar  →  frostguard/fg-watcher.bat
      */
-    private File resolveBatFile() {
+    private File resolveWatcherLauncher() {
+        String packagedLauncher = System.getProperty(WATCHER_LAUNCHER_PROPERTY, "").trim();
+        if (!packagedLauncher.isBlank()) {
+            File launcher = new File(packagedLauncher);
+            if (launcher.isFile()) return launcher;
+        }
         // 1. Walk up from the bot JAR path shown in the UI (most reliable)
         String jarPath = textFieldBotJarPath.getText().trim();
         if (!jarPath.isBlank()) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/TelegramLayoutController.java
@@ -1,5 +1,7 @@
 package dev.frostguard.app.panel.misc;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -189,7 +191,7 @@ public class TelegramLayoutController {
             
             // Ensure localPort exists
             if (!props.containsKey("localPort")) {
-                props.setProperty("localPort", "8765");
+                props.setProperty("localPort", String.valueOf(WorkspacePaths.current().defaultLocalPort()));
             }
             
             try (FileOutputStream fos = new FileOutputStream(cfg.toFile())) {
@@ -266,7 +268,7 @@ public class TelegramLayoutController {
 
     /** Mirrors TelegramWatcher.configFilePath() – path convention kept in sync manually. */
     private static Path watcherConfigPath() {
-        return Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+        return WorkspacePaths.current().watcherConfig();
     }
 
     // ── Startup registration ──────────────────────────────────────────────────
@@ -289,11 +291,12 @@ public class TelegramLayoutController {
         }
         Path shortcut = startupFolder().resolve(SHORTCUT_NAME);
         try {
+            Path workspaceLauncher = writeWorkspaceWatcherLauncher(batFile);
             String vbs =
                 "Set oWS = WScript.CreateObject(\"WScript.Shell\")\n" +
-                "Set oLink = oWS.CreateShortcut(\"" + shortcut.toString().replace("\\", "\\\\") + "\")\n" +
-                "oLink.TargetPath = \"" + batFile.getAbsolutePath().replace("\\", "\\\\") + "\"\n" +
-                "oLink.WorkingDirectory = \"" + batFile.getParent().replace("\\", "\\\\") + "\"\n" +
+                "Set oLink = oWS.CreateShortcut(\"" + escapeVbsString(shortcut.toString()) + "\")\n" +
+                "oLink.TargetPath = \"" + escapeVbsString(workspaceLauncher.toString()) + "\"\n" +
+                "oLink.WorkingDirectory = \"" + escapeVbsString(workspaceLauncher.getParent().toString()) + "\"\n" +
                 "oLink.Description = \"Frostguard Telegram Watcher (auto-start)\"\n" +
                 "oLink.WindowStyle = 0\n" +
                 "oLink.Save\n";
@@ -315,6 +318,30 @@ public class TelegramLayoutController {
             showError("Failed to register startup shortcut: " + e.getMessage());
             checkBoxAutoStart.setSelected(false);
         }
+    }
+
+    private static Path writeWorkspaceWatcherLauncher(File batFile) throws IOException {
+        WorkspacePaths workspace = WorkspacePaths.current();
+        Path launcher = workspace.watcher().resolve("Start-Frostguard-Watcher.cmd");
+        Files.createDirectories(launcher.getParent());
+        Files.writeString(launcher, workspaceWatcherLauncherContent(batFile.toPath(), workspace));
+        return launcher;
+    }
+
+    static String workspaceWatcherLauncherContent(Path batFile, WorkspacePaths workspace) {
+        return "@echo off\r\n"
+                + "setlocal DisableDelayedExpansion\r\n"
+                + "set \"FROSTGUARD_WORKSPACE=" + escapeBatchValue(workspace.root().toString()) + "\"\r\n"
+                + "set \"FROSTGUARD_CHANNEL=" + workspace.channel().directoryName() + "\"\r\n"
+                + "call \"" + escapeBatchValue(batFile.toAbsolutePath().normalize().toString()) + "\"\r\n";
+    }
+
+    private static String escapeBatchValue(String value) {
+        return value.replace("^", "^^").replace("%", "%%");
+    }
+
+    private static String escapeVbsString(String value) {
+        return value.replace("\"", "\"\"");
     }
 
     private void removeStartup() {

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateExitCoordinator.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateExitCoordinator.java
@@ -1,0 +1,29 @@
+package dev.frostguard.app.panel.update;
+
+import dev.frostguard.update.InstallerHandoff;
+
+final class UpdateExitCoordinator {
+    private final ShutdownAction shutdown;
+    private final Runnable exit;
+
+    UpdateExitCoordinator(ShutdownAction shutdown, Runnable exit) {
+        this.shutdown = shutdown;
+        this.exit = exit;
+    }
+
+    void execute(InstallerHandoff.HandoffSession session) throws Exception {
+        session.authorize();
+        try {
+            shutdown.run();
+        } catch (Exception exception) {
+            session.cancel();
+            throw exception;
+        }
+        exit.run();
+    }
+
+    @FunctionalInterface
+    interface ShutdownAction {
+        void run() throws Exception;
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateLayoutController.java
@@ -1,0 +1,195 @@
+package dev.frostguard.app.panel.update;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.app.BuildMetadata;
+import dev.frostguard.app.bootstrap.ApplicationLifecycle;
+import dev.frostguard.update.InstallerHandoff;
+import dev.frostguard.update.PreparedUpdate;
+import dev.frostguard.update.RunningBuild;
+import dev.frostguard.update.SemanticVersion;
+import dev.frostguard.update.UpdateCandidate;
+import dev.frostguard.update.UpdateEndpointResolver;
+import dev.frostguard.update.UpdateException;
+import dev.frostguard.update.UpdateManager;
+import dev.frostguard.update.UpdatePlatform;
+import dev.frostguard.update.WindowsAuthenticodeVerifier;
+import dev.frostguard.update.WindowsInstallerHandoff;
+import javafx.application.Platform;
+import javafx.fxml.FXML;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressIndicator;
+import javafx.scene.layout.VBox;
+
+import java.awt.Desktop;
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+
+public final class UpdateLayoutController {
+    @FXML private Label labelCurrentVersion;
+    @FXML private Label labelChannel;
+    @FXML private Label labelStatus;
+    @FXML private VBox availableUpdatePane;
+    @FXML private Label labelAvailableVersion;
+    @FXML private Label labelArtifactDetails;
+    @FXML private Hyperlink linkReleaseNotes;
+    @FXML private Button buttonCheck;
+    @FXML private Button buttonDownloadInstall;
+    @FXML private ProgressIndicator progress;
+
+    private final UpdateEndpointResolver endpoints = new UpdateEndpointResolver();
+    private final UpdateManager manager = new UpdateManager(
+            new WindowsAuthenticodeVerifier(), new WindowsInstallerHandoff());
+    private RunningBuild runningBuild;
+    private UpdateCandidate candidate;
+
+    @FXML
+    private void initialize() {
+        runningBuild = runningBuild();
+        labelCurrentVersion.setText("Current version: " + runningBuild.version());
+        labelChannel.setText("Channel: " + runningBuild.channel().directoryName());
+        setAvailableUpdateVisible(false);
+        progress.setVisible(false);
+
+        if (!runningBuild.permitsAutomaticUpdates()) {
+            buttonCheck.setDisable(true);
+            if (runningBuild.pullRequestBuild()) {
+                labelStatus.setText("PR-test builds cannot use automatic updates.");
+            } else if (runningBuild.channel() == RuntimeChannel.DEVELOPMENT) {
+                labelStatus.setText("Development builds do not use release update feeds.");
+            } else {
+                labelStatus.setText("This build has no pinned release-signing identity.");
+            }
+        } else if (runningBuild.platform().operatingSystem() != UpdatePlatform.OperatingSystem.WINDOWS) {
+            buttonCheck.setDisable(true);
+            labelStatus.setText("Automatic installer handoff is currently available on Windows only.");
+        } else {
+            labelStatus.setText("Check the configured " + runningBuild.channel().directoryName() + " release feed.");
+        }
+    }
+
+    @FXML
+    private void handleCheck() {
+        setBusy(true, "Checking for updates...");
+        runAsync(() -> {
+            URI endpoint = endpoints.resolve(runningBuild.channel())
+                    .orElseThrow(() -> new UpdateException("No update feed is configured for this channel"));
+            return manager.check(endpoint, runningBuild);
+        }, this::showCheckResult);
+    }
+
+    @FXML
+    private void handleDownloadInstall() {
+        if (candidate == null) {
+            return;
+        }
+        Alert confirmation = new Alert(Alert.AlertType.CONFIRMATION);
+        confirmation.setTitle("Install Frostguard update");
+        confirmation.setHeaderText("Install Frostguard " + candidate.version() + "?");
+        confirmation.setContentText("Channel: " + candidate.channel().directoryName() + "\n"
+                + "Download: " + formatSize(candidate.artifact().size()) + "\n\n"
+                + "Frostguard will stop automation, close its workspace, exit, and then launch the signed installer.");
+        if (confirmation.showAndWait().filter(ButtonType.OK::equals).isEmpty()) {
+            return;
+        }
+        setBusy(true, "Downloading and verifying the signed installer...");
+        runAsync(() -> manager.prepare(candidate, WorkspacePaths.current().cache()), this::beginHandoff);
+    }
+
+    @FXML
+    private void openReleaseNotes() {
+        if (candidate == null || !Desktop.isDesktopSupported()) {
+            return;
+        }
+        try {
+            Desktop.getDesktop().browse(candidate.releaseNotes());
+        } catch (Exception exception) {
+            showFailure(new UpdateException("Could not open release notes: " + exception.getMessage(), exception));
+        }
+    }
+
+    private void showCheckResult(Optional<UpdateCandidate> result) {
+        setBusy(false, result.isPresent() ? "An update is available." : "Frostguard is up to date.");
+        candidate = result.orElse(null);
+        setAvailableUpdateVisible(candidate != null);
+        if (candidate != null) {
+            labelAvailableVersion.setText("Frostguard " + candidate.version());
+            labelArtifactDetails.setText(candidate.channel().directoryName() + " / " + candidate.platform().key()
+                    + " / " + formatSize(candidate.artifact().size()));
+            linkReleaseNotes.setText(candidate.releaseNotes().toString());
+        }
+    }
+
+    private void beginHandoff(PreparedUpdate prepared) {
+        labelStatus.setText("Installer verified. Stopping Frostguard safely...");
+        InstallerHandoff.HandoffSession session = null;
+        try {
+            session = manager.stageHandoff(prepared, ProcessHandle.current().pid());
+            UpdateExitCoordinator coordinator = new UpdateExitCoordinator(
+                    ApplicationLifecycle::stopForUpdate, ApplicationLifecycle::exitAfterUpdateHandoff);
+            coordinator.execute(session);
+        } catch (Exception exception) {
+            if (session != null) {
+                session.cancel();
+            }
+            showFailure(exception);
+        }
+    }
+
+    private <T> void runAsync(Callable<T> operation, Consumer<T> success) {
+        Thread.ofVirtual().name("frostguard-update-operation").start(() -> {
+            try {
+                T result = operation.call();
+                Platform.runLater(() -> success.accept(result));
+            } catch (Exception exception) {
+                Platform.runLater(() -> showFailure(exception));
+            }
+        });
+    }
+
+    private void showFailure(Exception exception) {
+        setBusy(false, exception.getMessage() == null ? "Update operation failed." : exception.getMessage());
+        Alert alert = new Alert(Alert.AlertType.ERROR);
+        alert.setTitle("Frostguard update failed");
+        alert.setHeaderText("The current installation was not replaced.");
+        alert.setContentText(labelStatus.getText());
+        alert.show();
+    }
+
+    private void setBusy(boolean busy, String status) {
+        progress.setVisible(busy);
+        buttonCheck.setDisable(busy || !runningBuild.permitsAutomaticUpdates());
+        buttonDownloadInstall.setDisable(busy);
+        labelStatus.setText(status);
+    }
+
+    private void setAvailableUpdateVisible(boolean visible) {
+        availableUpdatePane.setVisible(visible);
+        availableUpdatePane.setManaged(visible);
+    }
+
+    static RunningBuild runningBuild() {
+        String version = Optional.ofNullable(UpdateLayoutController.class.getPackage().getImplementationVersion())
+                .filter(value -> !value.isBlank())
+                .orElseGet(() -> System.getProperty("frostguard.version", "2.1.0"));
+        BuildMetadata metadata = BuildMetadata.current();
+        return new RunningBuild(SemanticVersion.parse(version), SemanticVersion.parse(version),
+                WorkspacePaths.current().channel(), UpdatePlatform.current(),
+                metadata.pullRequestBuild(), metadata.authenticodePublisher());
+    }
+
+    static String formatSize(long bytes) {
+        if (bytes < 1024) return bytes + " B";
+        double value = bytes / 1024.0;
+        if (value < 1024) return String.format(java.util.Locale.ROOT, "%.1f KiB", value);
+        value /= 1024.0;
+        if (value < 1024) return String.format(java.util.Locale.ROOT, "%.1f MiB", value);
+        return String.format(java.util.Locale.ROOT, "%.1f GiB", value / 1024.0);
+    }
+}

--- a/modules/desktop/src/main/resources/dev/frostguard/app/frostguard-build.properties
+++ b/modules/desktop/src/main/resources/dev/frostguard/app/frostguard-build.properties
@@ -1,0 +1,2 @@
+pullRequestBuild=${frostguard.pull-request-build}
+authenticodePublisher=${frostguard.update.authenticode-publisher}

--- a/modules/desktop/src/main/resources/layout/UpdateLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/UpdateLayout.fxml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Hyperlink?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ProgressIndicator?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1"
+      spacing="14" style="-fx-background-color: #11141a;">
+    <padding>
+        <Insets top="20" right="24" bottom="20" left="24" />
+    </padding>
+
+    <Label text="Application Updates"
+           style="-fx-font-size: 20px; -fx-font-weight: bold; -fx-text-fill: #e6edf3;" />
+    <Label text="Updates are selected for this product identity and verified before Frostguard exits."
+           wrapText="true" style="-fx-text-fill: #9da7b3;" />
+
+    <HBox spacing="20">
+        <Label fx:id="labelCurrentVersion" style="-fx-text-fill: #e6edf3; -fx-font-weight: bold;" />
+        <Label fx:id="labelChannel" style="-fx-text-fill: #e6edf3; -fx-font-weight: bold;" />
+    </HBox>
+
+    <HBox alignment="CENTER_LEFT" spacing="10">
+        <Button fx:id="buttonCheck" text="Check for updates" onAction="#handleCheck" />
+        <ProgressIndicator fx:id="progress" prefWidth="24" prefHeight="24" maxWidth="24" maxHeight="24" />
+        <Label fx:id="labelStatus" wrapText="true" style="-fx-text-fill: #9da7b3;" />
+    </HBox>
+
+    <VBox fx:id="availableUpdatePane" spacing="10"
+          style="-fx-background-color: #1b2028; -fx-background-radius: 6; -fx-padding: 16;">
+        <Label fx:id="labelAvailableVersion"
+               style="-fx-font-size: 16px; -fx-font-weight: bold; -fx-text-fill: #e6edf3;" />
+        <Label fx:id="labelArtifactDetails" style="-fx-text-fill: #9da7b3;" />
+        <Hyperlink fx:id="linkReleaseNotes" text="Release notes" onAction="#openReleaseNotes" />
+        <Button fx:id="buttonDownloadInstall" text="Download and install"
+                onAction="#handleDownloadInstall" />
+    </VBox>
+</VBox>

--- a/modules/desktop/src/main/resources/logback.xml
+++ b/modules/desktop/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration scan="true" scanPeriod="30 seconds">
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
-    <property name="LOG_DIR" value="log"/>
+    <property name="LOG_DIR" value="${frostguard.log.dir:-log}"/>
     <property name="LOG_FILE" value="${LOG_DIR}/frostguard.log"/>
     <property name="APP_PATTERN" value="%d{HH:mm:ss.SSS} %-5level [%thread] %logger{32} - %msg%n"/>
     <property name="FILE_PATTERN" value="%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] %logger{48} - %msg%n"/>

--- a/modules/desktop/src/test/java/dev/frostguard/app/BuildMetadataTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/BuildMetadataTest.java
@@ -1,0 +1,31 @@
+package dev.frostguard.app;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BuildMetadataTest {
+    @Test
+    void readsFilteredPrBuildIdentity() {
+        BuildMetadata release = BuildMetadata.read(stream(
+                "pullRequestBuild=false\nauthenticodePublisher=CN=Frostguard Project, O=Frostguard"));
+        assertFalse(release.pullRequestBuild());
+        assertEquals("CN=Frostguard Project, O=Frostguard", release.authenticodePublisher());
+        assertTrue(BuildMetadata.read(stream("pullRequestBuild=true")).pullRequestBuild());
+    }
+
+    @Test
+    void missingOrInvalidIdentityDisablesAutomaticUpdates() {
+        assertTrue(BuildMetadata.read(null).pullRequestBuild());
+        assertTrue(BuildMetadata.read(stream("pullRequestBuild=maybe")).pullRequestBuild());
+    }
+
+    private static ByteArrayInputStream stream(String value) {
+        return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/bootstrap/RuntimeShutdownCoordinatorTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/bootstrap/RuntimeShutdownCoordinatorTest.java
@@ -1,0 +1,40 @@
+package dev.frostguard.app.bootstrap;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RuntimeShutdownCoordinatorTest {
+    @Test
+    void runsEveryStepInOrder() throws Exception {
+        List<String> calls = new ArrayList<>();
+        RuntimeShutdownCoordinator coordinator = new RuntimeShutdownCoordinator(List.of(
+                new RuntimeShutdownCoordinator.Step("scheduler", () -> calls.add("scheduler")),
+                new RuntimeShutdownCoordinator.Step("database", () -> calls.add("database"))));
+
+        coordinator.shutdown();
+
+        assertEquals(List.of("scheduler", "database"), calls);
+    }
+
+    @Test
+    void reportsFailuresAfterAttemptingRemainingSteps() {
+        List<String> calls = new ArrayList<>();
+        RuntimeShutdownCoordinator coordinator = new RuntimeShutdownCoordinator(List.of(
+                new RuntimeShutdownCoordinator.Step("scheduler", () -> {
+                    calls.add("scheduler");
+                    throw new IllegalStateException("busy");
+                }),
+                new RuntimeShutdownCoordinator.Step("database", () -> calls.add("database"))));
+
+        RuntimeShutdownCoordinator.ShutdownException exception = assertThrows(
+                RuntimeShutdownCoordinator.ShutdownException.class, coordinator::shutdown);
+
+        assertEquals(List.of("scheduler", "database"), calls);
+        assertEquals(List.of("scheduler: busy"), exception.failures());
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/TelegramLayoutControllerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/TelegramLayoutControllerTest.java
@@ -1,0 +1,30 @@
+package dev.frostguard.app.panel.misc;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+class TelegramLayoutControllerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void startupWrapperPreservesWorkspaceIdentity() {
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("Bot 1"), RuntimeChannel.STABLE);
+        Path watcherLauncher = tempDir.resolve("install/Start-Frostguard-Watcher.bat");
+
+        String script = TelegramLayoutController.workspaceWatcherLauncherContent(
+                watcherLauncher, workspace);
+
+        assertTrue(script.contains("set \"FROSTGUARD_WORKSPACE=" + workspace.root() + "\""));
+        assertTrue(script.contains("set \"FROSTGUARD_CHANNEL=stable\""));
+        assertTrue(script.contains("call \"" + watcherLauncher.toAbsolutePath().normalize() + "\""));
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/TelegramLayoutControllerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/TelegramLayoutControllerTest.java
@@ -27,4 +27,16 @@ class TelegramLayoutControllerTest {
         assertTrue(script.contains("set \"FROSTGUARD_CHANNEL=stable\""));
         assertTrue(script.contains("call \"" + watcherLauncher.toAbsolutePath().normalize() + "\""));
     }
+
+    @Test
+    void startupWrapperStartsThePackagedNativeWatcher() {
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("Bot 1"), RuntimeChannel.STABLE);
+        Path watcherLauncher = tempDir.resolve("install/FrostguardWatcher.exe");
+
+        String script = TelegramLayoutController.workspaceWatcherLauncherContent(
+                watcherLauncher, workspace);
+
+        assertTrue(script.contains("start \"\" \""
+                + watcherLauncher.toAbsolutePath().normalize() + "\""));
+    }
 }

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateExitCoordinatorTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateExitCoordinatorTest.java
@@ -1,0 +1,57 @@
+package dev.frostguard.app.panel.update;
+
+import dev.frostguard.update.InstallerHandoff;
+import dev.frostguard.update.UpdateException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UpdateExitCoordinatorTest {
+    @Test
+    void authorizesThenShutsDownAndExits() throws Exception {
+        Session session = new Session();
+        AtomicBoolean shutdown = new AtomicBoolean();
+        AtomicBoolean exited = new AtomicBoolean();
+        UpdateExitCoordinator coordinator = new UpdateExitCoordinator(() -> shutdown.set(true),
+                () -> exited.set(true));
+
+        coordinator.execute(session);
+
+        assertTrue(session.authorized);
+        assertTrue(shutdown.get());
+        assertTrue(exited.get());
+        assertFalse(session.cancelled);
+    }
+
+    @Test
+    void cancelsHandoffAndDoesNotExitWhenShutdownFails() {
+        Session session = new Session();
+        AtomicBoolean exited = new AtomicBoolean();
+        UpdateExitCoordinator coordinator = new UpdateExitCoordinator(
+                () -> { throw new IllegalStateException("database busy"); }, () -> exited.set(true));
+
+        assertThrows(IllegalStateException.class, () -> coordinator.execute(session));
+        assertTrue(session.authorized);
+        assertTrue(session.cancelled);
+        assertFalse(exited.get());
+    }
+
+    private static final class Session implements InstallerHandoff.HandoffSession {
+        private boolean authorized;
+        private boolean cancelled;
+
+        @Override
+        public void authorize() throws UpdateException {
+            authorized = true;
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+        }
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateLayoutControllerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateLayoutControllerTest.java
@@ -1,0 +1,14 @@
+package dev.frostguard.app.panel.update;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UpdateLayoutControllerTest {
+    @Test
+    void formatsInstallerSizesForReview() {
+        assertEquals("512 B", UpdateLayoutController.formatSize(512));
+        assertEquals("1.5 KiB", UpdateLayoutController.formatSize(1536));
+        assertEquals("273.5 MiB", UpdateLayoutController.formatSize(286_739_610));
+    }
+}

--- a/modules/persistence/src/main/java/dev/frostguard/data/access/DataStore.java
+++ b/modules/persistence/src/main/java/dev/frostguard/data/access/DataStore.java
@@ -1,5 +1,6 @@
 package dev.frostguard.data.access;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -13,6 +14,7 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.TypedQuery;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 /**
  * Centralized transactional gateway for all Frostguard persistence operations.
@@ -31,7 +33,10 @@ public final class DataStore implements AutoCloseable {
 
 	private DataStore(Map<String, Object> overrides) {
 		try {
-			this.emf = Persistence.createEntityManagerFactory(PERSISTENCE_UNIT, overrides);
+			Map<String, Object> effectiveOverrides = new HashMap<>(overrides);
+			effectiveOverrides.putIfAbsent("jakarta.persistence.jdbc.url",
+					"jdbc:sqlite:" + WorkspacePaths.current().database() + "?busy_timeout=1000&journal_mode=WAL");
+			this.emf = Persistence.createEntityManagerFactory(PERSISTENCE_UNIT, effectiveOverrides);
 			DataSeeder.populate(this);
 			LOG.info("Frostguard data store initialized");
 		} catch (Exception cause) {

--- a/modules/persistence/src/test/java/dev/frostguard/data/access/DataStoreWorkspaceTest.java
+++ b/modules/persistence/src/test/java/dev/frostguard/data/access/DataStoreWorkspaceTest.java
@@ -1,0 +1,32 @@
+package dev.frostguard.data.access;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+class DataStoreWorkspaceTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void opensTheDefaultDatabaseInsideTheSelectedWorkspace() {
+        String previous = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+        try (DataStore ignored = DataStore.openIsolated(Map.of("hibernate.hbm2ddl.auto", "create"))) {
+            assertTrue(Files.isRegularFile(tempDir.resolve("frostguard.db")));
+        } finally {
+            if (previous == null) {
+                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+            } else {
+                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, previous);
+            }
+        }
+    }
+}

--- a/modules/update/pom.xml
+++ b/modules/update/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.frostguard</groupId>
+        <artifactId>frostguard</artifactId>
+        <version>${revision}</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>frostguard-update</artifactId>
+    <name>Frostguard Update</name>
+    <description>Release manifest, update policy, verified download, and installer handoff.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.frostguard</groupId>
+            <artifactId>frostguard-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/modules/update/src/main/java/dev/frostguard/update/ArtifactVerifier.java
+++ b/modules/update/src/main/java/dev/frostguard/update/ArtifactVerifier.java
@@ -1,0 +1,43 @@
+package dev.frostguard.update;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public final class ArtifactVerifier {
+    public void verify(Path artifact, UpdateArtifact expected) throws UpdateException {
+        try {
+            long actualSize = Files.size(artifact);
+            if (actualSize != expected.size()) {
+                throw new UpdateException("Downloaded artifact size mismatch: expected " + expected.size()
+                        + " bytes, received " + actualSize);
+            }
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (InputStream input = Files.newInputStream(artifact)) {
+                input.transferTo(new java.io.OutputStream() {
+                    @Override
+                    public void write(int value) {
+                        digest.update((byte) value);
+                    }
+
+                    @Override
+                    public void write(byte[] bytes, int offset, int length) {
+                        digest.update(bytes, offset, length);
+                    }
+                });
+            }
+            String actualHash = HexFormat.of().formatHex(digest.digest());
+            if (!actualHash.equalsIgnoreCase(expected.sha256())) {
+                throw new UpdateException("Downloaded artifact SHA-256 mismatch");
+            }
+        } catch (IOException exception) {
+            throw new UpdateException("Could not verify downloaded artifact: " + exception.getMessage(), exception);
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is unavailable", impossible);
+        }
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/CommandRunner.java
+++ b/modules/update/src/main/java/dev/frostguard/update/CommandRunner.java
@@ -1,0 +1,14 @@
+package dev.frostguard.update;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+interface CommandRunner {
+    CommandResult run(List<String> command, Map<String, String> environment, Duration timeout)
+            throws IOException, InterruptedException;
+
+    record CommandResult(int exitCode, String output) {
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/DownloadTransport.java
+++ b/modules/update/src/main/java/dev/frostguard/update/DownloadTransport.java
@@ -1,0 +1,17 @@
+package dev.frostguard.update;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+public interface DownloadTransport {
+    Response open(URI uri, long offset) throws IOException, InterruptedException;
+
+    interface Response extends AutoCloseable {
+        int statusCode();
+        InputStream body();
+
+        @Override
+        void close() throws IOException;
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/InstallerHandoff.java
+++ b/modules/update/src/main/java/dev/frostguard/update/InstallerHandoff.java
@@ -1,0 +1,12 @@
+package dev.frostguard.update;
+
+import java.nio.file.Path;
+
+public interface InstallerHandoff {
+    HandoffSession stage(Path installer, long parentPid) throws UpdateException;
+
+    interface HandoffSession {
+        void authorize() throws UpdateException;
+        void cancel();
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/InstallerTrustVerifier.java
+++ b/modules/update/src/main/java/dev/frostguard/update/InstallerTrustVerifier.java
@@ -1,0 +1,7 @@
+package dev.frostguard.update;
+
+import java.nio.file.Path;
+
+public interface InstallerTrustVerifier {
+    void verify(Path installer, SignatureRequirement requirement) throws UpdateException;
+}

--- a/modules/update/src/main/java/dev/frostguard/update/JdkDownloadTransport.java
+++ b/modules/update/src/main/java/dev/frostguard/update/JdkDownloadTransport.java
@@ -1,0 +1,46 @@
+package dev.frostguard.update;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+public final class JdkDownloadTransport implements DownloadTransport {
+    private final HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(15))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+
+    @Override
+    public Response open(URI uri, long offset) throws IOException, InterruptedException {
+        if (uri == null || !"https".equalsIgnoreCase(uri.getScheme()) || uri.getHost() == null) {
+            throw new IOException("Artifact URL must use HTTPS");
+        }
+        HttpRequest.Builder request = HttpRequest.newBuilder(uri)
+                .timeout(Duration.ofMinutes(10))
+                .GET();
+        if (offset > 0) {
+            request.header("Range", "bytes=" + offset + "-");
+        }
+        HttpResponse<InputStream> response = client.send(request.build(), HttpResponse.BodyHandlers.ofInputStream());
+        return new Response() {
+            @Override
+            public int statusCode() {
+                return response.statusCode();
+            }
+
+            @Override
+            public InputStream body() {
+                return response.body();
+            }
+
+            @Override
+            public void close() throws IOException {
+                response.body().close();
+            }
+        };
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/ManifestClient.java
+++ b/modules/update/src/main/java/dev/frostguard/update/ManifestClient.java
@@ -1,0 +1,62 @@
+package dev.frostguard.update;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+public final class ManifestClient {
+    private static final int MAX_MANIFEST_BYTES = 1024 * 1024;
+    private final HttpClient client;
+    private final ManifestCodec codec;
+
+    public ManifestClient() {
+        this(HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build(), new ManifestCodec());
+    }
+
+    ManifestClient(HttpClient client, ManifestCodec codec) {
+        this.client = client;
+        this.codec = codec;
+    }
+
+    public UpdateManifest fetch(URI uri) throws UpdateException {
+        requireHttps(uri);
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .timeout(Duration.ofSeconds(20))
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+        try {
+            HttpResponse<java.io.InputStream> response = client.send(
+                    request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() != 200) {
+                response.body().close();
+                throw new UpdateException("Manifest request returned HTTP " + response.statusCode());
+            }
+            byte[] body;
+            try (java.io.InputStream input = response.body()) {
+                body = input.readNBytes(MAX_MANIFEST_BYTES + 1);
+            }
+            if (body.length > MAX_MANIFEST_BYTES) {
+                throw new UpdateException("Manifest exceeds the 1 MiB safety limit");
+            }
+            return codec.read(body);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new UpdateException("Manifest request was interrupted", exception);
+        } catch (IOException exception) {
+            throw new UpdateException("Manifest request failed: " + exception.getMessage(), exception);
+        }
+    }
+
+    private static void requireHttps(URI uri) throws UpdateException {
+        if (uri == null || !"https".equalsIgnoreCase(uri.getScheme()) || uri.getHost() == null) {
+            throw new UpdateException("Manifest URL must use HTTPS");
+        }
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/ManifestCodec.java
+++ b/modules/update/src/main/java/dev/frostguard/update/ManifestCodec.java
@@ -1,0 +1,108 @@
+package dev.frostguard.update;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.frostguard.api.runtime.RuntimeChannel;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.HexFormat;
+import java.util.Map;
+
+public final class ManifestCodec {
+    public static final int SUPPORTED_SCHEMA_VERSION = 1;
+    private final ObjectMapper mapper = new ObjectMapper()
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+
+    public UpdateManifest read(byte[] json) throws UpdateException {
+        try {
+            UpdateManifest manifest = mapper.readValue(json, UpdateManifest.class);
+            validate(manifest);
+            return manifest;
+        } catch (IOException | IllegalArgumentException exception) {
+            throw new UpdateException("Update manifest is invalid: " + exception.getMessage(), exception);
+        }
+    }
+
+    private void validate(UpdateManifest manifest) {
+        if (manifest.schemaVersion() != SUPPORTED_SCHEMA_VERSION) {
+            throw new IllegalArgumentException("unsupported schema version " + manifest.schemaVersion());
+        }
+        RuntimeChannel channel = RuntimeChannel.from(required(manifest.channel(), "channel"));
+        if (channel == RuntimeChannel.DEVELOPMENT) {
+            throw new IllegalArgumentException("development manifests are not publishable");
+        }
+        SemanticVersion version = SemanticVersion.parse(manifest.version());
+        SemanticVersion.parse(manifest.minimumUpdaterVersion());
+        parseInstant(manifest.publishedAt());
+        requireHttps(manifest.releaseNotesUrl(), "release notes URL");
+        if (manifest.artifacts() == null || manifest.artifacts().isEmpty()) {
+            throw new IllegalArgumentException("at least one update artifact is required");
+        }
+        for (Map.Entry<String, UpdateArtifact> entry : manifest.artifacts().entrySet()) {
+            validateArtifact(entry.getKey(), entry.getValue(), version);
+        }
+    }
+
+    private void validateArtifact(String key, UpdateArtifact artifact, SemanticVersion version) {
+        if (artifact == null) {
+            throw new IllegalArgumentException("artifact " + key + " is missing");
+        }
+        UpdatePlatform platform = new UpdatePlatform(
+                UpdatePlatform.OperatingSystem.from(required(artifact.operatingSystem(), "artifact operating system")),
+                UpdatePlatform.Architecture.from(required(artifact.architecture(), "artifact architecture")));
+        if (!platform.key().equals(key)) {
+            throw new IllegalArgumentException("artifact key " + key + " does not match " + platform.key());
+        }
+        String fileName = required(artifact.fileName(), "artifact file name");
+        if (fileName.contains("/") || fileName.contains("\\") || fileName.equals(".") || fileName.equals("..")) {
+            throw new IllegalArgumentException("artifact file name must not contain a path");
+        }
+        URI artifactUri = requireHttps(artifact.url(), "artifact URL");
+        String path = artifactUri.getPath();
+        if (path == null || !path.endsWith("/" + fileName) || !fileName.contains(version.toString())) {
+            throw new IllegalArgumentException("artifact URL and file name must carry the immutable release version");
+        }
+        if (artifact.size() <= 0) {
+            throw new IllegalArgumentException("artifact size must be positive");
+        }
+        String hash = required(artifact.sha256(), "artifact SHA-256");
+        if (hash.length() != 64) {
+            throw new IllegalArgumentException("artifact SHA-256 must contain 64 hexadecimal characters");
+        }
+        HexFormat.of().parseHex(hash);
+        if (platform.operatingSystem() == UpdatePlatform.OperatingSystem.WINDOWS) {
+            SignatureRequirement signature = artifact.signature();
+            if (signature == null || !"authenticode".equalsIgnoreCase(signature.type())
+                    || required(signature.publisher(), "Authenticode publisher").isBlank()) {
+                throw new IllegalArgumentException("Windows artifacts require an Authenticode publisher");
+            }
+        }
+    }
+
+    private static Instant parseInstant(String value) {
+        try {
+            return Instant.parse(required(value, "publication time"));
+        } catch (DateTimeParseException exception) {
+            throw new IllegalArgumentException("publication time must use ISO-8601 UTC", exception);
+        }
+    }
+
+    private static URI requireHttps(String value, String label) {
+        URI uri = URI.create(required(value, label));
+        if (!"https".equalsIgnoreCase(uri.getScheme()) || uri.getHost() == null) {
+            throw new IllegalArgumentException(label + " must use HTTPS");
+        }
+        return uri;
+    }
+
+    private static String required(String value, String label) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(label + " is required");
+        }
+        return value.trim();
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/PreparedUpdate.java
+++ b/modules/update/src/main/java/dev/frostguard/update/PreparedUpdate.java
@@ -1,0 +1,6 @@
+package dev.frostguard.update;
+
+import java.nio.file.Path;
+
+public record PreparedUpdate(UpdateCandidate candidate, Path installer) {
+}

--- a/modules/update/src/main/java/dev/frostguard/update/ProcessCommandRunner.java
+++ b/modules/update/src/main/java/dev/frostguard/update/ProcessCommandRunner.java
@@ -1,0 +1,27 @@
+package dev.frostguard.update;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+final class ProcessCommandRunner implements CommandRunner {
+    private static final int MAX_OUTPUT_BYTES = 64 * 1024;
+
+    @Override
+    public CommandResult run(List<String> command, Map<String, String> environment, Duration timeout)
+            throws IOException, InterruptedException {
+        ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);
+        builder.environment().putAll(environment);
+        Process process = builder.start();
+        boolean finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        if (!finished) {
+            process.destroyForcibly();
+            throw new IOException("Command timed out after " + timeout.toSeconds() + " seconds");
+        }
+        byte[] output = process.getInputStream().readNBytes(MAX_OUTPUT_BYTES);
+        return new CommandResult(process.exitValue(), new String(output, StandardCharsets.UTF_8).trim());
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/RunningBuild.java
+++ b/modules/update/src/main/java/dev/frostguard/update/RunningBuild.java
@@ -1,0 +1,23 @@
+package dev.frostguard.update;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+
+public record RunningBuild(
+        SemanticVersion version,
+        SemanticVersion updaterVersion,
+        RuntimeChannel channel,
+        UpdatePlatform platform,
+        boolean pullRequestBuild,
+        String authenticodePublisher) {
+
+    public RunningBuild {
+        if (version == null || updaterVersion == null || channel == null || platform == null) {
+            throw new IllegalArgumentException("Running build identity is incomplete");
+        }
+        authenticodePublisher = authenticodePublisher == null ? "" : authenticodePublisher.trim();
+    }
+
+    public boolean permitsAutomaticUpdates() {
+        return channel != RuntimeChannel.DEVELOPMENT && !pullRequestBuild && !authenticodePublisher.isBlank();
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/SemanticVersion.java
+++ b/modules/update/src/main/java/dev/frostguard/update/SemanticVersion.java
@@ -1,0 +1,95 @@
+package dev.frostguard.update;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class SemanticVersion implements Comparable<SemanticVersion> {
+    private static final Pattern FORMAT = Pattern.compile(
+            "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)"
+                    + "(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?"
+                    + "(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$");
+
+    private final String value;
+    private final int major;
+    private final int minor;
+    private final int patch;
+    private final List<String> prerelease;
+
+    private SemanticVersion(String value, int major, int minor, int patch, List<String> prerelease) {
+        this.value = value;
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+        this.prerelease = List.copyOf(prerelease);
+    }
+
+    public static SemanticVersion parse(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Semantic version is required");
+        }
+        Matcher matcher = FORMAT.matcher(value.trim());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid semantic version: " + value);
+        }
+        List<String> prerelease = new ArrayList<>();
+        if (matcher.group(4) != null) {
+            for (String identifier : matcher.group(4).split("\\.")) {
+                if (identifier.matches("\\d+") && identifier.length() > 1 && identifier.startsWith("0")) {
+                    throw new IllegalArgumentException(
+                            "Numeric prerelease identifiers cannot contain leading zeroes: " + value);
+                }
+                prerelease.add(identifier);
+            }
+        }
+        return new SemanticVersion(value.trim(), Integer.parseInt(matcher.group(1)),
+                Integer.parseInt(matcher.group(2)), Integer.parseInt(matcher.group(3)), prerelease);
+    }
+
+    @Override
+    public int compareTo(SemanticVersion other) {
+        int result = Integer.compare(major, other.major);
+        if (result == 0) result = Integer.compare(minor, other.minor);
+        if (result == 0) result = Integer.compare(patch, other.patch);
+        if (result != 0) return result;
+        if (prerelease.isEmpty()) return other.prerelease.isEmpty() ? 0 : 1;
+        if (other.prerelease.isEmpty()) return -1;
+        int count = Math.max(prerelease.size(), other.prerelease.size());
+        for (int index = 0; index < count; index++) {
+            if (index >= prerelease.size()) return -1;
+            if (index >= other.prerelease.size()) return 1;
+            result = compareIdentifier(prerelease.get(index), other.prerelease.get(index));
+            if (result != 0) return result;
+        }
+        return 0;
+    }
+
+    private static int compareIdentifier(String left, String right) {
+        boolean leftNumeric = left.matches("\\d+");
+        boolean rightNumeric = right.matches("\\d+");
+        if (leftNumeric && rightNumeric) {
+            return new java.math.BigInteger(left).compareTo(new java.math.BigInteger(right));
+        }
+        if (leftNumeric != rightNumeric) {
+            return leftNumeric ? -1 : 1;
+        }
+        return left.compareTo(right);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        return object instanceof SemanticVersion other && compareTo(other) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(major, minor, patch, prerelease);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/SignatureRequirement.java
+++ b/modules/update/src/main/java/dev/frostguard/update/SignatureRequirement.java
@@ -1,0 +1,4 @@
+package dev.frostguard.update;
+
+public record SignatureRequirement(String type, String publisher) {
+}

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateArtifact.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateArtifact.java
@@ -1,0 +1,11 @@
+package dev.frostguard.update;
+
+public record UpdateArtifact(
+        String operatingSystem,
+        String architecture,
+        String fileName,
+        String url,
+        String sha256,
+        long size,
+        SignatureRequirement signature) {
+}

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateCandidate.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateCandidate.java
@@ -1,0 +1,15 @@
+package dev.frostguard.update;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+
+import java.net.URI;
+import java.time.Instant;
+
+public record UpdateCandidate(
+        RuntimeChannel channel,
+        SemanticVersion version,
+        Instant publishedAt,
+        URI releaseNotes,
+        UpdatePlatform platform,
+        UpdateArtifact artifact) {
+}

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateDownloader.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateDownloader.java
@@ -1,0 +1,113 @@
+package dev.frostguard.update;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+
+public final class UpdateDownloader {
+    private final DownloadTransport transport;
+    private final ArtifactVerifier verifier;
+
+    public UpdateDownloader() {
+        this(new JdkDownloadTransport(), new ArtifactVerifier());
+    }
+
+    UpdateDownloader(DownloadTransport transport, ArtifactVerifier verifier) {
+        this.transport = transport;
+        this.verifier = verifier;
+    }
+
+    public Path download(UpdateCandidate candidate, Path workspaceCache) throws UpdateException {
+        UpdateArtifact artifact = candidate.artifact();
+        Path directory = workspaceCache.resolve("updates")
+                .resolve(candidate.channel().directoryName())
+                .resolve(candidate.version().toString());
+        Path completed = directory.resolve(artifact.fileName());
+        Path partial = directory.resolve(artifact.fileName() + ".part");
+        Path lockPath = directory.resolve(artifact.fileName() + ".lock");
+        try {
+            Files.createDirectories(directory);
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = tryLock(channel)) {
+                if (Files.isRegularFile(completed)) {
+                    try {
+                        verifier.verify(completed, artifact);
+                        return completed;
+                    } catch (UpdateException invalidCompletedArtifact) {
+                        Files.delete(completed);
+                    }
+                }
+                long offset = Files.isRegularFile(partial) ? Files.size(partial) : 0L;
+                if (offset > artifact.size()) {
+                    Files.delete(partial);
+                    offset = 0L;
+                }
+                transfer(URI.create(artifact.url()), partial, offset, artifact.size());
+                try {
+                    verifier.verify(partial, artifact);
+                } catch (UpdateException invalidDownload) {
+                    Files.deleteIfExists(partial);
+                    throw invalidDownload;
+                }
+                promote(partial, completed);
+                return completed;
+            }
+        } catch (OverlappingFileLockException exception) {
+            throw new UpdateException("Another update download is already running", exception);
+        } catch (IOException exception) {
+            throw new UpdateException("Update download failed: " + exception.getMessage(), exception);
+        }
+    }
+
+    private FileLock tryLock(FileChannel channel) throws IOException, UpdateException {
+        FileLock lock = channel.tryLock();
+        if (lock == null) {
+            throw new UpdateException("Another update download is already running");
+        }
+        return lock;
+    }
+
+    private void transfer(URI uri, Path partial, long offset, long expectedSize) throws UpdateException, IOException {
+        try (DownloadTransport.Response response = transport.open(uri, offset)) {
+            boolean append = offset > 0 && response.statusCode() == 206;
+            if (response.statusCode() != 200 && !append) {
+                throw new UpdateException("Artifact request returned HTTP " + response.statusCode());
+            }
+            if (!append) {
+                offset = 0L;
+            }
+            StandardOpenOption[] options = append
+                    ? new StandardOpenOption[]{StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+                            StandardOpenOption.APPEND}
+                    : new StandardOpenOption[]{StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+                            StandardOpenOption.TRUNCATE_EXISTING};
+            try (InputStream input = response.body(); OutputStream output = Files.newOutputStream(partial, options)) {
+                byte[] buffer = new byte[64 * 1024];
+                long total = offset;
+                int read;
+                while ((read = input.read(buffer)) >= 0) {
+                    total += read;
+                    if (total > expectedSize) {
+                        throw new UpdateException("Artifact download exceeded its declared size");
+                    }
+                    output.write(buffer, 0, read);
+                }
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new UpdateException("Update download was interrupted", exception);
+        }
+    }
+
+    private static void promote(Path partial, Path completed) throws IOException {
+        Files.move(partial, completed, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateEndpointResolver.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateEndpointResolver.java
@@ -1,0 +1,32 @@
+package dev.frostguard.update;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+
+import java.net.URI;
+import java.util.Optional;
+
+public final class UpdateEndpointResolver {
+    public static final String STABLE_PROPERTY = "frostguard.update.manifest.stable";
+    public static final String NIGHTLY_PROPERTY = "frostguard.update.manifest.nightly";
+
+    public Optional<URI> resolve(RuntimeChannel channel) throws UpdateException {
+        if (channel == RuntimeChannel.DEVELOPMENT) {
+            return Optional.empty();
+        }
+        String property = channel == RuntimeChannel.STABLE ? STABLE_PROPERTY : NIGHTLY_PROPERTY;
+        String value = System.getProperty(property);
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        URI uri;
+        try {
+            uri = URI.create(value.trim());
+        } catch (IllegalArgumentException exception) {
+            throw new UpdateException("Configured update manifest URL is invalid", exception);
+        }
+        if (!"https".equalsIgnoreCase(uri.getScheme()) || uri.getHost() == null) {
+            throw new UpdateException("Configured update manifest URL must use HTTPS");
+        }
+        return Optional.of(uri);
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateException.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateException.java
@@ -1,0 +1,11 @@
+package dev.frostguard.update;
+
+public class UpdateException extends Exception {
+    public UpdateException(String message) {
+        super(message);
+    }
+
+    public UpdateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateManager.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateManager.java
@@ -1,0 +1,64 @@
+package dev.frostguard.update;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class UpdateManager {
+    private final ManifestClient manifests;
+    private final UpdateSelector selector;
+    private final UpdateDownloader downloader;
+    private final InstallerTrustVerifier trustVerifier;
+    private final InstallerHandoff handoff;
+    private final AtomicBoolean operationActive = new AtomicBoolean();
+
+    public UpdateManager(InstallerTrustVerifier trustVerifier, InstallerHandoff handoff) {
+        this(new ManifestClient(), new UpdateSelector(), new UpdateDownloader(), trustVerifier, handoff);
+    }
+
+    UpdateManager(ManifestClient manifests, UpdateSelector selector, UpdateDownloader downloader,
+                  InstallerTrustVerifier trustVerifier, InstallerHandoff handoff) {
+        this.manifests = manifests;
+        this.selector = selector;
+        this.downloader = downloader;
+        this.trustVerifier = trustVerifier;
+        this.handoff = handoff;
+    }
+
+    public Optional<UpdateCandidate> check(URI manifestUri, RunningBuild running) throws UpdateException {
+        return exclusive(() -> selector.select(manifests.fetch(manifestUri), running));
+    }
+
+    public PreparedUpdate prepare(UpdateCandidate candidate, Path workspaceCache) throws UpdateException {
+        return exclusive(() -> {
+            Path installer = downloader.download(candidate, workspaceCache);
+            trustVerifier.verify(installer, candidate.artifact().signature());
+            return new PreparedUpdate(candidate, installer);
+        });
+    }
+
+    public InstallerHandoff.HandoffSession stageHandoff(PreparedUpdate update, long parentPid) throws UpdateException {
+        return exclusive(() -> handoff.stage(update.installer(), parentPid));
+    }
+
+    public boolean isOperationActive() {
+        return operationActive.get();
+    }
+
+    private <T> T exclusive(UpdateOperation<T> operation) throws UpdateException {
+        if (!operationActive.compareAndSet(false, true)) {
+            throw new UpdateException("Another update operation is already running");
+        }
+        try {
+            return operation.run();
+        } finally {
+            operationActive.set(false);
+        }
+    }
+
+    @FunctionalInterface
+    private interface UpdateOperation<T> {
+        T run() throws UpdateException;
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateManifest.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateManifest.java
@@ -1,0 +1,13 @@
+package dev.frostguard.update;
+
+import java.util.Map;
+
+public record UpdateManifest(
+        int schemaVersion,
+        String channel,
+        String version,
+        String publishedAt,
+        String minimumUpdaterVersion,
+        String releaseNotesUrl,
+        Map<String, UpdateArtifact> artifacts) {
+}

--- a/modules/update/src/main/java/dev/frostguard/update/UpdatePlatform.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdatePlatform.java
@@ -1,0 +1,77 @@
+package dev.frostguard.update;
+
+import java.util.Locale;
+
+public record UpdatePlatform(OperatingSystem operatingSystem, Architecture architecture) {
+    public UpdatePlatform {
+        if (operatingSystem == null || architecture == null) {
+            throw new IllegalArgumentException("Update platform requires an operating system and architecture");
+        }
+    }
+
+    public String key() {
+        return operatingSystem.id() + "-" + architecture.id();
+    }
+
+    public static UpdatePlatform current() {
+        return new UpdatePlatform(OperatingSystem.detect(System.getProperty("os.name")),
+                Architecture.detect(System.getProperty("os.arch")));
+    }
+
+    public enum OperatingSystem {
+        WINDOWS("windows"), MACOS("macos"), LINUX("linux");
+
+        private final String id;
+
+        OperatingSystem(String id) {
+            this.id = id;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public static OperatingSystem from(String value) {
+            for (OperatingSystem candidate : values()) {
+                if (candidate.id.equalsIgnoreCase(value)) return candidate;
+            }
+            throw new IllegalArgumentException("Unsupported operating system: " + value);
+        }
+
+        static OperatingSystem detect(String value) {
+            String normalized = value == null ? "" : value.toLowerCase(Locale.ROOT);
+            if (normalized.contains("win")) return WINDOWS;
+            if (normalized.contains("mac") || normalized.contains("darwin")) return MACOS;
+            if (normalized.contains("linux")) return LINUX;
+            throw new IllegalStateException("Unsupported operating system: " + value);
+        }
+    }
+
+    public enum Architecture {
+        X64("x64"), ARM64("arm64");
+
+        private final String id;
+
+        Architecture(String id) {
+            this.id = id;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public static Architecture from(String value) {
+            for (Architecture candidate : values()) {
+                if (candidate.id.equalsIgnoreCase(value)) return candidate;
+            }
+            throw new IllegalArgumentException("Unsupported architecture: " + value);
+        }
+
+        static Architecture detect(String value) {
+            String normalized = value == null ? "" : value.toLowerCase(Locale.ROOT);
+            if (normalized.equals("amd64") || normalized.equals("x86_64") || normalized.equals("x64")) return X64;
+            if (normalized.equals("aarch64") || normalized.equals("arm64")) return ARM64;
+            throw new IllegalStateException("Unsupported architecture: " + value);
+        }
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateSelector.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateSelector.java
@@ -1,0 +1,46 @@
+package dev.frostguard.update;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Optional;
+
+public final class UpdateSelector {
+    public Optional<UpdateCandidate> select(UpdateManifest manifest, RunningBuild running) throws UpdateException {
+        if (!running.permitsAutomaticUpdates()) {
+            return Optional.empty();
+        }
+        RuntimeChannel manifestChannel = RuntimeChannel.from(manifest.channel());
+        if (manifestChannel != running.channel()) {
+            throw new UpdateException("Update channel mismatch: running " + running.channel().directoryName()
+                    + ", manifest " + manifestChannel.directoryName());
+        }
+        SemanticVersion minimumUpdater = SemanticVersion.parse(manifest.minimumUpdaterVersion());
+        if (running.updaterVersion().compareTo(minimumUpdater) < 0) {
+            throw new UpdateException("Updater " + running.updaterVersion()
+                    + " is older than required version " + minimumUpdater);
+        }
+        SemanticVersion release = SemanticVersion.parse(manifest.version());
+        if (release.compareTo(running.version()) <= 0) {
+            return Optional.empty();
+        }
+        UpdateArtifact artifact = manifest.artifacts().get(running.platform().key());
+        if (artifact == null) {
+            throw new UpdateException("Manifest has no artifact for " + running.platform().key());
+        }
+        UpdatePlatform artifactPlatform = new UpdatePlatform(
+                UpdatePlatform.OperatingSystem.from(artifact.operatingSystem()),
+                UpdatePlatform.Architecture.from(artifact.architecture()));
+        if (!artifactPlatform.equals(running.platform())) {
+            throw new UpdateException("Selected artifact platform does not match the running application");
+        }
+        String manifestPublisher = artifact.signature() == null ? null : artifact.signature().publisher();
+        if (manifestPublisher == null || !running.authenticodePublisher()
+                .equalsIgnoreCase(manifestPublisher.trim())) {
+            throw new UpdateException("Manifest signer does not match the publisher pinned in this build");
+        }
+        return Optional.of(new UpdateCandidate(manifestChannel, release, Instant.parse(manifest.publishedAt()),
+                URI.create(manifest.releaseNotesUrl()), artifactPlatform, artifact));
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/WindowsAuthenticodeVerifier.java
+++ b/modules/update/src/main/java/dev/frostguard/update/WindowsAuthenticodeVerifier.java
@@ -1,0 +1,61 @@
+package dev.frostguard.update;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+public final class WindowsAuthenticodeVerifier implements InstallerTrustVerifier {
+    private static final String INSTALLER_ENV = "FROSTGUARD_UPDATE_INSTALLER";
+    private static final String POWERSHELL = "$signature = Get-AuthenticodeSignature -LiteralPath $env:"
+            + INSTALLER_ENV + "; if ($null -eq $signature.SignerCertificate) { "
+            + "Write-Output ($signature.Status.ToString() + \"`t\"); exit 0 }; "
+            + "Write-Output ($signature.Status.ToString() + \"`t\" + $signature.SignerCertificate.Subject)";
+
+    private final CommandRunner runner;
+
+    public WindowsAuthenticodeVerifier() {
+        this(new ProcessCommandRunner());
+    }
+
+    WindowsAuthenticodeVerifier(CommandRunner runner) {
+        this.runner = runner;
+    }
+
+    @Override
+    public void verify(Path installer, SignatureRequirement requirement) throws UpdateException {
+        if (!Files.isRegularFile(installer)) {
+            throw new UpdateException("Verified installer does not exist: " + installer);
+        }
+        if (requirement == null || !"authenticode".equalsIgnoreCase(requirement.type())
+                || requirement.publisher() == null || requirement.publisher().isBlank()) {
+            throw new UpdateException("Windows update is missing its Authenticode trust requirement");
+        }
+        try {
+            CommandRunner.CommandResult result = runner.run(List.of(
+                            "powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+                            "-Command", POWERSHELL),
+                    Map.of(INSTALLER_ENV, installer.toAbsolutePath().normalize().toString()), Duration.ofSeconds(30));
+            if (result.exitCode() != 0) {
+                throw new UpdateException("Authenticode verification command failed with exit " + result.exitCode());
+            }
+            String[] fields = result.output().split("\\t", 2);
+            String status = fields.length > 0 ? fields[0].trim() : "";
+            String subject = fields.length > 1 ? fields[1].trim() : "";
+            if (!"valid".equalsIgnoreCase(status)) {
+                throw new UpdateException(
+                        "Installer Authenticode status is " + (status.isBlank() ? "unknown" : status));
+            }
+            if (!subject.equalsIgnoreCase(requirement.publisher().trim())) {
+                throw new UpdateException("Installer signer does not match the required publisher");
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new UpdateException("Authenticode verification was interrupted", exception);
+        } catch (IOException exception) {
+            throw new UpdateException("Authenticode verification failed: " + exception.getMessage(), exception);
+        }
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/WindowsInstallerHandoff.java
+++ b/modules/update/src/main/java/dev/frostguard/update/WindowsInstallerHandoff.java
@@ -1,0 +1,102 @@
+package dev.frostguard.update;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public final class WindowsInstallerHandoff implements InstallerHandoff {
+    static final String INSTALLER_ENV = "FROSTGUARD_UPDATE_INSTALLER";
+    static final String PID_ENV = "FROSTGUARD_UPDATE_PARENT_PID";
+    static final String TOKEN_PATH_ENV = "FROSTGUARD_UPDATE_TOKEN_PATH";
+    static final String TOKEN_VALUE_ENV = "FROSTGUARD_UPDATE_TOKEN_VALUE";
+    private static final String HANDOFF_SCRIPT = "$targetPid = [int]$env:" + PID_ENV + "; "
+            + "$deadline = [DateTime]::UtcNow.AddMinutes(5); "
+            + "while ((Get-Process -Id $targetPid -ErrorAction SilentlyContinue) -and "
+            + "[DateTime]::UtcNow -lt $deadline) { Start-Sleep -Milliseconds 200 }; "
+            + "if (Get-Process -Id $targetPid -ErrorAction SilentlyContinue) { exit 2 }; "
+            + "if (-not (Test-Path -LiteralPath $env:" + TOKEN_PATH_ENV + ")) { exit 3 }; "
+            + "$token = Get-Content -Raw -LiteralPath $env:" + TOKEN_PATH_ENV + "; "
+            + "if ($token -ne $env:" + TOKEN_VALUE_ENV + ") { exit 4 }; "
+            + "Remove-Item -LiteralPath $env:" + TOKEN_PATH_ENV + " -Force; "
+            + "Start-Process -FilePath $env:" + INSTALLER_ENV;
+
+    private final DetachedProcessStarter processStarter;
+
+    public WindowsInstallerHandoff() {
+        this((command, environment) -> {
+            ProcessBuilder builder = new ProcessBuilder(command);
+            builder.environment().putAll(environment);
+            builder.start();
+        });
+    }
+
+    WindowsInstallerHandoff(DetachedProcessStarter processStarter) {
+        this.processStarter = processStarter;
+    }
+
+    @Override
+    public HandoffSession stage(Path installer, long parentPid) throws UpdateException {
+        if (!Files.isRegularFile(installer)) {
+            throw new UpdateException("Installer handoff target does not exist: " + installer);
+        }
+        if (parentPid <= 0) {
+            throw new UpdateException("Installer handoff requires a valid Frostguard process ID");
+        }
+        List<String> command = List.of(
+                "powershell.exe", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden",
+                "-ExecutionPolicy", "Bypass", "-Command", HANDOFF_SCRIPT);
+        String tokenValue = UUID.randomUUID().toString();
+        Path tokenPath = installer.resolveSibling(installer.getFileName() + ".handoff-ready");
+        try {
+            Files.deleteIfExists(tokenPath);
+        } catch (IOException exception) {
+            throw new UpdateException("Could not clear an earlier installer handoff token", exception);
+        }
+        Map<String, String> environment = Map.of(
+                INSTALLER_ENV, installer.toAbsolutePath().normalize().toString(),
+                PID_ENV, Long.toString(parentPid),
+                TOKEN_PATH_ENV, tokenPath.toAbsolutePath().normalize().toString(),
+                TOKEN_VALUE_ENV, tokenValue);
+        try {
+            processStarter.start(command, environment);
+        } catch (IOException exception) {
+            throw new UpdateException(
+                    "Could not start the external installer handoff: " + exception.getMessage(), exception);
+        }
+        return new HandoffSession() {
+            @Override
+            public void authorize() throws UpdateException {
+                Path temporary = tokenPath.resolveSibling(tokenPath.getFileName() + ".tmp");
+                try {
+                    Files.writeString(temporary, tokenValue);
+                    try {
+                        Files.move(temporary, tokenPath, StandardCopyOption.ATOMIC_MOVE,
+                                StandardCopyOption.REPLACE_EXISTING);
+                    } catch (java.nio.file.AtomicMoveNotSupportedException exception) {
+                        Files.move(temporary, tokenPath, StandardCopyOption.REPLACE_EXISTING);
+                    }
+                } catch (IOException exception) {
+                    throw new UpdateException("Could not authorize the installer handoff", exception);
+                }
+            }
+
+            @Override
+            public void cancel() {
+                try {
+                    Files.deleteIfExists(tokenPath);
+                    Files.deleteIfExists(tokenPath.resolveSibling(tokenPath.getFileName() + ".tmp"));
+                } catch (IOException ignored) {
+                }
+            }
+        };
+    }
+
+    @FunctionalInterface
+    interface DetachedProcessStarter {
+        void start(List<String> command, Map<String, String> environment) throws IOException;
+    }
+}

--- a/modules/update/src/test/java/dev/frostguard/update/ManifestCodecTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/ManifestCodecTest.java
@@ -1,0 +1,76 @@
+package dev.frostguard.update;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ManifestCodecTest {
+    private final ManifestCodec codec = new ManifestCodec();
+
+    @Test
+    void acceptsStrictSchemaOneManifest() throws Exception {
+        UpdateManifest manifest = codec.read(validManifest().getBytes(StandardCharsets.UTF_8));
+
+        assertEquals(1, manifest.schemaVersion());
+        assertEquals("stable", manifest.channel());
+        assertEquals("Frostguard-3.0.1-windows-x64.exe",
+                manifest.artifacts().get("windows-x64").fileName());
+    }
+
+    @Test
+    void rejectsUnknownFields() {
+        String json = validManifest().replace("\"schemaVersion\": 1,", "\"schemaVersion\": 1, \"extra\": true,");
+        assertThrows(UpdateException.class, () -> codec.read(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void rejectsUnsupportedSchema() {
+        String json = validManifest().replace("\"schemaVersion\": 1", "\"schemaVersion\": 2");
+        assertThrows(UpdateException.class, () -> codec.read(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void rejectsDevelopmentManifest() {
+        String json = validManifest().replace("\"channel\": \"stable\"", "\"channel\": \"development\"");
+        assertThrows(UpdateException.class, () -> codec.read(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void rejectsMutableOrMismatchedArtifactName() {
+        String json = validManifest().replace("Frostguard-3.0.1-windows-x64.exe", "Frostguard-latest.exe");
+        assertThrows(UpdateException.class, () -> codec.read(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void rejectsUnsignedWindowsArtifact() {
+        String json = validManifest().replace("\"type\": \"authenticode\"", "\"type\": \"none\"");
+        assertThrows(UpdateException.class, () -> codec.read(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    static String validManifest() {
+        return """
+                {
+                  "schemaVersion": 1,
+                  "channel": "stable",
+                  "version": "3.0.1",
+                  "publishedAt": "2026-08-10T04:00:00Z",
+                  "minimumUpdaterVersion": "3.0.0",
+                  "releaseNotesUrl": "https://example.com/releases/3.0.1",
+                  "artifacts": {
+                    "windows-x64": {
+                      "operatingSystem": "windows",
+                      "architecture": "x64",
+                      "fileName": "Frostguard-3.0.1-windows-x64.exe",
+                      "url": "https://example.com/releases/3.0.1/Frostguard-3.0.1-windows-x64.exe",
+                      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                      "size": 123,
+                      "signature": {"type": "authenticode", "publisher": "CN=Frostguard Project, O=Frostguard"}
+                    }
+                  }
+                }
+                """;
+    }
+}

--- a/modules/update/src/test/java/dev/frostguard/update/SemanticVersionTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/SemanticVersionTest.java
@@ -1,0 +1,36 @@
+package dev.frostguard.update;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SemanticVersionTest {
+    @Test
+    void ordersStableAfterPrerelease() {
+        assertTrue(SemanticVersion.parse("3.1.0").compareTo(
+                SemanticVersion.parse("3.1.0-nightly.20260810.1")) > 0);
+    }
+
+    @Test
+    void ordersNumericNightlyBuildsNumerically() {
+        assertTrue(SemanticVersion.parse("3.1.0-nightly.10").compareTo(
+                SemanticVersion.parse("3.1.0-nightly.2")) > 0);
+    }
+
+    @Test
+    void ignoresBuildMetadataForPrecedence() {
+        assertEquals(SemanticVersion.parse("3.0.1+first"), SemanticVersion.parse("3.0.1+second"));
+    }
+
+    @Test
+    void rejectsLeadingZeroInNumericPrerelease() {
+        assertThrows(IllegalArgumentException.class, () -> SemanticVersion.parse("3.0.0-nightly.01"));
+    }
+
+    @Test
+    void rejectsNonSemanticVersion() {
+        assertThrows(IllegalArgumentException.class, () -> SemanticVersion.parse("3.0"));
+    }
+}

--- a/modules/update/src/test/java/dev/frostguard/update/UpdateDownloaderTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/UpdateDownloaderTest.java
@@ -1,0 +1,142 @@
+package dev.frostguard.update;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UpdateDownloaderTest {
+    private static final byte[] INSTALLER = "signed-installer-data".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    @TempDir
+    Path temp;
+
+    @Test
+    void resumesPartialDownloadWithRangeResponse() throws Exception {
+        UpdateCandidate candidate = candidate(INSTALLER, sha256(INSTALLER));
+        Path partial = updateDirectory(candidate).resolve(candidate.artifact().fileName() + ".part");
+        Files.createDirectories(partial.getParent());
+        Files.write(partial, java.util.Arrays.copyOf(INSTALLER, 7));
+        AtomicLong requestedOffset = new AtomicLong();
+        DownloadTransport transport = (uri, offset) -> {
+            requestedOffset.set(offset);
+            return response(206, java.util.Arrays.copyOfRange(INSTALLER, (int) offset, INSTALLER.length));
+        };
+
+        Path result = new UpdateDownloader(transport, new ArtifactVerifier()).download(candidate, temp);
+
+        assertEquals(7L, requestedOffset.get());
+        assertArrayEquals(INSTALLER, Files.readAllBytes(result));
+        assertFalse(Files.exists(partial));
+    }
+
+    @Test
+    void restartsWhenServerIgnoresRange() throws Exception {
+        UpdateCandidate candidate = candidate(INSTALLER, sha256(INSTALLER));
+        Path partial = updateDirectory(candidate).resolve(candidate.artifact().fileName() + ".part");
+        Files.createDirectories(partial.getParent());
+        Files.writeString(partial, "stale");
+
+        Path result = new UpdateDownloader((uri, offset) -> response(200, INSTALLER), new ArtifactVerifier())
+                .download(candidate, temp);
+
+        assertArrayEquals(INSTALLER, Files.readAllBytes(result));
+    }
+
+    @Test
+    void replacesCorruptCompletedDownload() throws Exception {
+        UpdateCandidate candidate = candidate(INSTALLER, sha256(INSTALLER));
+        Path completed = updateDirectory(candidate).resolve(candidate.artifact().fileName());
+        Files.createDirectories(completed.getParent());
+        Files.writeString(completed, "corrupt");
+        AtomicLong requestedOffset = new AtomicLong(-1L);
+
+        Path result = new UpdateDownloader((uri, offset) -> {
+            requestedOffset.set(offset);
+            return response(200, INSTALLER);
+        }, new ArtifactVerifier()).download(candidate, temp);
+
+        assertEquals(0L, requestedOffset.get());
+        assertArrayEquals(INSTALLER, Files.readAllBytes(result));
+    }
+
+    @Test
+    void neverPromotesHashMismatch() throws Exception {
+        UpdateCandidate candidate = candidate(INSTALLER, "a".repeat(64));
+        UpdateDownloader downloader = new UpdateDownloader((uri, offset) -> response(200, INSTALLER),
+                new ArtifactVerifier());
+
+        assertThrows(UpdateException.class, () -> downloader.download(candidate, temp));
+        assertFalse(Files.exists(updateDirectory(candidate).resolve(candidate.artifact().fileName())));
+        assertFalse(Files.exists(updateDirectory(candidate).resolve(candidate.artifact().fileName() + ".part")));
+    }
+
+    @Test
+    void rejectsConcurrentDownloadLock() throws Exception {
+        UpdateCandidate candidate = candidate(INSTALLER, sha256(INSTALLER));
+        Path lockPath = updateDirectory(candidate).resolve(candidate.artifact().fileName() + ".lock");
+        Files.createDirectories(lockPath.getParent());
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            UpdateDownloader downloader = new UpdateDownloader((uri, offset) -> response(200, INSTALLER),
+                    new ArtifactVerifier());
+            assertThrows(UpdateException.class, () -> downloader.download(candidate, temp));
+        }
+    }
+
+    private Path updateDirectory(UpdateCandidate candidate) {
+        return temp.resolve("updates").resolve("stable").resolve(candidate.version().toString());
+    }
+
+    private static UpdateCandidate candidate(byte[] bytes, String hash) {
+        UpdateArtifact artifact = new UpdateArtifact("windows", "x64",
+                "Frostguard-3.0.1-windows-x64.exe",
+                "https://example.com/releases/3.0.1/Frostguard-3.0.1-windows-x64.exe",
+                hash, bytes.length, new SignatureRequirement("authenticode", "CN=Frostguard Project, O=Frostguard"));
+        return new UpdateCandidate(RuntimeChannel.STABLE, SemanticVersion.parse("3.0.1"),
+                java.time.Instant.parse("2026-08-10T04:00:00Z"), URI.create("https://example.com/releases/3.0.1"),
+                UpdateSelectorTest.windowsX64(), artifact);
+    }
+
+    private static DownloadTransport.Response response(int status, byte[] body) {
+        return new DownloadTransport.Response() {
+            private final InputStream input = new ByteArrayInputStream(body);
+
+            @Override
+            public int statusCode() {
+                return status;
+            }
+
+            @Override
+            public InputStream body() {
+                return input;
+            }
+
+            @Override
+            public void close() throws IOException {
+                input.close();
+            }
+        };
+    }
+
+    private static String sha256(byte[] bytes) throws Exception {
+        return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+    }
+}

--- a/modules/update/src/test/java/dev/frostguard/update/UpdateEndpointResolverTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/UpdateEndpointResolverTest.java
@@ -1,0 +1,37 @@
+package dev.frostguard.update;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UpdateEndpointResolverTest {
+    private final UpdateEndpointResolver resolver = new UpdateEndpointResolver();
+
+    @AfterEach
+    void clearProperties() {
+        System.clearProperty(UpdateEndpointResolver.STABLE_PROPERTY);
+        System.clearProperty(UpdateEndpointResolver.NIGHTLY_PROPERTY);
+    }
+
+    @Test
+    void developmentHasNoEndpoint() throws Exception {
+        assertFalse(resolver.resolve(RuntimeChannel.DEVELOPMENT).isPresent());
+    }
+
+    @Test
+    void resolvesChannelSpecificHttpsEndpoint() throws Exception {
+        System.setProperty(UpdateEndpointResolver.STABLE_PROPERTY, "https://updates.example.com/stable.json");
+        assertEquals("https://updates.example.com/stable.json",
+                resolver.resolve(RuntimeChannel.STABLE).orElseThrow().toString());
+    }
+
+    @Test
+    void rejectsInsecureEndpoint() {
+        System.setProperty(UpdateEndpointResolver.STABLE_PROPERTY, "http://updates.example.com/stable.json");
+        assertThrows(UpdateException.class, () -> resolver.resolve(RuntimeChannel.STABLE));
+    }
+}

--- a/modules/update/src/test/java/dev/frostguard/update/UpdateSelectorTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/UpdateSelectorTest.java
@@ -1,0 +1,76 @@
+package dev.frostguard.update;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UpdateSelectorTest {
+    private static final String TRUSTED_PUBLISHER = "CN=Frostguard Project, O=Frostguard";
+    private final ManifestCodec codec = new ManifestCodec();
+    private final UpdateSelector selector = new UpdateSelector();
+
+    @Test
+    void selectsNewerExactPlatformRelease() throws Exception {
+        UpdateCandidate candidate = selector.select(manifest(), running(RuntimeChannel.STABLE, "3.0.0", false)).orElseThrow();
+
+        assertEquals(SemanticVersion.parse("3.0.1"), candidate.version());
+        assertEquals("windows-x64", candidate.platform().key());
+    }
+
+    @Test
+    void ignoresCurrentOrOlderRelease() throws Exception {
+        assertFalse(selector.select(manifest(), running(RuntimeChannel.STABLE, "3.0.1", false)).isPresent());
+    }
+
+    @Test
+    void developmentAndPullRequestBuildsCannotUpdate() throws Exception {
+        assertFalse(selector.select(manifest(), running(RuntimeChannel.DEVELOPMENT, "2.1.0", false)).isPresent());
+        assertFalse(selector.select(manifest(), running(RuntimeChannel.STABLE, "2.1.0", true)).isPresent());
+    }
+
+    @Test
+    void buildWithoutPinnedPublisherCannotUpdate() throws Exception {
+        RunningBuild build = new RunningBuild(SemanticVersion.parse("3.0.0"), SemanticVersion.parse("3.0.0"),
+                RuntimeChannel.STABLE, windowsX64(), false, "");
+        assertFalse(selector.select(manifest(), build).isPresent());
+    }
+
+    @Test
+    void rejectsManifestSignerThatDiffersFromPinnedPublisher() throws Exception {
+        String json = ManifestCodecTest.validManifest().replace(TRUSTED_PUBLISHER, "CN=Unexpected Publisher");
+        UpdateManifest manifest = codec.read(json.getBytes(StandardCharsets.UTF_8));
+        assertThrows(UpdateException.class,
+                () -> selector.select(manifest, running(RuntimeChannel.STABLE, "3.0.0", false)));
+    }
+
+    @Test
+    void rejectsCrossChannelManifest() throws Exception {
+        assertThrows(UpdateException.class,
+                () -> selector.select(manifest(), running(RuntimeChannel.NIGHTLY, "3.0.0", false)));
+    }
+
+    @Test
+    void rejectsUpdaterBelowManifestMinimum() throws Exception {
+        RunningBuild build = new RunningBuild(SemanticVersion.parse("2.9.0"), SemanticVersion.parse("2.9.0"),
+                RuntimeChannel.STABLE, windowsX64(), false, TRUSTED_PUBLISHER);
+        assertThrows(UpdateException.class, () -> selector.select(manifest(), build));
+    }
+
+    private UpdateManifest manifest() throws Exception {
+        return codec.read(ManifestCodecTest.validManifest().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static RunningBuild running(RuntimeChannel channel, String version, boolean pullRequest) {
+        return new RunningBuild(SemanticVersion.parse(version), SemanticVersion.parse(version),
+                channel, windowsX64(), pullRequest, TRUSTED_PUBLISHER);
+    }
+
+    static UpdatePlatform windowsX64() {
+        return new UpdatePlatform(UpdatePlatform.OperatingSystem.WINDOWS, UpdatePlatform.Architecture.X64);
+    }
+}

--- a/modules/update/src/test/java/dev/frostguard/update/WindowsAuthenticodeVerifierTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/WindowsAuthenticodeVerifierTest.java
@@ -1,0 +1,56 @@
+package dev.frostguard.update;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WindowsAuthenticodeVerifierTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void acceptsValidExpectedPublisher() throws Exception {
+        Path installer = Files.writeString(temp.resolve("installer.exe"), "test");
+        WindowsAuthenticodeVerifier verifier = new WindowsAuthenticodeVerifier(
+                (command, environment, timeout) -> new CommandRunner.CommandResult(
+                        0, "Valid\tCN=Frostguard Project, O=Frostguard"));
+
+        assertDoesNotThrow(() -> verifier.verify(installer,
+                new SignatureRequirement("authenticode", "CN=Frostguard Project, O=Frostguard")));
+    }
+
+    @Test
+    void rejectsUnsignedInstaller() throws Exception {
+        Path installer = Files.writeString(temp.resolve("installer.exe"), "test");
+        WindowsAuthenticodeVerifier verifier = new WindowsAuthenticodeVerifier(
+                (command, environment, timeout) -> new CommandRunner.CommandResult(0, "NotSigned\t"));
+
+        assertThrows(UpdateException.class, () -> verifier.verify(installer,
+                new SignatureRequirement("authenticode", "Frostguard Project")));
+    }
+
+    @Test
+    void rejectsUnexpectedPublisher() throws Exception {
+        Path installer = Files.writeString(temp.resolve("installer.exe"), "test");
+        WindowsAuthenticodeVerifier verifier = new WindowsAuthenticodeVerifier(
+                (command, environment, timeout) -> new CommandRunner.CommandResult(0, "Valid\tCN=Someone Else"));
+
+        assertThrows(UpdateException.class, () -> verifier.verify(installer,
+                new SignatureRequirement("authenticode", "Frostguard Project")));
+    }
+
+    @Test
+    void rejectsMissingInstallerBeforeRunningPowerShell() {
+        WindowsAuthenticodeVerifier verifier = new WindowsAuthenticodeVerifier(
+                (command, environment, timeout) -> {
+                    throw new AssertionError("PowerShell should not run");
+                });
+        assertThrows(UpdateException.class, () -> verifier.verify(temp.resolve("missing.exe"),
+                new SignatureRequirement("authenticode", "Frostguard Project")));
+    }
+}

--- a/modules/update/src/test/java/dev/frostguard/update/WindowsInstallerHandoffTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/WindowsInstallerHandoffTest.java
@@ -1,0 +1,60 @@
+package dev.frostguard.update;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WindowsInstallerHandoffTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void startsHiddenWaiterWithInstallerAndParentIdentity() throws Exception {
+        Path installer = Files.writeString(temp.resolve("Frostguard-3.0.1.exe"), "test");
+        AtomicReference<java.util.List<String>> command = new AtomicReference<>();
+        AtomicReference<java.util.Map<String, String>> environment = new AtomicReference<>();
+        WindowsInstallerHandoff handoff = new WindowsInstallerHandoff((actualCommand, actualEnvironment) -> {
+            command.set(actualCommand);
+            environment.set(actualEnvironment);
+        });
+
+        InstallerHandoff.HandoffSession session = handoff.stage(installer, 4242L);
+
+        assertTrue(command.get().contains("Hidden"));
+        assertTrue(command.get().getLast().contains("Get-Process -Id $targetPid"));
+        assertEquals("4242", environment.get().get(WindowsInstallerHandoff.PID_ENV));
+        assertEquals(installer.toAbsolutePath().normalize().toString(),
+                environment.get().get(WindowsInstallerHandoff.INSTALLER_ENV));
+        Path token = Path.of(environment.get().get(WindowsInstallerHandoff.TOKEN_PATH_ENV));
+        assertTrue(command.get().getLast().contains("TOKEN_PATH"));
+        session.authorize();
+        assertEquals(environment.get().get(WindowsInstallerHandoff.TOKEN_VALUE_ENV), Files.readString(token));
+        session.cancel();
+        assertTrue(Files.notExists(token));
+    }
+
+    @Test
+    void rejectsInvalidInputsBeforeStartingWaiter() {
+        WindowsInstallerHandoff handoff = new WindowsInstallerHandoff((command, environment) -> {
+            throw new AssertionError("Waiter should not start");
+        });
+        assertThrows(UpdateException.class, () -> handoff.stage(temp.resolve("missing.exe"), 10L));
+    }
+
+    @Test
+    void reportsWaiterLaunchFailure() throws Exception {
+        Path installer = Files.writeString(temp.resolve("Frostguard-3.0.1.exe"), "test");
+        WindowsInstallerHandoff handoff = new WindowsInstallerHandoff((command, environment) -> {
+            throw new IOException("blocked");
+        });
+        assertThrows(UpdateException.class, () -> handoff.stage(installer, 10L));
+    }
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/logging/ProfileContextLogger.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/logging/ProfileContextLogger.java
@@ -3,10 +3,10 @@ package dev.frostguard.vision.logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 import java.io.*;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
@@ -62,7 +62,7 @@ public final class ProfileContextLogger {
 
     private void ensureLogDirectory() {
         try {
-            Files.createDirectories(Paths.get("logs"));
+            Files.createDirectories(WorkspacePaths.current().logs());
         } catch (IOException e) {
             rootLog.error("Base directory creation failed: {}", e.getMessage());
         }
@@ -71,8 +71,8 @@ public final class ProfileContextLogger {
     private synchronized void initWriter(AccountDescriptor acc) throws IOException {
         if (writerRegistry.containsKey(acc.getId())) return;
 
-        String path = String.format("logs/account_%s_%d.log", cleanPath(acc.getName()), acc.getId());
-        File handle = new File(path);
+        File handle = WorkspacePaths.current().logs()
+                .resolve(String.format("account_%s_%d.log", cleanPath(acc.getName()), acc.getId())).toFile();
 
         if (handle.exists() && handle.length() > MAX_BYTES) {
             rollover(handle);
@@ -186,8 +186,8 @@ public final class ProfileContextLogger {
     private void enforceSizeLimit() {
         if (profile == null) return;
         
-        String path = String.format("logs/account_%s_%d.log", cleanPath(profile.getName()), profile.getId());
-        File handle = new File(path);
+        File handle = WorkspacePaths.current().logs()
+                .resolve(String.format("account_%s_%d.log", cleanPath(profile.getName()), profile.getId())).toFile();
         
         if (handle.exists() && handle.length() > MAX_BYTES) {
             try {

--- a/modules/vision/src/main/java/dev/frostguard/vision/match/OpenCvPatternLocator.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/match/OpenCvPatternLocator.java
@@ -29,6 +29,7 @@ import dev.frostguard.api.domain.SizeData;
 import dev.frostguard.api.configs.TemplatesEnum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 /**
  * Performs normalised cross-correlation between device screen captures
@@ -1943,7 +1944,7 @@ public class OpenCvPatternLocator {
         String[] segments = resourcePath.split("/");
         String fileName = segments[segments.length - 1];
 
-        Path targetDir = Path.of("lib", "opencv");
+        Path targetDir = WorkspacePaths.current().cache().resolve("native").resolve("opencv");
         Files.createDirectories(targetDir);
         Path dest = targetDir.resolve(fileName);
 

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
@@ -21,6 +21,7 @@ import net.sourceforge.tess4j.Tesseract;
 import net.sourceforge.tess4j.TesseractException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import dev.frostguard.api.runtime.WorkspacePaths;
 
 /**
  * Provides text recognition from captured device screens or local image
@@ -364,14 +365,14 @@ public final class TesseractOcrProvider {
     // =====================================================================
 
     /**
-     * Writes a side-by-side diagnostic PNG to {@code <cwd>/temp/}.
+     * Writes a side-by-side diagnostic PNG to the active workspace cache.
      */
     private static void exportDiagnosticImage(RawImageData capture, BufferedImage processed,
             int cx, int cy, int cw, int ch,
             TesseractSettingsData cfg, String text) {
         long t0 = System.currentTimeMillis();
         try {
-            Path tempDir = Paths.get(System.getProperty("user.dir")).resolve("temp");
+            Path tempDir = WorkspacePaths.current().cache().resolve("ocr");
             Files.createDirectories(tempDir);
 
             String summary = formatSettingsSummary(cfg, text);

--- a/modules/watcher/pom.xml
+++ b/modules/watcher/pom.xml
@@ -18,6 +18,10 @@
 
 	<!-- ─── Runtime dependencies ─── -->
 	<dependencies>
+		<dependency>
+			<groupId>dev.frostguard</groupId>
+			<artifactId>frostguard-api</artifactId>
+		</dependency>
 		<!-- JSON serialisation (version managed by parent) -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/modules/watcher/pom.xml
+++ b/modules/watcher/pom.xml
@@ -40,6 +40,11 @@
 			<artifactId>logback-classic</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<!-- ─── Build plugins ─── -->

--- a/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
+++ b/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
@@ -1,5 +1,7 @@
 package dev.frostguard.watcher;
 
+import dev.frostguard.api.runtime.WorkspacePaths;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -19,7 +21,6 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.Properties;
@@ -43,10 +44,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * Everything else is forwarded to http://127.0.0.1:{localPort}/command.
  * Callback queries (inline keyboard taps) are also forwarded to the app.
  *
- * Single-instance guarantee: a FileLock on %USERPROFILE%/.frostguard/watcher.lock
- * prevents multiple watcher processes from running simultaneously.
+ * Single-instance guarantee: a FileLock in the selected workspace's watcher
+ * directory prevents duplicate watcher processes for that workspace.
  *
- * Configuration: %USERPROFILE%\.frostguard\telegram-watcher.properties
+ * Configuration: &lt;workspace&gt;/watcher/telegram-watcher.properties
  *   token=<BotFather token>
  *   chatId=<your Telegram numeric chat-ID>
  *   botJarPath=<absolute path to frostguard-x.x.x.jar>
@@ -57,10 +58,9 @@ public class TelegramWatcher {
     private static final Logger logger = LoggerFactory.getLogger(TelegramWatcher.class);
     private static final String API_BASE         = "https://api.telegram.org/bot";
     private static final int    LONG_POLL_TIMEOUT = 30;
-    private static final int    DEFAULT_LOCAL_PORT = 8765;
 
     public static Path configFilePath() {
-        return Paths.get(System.getProperty("user.home"), ".frostguard", "telegram-watcher.properties");
+        return WorkspacePaths.current().watcherConfig();
     }
 
     // ── entry point ───────────────────────────────────────────────────────────
@@ -72,7 +72,7 @@ public class TelegramWatcher {
         System.out.println("==============================================");
 
         // ── Single-instance lock ───────────────────────────────────────────────
-        Path lockFilePath = configFilePath().resolveSibling("watcher.lock");
+        Path lockFilePath = WorkspacePaths.current().watcherLock();
         Files.createDirectories(lockFilePath.getParent());
         FileChannel lockChannel = FileChannel.open(lockFilePath,
                 StandardOpenOption.CREATE, StandardOpenOption.WRITE);
@@ -94,9 +94,10 @@ public class TelegramWatcher {
         int    localPort;
         try {
             localPort = Integer.parseInt(
-                    cfg.getProperty("localPort", String.valueOf(DEFAULT_LOCAL_PORT)).trim());
+                    cfg.getProperty("localPort",
+                            String.valueOf(WorkspacePaths.current().defaultLocalPort())).trim());
         } catch (NumberFormatException e) {
-            localPort = DEFAULT_LOCAL_PORT;
+            localPort = WorkspacePaths.current().defaultLocalPort();
         }
 
         if (token.isBlank()) {
@@ -127,6 +128,7 @@ public class TelegramWatcher {
     private final File          botJar;
     private final File          botJarDir;
     private final int           localPort;
+    private final String        workspaceId;
     private final HttpClient    httpClient;
     private final ObjectMapper  mapper = new ObjectMapper();
 
@@ -144,6 +146,7 @@ public class TelegramWatcher {
         this.botJar        = new File(jarPath);
         this.botJarDir     = botJar.getParentFile();
         this.localPort     = localPort;
+        this.workspaceId   = WorkspacePaths.current().identity();
         this.httpClient    = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
@@ -271,9 +274,15 @@ public class TelegramWatcher {
             }
             try {
                 String javaExe = ProcessHandle.current().info().command().orElse("java");
-                ProcessBuilder pb = headless
-                        ? new ProcessBuilder(javaExe, "-jar", botJar.getName(), "--headless")
-                        : new ProcessBuilder(javaExe, "-jar", botJar.getName());
+                java.util.List<String> command = new java.util.ArrayList<>();
+                command.add(javaExe);
+                command.add("-D" + WorkspacePaths.WORKSPACE_PROPERTY + "=" + WorkspacePaths.current().root());
+                command.add("-D" + WorkspacePaths.CHANNEL_PROPERTY + "="
+                        + WorkspacePaths.current().channel().directoryName());
+                command.add("-jar");
+                command.add(botJar.getAbsolutePath());
+                if (headless) command.add("--headless");
+                ProcessBuilder pb = new ProcessBuilder(command);
                 
                 // Use the parent of the bot jar as the working directory, unless it's in a 'target' dir
                 // (to support Maven multi-module dev workflows where the root is one level up).
@@ -283,9 +292,6 @@ public class TelegramWatcher {
                     workDir = botJarDir.getParentFile().getParentFile().getParentFile();
                 }
                 pb.directory(workDir);
-
-                // When changing workDir, we must execute the jar using a path relative to workDir or absolute path.
-                pb.command().set(2, botJar.getAbsolutePath());
 
                 pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
                 pb.redirectError(ProcessBuilder.Redirect.DISCARD);
@@ -319,22 +325,7 @@ public class TelegramWatcher {
         }
         
         // Try to get the PID from the bot's command server
-        Long remotePid = null;
-        try {
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create("http://127.0.0.1:" + localPort + "/pid"))
-                    .timeout(Duration.ofSeconds(2))
-                    .GET()
-                    .build();
-            HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            if (resp.statusCode() == 200) {
-                JsonNode json = mapper.readTree(resp.body());
-                remotePid = json.path("pid").asLong(-1);
-                if (remotePid == -1) remotePid = null;
-            }
-        } catch (Exception e) {
-            logger.debug("Could not get PID from /pid endpoint: {}", e.getMessage());
-        }
+        Long remotePid = fetchWorkspacePid();
         
         // If we got a PID from the server, kill that process
         if (remotePid != null) {
@@ -367,6 +358,7 @@ public class TelegramWatcher {
                         || cmdLine.contains("dev.frostguard.app.bootstrap.Main")
                         || cmdLine.contains("dev.frostguard.app.bootstrap.FXApp")
                         || cmdLine.contains("dev.frostguard.app.bootstrap.HeadlessApp");
+                    matches = matches && cmdLine.contains(WorkspacePaths.current().root().toString());
                     
                     if (matches) {
                         logger.debug("Found matching process PID {}: {}", ph.pid(), cmdLine);
@@ -412,6 +404,7 @@ public class TelegramWatcher {
             body.put("type",   "message");
             body.put("chatId", chatId);
             body.put("text",   text);
+            body.put("workspaceId", workspaceId);
 
             HttpRequest req = HttpRequest.newBuilder()
                     .uri(URI.create("http://127.0.0.1:" + localPort + "/command"))
@@ -441,6 +434,7 @@ public class TelegramWatcher {
             body.put("messageId",  messageId);
             body.put("callbackId", callbackId);
             body.put("data",       data);
+            body.put("workspaceId", workspaceId);
 
             HttpRequest req = HttpRequest.newBuilder()
                     .uri(URI.create("http://127.0.0.1:" + localPort + "/command"))
@@ -469,27 +463,8 @@ public class TelegramWatcher {
             botProcess = null; // clear stale reference
         }
         
-        // Try to connect to the bot's command server as a reliable check
-        // If the server responds (even with an error), the bot is definitely running
-        try {
-            ObjectNode testBody = mapper.createObjectNode();
-            testBody.put("type", "ping");
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create("http://127.0.0.1:" + localPort + "/command"))
-                    .timeout(Duration.ofSeconds(1))
-                    .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(testBody.toString()))
-                    .build();
-            httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            // If we get ANY response (success or error), the server is up
+        if (fetchWorkspacePid() != null) {
             logger.debug("Bot process alive via network check on port {}", localPort);
-            return true;
-        } catch (ConnectException e) {
-            // Connection refused = server not running, continue to process search
-            logger.debug("Network check failed (connection refused), trying process search");
-        } catch (Exception e) {
-            // Any other response (including errors) means the server is up
-            logger.debug("Bot process alive via network check (got response: {})", e.getClass().getSimpleName());
             return true;
         }
         
@@ -498,10 +473,11 @@ public class TelegramWatcher {
                 .filter(ph -> ph.info().command().map(c -> c.toLowerCase().contains("java")).orElse(false))
                 .filter(ph -> {
                     String cmd = ph.info().commandLine().orElse("");
-                    return cmd.contains(botJar.getName())
+                    boolean matchesApp = cmd.contains(botJar.getName())
                         || cmd.contains("dev.frostguard.app.bootstrap.Main")
                         || cmd.contains("dev.frostguard.app.bootstrap.FXApp")
                         || cmd.contains("dev.frostguard.app.bootstrap.HeadlessApp");
+                    return matchesApp && cmd.contains(WorkspacePaths.current().root().toString());
                 })
                 .findFirst()
                 .isPresent();
@@ -512,6 +488,34 @@ public class TelegramWatcher {
             logger.debug("Bot process not found via any method");
         }
         return found;
+    }
+
+    private Long fetchWorkspacePid() {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + localPort + "/pid"))
+                    .timeout(Duration.ofSeconds(2))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                logger.debug("PID endpoint on port {} replied HTTP {}", localPort, response.statusCode());
+                return null;
+            }
+            JsonNode json = mapper.readTree(response.body());
+            if (!workspaceId.equals(json.path("workspaceId").asText())) {
+                logger.warn("Ignoring command server on port {} because it belongs to another workspace", localPort);
+                return null;
+            }
+            long pid = json.path("pid").asLong(-1);
+            return pid > 0 ? pid : null;
+        } catch (ConnectException connectionRefused) {
+            logger.debug("No command server listening on port {}", localPort);
+            return null;
+        } catch (Exception failure) {
+            logger.debug("Could not read matching PID from port {}: {}", localPort, failure.getMessage());
+            return null;
+        }
     }
 
     private static String buildHelpMessage() {
@@ -616,7 +620,7 @@ public class TelegramWatcher {
                   + "token=\n"
                   + "chatId=\n"
                   + "botJarPath=\n"
-                  + "localPort=8765\n");
+                  + "localPort=" + WorkspacePaths.current().defaultLocalPort() + "\n");
             System.out.println("[INFO] Created config template at: " + cfg);
         }
         Properties props = new Properties();

--- a/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
+++ b/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
@@ -1,6 +1,7 @@
 package dev.frostguard.watcher;
 
 import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.api.runtime.WorkspaceSession;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,6 +20,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -58,6 +60,9 @@ public class TelegramWatcher {
     private static final Logger logger = LoggerFactory.getLogger(TelegramWatcher.class);
     private static final String API_BASE         = "https://api.telegram.org/bot";
     private static final int    LONG_POLL_TIMEOUT = 30;
+    private static final String APP_LAUNCHER_PROPERTY = "frostguard.launcher";
+    private static final String WATCHER_LAUNCHER_PROPERTY = "frostguard.watcher.launcher";
+    private static final String NATIVE_SMOKE_ARGUMENT = "--frostguard-native-smoke-test";
 
     public static Path configFilePath() {
         return WorkspacePaths.current().watcherConfig();
@@ -66,6 +71,19 @@ public class TelegramWatcher {
     // ── entry point ───────────────────────────────────────────────────────────
 
     public static void main(String[] args) throws Exception {
+        WorkspacePaths workspace = WorkspacePaths.current();
+        WorkspaceSession.initializeLayout(workspace);
+        if (java.util.Arrays.asList(args).contains(NATIVE_SMOKE_ARGUMENT)) {
+            loadConfig();
+            Files.writeString(workspace.cache().resolve("native-watcher-smoke.properties"),
+                    "channel=" + workspace.channel().directoryName() + "\n"
+                            + "workspace=" + workspace.root() + "\n"
+                            + "applicationDir=" + System.getProperty("user.dir") + "\n"
+                            + "appLauncher=" + System.getProperty(APP_LAUNCHER_PROPERTY, "") + "\n"
+                            + "watcherLauncher=" + System.getProperty(WATCHER_LAUNCHER_PROPERTY, "") + "\n",
+                    StandardCharsets.UTF_8);
+            return;
+        }
         System.out.println("==============================================");
         System.out.println("  Frostguard – Telegram Watcher");
         System.out.println("  Config: " + configFilePath());
@@ -127,6 +145,7 @@ public class TelegramWatcher {
     private final long          allowedChatId;
     private final File          botJar;
     private final File          botJarDir;
+    private final File          botLauncher;
     private final int           localPort;
     private final String        workspaceId;
     private final HttpClient    httpClient;
@@ -145,6 +164,8 @@ public class TelegramWatcher {
         this.allowedChatId = allowedChatId;
         this.botJar        = new File(jarPath);
         this.botJarDir     = botJar.getParentFile();
+        String launcherPath = System.getProperty(APP_LAUNCHER_PROPERTY, "").trim();
+        this.botLauncher   = launcherPath.isBlank() ? null : new File(launcherPath);
         this.localPort     = localPort;
         this.workspaceId   = WorkspacePaths.current().identity();
         this.httpClient    = HttpClient.newBuilder()
@@ -267,29 +288,32 @@ public class TelegramWatcher {
                 sendMessage(chatId, "ℹ️ Bot app is already running.");
                 return;
             }
-            if (!botJar.exists()) {
+            if ((botLauncher == null || !botLauncher.isFile()) && !botJar.exists()) {
                 sendMessage(chatId, "❌ JAR not found at:\n`" + botJar.getAbsolutePath()
                         + "`\nCheck the path in the Telegram config panel.");
                 return;
             }
             try {
                 String javaExe = ProcessHandle.current().info().command().orElse("java");
-                java.util.List<String> command = new java.util.ArrayList<>();
-                command.add(javaExe);
-                command.add("-D" + WorkspacePaths.WORKSPACE_PROPERTY + "=" + WorkspacePaths.current().root());
-                command.add("-D" + WorkspacePaths.CHANNEL_PROPERTY + "="
-                        + WorkspacePaths.current().channel().directoryName());
-                command.add("-jar");
-                command.add(botJar.getAbsolutePath());
-                if (headless) command.add("--headless");
+                java.util.List<String> command = botLaunchCommand(
+                        botLauncher == null ? null : botLauncher.toPath(),
+                        Path.of(javaExe), botJar.toPath(), WorkspacePaths.current(), headless);
                 ProcessBuilder pb = new ProcessBuilder(command);
                 
                 // Use the parent of the bot jar as the working directory, unless it's in a 'target' dir
                 // (to support Maven multi-module dev workflows where the root is one level up).
-                File workDir = botJarDir;
-                if ("target".equalsIgnoreCase(botJarDir.getName())
-                        && botJarDir.toPath().endsWith(Path.of("modules", "desktop", "target"))) {
-                    workDir = botJarDir.getParentFile().getParentFile().getParentFile();
+                File workDir;
+                if (botLauncher != null && botLauncher.isFile()) {
+                    workDir = botLauncher.getParentFile();
+                    pb.environment().put("FROSTGUARD_WORKSPACE", WorkspacePaths.current().root().toString());
+                    pb.environment().put("FROSTGUARD_CHANNEL",
+                            WorkspacePaths.current().channel().directoryName());
+                } else {
+                    workDir = botJarDir;
+                    if ("target".equalsIgnoreCase(botJarDir.getName())
+                            && botJarDir.toPath().endsWith(Path.of("modules", "desktop", "target"))) {
+                        workDir = botJarDir.getParentFile().getParentFile().getParentFile();
+                    }
                 }
                 pb.directory(workDir);
 
@@ -306,6 +330,25 @@ public class TelegramWatcher {
         } finally {
             launchLock.unlock();
         }
+    }
+
+    static java.util.List<String> botLaunchCommand(Path nativeLauncher, Path javaExecutable,
+            Path botJar, WorkspacePaths workspace, boolean headless) {
+        java.util.List<String> command = new java.util.ArrayList<>();
+        if (nativeLauncher != null) {
+            command.add(nativeLauncher.toAbsolutePath().normalize().toString());
+        } else {
+            command.add(javaExecutable.toString());
+            command.add("-D" + WorkspacePaths.WORKSPACE_PROPERTY + "=" + workspace.root());
+            command.add("-D" + WorkspacePaths.CHANNEL_PROPERTY + "="
+                    + workspace.channel().directoryName());
+            command.add("-jar");
+            command.add(botJar.toAbsolutePath().normalize().toString());
+        }
+        if (headless) {
+            command.add("--headless");
+        }
+        return command;
     }
 
     private void handleKill(long chatId) {

--- a/modules/watcher/src/test/java/dev/frostguard/watcher/TelegramWatcherTest.java
+++ b/modules/watcher/src/test/java/dev/frostguard/watcher/TelegramWatcherTest.java
@@ -1,0 +1,42 @@
+package dev.frostguard.watcher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+class TelegramWatcherTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void packagedWatcherLaunchesTheNativeApplication() {
+        Path launcher = tempDir.resolve("Frostguard.exe");
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("Bot 1"), RuntimeChannel.STABLE);
+
+        assertEquals(List.of(launcher.toAbsolutePath().toString(), "--headless"),
+                TelegramWatcher.botLaunchCommand(launcher, Path.of("java"),
+                        tempDir.resolve("frostguard.jar"), workspace, true));
+    }
+
+    @Test
+    void sourceWatcherPreservesWorkspaceThroughJvmOptions() {
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("Bot 1"), RuntimeChannel.DEVELOPMENT);
+        Path jar = tempDir.resolve("frostguard.jar");
+
+        assertEquals(List.of(
+                "java",
+                "-Dfrostguard.workspace=" + workspace.root(),
+                "-Dfrostguard.channel=development",
+                "-jar",
+                jar.toAbsolutePath().toString()),
+                TelegramWatcher.botLaunchCommand(null, Path.of("java"), jar, workspace, false));
+    }
+}

--- a/packaging/desktop/pom.xml
+++ b/packaging/desktop/pom.xml
@@ -13,7 +13,7 @@
 
     <artifactId>frostguard-desktop-package</artifactId>
     <name>Frostguard Desktop Packaging</name>
-    <description>Platform packaging inputs and transitional desktop bundle</description>
+    <description>Platform packaging inputs, native application images, and installers</description>
     <packaging>pom</packaging>
 
     <dependencies>
@@ -114,6 +114,59 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>stage-template-browser-assets</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/input/templates</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.parent.basedir}/modules/vision/src/main/resources/templates</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stage-custom-task-examples</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/input/custom_tasks</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.parent.basedir}/examples/custom-tasks</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>prepare-jpackage-launchers</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/jpackage</outputDirectory>
+                            <encoding>UTF-8</encoding>
+                            <propertiesEncoding>UTF-8</propertiesEncoding>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/src/main/windows</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>Frostguard-Watcher.properties</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -138,4 +191,155 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>windows-app-image</id>
+            <activation>
+                <property>
+                    <name>windows.app.image</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-windows-app-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <condition property="jpackage.executable"
+                                                value="${java.home}/bin/jpackage.exe"
+                                                else="${java.home}/bin/jpackage">
+                                            <os family="windows" />
+                                        </condition>
+                                        <delete dir="${project.build.directory}/app-image/Frostguard" />
+                                        <mkdir dir="${project.build.directory}/app-image" />
+                                        <exec executable="powershell.exe" failonerror="true">
+                                            <arg value="-NoProfile" />
+                                            <arg value="-NonInteractive" />
+                                            <arg value="-ExecutionPolicy" />
+                                            <arg value="Bypass" />
+                                            <arg value="-File" />
+                                            <arg path="${maven.multiModuleProjectDirectory}/build-support/packaging/write_windows_icon.ps1" />
+                                            <arg value="-InputPath" />
+                                            <arg path="${maven.multiModuleProjectDirectory}/modules/desktop/src/main/resources/icons/appIcon.png" />
+                                            <arg value="-OutputPath" />
+                                            <arg path="${project.build.directory}/jpackage/Frostguard.ico" />
+                                        </exec>
+                                        <exec executable="${jpackage.executable}" failonerror="true">
+                                            <arg value="--type" />
+                                            <arg value="app-image" />
+                                            <arg value="--dest" />
+                                            <arg path="${project.build.directory}/app-image" />
+                                            <arg value="--input" />
+                                            <arg path="${project.build.directory}/input" />
+                                            <arg value="--name" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--app-version" />
+                                            <arg value="${project.version}" />
+                                            <arg value="--vendor" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--description" />
+                                            <arg value="Frostguard automation desktop application" />
+                                            <arg value="--icon" />
+                                            <arg path="${project.build.directory}/jpackage/Frostguard.ico" />
+                                            <arg value="--main-jar" />
+                                            <arg value="frostguard-desktop-${project.version}.jar" />
+                                            <arg value="--main-class" />
+                                            <arg value="dev.frostguard.app.bootstrap.Main" />
+                                            <arg value="--java-options" />
+                                            <arg value="--enable-native-access=ALL-UNNAMED" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Dfrostguard.channel=stable" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Duser.dir=$APPDIR" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Dfrostguard.launcher=$APPDIR/../Frostguard.exe" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe" />
+                                            <arg value="--add-launcher" />
+                                            <arg value="FrostguardWatcher=${project.build.directory}/jpackage/Frostguard-Watcher.properties" />
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>windows-installer</id>
+            <activation>
+                <property>
+                    <name>windows.installer</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-windows-installer</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <condition property="jpackage.executable"
+                                                value="${java.home}/bin/jpackage.exe"
+                                                else="${java.home}/bin/jpackage">
+                                            <os family="windows" />
+                                        </condition>
+                                        <delete dir="${project.build.directory}/installers" />
+                                        <mkdir dir="${project.build.directory}/installers" />
+                                        <exec executable="${jpackage.executable}" failonerror="true">
+                                            <arg value="--verbose" />
+                                            <arg value="--type" />
+                                            <arg value="exe" />
+                                            <arg value="--dest" />
+                                            <arg path="${project.build.directory}/installers" />
+                                            <arg value="--name" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--app-version" />
+                                            <arg value="${project.version}" />
+                                            <arg value="--vendor" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--description" />
+                                            <arg value="Frostguard automation desktop application" />
+                                            <arg value="--app-image" />
+                                            <arg path="${project.build.directory}/app-image/Frostguard" />
+                                            <!-- Nested per-user install paths can trigger inconsistent WiX
+                                                 directory validation (JDK-8226534). -->
+                                            <arg value="--install-dir" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--win-per-user-install" />
+                                            <arg value="--win-dir-chooser" />
+                                            <arg value="--win-menu" />
+                                            <arg value="--win-menu-group" />
+                                            <arg value="Frostguard" />
+                                            <arg value="--win-shortcut-prompt" />
+                                            <arg value="--win-upgrade-uuid" />
+                                            <arg value="fa0d66f6-1f7d-4da8-9701-88f7b4570797" />
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/packaging/desktop/pom.xml
+++ b/packaging/desktop/pom.xml
@@ -70,7 +70,7 @@
                             <outputDirectory>${project.build.directory}/input/lib</outputDirectory>
                             <includeScope>runtime</includeScope>
                             <excludeArtifactIds>frostguard-desktop,frostguard-watcher</excludeArtifactIds>
-                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteReleases>true</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
                         </configuration>
@@ -258,6 +258,10 @@
                                             <arg value="--enable-native-access=ALL-UNNAMED" />
                                             <arg value="--java-options" />
                                             <arg value="-Dfrostguard.channel=stable" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Dfrostguard.update.pullRequestBuild=${frostguard.pull-request-build}" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Dfrostguard.update.manifest.stable=${frostguard.update.manifest.stable}" />
                                             <arg value="--java-options" />
                                             <arg value="-Duser.dir=$APPDIR" />
                                             <arg value="--java-options" />

--- a/packaging/desktop/src/main/common/zip.xml
+++ b/packaging/desktop/src/main/common/zip.xml
@@ -11,9 +11,5 @@
     <fileSets>
         <fileSet><directory>${project.build.directory}/input</directory><outputDirectory>.</outputDirectory><useDefaultExcludes>true</useDefaultExcludes><fileMode>0644</fileMode><directoryMode>0755</directoryMode><includes><include>**/*</include></includes><excludes><exclude>**/*.lastUpdated</exclude><exclude>**/_remote.repositories</exclude><exclude>lib/adb/**</exclude></excludes></fileSet>
         <fileSet><directory>${project.build.directory}/input/lib/adb</directory><outputDirectory>lib/adb</outputDirectory><useDefaultExcludes>true</useDefaultExcludes><fileMode>0755</fileMode><directoryMode>0755</directoryMode><includes><include>**/*</include></includes><excludes><exclude>**/*.tmp</exclude></excludes></fileSet>
-        <fileSet><directory>${project.parent.basedir}/examples/custom-tasks</directory><outputDirectory>custom_tasks</outputDirectory><useDefaultExcludes>true</useDefaultExcludes><fileMode>0644</fileMode><directoryMode>0755</directoryMode><includes><include>**/*</include></includes></fileSet>
-        <!-- pernerch/2026-07-02: Include 361 template PNG files in distribution ZIP for Debugging UI template search -->
-        <!-- Templates are used for image pattern matching in the Image Recognition debugging tool -->
-        <fileSet><directory>${project.parent.basedir}/modules/vision/src/main/resources/templates</directory><outputDirectory>templates</outputDirectory><useDefaultExcludes>true</useDefaultExcludes><fileMode>0644</fileMode><directoryMode>0755</directoryMode><includes><include>**/*</include></includes></fileSet>
     </fileSets>
 </assembly>

--- a/packaging/desktop/src/main/windows/Frostguard-Watcher.properties
+++ b/packaging/desktop/src/main/windows/Frostguard-Watcher.properties
@@ -1,0 +1,4 @@
+main-jar=frostguard-watcher-${project.version}.jar
+main-class=dev.frostguard.watcher.TelegramWatcher
+description=Frostguard Telegram Watcher
+java-options=--enable-native-access=ALL-UNNAMED -Dfrostguard.channel=stable "-Duser.dir=$APPDIR" "-Dfrostguard.launcher=$APPDIR/../Frostguard.exe" "-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe"

--- a/packaging/desktop/src/main/windows/Frostguard-Watcher.properties
+++ b/packaging/desktop/src/main/windows/Frostguard-Watcher.properties
@@ -1,4 +1,4 @@
 main-jar=frostguard-watcher-${project.version}.jar
 main-class=dev.frostguard.watcher.TelegramWatcher
 description=Frostguard Telegram Watcher
-java-options=--enable-native-access=ALL-UNNAMED -Dfrostguard.channel=stable "-Duser.dir=$APPDIR" "-Dfrostguard.launcher=$APPDIR/../Frostguard.exe" "-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe"
+java-options=--enable-native-access=ALL-UNNAMED -Dfrostguard.channel=stable -Dfrostguard.update.pullRequestBuild=${frostguard.pull-request-build} "-Duser.dir=$APPDIR" "-Dfrostguard.launcher=$APPDIR/../Frostguard.exe" "-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe"

--- a/packaging/desktop/src/main/windows/Start-Frostguard-Watcher.bat
+++ b/packaging/desktop/src/main/windows/Start-Frostguard-Watcher.bat
@@ -45,6 +45,5 @@ exit /b 1
 :found
 echo Starting Frostguard Telegram Watcher (background)...
 echo JAR: %JAR%
-echo Log: %USERPROFILE%\.frostguard\tg-watcher.log
 start "FG-TG-Watcher" /b javaw -jar "%JAR%"
 exit /b 0

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,9 @@
 	     ────────────────────────────────────────────── -->
 	<properties>
 		<revision>2.1.0</revision>
+		<frostguard.pull-request-build>false</frostguard.pull-request-build>
+		<frostguard.update.manifest.stable></frostguard.update.manifest.stable>
+		<frostguard.update.authenticode-publisher></frostguard.update.authenticode-publisher>
 
 		<!-- JDK baseline -->
 		<java.version>21</java.version>
@@ -88,6 +91,7 @@
 		<module>modules/automation</module>
 		<module>modules/tasks</module>
 		<module>modules/watcher</module>
+		<module>modules/update</module>
 		<module>modules/desktop</module>
 		<module>packaging/desktop</module>
 	</modules>
@@ -112,6 +116,11 @@
 			<dependency>
 				<groupId>dev.frostguard</groupId>
 				<artifactId>frostguard-api</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>dev.frostguard</groupId>
+				<artifactId>frostguard-update</artifactId>
 				<version>${revision}</version>
 			</dependency>
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,12 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven.surefire.plugin.version}</version>
+					<configuration>
+						<systemPropertyVariables>
+							<frostguard.channel>development</frostguard.channel>
+							<frostguard.workspace>${project.build.directory}/test-workspace</frostguard.workspace>
+						</systemPropertyVariables>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

- add a platform-neutral `modules/update` reactor module with strict schema-1 manifests, semantic version/channel/platform selection, resumable downloads, atomic completion, and size/SHA-256 verification
- pin the trusted Authenticode certificate subject inside the packaged desktop JAR, reject unsigned or mismatched Windows installers, and prevent Development or PR-test builds from updating
- add **Config > Updates**, explicit install confirmation, coordinated service/database/workspace shutdown, and a token-authorized external waiter that launches only after the Frostguard PID exits
- extend native-package verification, incremental reactor staging, and the release/operator documentation

## Why

Frostguard 3.0 needs a secure update boundary before Stable or Nightly installer feeds can be published. The running application must never replace its own files, an update manifest must not be able to choose its own trust anchor, and partial or concurrent downloads must never become installable artifacts.

This is implementation PR 4 of #130 and depends on #152 / #153. Because the preceding PR heads live in a fork, this PR targets `main` and temporarily displays the complete stacked Frostguard 3.0 diff. It must not be merged independently; the diff will shrink as #147, #151, and #153 land.

Closes #156.

## User and developer impact

Installed Windows release builds gain an Updates tab and the verified installer handoff. Public automatic updates remain disabled because the checked-in feed endpoint and Authenticode publisher are intentionally empty. Source-development and PR-test builds remain unable to install release updates.

Native packaging now refreshes reactor dependencies during non-`clean` builds, so an app image cannot silently reuse stale Frostguard module JARs.

## Validation

- `.\mvnw.cmd package` — 294 tests passed; 0 failures, errors, or skips
- `.\mvnw.cmd -pl modules/update -am test` — 33 update tests plus 15 API tests passed
- `.\mvnw.cmd -pl modules/desktop -am test` — passed
- `python build-support\verification\test_verify_app_image.py` — 8 tests passed
- `python build-support\verification\test_project_layout.py` — 6 tests passed
- `python build-support\verification\check_workflow_python.py` — all inline workflow snippets compiled
- `.\mvnw.cmd "-Dfrostguard.pull-request-build=true" -pl packaging/desktop -am -Pwindows-app-image package -DskipTests` — passed without `clean`
- `python build-support\verification\verify_app_image.py packaging\desktop\target\app-image\Frostguard` — passed
- `powershell -ExecutionPolicy Bypass -File build-support\verification\smoke_test_app_image.ps1 -ImagePath packaging\desktop\target\app-image\Frostguard` — app and watcher exited 0 without system Java

Evidence level: automated tests and native app-image smoke verification.

## Risks

- No production signing certificate or release endpoint is stored locally, so a real signed-installer update and live installer launch have not been performed.
- WiX is not installed in the local environment; the GitHub Windows check must build and verify the EXE installer.
- The coordinated shutdown and external handoff have deterministic unit coverage, but still need release-stage end-to-end confirmation with a genuinely signed installer.
- This PR is intentionally stacked and should be reviewed/merged only as part of the coordinated #130 sequence.
