### PR TITLE
feat(release): add Stable and Nightly channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MAVEN_ARGS: "-B --no-transfer-progress -Dstyle.color=never"
+
+jobs:
+  test:
+    name: Build and test on Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Verify Git LFS assets are real binaries
+        run: build-support/verification/check_lfs_assets.sh
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Test build and release tooling
+        run: |
+          python3 -m unittest discover -s build-support/verification -p "test_*.py"
+          python3 -m unittest discover -s build-support/release -p "test_*.py"
+          python3 -m unittest discover -s build-support/notifications -p "test_*.py"
+          python3 build-support/verification/check_workflow_python.py
+
+      # Saved-frame OCR tests bind the host Tesseract libraries through tess4j.
+      # JavaFX controller tests need a virtual display on the headless runner.
+      - name: Install Linux test runtimes
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            tesseract-ocr libtesseract-dev libleptonica-dev xvfb
+
+      - name: Build and test Maven reactor
+        run: |
+          read -r -a maven_args <<< "${MAVEN_ARGS}"
+          xvfb-run --auto-servernum ./mvnw "${maven_args[@]}" package
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-surefire-reports
+          path: "**/target/surefire-reports/*.xml"
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -1,20 +1,6 @@
-name: Daily Windows Bundle
+name: Nightly Windows Bundle
 
 on:
-  push:
-    branches:
-      - "build-support/**"
-  pull_request:
-    paths:
-      - "**/pom.xml"
-      - "**/src/**"
-      - "tools/**"
-      - "examples/custom-tasks/**"
-      - "build-support/**"
-      - "packaging/desktop/src/main/windows/Start-Frostguard-Watcher.bat"
-      - "packaging/desktop/src/main/windows/Start-Frostguard.bat"
-      - ".gitattributes"
-      - ".github/workflows/daily-windows-bundle.yml"
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:
@@ -33,7 +19,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: daily-windows-bundle-${{ github.ref }}
+  group: nightly-windows-bundle-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -43,7 +29,7 @@ env:
 
 jobs:
   build-windows-bundle:
-    name: Build Windows desktop bundle on Linux
+    name: Build and publish nightly Windows bundle
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -215,15 +201,11 @@ jobs:
           retention-days: 7
 
       # A rolling prerelease gives the Discord message a stable, public,
-      # login-free download URL. Pull requests are excluded on purpose: a PR
-      # from a fork gets a read-only token, and republishing `nightly` from an
-      # unmerged branch would hand testers an unreviewed build.
+      # login-free download URL. This workflow only runs from the default
+      # branch on its schedule or through an explicit manual dispatch.
       - name: Publish the rolling nightly release
         id: release
-        if: >-
-          success() &&
-          github.event_name != 'pull_request' &&
-          github.ref == 'refs/heads/main'
+        if: success() && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ZIP_PATH: ${{ steps.bundle.outputs.path }}
@@ -321,12 +303,12 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
           echo "Published and verified ${asset} at ${url} (HTTP ${code})"
 
-      # Keep one maintained Daily message instead of adding one post per run.
+      # Keep one maintained Nightly message instead of adding one post per run.
       # Failures remain visible in Actions and never overwrite the last working
       # public download.
-      - name: Update the Daily Discord message
+      - name: Update the Nightly Discord message
         id: discord
-        if: success() && github.event_name != 'pull_request'
+        if: success() && github.ref == 'refs/heads/main'
         continue-on-error: true
         env:
           DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
@@ -382,14 +364,20 @@ jobs:
             "${discord_target[@]}"
 
       - name: Delete the superseded Discord message
-        if: success() && inputs.recreate_discord_message
+        if: >-
+          success() &&
+          github.ref == 'refs/heads/main' &&
+          inputs.recreate_discord_message &&
+          steps.discord.outcome == 'success'
         env:
           DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
           OLD_MESSAGE_ID: ${{ vars.DISCORD_DAILY_MESSAGE_ID }}
           NEW_MESSAGE_ID: ${{ steps.discord.outputs.message_id }}
         run: |
           set -euo pipefail
-          if [[ ! "${OLD_MESSAGE_ID}" =~ ^[0-9]+$ || "${OLD_MESSAGE_ID}" == "${NEW_MESSAGE_ID}" ]]; then
+          if [[ ! "${OLD_MESSAGE_ID}" =~ ^[0-9]+$ ||
+                ! "${NEW_MESSAGE_ID}" =~ ^[0-9]+$ ||
+                "${OLD_MESSAGE_ID}" == "${NEW_MESSAGE_ID}" ]]; then
             echo "::error::Refusing to delete an invalid or current Discord message ID."
             exit 1
           fi

--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -1,0 +1,325 @@
+name: Signed Windows Channel Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Release identity to publish"
+        required: true
+        type: choice
+        options:
+          - stable
+          - nightly
+      version:
+        description: "Stable X.Y.Z or Nightly X.Y.Z-nightly.YYYYMMDD.N"
+        required: true
+        type: string
+      minimum_updater_version:
+        description: "Oldest Frostguard SemVer allowed to install this release"
+        required: true
+        default: "3.0.0-nightly.0"
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: signed-windows-${{ inputs.channel }}-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Sign and publish ${{ inputs.channel }} Windows release
+    if: github.ref == 'refs/heads/main'
+    runs-on: windows-latest
+    timeout-minutes: 75
+    permissions:
+      contents: write
+    env:
+      MAVEN_ARGS: "-B --no-transfer-progress -Dstyle.color=never"
+      CHANNEL: ${{ inputs.channel }}
+      VERSION: ${{ inputs.version }}
+      MINIMUM_UPDATER_VERSION: ${{ inputs.minimum_updater_version }}
+      AUTHENTICODE_PUBLISHER: ${{ secrets.FROSTGUARD_AUTHENTICODE_PUBLISHER }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Check out main with release assets
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Verify Git LFS assets are real binaries
+        shell: bash
+        run: build-support/verification/check_lfs_assets.sh
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Install WiX Toolset 3
+        shell: pwsh
+        run: |
+          choco install wixtoolset --version=3.14.1.20250415 --no-progress -y
+          $wixBin = "${env:ProgramFiles(x86)}\WiX Toolset v3.14\bin"
+          if (-not (Test-Path -LiteralPath (Join-Path $wixBin "candle.exe"))) {
+              throw "WiX candle.exe was not installed below $wixBin"
+          }
+          $wixBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Validate immutable release identity
+        id: identity
+        shell: pwsh
+        run: |
+          if ($env:VERSION -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$') {
+              throw "Version must use semantic versioning without build metadata"
+          }
+          if ($env:MINIMUM_UPDATER_VERSION -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$') {
+              throw "minimum_updater_version must use semantic versioning without build metadata"
+          }
+          if ($env:CHANNEL -eq 'stable' -and $env:VERSION.Contains('-')) {
+              throw "Stable releases must not use a prerelease version"
+          }
+          if ([string]::IsNullOrWhiteSpace($env:AUTHENTICODE_PUBLISHER)) {
+              throw "FROSTGUARD_AUTHENTICODE_PUBLISHER is not configured"
+          }
+          $manifestName = "frostguard-$($env:CHANNEL)-manifest.json"
+          $feedTag = if ($env:CHANNEL -eq 'nightly') {
+              if (gh release view updates-nightly --repo $env:GITHUB_REPOSITORY 2>$null) {
+                  'updates-nightly'
+              }
+          } else {
+              gh release view --repo $env:GITHUB_REPOSITORY --json tagName --jq .tagName 2>$null
+          }
+          $previousVersion = $null
+          if (-not [string]::IsNullOrWhiteSpace($feedTag)) {
+              $assetId = gh api "repos/$($env:GITHUB_REPOSITORY)/releases/tags/$feedTag" `
+                  --jq ".assets[] | select(.name == \"$manifestName\") | .id"
+              if (-not [string]::IsNullOrWhiteSpace($assetId)) {
+                  $previousManifest = Join-Path $env:RUNNER_TEMP "previous-$manifestName"
+                  gh api "repos/$($env:GITHUB_REPOSITORY)/releases/assets/$assetId" `
+                      -H "Accept: application/octet-stream" > $previousManifest
+                  $previousVersion = (Get-Content -Raw -LiteralPath $previousManifest |
+                      ConvertFrom-Json).version
+              }
+          }
+          $versionArgs = @('--channel', $env:CHANNEL, '--version', $env:VERSION)
+          if (-not [string]::IsNullOrWhiteSpace($previousVersion)) {
+              $versionArgs += @('--previous-version', $previousVersion)
+          }
+          $windowsVersion = python build-support/release/windows_installer_version.py @versionArgs
+          if ($LASTEXITCODE -ne 0) {
+              throw "Could not derive a monotonic Windows installer version"
+          }
+          $windowsVersion = $windowsVersion.Trim()
+          $productName = if ($env:CHANNEL -eq 'nightly') { 'Frostguard Nightly' } else { 'Frostguard' }
+          $profile = if ($env:CHANNEL -eq 'nightly') { ',windows-nightly' } else { '' }
+          $tag = if ($env:CHANNEL -eq 'nightly') { "nightly-$($env:VERSION)" } else { "v$($env:VERSION)" }
+          $assetPrefix = if ($env:CHANNEL -eq 'nightly') { 'Frostguard-Nightly' } else { 'Frostguard' }
+          @{
+              windows_version = $windowsVersion
+              product_name = $productName
+              profile = $profile
+              tag = $tag
+              installer_name = "$assetPrefix-$($env:VERSION)-windows-x64.exe"
+              manifest_name = $manifestName
+          }.GetEnumerator() | ForEach-Object {
+              "$($_.Key)=$($_.Value)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          }
+          if (gh release view $tag --repo $env:GITHUB_REPOSITORY 2>$null) {
+              throw "Immutable release $tag already exists"
+          }
+
+      - name: Import release-signing certificate
+        id: certificate
+        env:
+          SIGNING_CERTIFICATE_BASE64: ${{ secrets.FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
+          SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:SIGNING_CERTIFICATE_BASE64) -or
+              [string]::IsNullOrWhiteSpace($env:SIGNING_CERTIFICATE_PASSWORD)) {
+              throw "Windows signing certificate secrets are not configured"
+          }
+          $certificatePath = Join-Path $env:RUNNER_TEMP "frostguard-release-signing.pfx"
+          [IO.File]::WriteAllBytes($certificatePath,
+              [Convert]::FromBase64String($env:SIGNING_CERTIFICATE_BASE64))
+          $password = ConvertTo-SecureString $env:SIGNING_CERTIFICATE_PASSWORD -AsPlainText -Force
+          $certificate = Get-PfxCertificate -FilePath $certificatePath -Password $password
+          if ($certificate.Subject -cne $env:AUTHENTICODE_PUBLISHER) {
+              throw "Signing certificate subject does not match the pinned publisher"
+          }
+          Import-PfxCertificate -FilePath $certificatePath -Password $password `
+              -CertStoreLocation Cert:\CurrentUser\My | Out-Null
+          "thumbprint=$($certificate.Thumbprint)" | Out-File `
+              -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "path=$certificatePath" | Out-File `
+              -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Build channel application image and installer
+        shell: pwsh
+        env:
+          WINDOWS_VERSION: ${{ steps.identity.outputs.windows_version }}
+          EXTRA_PROFILE: ${{ steps.identity.outputs.profile }}
+        run: |
+          $mavenArgs = $env:MAVEN_ARGS -split " "
+          $profiles = "windows-app-image,windows-installer$($env:EXTRA_PROFILE)"
+          $stableManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/latest/download/frostguard-stable-manifest.json"
+          $nightlyManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/download/updates-nightly/frostguard-nightly-manifest.json"
+          & .\mvnw.cmd @mavenArgs "-Drevision=$($env:VERSION)" `
+              "-Dfrostguard.windows.app-version=$($env:WINDOWS_VERSION)" `
+              "-Dfrostguard.update.authenticode-publisher=$($env:AUTHENTICODE_PUBLISHER)" `
+              "-Dfrostguard.update.manifest.stable=$stableManifest" `
+              "-Dfrostguard.update.manifest.nightly=$nightlyManifest" `
+              "-P$profiles" package
+
+      - name: Verify and smoke-test channel application image
+        shell: pwsh
+        env:
+          PRODUCT_NAME: ${{ steps.identity.outputs.product_name }}
+        run: |
+          $image = "packaging/desktop/target/app-image/$($env:PRODUCT_NAME)"
+          python build-support/verification/verify_app_image.py $image `
+              --channel $env:CHANNEL --product-name $env:PRODUCT_NAME
+          powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+              -File build-support/verification/smoke_test_app_image.ps1 `
+              -ImagePath $image -Channel $env:CHANNEL -ProductName $env:PRODUCT_NAME
+
+      - name: Sign and verify immutable installer
+        id: installer
+        shell: pwsh
+        env:
+          IMMUTABLE_NAME: ${{ steps.identity.outputs.installer_name }}
+          CERTIFICATE_THUMBPRINT: ${{ steps.certificate.outputs.thumbprint }}
+        run: |
+          $source = @(Get-ChildItem "packaging/desktop/target/installers/$($env:CHANNEL)" `
+              -Filter '*.exe' -File)
+          if ($source.Count -ne 1) {
+              throw "Expected exactly one unsigned installer, found $($source.Count)"
+          }
+          $installer = Join-Path $env:RUNNER_TEMP $env:IMMUTABLE_NAME
+          Copy-Item -LiteralPath $source[0].FullName -Destination $installer
+          $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" `
+              -Recurse -Filter signtool.exe | Where-Object FullName -Match '\\x64\\' `
+              | Sort-Object FullName -Descending | Select-Object -First 1
+          if ($null -eq $signtool) {
+              throw "Windows SDK signtool.exe was not found"
+          }
+          & $signtool.FullName sign /sha1 $env:CERTIFICATE_THUMBPRINT /fd SHA256 `
+              /td SHA256 /tr http://timestamp.digicert.com $installer
+          & $signtool.FullName verify /pa /v $installer
+          if ($LASTEXITCODE -ne 0) {
+              throw "Authenticode verification failed"
+          }
+          $signature = Get-AuthenticodeSignature -LiteralPath $installer
+          if ($signature.Status -ne 'Valid' -or
+              $signature.SignerCertificate.Subject -cne $env:AUTHENTICODE_PUBLISHER) {
+              throw "Signed installer does not match the pinned publisher"
+          }
+          "path=$installer" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Create draft release and verify uploaded installer
+        id: draft
+        shell: pwsh
+        env:
+          TAG: ${{ steps.identity.outputs.tag }}
+          INSTALLER: ${{ steps.installer.outputs.path }}
+        run: |
+          $title = if ($env:CHANNEL -eq 'nightly') {
+              "Frostguard Nightly $($env:VERSION)"
+          } else {
+              "Frostguard $($env:VERSION)"
+          }
+          gh release create $env:TAG $env:INSTALLER --repo $env:GITHUB_REPOSITORY `
+              --target $env:GITHUB_SHA --title $title --generate-notes --draft
+          $asset = gh api "repos/$($env:GITHUB_REPOSITORY)/releases/tags/$($env:TAG)" `
+              --jq ".assets[] | select(.name == \"$([IO.Path]::GetFileName($env:INSTALLER))\") | [.id,.browser_download_url] | @tsv"
+          $parts = $asset -split "`t"
+          if ($parts.Count -ne 2) {
+              throw "Uploaded installer could not be resolved"
+          }
+          $downloaded = Join-Path $env:RUNNER_TEMP "uploaded-installer.exe"
+          gh api "repos/$($env:GITHUB_REPOSITORY)/releases/assets/$($parts[0])" `
+              -H "Accept: application/octet-stream" > $downloaded
+          if ((Get-FileHash $downloaded -Algorithm SHA256).Hash -ne
+              (Get-FileHash $env:INSTALLER -Algorithm SHA256).Hash) {
+              throw "Uploaded installer hash does not match the signed source"
+          }
+          "download_url=$($parts[1])" | Out-File `
+              -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Generate update manifest from the signed installer
+        id: manifest
+        shell: pwsh
+        env:
+          INSTALLER: ${{ steps.installer.outputs.path }}
+          INSTALLER_URL: ${{ steps.draft.outputs.download_url }}
+          MANIFEST_NAME: ${{ steps.identity.outputs.manifest_name }}
+          TAG: ${{ steps.identity.outputs.tag }}
+        run: |
+          $manifest = Join-Path $env:RUNNER_TEMP $env:MANIFEST_NAME
+          $publishedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+          $releaseNotes = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/tag/$($env:TAG)"
+          python build-support/release/write_update_manifest.py `
+              --channel $env:CHANNEL --version $env:VERSION `
+              --minimum-updater-version $env:MINIMUM_UPDATER_VERSION `
+              --published-at $publishedAt --release-notes-url $releaseNotes `
+              --installer-url $env:INSTALLER_URL --installer $env:INSTALLER `
+              --publisher $env:AUTHENTICODE_PUBLISHER --output $manifest
+          "path=$manifest" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Publish immutable release and channel manifest last
+        id: publish
+        shell: pwsh
+        env:
+          TAG: ${{ steps.identity.outputs.tag }}
+          MANIFEST: ${{ steps.manifest.outputs.path }}
+        run: |
+          gh release upload $env:TAG $env:MANIFEST --repo $env:GITHUB_REPOSITORY
+          if ($env:CHANNEL -eq 'stable') {
+              gh release edit $env:TAG --repo $env:GITHUB_REPOSITORY --draft=false --latest
+          } else {
+              gh release edit $env:TAG --repo $env:GITHUB_REPOSITORY --draft=false --prerelease
+              if (-not (gh release view updates-nightly --repo $env:GITHUB_REPOSITORY 2>$null)) {
+                  gh release create updates-nightly --repo $env:GITHUB_REPOSITORY `
+                      --target $env:GITHUB_SHA --title "Frostguard Nightly update feed" `
+                      --notes "The manifest asset is replaced only after a signed immutable Nightly release is verified." `
+                      --prerelease
+              }
+              gh release upload updates-nightly $env:MANIFEST --repo $env:GITHUB_REPOSITORY --clobber
+          }
+
+      - name: Remove an abandoned draft release
+        if: failure() && steps.draft.outcome != 'skipped'
+        shell: pwsh
+        env:
+          TAG: ${{ steps.identity.outputs.tag }}
+        run: |
+          $release = gh release view $env:TAG --repo $env:GITHUB_REPOSITORY `
+              --json isDraft 2>$null | ConvertFrom-Json
+          if ($null -ne $release -and $release.isDraft) {
+              gh release delete $env:TAG --repo $env:GITHUB_REPOSITORY --cleanup-tag --yes
+          }
+
+      - name: Upload signed release evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: frostguard-${{ inputs.channel }}-${{ inputs.version }}-signed-release
+          path: |
+            ${{ steps.installer.outputs.path }}
+            ${{ steps.manifest.outputs.path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 30
+
+      - name: Remove the temporary certificate file
+        if: always()
+        shell: pwsh
+        env:
+          CERTIFICATE_PATH: ${{ steps.certificate.outputs.path }}
+        run: |
+          if (-not [string]::IsNullOrWhiteSpace($env:CERTIFICATE_PATH)) {
+              Remove-Item -LiteralPath $env:CERTIFICATE_PATH -Force -ErrorAction SilentlyContinue
+          }

--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       daily_run_id:
-        description: "Successful Daily Windows Bundle run ID from main"
+        description: "Successful Nightly Windows Bundle run ID from main"
         required: true
         type: string
 
@@ -55,7 +55,7 @@ jobs:
             exit 1
           fi
           if [[ "${workflow}" != ".github/workflows/daily-windows-bundle.yml" ]]; then
-            echo "::error::Selected run does not belong to Daily Windows Bundle."
+            echo "::error::Selected run does not belong to Nightly Windows Bundle."
             exit 1
           fi
           echo "sha=${sha}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -83,6 +83,10 @@ jobs:
             echo "::error::version must use X.Y.Z format."
             exit 1
           fi
+          if (( ${VERSION%%.*} >= 3 )); then
+            echo "::error::Frostguard 3.x must use Signed Windows Channel Release; the legacy ZIP workflow cannot publish an installed Stable identity."
+            exit 1
+          fi
           project_version="$(./mvnw -B --no-transfer-progress -q help:evaluate -Dexpression=project.version -DforceStdout)"
           if [[ "${VERSION}" != "${project_version}" ]]; then
             echo "::error::Requested ${VERSION}, but pom.xml declares ${project_version}."

--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -7,11 +7,14 @@ on:
       - "modules/**/src/**"
       - "packaging/desktop/**"
       - "build-support/packaging/**"
+      - "build-support/release/**"
       - "build-support/verification/*app_image*"
+      - "build-support/verification/test_channel_packaging.py"
       - "build-support/verification/smoke_test_app_image.ps1"
       - "tools/**"
       - "examples/custom-tasks/**"
       - ".github/workflows/windows-native-package.yml"
+      - ".github/workflows/signed-windows-channel-release.yml"
   workflow_dispatch:
 
 permissions:
@@ -60,7 +63,7 @@ jobs:
           }
           $wixBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Build application image and installer
+      - name: Build Stable application image and installer
         shell: pwsh
         run: |
           $mavenArgs = $env:MAVEN_ARGS -split " "
@@ -68,25 +71,29 @@ jobs:
               "-Pwindows-app-image,windows-installer" package
 
       - name: Test the application-image verifier
-        run: python build-support/verification/test_verify_app_image.py
+        run: |
+          python build-support/verification/test_verify_app_image.py
+          python build-support/verification/test_channel_packaging.py
+          python build-support/release/test_write_update_manifest.py
+          python build-support/release/test_windows_installer_version.py
 
-      - name: Verify application image
+      - name: Verify Stable application image
         run: >-
           python build-support/verification/verify_app_image.py
           packaging/desktop/target/app-image/Frostguard
 
-      - name: Smoke test native launchers and workspace isolation
+      - name: Smoke test Stable launchers and workspace isolation
         shell: pwsh
         run: |
           powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
               -File build-support/verification/smoke_test_app_image.ps1 `
               -ImagePath packaging/desktop/target/app-image/Frostguard
 
-      - name: Verify installer boundary
-        id: installer
+      - name: Verify Stable installer boundary
+        id: stable-installer
         shell: pwsh
         run: |
-          $installers = @(Get-ChildItem -LiteralPath packaging/desktop/target/installers `
+          $installers = @(Get-ChildItem -LiteralPath packaging/desktop/target/installers/stable `
               -Filter "Frostguard-*.exe" -File)
           if ($installers.Count -ne 1) {
               throw "Expected exactly one versioned installer, found $($installers.Count)"
@@ -97,10 +104,47 @@ jobs:
           "path=$($installers[0].FullName)" | Out-File `
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
+      - name: Build Nightly application image and installer
+        shell: pwsh
+        run: |
+          $mavenArgs = $env:MAVEN_ARGS -split " "
+          & .\mvnw.cmd @mavenArgs -DskipTests "-Dfrostguard.pull-request-build=true" `
+              "-Pwindows-app-image,windows-installer,windows-nightly" package
+
+      - name: Verify Nightly application image
+        run: >-
+          python build-support/verification/verify_app_image.py
+          "packaging/desktop/target/app-image/Frostguard Nightly"
+          --channel nightly
+          --product-name "Frostguard Nightly"
+
+      - name: Smoke test Nightly launchers and workspace isolation
+        shell: pwsh
+        run: |
+          powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+              -File build-support/verification/smoke_test_app_image.ps1 `
+              -ImagePath "packaging/desktop/target/app-image/Frostguard Nightly" `
+              -Channel nightly -ProductName "Frostguard Nightly"
+
+      - name: Verify Nightly installer boundary
+        id: nightly-installer
+        shell: pwsh
+        run: |
+          $installers = @(Get-ChildItem -LiteralPath packaging/desktop/target/installers/nightly `
+              -Filter "Frostguard Nightly-*.exe" -File)
+          if ($installers.Count -ne 1) {
+              throw "Expected exactly one versioned Nightly installer, found $($installers.Count)"
+          }
+          if ($installers[0].Length -lt 1MB) {
+              throw "Nightly installer is unexpectedly small: $($installers[0].Length) bytes"
+          }
+          "path=$($installers[0].FullName)" | Out-File `
+              -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
       - name: Upload native application image
         uses: actions/upload-artifact@v4
         with:
-          name: frostguard-windows-app-image
+          name: frostguard-stable-windows-app-image
           path: packaging/desktop/target/app-image/Frostguard
           if-no-files-found: error
           retention-days: 14
@@ -108,8 +152,25 @@ jobs:
       - name: Upload Windows installer
         uses: actions/upload-artifact@v4
         with:
-          name: frostguard-windows-installer
-          path: ${{ steps.installer.outputs.path }}
+          name: frostguard-stable-windows-installer
+          path: ${{ steps.stable-installer.outputs.path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+      - name: Upload Nightly application image
+        uses: actions/upload-artifact@v4
+        with:
+          name: frostguard-nightly-windows-app-image
+          path: packaging/desktop/target/app-image/Frostguard Nightly
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload Nightly installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: frostguard-nightly-windows-installer
+          path: ${{ steps.nightly-installer.outputs.path }}
           if-no-files-found: error
           compression-level: 0
           retention-days: 14

--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -1,4 +1,4 @@
-name: Native Windows Package
+name: Windows Installers
 
 on:
   pull_request:
@@ -29,7 +29,7 @@ env:
 
 jobs:
   package:
-    name: Build and verify native Windows package
+    name: Build and smoke-test Stable and Nightly installers
     runs-on: windows-latest
     timeout-minutes: 60
 

--- a/README.md
+++ b/README.md
@@ -212,35 +212,25 @@ Choose the path that matches what you want to do:
 | **PR build** | A temporary build containing selected open pull requests | Expires automatically |
 | **Source build** | A local Maven build from the repository | Built on demand from the checked-out commit |
 
-### ⬇️ Download a Windows bundle
+### ⬇️ Install Frostguard on Windows
 
-Frostguard currently provides verified Windows desktop bundles. Java 21 or
-newer is required; Git and Maven are not.
+Stable and Nightly use separate, self-contained Windows applications. Git,
+Maven, and a separately installed Java runtime are not required.
 
-- **[Stable for Windows](https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip)**
-- **[Nightly for Windows](https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip)**
+- **[Latest Stable release](https://github.com/Shederator/wosbot/releases/latest)**
+- **[Signed Nightly releases](https://github.com/Shederator/wosbot/releases)**
 
 After choosing a build:
 
-1. Extract the complete ZIP into an empty folder. Do not run it from inside the ZIP.
-2. Double-click the versioned **`frostguard-<version>.jar`** file.
-3. Open **Configuration** and select your emulator's command-line controller.
-
-> [!NOTE]
-> The included `Start Frostguard.bat` launcher is currently unsigned and may be
-> blocked by Windows 11 Smart App Control. Do not disable Windows security solely
-> to run Frostguard. If double-clicking the JAR does not start Frostguard, or if
-> you want to see its startup output, open PowerShell in the extracted folder and
-> run:
->
-> ```powershell
-> $appJar = Get-ChildItem -File "frostguard-*.jar" | Select-Object -First 1
-> java --enable-native-access=ALL-UNNAMED -jar $appJar.FullName
-> ```
+1. Download the Windows x64 EXE for the desired channel.
+2. Verify the Frostguard publisher shown by Windows and run the installer.
+3. Start **Frostguard** or **Frostguard Nightly** from its shortcut.
+4. Open **Configuration** and select your emulator's command-line controller.
 
 > [!IMPORTANT]
-> Keep the extracted folder together. The launcher, application JAR, runtime
-> libraries, OCR data and templates are all part of the installation.
+> Stable and Nightly keep separate settings and databases and can run side by
+> side. The first Nightly start can copy a one-time Stable snapshot; changes are
+> not synchronized afterward.
 
 See the **[complete installation guide](docs/installation.md)** for Java,
 emulator and game settings.

--- a/build-support/release/test_windows_installer_version.py
+++ b/build-support/release/test_windows_installer_version.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from windows_installer_version import require_newer_version, windows_installer_version  # noqa: E402
+
+
+class WindowsInstallerVersionTest(unittest.TestCase):
+    def test_preserves_valid_stable_version(self):
+        self.assertEqual("3.0.1", windows_installer_version("stable", "3.0.1"))
+
+    def test_maps_nightly_date_and_sequence_to_monotonic_windows_fields(self):
+        self.assertEqual("26.8.11001", windows_installer_version(
+            "nightly", "3.1.0-nightly.20260811.1"))
+        self.assertEqual("26.8.11002", windows_installer_version(
+            "nightly", "3.1.0-nightly.20260811.2"))
+        self.assertEqual("26.9.1001", windows_installer_version(
+            "nightly", "3.1.0-nightly.20260901.1"))
+
+    def test_rejects_ambiguous_or_invalid_release_versions(self):
+        for channel, version in (
+                ("nightly", "3.1.0-nightly.1"),
+                ("nightly", "3.1.0-nightly.20260230.1"),
+                ("nightly", "3.1.0-nightly.20260811.1000"),
+                ("nightly", "3.1.0-nightly.19990811.1"),
+                ("stable", "256.0.0"),
+                ("stable", "3.0.0-nightly.20260811.1")):
+            with self.subTest(channel=channel, version=version):
+                with self.assertRaises(ValueError):
+                    windows_installer_version(channel, version)
+
+    def test_requires_each_channel_installer_version_to_increase(self):
+        require_newer_version("stable", "3.0.2", "3.0.1")
+        require_newer_version(
+            "nightly", "3.1.0-nightly.20260812.1", "3.1.0-nightly.20260811.2")
+        with self.assertRaises(ValueError):
+            require_newer_version("stable", "3.0.1", "3.0.1")
+        with self.assertRaises(ValueError):
+            require_newer_version(
+                "nightly", "3.1.0-nightly.20260811.1", "3.1.0-nightly.20260811.2")
+        with self.assertRaises(ValueError):
+            require_newer_version(
+                "nightly", "3.0.0-nightly.20260812.1", "3.1.0-nightly.20260811.1")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/build-support/release/test_write_update_manifest.py
+++ b/build-support/release/test_write_update_manifest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from write_update_manifest import write_manifest  # noqa: E402
+
+
+class WriteUpdateManifestTest(unittest.TestCase):
+    def test_writes_hash_size_identity_and_channel_after_installer_exists(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            installer = root / "Frostguard-Nightly-3.1.0-nightly.20260811.1-windows-x64.exe"
+            installer.write_bytes(b"signed-installer")
+            output = root / "manifest.json"
+
+            manifest = write_manifest(
+                channel="nightly",
+                version="3.1.0-nightly.20260811.1",
+                minimum_updater_version="3.0.0-nightly.0",
+                published_at="2026-08-11T14:00:00Z",
+                release_notes_url="https://github.com/Shederator/wosbot/releases/tag/nightly-test",
+                installer_url=f"https://github.com/Shederator/wosbot/releases/download/nightly-test/{installer.name}",
+                installer=installer,
+                publisher="CN=Frostguard Project, O=Frostguard",
+                output=output,
+            )
+
+            self.assertEqual(16, manifest["artifacts"]["windows-x64"]["size"])
+            self.assertEqual(64, len(manifest["artifacts"]["windows-x64"]["sha256"]))
+            self.assertEqual("3.0.0-nightly.0", manifest["minimumUpdaterVersion"])
+            self.assertEqual(manifest, json.loads(output.read_text(encoding="utf-8")))
+
+    def test_rejects_mutable_or_cross_channel_inputs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            installer = root / "Frostguard-latest.exe"
+            installer.write_bytes(b"installer")
+            common = dict(
+                channel="stable",
+                version="3.0.1-nightly.1",
+                minimum_updater_version="3.0.0",
+                published_at="2026-08-11T14:00:00Z",
+                release_notes_url="https://example.com/release",
+                installer_url="https://example.com/Frostguard-latest.exe",
+                installer=installer,
+                publisher="CN=Frostguard",
+                output=root / "manifest.json",
+            )
+
+            with self.assertRaises(ValueError):
+                write_manifest(**common)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/build-support/release/windows_installer_version.py
+++ b/build-support/release/windows_installer_version.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Resolve a release version to Windows Installer's three numeric fields."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from datetime import datetime
+
+STABLE_VERSION = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+NIGHTLY_VERSION = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"-nightly\.(\d{8})\.(0|[1-9]\d*)$"
+)
+
+
+def windows_installer_version(channel: str, version: str) -> str:
+    return ".".join(str(value) for value in _windows_installer_fields(channel, version))
+
+
+def require_newer_version(channel: str, version: str, previous_version: str) -> None:
+    current = _windows_installer_fields(channel, version)
+    previous = _windows_installer_fields(channel, previous_version)
+    if _release_order(channel, version) <= _release_order(channel, previous_version):
+        raise ValueError(f"Release version {version} must be newer than {previous_version}")
+    if current <= previous:
+        raise ValueError(
+            f"Windows installer version {'.'.join(map(str, current))} must be newer than "
+            f"{'.'.join(map(str, previous))}")
+
+
+def _release_order(channel: str, version: str) -> tuple[int, ...]:
+    pattern = STABLE_VERSION if channel == "stable" else NIGHTLY_VERSION
+    match = pattern.fullmatch(version)
+    if match is None:
+        raise ValueError(f"Invalid {channel} release version: {version}")
+    return tuple(int(value) for value in match.groups())
+
+
+def _windows_installer_fields(channel: str, version: str) -> tuple[int, int, int]:
+    if channel == "stable":
+        match = STABLE_VERSION.fullmatch(version)
+        if match is None:
+            raise ValueError("Stable version must use X.Y.Z")
+        fields = tuple(int(value) for value in match.groups())
+        _validate_windows_fields(fields)
+        return fields
+
+    if channel != "nightly":
+        raise ValueError("channel must be stable or nightly")
+    match = NIGHTLY_VERSION.fullmatch(version)
+    if match is None:
+        raise ValueError("Nightly version must use X.Y.Z-nightly.YYYYMMDD.N")
+    release_date = datetime.strptime(match.group(4), "%Y%m%d").date()
+    sequence = int(match.group(5))
+    if sequence < 1 or sequence > 999:
+        raise ValueError("Nightly sequence must be between 1 and 999")
+    windows_version = (release_date.year - 2000, release_date.month,
+                       release_date.day * 1000 + sequence)
+    _validate_windows_fields(windows_version)
+    return windows_version
+
+
+def _validate_windows_fields(fields: tuple[int, int, int]) -> None:
+    if any(value < 0 for value in fields) or fields[0] > 255 or fields[1] > 255 or fields[2] > 65_535:
+        raise ValueError("Windows installer version exceeds 255.255.65535")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channel", required=True, choices=("stable", "nightly"))
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--previous-version")
+    args = parser.parse_args()
+    try:
+        if args.previous_version:
+            require_newer_version(args.channel, args.version, args.previous_version)
+        print(windows_installer_version(args.channel, args.version))
+    except ValueError as failure:
+        parser.error(str(failure))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build-support/release/write_update_manifest.py
+++ b/build-support/release/write_update_manifest.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Create a schema-1 Frostguard update manifest from a signed installer."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+SEMANTIC_VERSION = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+
+
+def write_manifest(
+        *, channel: str, version: str, minimum_updater_version: str,
+        published_at: str, release_notes_url: str, installer_url: str,
+        installer: Path, publisher: str, output: Path) -> dict:
+    if channel not in {"stable", "nightly"}:
+        raise ValueError("channel must be stable or nightly")
+    for value, label in ((version, "version"),
+                         (minimum_updater_version, "minimum updater version")):
+        if not SEMANTIC_VERSION.fullmatch(value):
+            raise ValueError(f"{label} must use semantic versioning")
+    if channel == "stable" and "-" in version:
+        raise ValueError("Stable versions must not use a prerelease identifier")
+    if channel == "nightly" and "nightly" not in version.lower():
+        raise ValueError("Nightly versions must carry a nightly prerelease identifier")
+    timestamp = datetime.fromisoformat(published_at.replace("Z", "+00:00"))
+    if timestamp.tzinfo is None or timestamp.utcoffset() != timezone.utc.utcoffset(timestamp):
+        raise ValueError("published-at must be an ISO-8601 UTC timestamp")
+    for value, label in ((release_notes_url, "release notes URL"),
+                         (installer_url, "installer URL")):
+        parsed = urlparse(value)
+        if parsed.scheme.lower() != "https" or not parsed.netloc:
+            raise ValueError(f"{label} must use HTTPS")
+    if not installer.is_file() or installer.stat().st_size <= 0:
+        raise ValueError("installer must be a non-empty file")
+    if Path(urlparse(installer_url).path).name != installer.name:
+        raise ValueError("installer URL must end with the exact installer file name")
+    if version not in installer.name:
+        raise ValueError("installer file name must contain the immutable release version")
+    if not publisher.strip():
+        raise ValueError("Authenticode publisher must not be blank")
+
+    manifest = {
+        "schemaVersion": 1,
+        "channel": channel,
+        "version": version,
+        "publishedAt": published_at,
+        "minimumUpdaterVersion": minimum_updater_version,
+        "releaseNotesUrl": release_notes_url,
+        "artifacts": {
+            "windows-x64": {
+                "operatingSystem": "windows",
+                "architecture": "x64",
+                "fileName": installer.name,
+                "url": installer_url,
+                "sha256": hashlib.sha256(installer.read_bytes()).hexdigest(),
+                "size": installer.stat().st_size,
+                "signature": {
+                    "type": "authenticode",
+                    "publisher": publisher.strip(),
+                },
+            }
+        },
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    temporary.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(output)
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channel", required=True, choices=("stable", "nightly"))
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--minimum-updater-version", required=True)
+    parser.add_argument("--published-at", required=True)
+    parser.add_argument("--release-notes-url", required=True)
+    parser.add_argument("--installer-url", required=True)
+    parser.add_argument("--installer", required=True, type=Path)
+    parser.add_argument("--publisher", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    write_manifest(
+        channel=args.channel,
+        version=args.version,
+        minimum_updater_version=args.minimum_updater_version,
+        published_at=args.published_at,
+        release_notes_url=args.release_notes_url,
+        installer_url=args.installer_url,
+        installer=args.installer,
+        publisher=args.publisher,
+        output=args.output,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build-support/verification/README.md
+++ b/build-support/verification/README.md
@@ -1,20 +1,22 @@
 # Continuous Integration
 
-Frostguard builds on GitHub Actions from
-[`.github/workflows/daily-windows-bundle.yml`](../../.github/workflows/daily-windows-bundle.yml).
-No manual activation step is needed — the workflow is live as soon as it lands on
-`main`, and the first scheduled run happens at the next 03:17 UTC.
+Pull requests and `main` are built and tested by
+[`ci.yml`](../../.github/workflows/ci.yml) with read-only repository access.
+The separate [`daily-windows-bundle.yml`](../../.github/workflows/daily-windows-bundle.yml)
+builds and publishes the rolling Nightly ZIP. No manual activation is needed;
+the first scheduled Nightly run happens at the next 03:17 UTC after the workflow
+lands on `main`.
 
 ## When it runs
 
-| Trigger | Purpose |
+| Workflow trigger | Purpose |
 |---|---|
-| `schedule` (03:17 UTC daily) | Publishes a nightly Windows bundle for testers, updates the `nightly` release and posts it to Discord |
-| `pull_request` | Guards Maven modules, packaging, tools, examples, build support, and workflow changes |
-| `push` to `build-support/**` | Lets build-support changes be iterated on a branch |
-| `workflow_dispatch` | On-demand build from the Actions tab |
+| CI: `pull_request` | Builds and tests the proposed tree without release permissions |
+| CI: `push` to `main` | Rechecks the integrated tree |
+| Nightly: `schedule` (03:17 UTC daily) | Publishes the rolling Windows ZIP and updates its Discord message |
+| Nightly: `workflow_dispatch` | On-demand Nightly build; publication is limited to `main` |
 
-## What the pipeline does
+## What the Nightly pipeline does
 
 1. Checks out the repository **with Git LFS**, then asserts that every LFS asset
    was really materialised. The check fails if `git lfs ls-files` returns nothing
@@ -28,9 +30,10 @@ No manual activation step is needed — the workflow is live as soon as it lands
 4. Runs the verifier's own unit tests (`build-support/verification/test_verify_bundle.py`), so a
    verification script that can no longer fail cannot silently green-light a
    broken artifact.
-5. Runs `./mvnw clean install -Djavafx.platform=win`. This **cross-builds the
-   Windows desktop bundle from Linux** while still executing the full JUnit 5
-   suite, including the vision and OCR saved-frame tests.
+5. Runs the full JUnit 5 suite against Linux JavaFX under Xvfb, including the
+   vision and OCR saved-frame tests, then **cross-builds the Windows desktop
+   bundle from Linux** with `-Djavafx.platform=win` and tests skipped in that
+   second Maven invocation.
 6. **Structurally verifies** the ZIP with [`verify_bundle.py`](verify_bundle.py):
    Windows JavaFX runtime present and no other platform's runtime leaking, the
    launcher and watcher JARs, bundled `adb`/OCR assets, template sprites,
@@ -165,7 +168,7 @@ substitution really took effect in both directions.
 ## Stable Windows releases
 
 [`stable-windows-release.yml`](../.github/workflows/stable-windows-release.yml)
-promotes a successful Daily Windows Bundle run from `main` instead of rebuilding
+promotes a successful Nightly Windows Bundle run from `main` instead of rebuilding
 a potentially different tree. A maintainer supplies the `X.Y.Z` version and
 daily run ID. The workflow validates the source run and Maven version, pins its
 commit, downloads and re-verifies its bundle, creates an immutable `vX.Y.Z`

--- a/build-support/verification/smoke_test_app_image.ps1
+++ b/build-support/verification/smoke_test_app_image.ps1
@@ -1,24 +1,27 @@
 param(
     [Parameter(Mandatory = $true)]
-    [string]$ImagePath
+    [string]$ImagePath,
+    [ValidateSet("stable", "nightly")]
+    [string]$Channel = "stable",
+    [string]$ProductName = "Frostguard"
 )
 
 $ErrorActionPreference = "Stop"
 $image = (Resolve-Path -LiteralPath $ImagePath).Path
-$appLauncher = Join-Path $image "Frostguard.exe"
+$appLauncher = Join-Path $image "$ProductName.exe"
 $watcherLauncher = Join-Path $image "FrostguardWatcher.exe"
 if (-not (Test-Path -LiteralPath $appLauncher -PathType Leaf)) {
-    throw "Frostguard.exe is missing from $image"
+    throw "$ProductName.exe is missing from $image"
 }
 if (-not (Test-Path -LiteralPath $watcherLauncher -PathType Leaf)) {
     throw "FrostguardWatcher.exe is missing from $image"
 }
 
 $versionInfo = (Get-Item -LiteralPath $appLauncher).VersionInfo
-if ($versionInfo.ProductName -ne "Frostguard" -or
+if ($versionInfo.ProductName -ne $ProductName -or
         $versionInfo.CompanyName -ne "Frostguard" -or
-        $versionInfo.FileDescription -ne "Frostguard automation desktop application") {
-    throw "Frostguard.exe has incomplete Windows application metadata"
+        $versionInfo.FileDescription -ne "$ProductName automation desktop application") {
+    throw "$ProductName.exe has incomplete Windows application metadata"
 }
 Add-Type -AssemblyName System.Drawing
 $icon = [System.Drawing.Icon]::ExtractAssociatedIcon($appLauncher)
@@ -48,8 +51,30 @@ try {
         throw "Native launcher did not create its isolated workspace marker"
     }
     $workspaceMetadata = Get-Content -Raw -LiteralPath $marker | ConvertFrom-Json
-    if ($workspaceMetadata.channel -ne "stable") {
-        throw "Native launcher selected '$($workspaceMetadata.channel)' instead of Stable"
+    if ($workspaceMetadata.channel -ne $Channel) {
+        throw "Native launcher selected '$($workspaceMetadata.channel)' instead of $Channel"
+    }
+    $appEvidencePath = Join-Path $appWorkspace "cache/native-app-smoke.properties"
+    if (-not (Test-Path -LiteralPath $appEvidencePath)) {
+        throw "Native app launcher did not write smoke-test evidence"
+    }
+    $appEvidence = @{}
+    Get-Content -LiteralPath $appEvidencePath | ForEach-Object {
+        if ($_ -match '^([^=]+)=(.*)$') {
+            $appEvidence[$matches[1]] = $matches[2]
+        }
+    }
+    $expectedApplicationId = if ($Channel -eq "nightly") {
+        "dev.frostguard.desktop.nightly"
+    } else {
+        "dev.frostguard.desktop"
+    }
+    if ($appEvidence["channel"] -ne $Channel -or
+            $appEvidence["applicationId"] -ne $expectedApplicationId -or
+            [System.IO.Path]::GetFullPath($appEvidence["workspace"]) -ne $appWorkspace -or
+            [System.IO.Path]::GetFullPath($appEvidence["applicationDir"]) -ne (Join-Path $image "app") -or
+            [System.IO.Path]::GetFullPath($appEvidence["appLauncher"]) -ne $appLauncher) {
+        throw "Native app launcher did not receive its packaged product identity"
     }
 
     $env:FROSTGUARD_WORKSPACE = $watcherWorkspace
@@ -67,8 +92,8 @@ try {
         throw "Native watcher launcher did not create its workspace marker"
     }
     $watcherMetadata = Get-Content -Raw -LiteralPath $watcherMarker | ConvertFrom-Json
-    if ($watcherMetadata.channel -ne "stable") {
-        throw "Native watcher launcher selected '$($watcherMetadata.channel)' instead of Stable"
+    if ($watcherMetadata.channel -ne $Channel) {
+        throw "Native watcher launcher selected '$($watcherMetadata.channel)' instead of $Channel"
     }
     $watcherEvidencePath = Join-Path $watcherWorkspace "cache/native-watcher-smoke.properties"
     if (-not (Test-Path -LiteralPath $watcherEvidencePath)) {
@@ -80,7 +105,8 @@ try {
             $watcherEvidence[$matches[1]] = $matches[2]
         }
     }
-    if ($watcherEvidence["channel"] -ne "stable" -or
+    if ($watcherEvidence["channel"] -ne $Channel -or
+            $watcherEvidence["applicationId"] -ne $expectedApplicationId -or
             [System.IO.Path]::GetFullPath($watcherEvidence["workspace"]) -ne $watcherWorkspace -or
             [System.IO.Path]::GetFullPath($watcherEvidence["applicationDir"]) -ne (Join-Path $image "app") -or
             [System.IO.Path]::GetFullPath($watcherEvidence["appLauncher"]) -ne $appLauncher -or

--- a/build-support/verification/smoke_test_app_image.ps1
+++ b/build-support/verification/smoke_test_app_image.ps1
@@ -9,12 +9,13 @@ param(
 $ErrorActionPreference = "Stop"
 $image = (Resolve-Path -LiteralPath $ImagePath).Path
 $appLauncher = Join-Path $image "$ProductName.exe"
-$watcherLauncher = Join-Path $image "FrostguardWatcher.exe"
+$watcherName = if ($Channel -eq "nightly") { "FrostguardNightlyWatcher" } else { "FrostguardWatcher" }
+$watcherLauncher = Join-Path $image "$watcherName.exe"
 if (-not (Test-Path -LiteralPath $appLauncher -PathType Leaf)) {
     throw "$ProductName.exe is missing from $image"
 }
 if (-not (Test-Path -LiteralPath $watcherLauncher -PathType Leaf)) {
-    throw "FrostguardWatcher.exe is missing from $image"
+    throw "$watcherName.exe is missing from $image"
 }
 
 $versionInfo = (Get-Item -LiteralPath $appLauncher).VersionInfo

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -33,12 +33,14 @@ class ChannelPackagingTest(unittest.TestCase):
             "frostguard.product.name": "Frostguard",
             "frostguard.product.identifier": "dev.frostguard.desktop",
             "frostguard.product.install-dir": "Frostguard",
+            "frostguard.watcher.name": "FrostguardWatcher",
         }
         expected_nightly = {
             "frostguard.release.channel": "nightly",
             "frostguard.product.name": "Frostguard Nightly",
             "frostguard.product.identifier": "dev.frostguard.desktop.nightly",
             "frostguard.product.install-dir": "Frostguard Nightly",
+            "frostguard.watcher.name": "FrostguardNightlyWatcher",
         }
         for key, value in expected_stable.items():
             self.assertEqual(value, stable[key])
@@ -54,8 +56,41 @@ class ChannelPackagingTest(unittest.TestCase):
             "-Dfrostguard.update.manifest.stable=${frostguard.update.manifest.stable}",
             "-Dfrostguard.update.manifest.nightly=${frostguard.update.manifest.nightly}",
             "${project.build.directory}/installers/${frostguard.release.channel}",
+            "${frostguard.watcher.name}=",
+            "--win-shortcut-prompt",
+            "--resource-dir",
         ):
             self.assertIn(contract, pom)
+
+        installer_arguments = [
+            argument.attrib["value"]
+            for argument in root.findall(
+                ".//m:profile[m:id='windows-installer']//m:arg[@value]", NS)
+        ]
+        self.assertIn("--win-shortcut", installer_arguments)
+
+    def test_installer_exposes_only_product_shortcuts_and_guards_running_apps(self):
+        watcher = (REPO_ROOT / "packaging/desktop/src/main/windows/"
+                   "Frostguard-Watcher.properties").read_text(encoding="utf-8")
+        self.assertIn("win-menu=false", watcher)
+        self.assertIn("win-shortcut=false", watcher)
+
+        installer = (REPO_ROOT / "packaging/desktop/src/main/windows/main.wxs").read_text(
+            encoding="utf-8")
+        for contract in (
+            'WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1"',
+            "Launch $(var.JpAppName)",
+            "JpSetLaunchTarget",
+            "JpLaunchApplication",
+            "JpDetectRunningApplication",
+            "JP_FROSTGUARD_RUNNING",
+            "NOT JP_FROSTGUARD_RUNNING",
+            "JpStopWatcher",
+            'Before="InstallValidate"',
+            "Installed OR JP_UPGRADABLE_FOUND OR JP_DOWNGRADABLE_FOUND",
+            '<Custom Action="WixCloseApplications" Before="LaunchConditions">1</Custom>',
+        ):
+            self.assertIn(contract, installer)
 
     def test_signed_release_publishes_manifest_after_signed_installer_verification(self):
         workflow = (REPO_ROOT / ".github/workflows/signed-windows-channel-release.yml").read_text(

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Verify Stable/Nightly packaging and release-publication contracts."""
+
+from __future__ import annotations
+
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NS = {"m": "http://maven.apache.org/POM/4.0.0"}
+
+
+def properties(element: ET.Element) -> dict[str, str]:
+    node = element.find("m:properties", NS)
+    if node is None:
+        return {}
+    return {child.tag.rsplit("}", 1)[-1]: child.text or "" for child in node}
+
+
+class ChannelPackagingTest(unittest.TestCase):
+    def test_stable_and_nightly_use_distinct_durable_windows_identities(self):
+        root = ET.parse(REPO_ROOT / "packaging/desktop/pom.xml").getroot()
+        stable = properties(root)
+        nightly_profile = next(
+            profile for profile in root.findall("m:profiles/m:profile", NS)
+            if profile.find("m:id", NS).text == "windows-nightly"
+        )
+        nightly = properties(nightly_profile)
+
+        expected_stable = {
+            "frostguard.release.channel": "stable",
+            "frostguard.product.name": "Frostguard",
+            "frostguard.product.identifier": "dev.frostguard.desktop",
+            "frostguard.product.install-dir": "Frostguard",
+        }
+        expected_nightly = {
+            "frostguard.release.channel": "nightly",
+            "frostguard.product.name": "Frostguard Nightly",
+            "frostguard.product.identifier": "dev.frostguard.desktop.nightly",
+            "frostguard.product.install-dir": "Frostguard Nightly",
+        }
+        for key, value in expected_stable.items():
+            self.assertEqual(value, stable[key])
+        for key, value in expected_nightly.items():
+            self.assertEqual(value, nightly[key])
+        self.assertNotEqual(stable["frostguard.product.upgrade-uuid"],
+                            nightly["frostguard.product.upgrade-uuid"])
+
+        pom = (REPO_ROOT / "packaging/desktop/pom.xml").read_text(encoding="utf-8")
+        for contract in (
+            "-Dfrostguard.application.id=${frostguard.product.identifier}",
+            "-Dfrostguard.channel=${frostguard.release.channel}",
+            "-Dfrostguard.update.manifest.stable=${frostguard.update.manifest.stable}",
+            "-Dfrostguard.update.manifest.nightly=${frostguard.update.manifest.nightly}",
+            "${project.build.directory}/installers/${frostguard.release.channel}",
+        ):
+            self.assertIn(contract, pom)
+
+    def test_signed_release_publishes_manifest_after_signed_installer_verification(self):
+        workflow = (REPO_ROOT / ".github/workflows/signed-windows-channel-release.yml").read_text(
+            encoding="utf-8")
+        ordered_steps = (
+            "Sign and verify immutable installer",
+            "Create draft release and verify uploaded installer",
+            "Generate update manifest from the signed installer",
+            "Publish immutable release and channel manifest last",
+        )
+        positions = [workflow.index(step) for step in ordered_steps]
+        self.assertEqual(sorted(positions), positions)
+        self.assertIn("FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_BASE64", workflow)
+        self.assertIn("Get-AuthenticodeSignature", workflow)
+        self.assertIn("windows_installer_version.py", workflow)
+        self.assertIn("gh release upload updates-nightly $env:MANIFEST", workflow)
+        self.assertIn("Remove an abandoned draft release", workflow)
+        self.assertIn("--cleanup-tag --yes", workflow)
+        legacy_stable = (REPO_ROOT / ".github/workflows/stable-windows-release.yml").read_text(
+            encoding="utf-8")
+        self.assertIn("Frostguard 3.x must use Signed Windows Channel Release", legacy_stable)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -19,6 +19,29 @@ def properties(element: ET.Element) -> dict[str, str]:
 
 
 class ChannelPackagingTest(unittest.TestCase):
+    def test_pr_ci_and_nightly_publication_are_separate_workflows(self):
+        ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        nightly = (REPO_ROOT / ".github/workflows/daily-windows-bundle.yml").read_text(
+            encoding="utf-8")
+        installers = (REPO_ROOT / ".github/workflows/windows-native-package.yml").read_text(
+            encoding="utf-8")
+
+        self.assertIn("name: CI", ci)
+        self.assertIn("  pull_request:", ci)
+        self.assertIn("  contents: read", ci)
+        self.assertIn("Build and test Maven reactor", ci)
+        self.assertNotIn("contents: write", ci)
+
+        self.assertIn("name: Nightly Windows Bundle", nightly)
+        self.assertIn("  schedule:", nightly)
+        self.assertIn("  workflow_dispatch:", nightly)
+        self.assertNotIn("  pull_request:", nightly)
+        self.assertNotIn("\n  push:\n", nightly)
+        self.assertIn("  contents: write", nightly)
+
+        self.assertIn("name: Windows Installers", installers)
+        self.assertIn("Build and smoke-test Stable and Nightly installers", installers)
+
     def test_stable_and_nightly_use_distinct_durable_windows_identities(self):
         root = ET.parse(REPO_ROOT / "packaging/desktop/pom.xml").getroot()
         stable = properties(root)

--- a/build-support/verification/test_verify_app_image.py
+++ b/build-support/verification/test_verify_app_image.py
@@ -20,7 +20,9 @@ class VerifyAppImageTest(unittest.TestCase):
         self.image = Path(self.temp.name) / "Frostguard"
         files = list(verify_app_image.STATIC_REQUIRED_FILES) + [
             "Frostguard.exe",
+            "FrostguardWatcher.exe",
             "app/Frostguard.cfg",
+            "app/FrostguardWatcher.cfg",
             "app/frostguard-desktop-3.0.0.jar",
             "app/frostguard-watcher-3.0.0.jar",
             "app/lib/frostguard-update-3.0.0.jar",
@@ -75,7 +77,8 @@ class VerifyAppImageTest(unittest.TestCase):
     def test_rejects_watcher_without_stable_channel(self):
         config = self.image / "app/FrostguardWatcher.cfg"
         config.write_text(config.read_text().replace("channel=stable", "channel=development"))
-        self.assertTrue(any("FrostguardWatcher.cfg" in item for item in verify_app_image.inspect_image(self.image)))
+        self.assertTrue(any("FrostguardWatcher.cfg" in item
+                            for item in verify_app_image.inspect_image(self.image)))
 
     def test_rejects_launcher_without_pr_build_identity(self):
         config = self.image / "app/Frostguard.cfg"
@@ -105,14 +108,20 @@ class VerifyAppImageTest(unittest.TestCase):
 
     def test_accepts_nightly_identity_and_rejects_stable_expectations(self):
         (self.image / "Frostguard.exe").rename(self.image / "Frostguard Nightly.exe")
+        (self.image / "FrostguardWatcher.exe").rename(
+            self.image / "FrostguardNightlyWatcher.exe")
         stable_config = self.image / "app/Frostguard.cfg"
         nightly_config = self.image / "app/Frostguard Nightly.cfg"
         stable_config.rename(nightly_config)
-        for config in (nightly_config, self.image / "app/FrostguardWatcher.cfg"):
+        stable_watcher_config = self.image / "app/FrostguardWatcher.cfg"
+        nightly_watcher_config = self.image / "app/FrostguardNightlyWatcher.cfg"
+        stable_watcher_config.rename(nightly_watcher_config)
+        for config in (nightly_config, nightly_watcher_config):
             config.write_text(config.read_text().replace(
                 "channel=stable", "channel=nightly").replace(
                 "application.id=dev.frostguard.desktop", "application.id=dev.frostguard.desktop.nightly").replace(
-                "../Frostguard.exe", "../Frostguard Nightly.exe"), encoding="utf-8")
+                "../Frostguard.exe", "../Frostguard Nightly.exe").replace(
+                "../FrostguardWatcher.exe", "../FrostguardNightlyWatcher.exe"), encoding="utf-8")
 
         self.assertEqual([], verify_app_image.inspect_image(
             self.image, "nightly", "Frostguard Nightly"))

--- a/build-support/verification/test_verify_app_image.py
+++ b/build-support/verification/test_verify_app_image.py
@@ -18,7 +18,9 @@ class VerifyAppImageTest(unittest.TestCase):
     def setUp(self):
         self.temp = tempfile.TemporaryDirectory()
         self.image = Path(self.temp.name) / "Frostguard"
-        files = list(verify_app_image.REQUIRED_FILES) + [
+        files = list(verify_app_image.STATIC_REQUIRED_FILES) + [
+            "Frostguard.exe",
+            "app/Frostguard.cfg",
             "app/frostguard-desktop-3.0.0.jar",
             "app/frostguard-watcher-3.0.0.jar",
             "app/lib/frostguard-update-3.0.0.jar",
@@ -37,15 +39,22 @@ class VerifyAppImageTest(unittest.TestCase):
                 verify_app_image.BUILD_METADATA,
                 "pullRequestBuild=false\nauthenticodePublisher=CN=Frostguard Project, O=Frostguard\n",
             )
-        common_options = "\n".join(verify_app_image.COMMON_JAVA_OPTIONS) + (
+        common_options = "\n".join((
+            "java-options=-Dfrostguard.channel=stable",
+            "java-options=-Dfrostguard.application.id=dev.frostguard.desktop",
+            "java-options=-Duser.dir=$APPDIR",
+            "java-options=-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe",
+        )) + (
             "\njava-options=-Dfrostguard.update.pullRequestBuild=false\n"
         )
         (self.image / "app/Frostguard.cfg").write_text(
             "app.mainclass=dev.frostguard.app.bootstrap.Main\n"
-            "java-options=-Dfrostguard.update.manifest.stable=\n" + common_options,
+            "java-options=-Dfrostguard.update.manifest.stable=\n"
+            "java-options=-Dfrostguard.update.manifest.nightly=\n" + common_options,
             encoding="utf-8")
         (self.image / "app/FrostguardWatcher.cfg").write_text(
-            "app.mainclass=dev.frostguard.watcher.TelegramWatcher\n" + common_options,
+            "app.mainclass=dev.frostguard.watcher.TelegramWatcher\n"
+            "java-options=-Dfrostguard.launcher=$APPDIR/../Frostguard.exe\n" + common_options,
             encoding="utf-8")
 
     def tearDown(self):
@@ -93,6 +102,21 @@ class VerifyAppImageTest(unittest.TestCase):
         leaked.parent.mkdir(parents=True)
         leaked.write_text("private runtime log")
         self.assertTrue(any("leaked" in item for item in verify_app_image.inspect_image(self.image)))
+
+    def test_accepts_nightly_identity_and_rejects_stable_expectations(self):
+        (self.image / "Frostguard.exe").rename(self.image / "Frostguard Nightly.exe")
+        stable_config = self.image / "app/Frostguard.cfg"
+        nightly_config = self.image / "app/Frostguard Nightly.cfg"
+        stable_config.rename(nightly_config)
+        for config in (nightly_config, self.image / "app/FrostguardWatcher.cfg"):
+            config.write_text(config.read_text().replace(
+                "channel=stable", "channel=nightly").replace(
+                "application.id=dev.frostguard.desktop", "application.id=dev.frostguard.desktop.nightly").replace(
+                "../Frostguard.exe", "../Frostguard Nightly.exe"), encoding="utf-8")
+
+        self.assertEqual([], verify_app_image.inspect_image(
+            self.image, "nightly", "Frostguard Nightly"))
+        self.assertTrue(verify_app_image.inspect_image(self.image))
 
 
 if __name__ == "__main__":

--- a/build-support/verification/verify_app_image.py
+++ b/build-support/verification/verify_app_image.py
@@ -10,9 +10,7 @@ from pathlib import Path
 
 MINIMUM_RUNTIME_JARS = 50
 STATIC_REQUIRED_FILES = (
-    "FrostguardWatcher.exe",
     "runtime/bin/server/jvm.dll",
-    "app/FrostguardWatcher.cfg",
     "app/lib/adb/adb.exe",
     "app/lib/adb/AdbWinApi.dll",
     "app/lib/adb/AdbWinUsbApi.dll",
@@ -40,7 +38,14 @@ def inspect_image(
         for path in image.rglob("*")
         if path.is_file()
     }
-    required_files = (*STATIC_REQUIRED_FILES, f"{product_name}.exe", f"app/{product_name}.cfg")
+    watcher_name = "FrostguardNightlyWatcher" if channel == "nightly" else "FrostguardWatcher"
+    required_files = (
+        *STATIC_REQUIRED_FILES,
+        f"{product_name}.exe",
+        f"{watcher_name}.exe",
+        f"app/{product_name}.cfg",
+        f"app/{watcher_name}.cfg",
+    )
     for required in required_files:
         if required not in files:
             problems.append(f"Application image is missing {required}")
@@ -68,7 +73,7 @@ def inspect_image(
         f"java-options=-Dfrostguard.channel={channel}",
         f"java-options=-Dfrostguard.application.id=dev.frostguard.desktop{'.nightly' if channel == 'nightly' else ''}",
         "java-options=-Duser.dir=$APPDIR",
-        "java-options=-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe",
+        f"java-options=-Dfrostguard.watcher.launcher=$APPDIR/../{watcher_name}.exe",
     )
     config_settings = {
         f"app/{product_name}.cfg": (
@@ -77,7 +82,7 @@ def inspect_image(
             "java-options=-Dfrostguard.update.manifest.nightly=",
             *common_java_options,
         ),
-        "app/FrostguardWatcher.cfg": (
+        f"app/{watcher_name}.cfg": (
             "app.mainclass=dev.frostguard.watcher.TelegramWatcher",
             f"java-options=-Dfrostguard.launcher=$APPDIR/../{product_name}.exe",
             *common_java_options,

--- a/build-support/verification/verify_app_image.py
+++ b/build-support/verification/verify_app_image.py
@@ -9,11 +9,9 @@ import zipfile
 from pathlib import Path
 
 MINIMUM_RUNTIME_JARS = 50
-REQUIRED_FILES = (
-    "Frostguard.exe",
+STATIC_REQUIRED_FILES = (
     "FrostguardWatcher.exe",
     "runtime/bin/server/jvm.dll",
-    "app/Frostguard.cfg",
     "app/FrostguardWatcher.cfg",
     "app/lib/adb/adb.exe",
     "app/lib/adb/AdbWinApi.dll",
@@ -28,26 +26,11 @@ FORBIDDEN_NAMES = {
     "telegram-watcher.properties",
 }
 BUILD_METADATA = "dev/frostguard/app/frostguard-build.properties"
-COMMON_JAVA_OPTIONS = (
-    "java-options=-Dfrostguard.channel=stable",
-    "java-options=-Duser.dir=$APPDIR",
-    "java-options=-Dfrostguard.launcher=$APPDIR/../Frostguard.exe",
-    "java-options=-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe",
-)
-CONFIG_SETTINGS = {
-    "app/Frostguard.cfg": (
-        "app.mainclass=dev.frostguard.app.bootstrap.Main",
-        "java-options=-Dfrostguard.update.manifest.stable=",
-        *COMMON_JAVA_OPTIONS,
-    ),
-    "app/FrostguardWatcher.cfg": (
-        "app.mainclass=dev.frostguard.watcher.TelegramWatcher",
-        *COMMON_JAVA_OPTIONS,
-    ),
-}
 
 
-def inspect_image(image: Path) -> list[str]:
+def inspect_image(
+        image: Path, channel: str = "stable", product_name: str = "Frostguard"
+) -> list[str]:
     problems: list[str] = []
     if not image.is_dir():
         return [f"Application image does not exist: {image}"]
@@ -57,7 +40,8 @@ def inspect_image(image: Path) -> list[str]:
         for path in image.rglob("*")
         if path.is_file()
     }
-    for required in REQUIRED_FILES:
+    required_files = (*STATIC_REQUIRED_FILES, f"{product_name}.exe", f"app/{product_name}.cfg")
+    for required in required_files:
         if required not in files:
             problems.append(f"Application image is missing {required}")
 
@@ -80,8 +64,27 @@ def inspect_image(image: Path) -> list[str]:
         if not any(re.match(pattern, name) for name in files):
             problems.append(f"Application image has no {description}")
 
+    common_java_options = (
+        f"java-options=-Dfrostguard.channel={channel}",
+        f"java-options=-Dfrostguard.application.id=dev.frostguard.desktop{'.nightly' if channel == 'nightly' else ''}",
+        "java-options=-Duser.dir=$APPDIR",
+        "java-options=-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe",
+    )
+    config_settings = {
+        f"app/{product_name}.cfg": (
+            "app.mainclass=dev.frostguard.app.bootstrap.Main",
+            "java-options=-Dfrostguard.update.manifest.stable=",
+            "java-options=-Dfrostguard.update.manifest.nightly=",
+            *common_java_options,
+        ),
+        "app/FrostguardWatcher.cfg": (
+            "app.mainclass=dev.frostguard.watcher.TelegramWatcher",
+            f"java-options=-Dfrostguard.launcher=$APPDIR/../{product_name}.exe",
+            *common_java_options,
+        ),
+    }
     config_identities: dict[str, str] = {}
-    for config_path, settings in CONFIG_SETTINGS.items():
+    for config_path, settings in config_settings.items():
         if config_path not in files:
             continue
         config = files[config_path].read_text(encoding="utf-8")
@@ -139,8 +142,10 @@ def inspect_image(image: Path) -> list[str]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("image", type=Path)
+    parser.add_argument("--channel", choices=("stable", "nightly"), default="stable")
+    parser.add_argument("--product-name", default="Frostguard")
     args = parser.parse_args(argv)
-    problems = inspect_image(args.image)
+    problems = inspect_image(args.image, args.channel, args.product_name)
     if problems:
         for problem in problems:
             print(f"::error::{problem}")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -255,19 +255,27 @@ with `./mvnw javafx:run`; its versioned JAR is not a standalone distribution.
 - executable jar: `modules/desktop/target/frostguard-desktop-<version>.jar`
 - transitional desktop zip: `packaging/desktop/target/frostguard-<version>-desktop-bundle.zip`
 - packaging inputs staged under `packaging/desktop/target/input`
-- Windows application image: `packaging/desktop/target/app-image/Frostguard`
-- Windows installer: versioned EXE under `packaging/desktop/target/installers`
+- Windows application images: `packaging/desktop/target/app-image/Frostguard`
+  and `app-image/Frostguard Nightly`
+- Windows installers: versioned EXEs under
+  `packaging/desktop/target/installers/<channel>`
 - ADB/Tesseract files staged from `tools/`
 - custom task examples staged from root `examples/custom-tasks/`
 - template PNGs staged from `modules/vision/src/main/resources/templates`
 
 The native Windows image contains the desktop and watcher launchers plus a
-`jlink` runtime. Both launchers receive the Stable channel and workspace
-contract through packaged JVM options. The watcher and Task Scheduler launch
+`jlink` runtime. Each launcher receives its Stable or Nightly channel and
+workspace contract through packaged JVM options. The watcher and Task Scheduler launch
 the native executables when those packaged launcher paths are present, with
 the Java/JAR paths retained only as the source and transitional-ZIP fallback.
 Native packaging is opt-in through Maven profiles so the normal reactor build
 stays platform-neutral.
+
+Stable and Nightly use distinct application IDs, upgrade UUIDs, install
+directories, shortcuts, update feeds, workspace paths, and workspace-scoped
+Java preferences. A first Nightly launch may copy a closed Stable workspace as
+a one-time snapshot before persistence opens. Live sharing, continuous sync,
+and automatic Nightly-to-Stable migration are not supported.
 
 The installed desktop exposes update controls only for eligible Stable or
 Nightly builds. A selected installer is downloaded to

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -271,6 +271,13 @@ the Java/JAR paths retained only as the source and transitional-ZIP fallback.
 Native packaging is opt-in through Maven profiles so the normal reactor build
 stays platform-neutral.
 
+The watcher launcher is channel-specific internal infrastructure and does not
+receive Start-menu or desktop shortcuts. The installer exposes only the desktop
+launcher, optionally creates its desktop shortcut, and can launch it from the
+completion page. Installer maintenance refuses to proceed while that channel's
+desktop process is running; its background watcher can be stopped independently
+without affecting the other channel.
+
 Stable and Nightly use distinct application IDs, upgrade UUIDs, install
 directories, shortcuts, update feeds, workspace paths, and workspace-scoped
 Java preferences. A first Nightly launch may copy a closed Stable workspace as

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,28 +7,30 @@ required emulator, and building the project from source on Windows.
 
 | Build | Use it when | Download |
 |:------|:------------|:---------|
-| Stable | You want a tested, versioned build that changes only with a release | [Latest Stable](https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip) |
-| Nightly | You want the latest `main` build, updated daily | [Latest Nightly](https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip) |
+| Stable | You want a tested, versioned build that changes only with a release | [Latest Stable release](https://github.com/Shederator/wosbot/releases/latest) |
+| Nightly | You want the latest signed preview without replacing Stable | [Nightly releases](https://github.com/Shederator/wosbot/releases) |
 | PR build | You want to test one or more open pull requests | Run `/build-pr` in Discord `#request-a-build` |
 
-Stable and Nightly are public Windows desktop bundles. They require Java 21,
-but not Git, Git LFS, or Maven. Nightly may contain unfinished changes; PR
-builds additionally contain unmerged code.
-
-The self-contained Windows installer is being introduced for Frostguard 3.0.
-Until it is published through the release workflows, the download links above
-continue to provide the existing ZIP distribution.
+Stable and Nightly use self-contained, signed Windows installers and do not
+require a separately installed Java runtime. Nightly may contain unfinished
+changes; PR builds additionally contain unmerged code and continue to use the
+temporary ZIP format.
 
 ## Install a downloaded build
 
-1. Install a Java 21 JDK, such as [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=21).
-2. Download the desired ZIP from the table above.
-3. Extract the complete ZIP into an empty folder. Do not run Frostguard from inside the ZIP.
-4. Double-click `Start Frostguard.bat`.
-5. Open **Configuration** and select the emulator command-line controller.
+1. Open the desired release and download its Windows x64 EXE installer.
+2. Confirm that Windows reports the expected Frostguard publisher before running it.
+3. Complete the per-user installation and start `Frostguard` or `Frostguard Nightly` from its shortcut.
+4. Open **Configuration** and select the emulator command-line controller.
 
-Keep the extracted installation together. Its launcher, application JAR,
-runtime libraries, OCR data and templates are all required.
+Stable and Nightly install as separate applications. They can run side by side
+and use separate workspaces, databases, profiles, schedules, Telegram settings,
+logs, caches, and locks.
+
+On the first Nightly start, Frostguard offers either a fresh configuration or a
+one-time snapshot of the matching Stable workspace. Stable and its watcher must
+be closed during the copy. Later changes are not synchronized, and Nightly data
+is never copied back into Stable automatically.
 
 ## Emulator Setup
 
@@ -137,18 +139,30 @@ Building the versioned installer additionally requires WiX Toolset 3.14.1 with
 .\mvnw.cmd "-Pwindows-app-image,windows-installer" package
 ```
 
-The installer is written below `packaging/desktop/target/installers`. It is a
+The installer is written below `packaging/desktop/target/installers/stable`. It is a
 per-user installer and defaults to
 `%LOCALAPPDATA%\Frostguard`; the installer can offer another location.
 Normal `mvn package` remains platform-neutral and does not invoke `jpackage` or
 install Frostguard.
 
-Native Stable and Nightly builds can expose a channel-specific update feed in
+Build the independent Nightly identity by adding its explicit profile:
+
+```powershell
+.\mvnw.cmd "-Pwindows-app-image,windows-installer,windows-nightly" package
+python build-support/verification/verify_app_image.py `
+  "packaging/desktop/target/app-image/Frostguard Nightly" `
+  --channel nightly --product-name "Frostguard Nightly"
+```
+
+Nightly uses its own application ID, upgrade UUID, installation directory,
+shortcut, launcher identity, workspace channel, and update feed.
+
+Signed Stable and Nightly builds expose a channel-specific update feed in
 **Config > Updates**. Development and pull-request builds cannot install from
 release feeds. Frostguard accepts an update only after the manifest identity,
 download size, SHA-256, and Windows Authenticode signer all match. The current
 public ZIP feeds are not used by this updater; automatic installer updates stay
-disabled until signed Frostguard 3.0 release manifests are published.
+disabled in ordinary local and PR builds.
 
 ### Run a source build
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,9 @@ temporary ZIP format.
 
 1. Open the desired release and download its Windows x64 EXE installer.
 2. Confirm that Windows reports the expected Frostguard publisher before running it.
-3. Complete the per-user installation and start `Frostguard` or `Frostguard Nightly` from its shortcut.
+3. Choose whether to create a desktop shortcut and complete the per-user
+   installation. The final page starts `Frostguard` or `Frostguard Nightly` by
+   default; clear the checkbox if you do not want to launch it yet.
 4. Open **Configuration** and select the emulator command-line controller.
 
 Stable and Nightly install as separate applications. They can run side by side
@@ -183,7 +185,15 @@ Installed runs use named workspaces below
 `%USERPROFILE%\.frostguard\workspaces\<channel>\<name>\`. Each workspace owns
 its database, configuration, logs, custom tasks, cache, Telegram watcher state,
 and process lock. A workspace can be opened by only one Frostguard process at a
-time; use a different workspace for another bot instance.
+time. A second normal launch reports the already-running instance instead of a
+generic JVM error. Advanced users can run another isolated instance with
+`Frostguard.exe --workspace <name>` or
+`Frostguard Nightly.exe --workspace <name>`.
+
+Close Frostguard before updating or uninstalling it. The installer refuses to
+continue while the matching desktop process is running, so Windows cannot leave
+an unregistered but partially installed application behind. The channel-specific
+background watcher is stopped automatically during maintenance.
 
 ## Migrating an older installation
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,7 +1,9 @@
 # Releases
 
-Frostguard publishes three distinct Windows bundle types. Do not mix their
-notifications or download locations.
+Frostguard publishes signed installed releases for Stable and Nightly plus
+temporary ZIP builds for pull-request testing. The existing daily and Stable
+ZIP workflows remain transitional until #155 separates validation from public
+Nightly publication.
 
 | Type | Audience | Lifetime | Discord notification |
 |---|---|---|---|
@@ -9,15 +11,54 @@ notifications or download locations.
 | Daily `nightly` | Testers | Replaced daily | Update the daily download, no mass mention |
 | PR test `pr-test-*` | Requester/testers | Temporary | Reply only to the requester |
 
-## Stable promotion
+## Signed installed releases
 
-Stable releases promote an already successful `Daily Windows Bundle` run from
+Run **Signed Windows Channel Release** manually from `main`. It requires a
+semantic version, the target `stable` or `nightly` identity, and the minimum
+supported updater version. Stable versions use `X.Y.Z`; Nightly versions use an
+immutable prerelease such as `3.1.0-nightly.20260811.1`.
+
+Windows Installer compares only three numeric version fields. Stable maps
+directly to `X.Y.Z`. Nightly derives an independent, monotonically increasing
+Windows identity from `YYYYMMDD.N`; for example, the Nightly above uses
+`26.8.11001`. Use the current date and a sequence from 1 through 999, increasing
+the sequence for additional Nightlies on the same day.
+
+The workflow requires these repository secrets:
+
+- `FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_BASE64` — the PFX encoded as Base64;
+- `FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_PASSWORD` — the PFX password;
+- `FROSTGUARD_AUTHENTICODE_PUBLISHER` — the exact certificate subject embedded
+  into the application and required by every update manifest.
+
+Stable and Nightly use different application IDs, upgrade UUIDs, install
+directories, shortcuts, workspaces, and feeds. The workflow builds and smokes
+the selected identity, signs the installer, verifies the exact subject,
+uploads and re-downloads the immutable installer, derives its final size and
+SHA-256, and publishes the manifest last. Stable exposes its manifest through
+the latest immutable release; Nightly points `updates-nightly` at an installer
+stored in an immutable `nightly-<version>` release.
+
+A failure before publication removes the abandoned draft release and tag so the
+same immutable version can be retried. If a Nightly release becomes public but
+promotion of the rolling `updates-nightly` manifest fails afterward, leave the
+immutable release intact and keep the previous rolling manifest active. Recover
+by verifying and promoting the manifest asset from that immutable release; do
+not rebuild or replace its installer.
+
+## Transitional ZIP promotion
+
+The legacy Stable ZIP workflow promotes an already successful `Daily Windows Bundle` run from
 `main`; they do not rebuild a different tree. Run **Stable Windows Release**
 manually with:
 
 - `version`: the `X.Y.Z` value declared in `pom.xml`;
 - `daily_run_id`: a successful scheduled or manually triggered daily run from
   `main` after the intended release commit.
+
+This workflow rejects Frostguard 3.x. Installed 3.x releases must use the
+signed channel workflow so an unsigned ZIP can never become the latest Stable
+product accidentally.
 
 The workflow pins the run's exact commit, downloads its versioned artifact,
 re-runs structural and launch verification, creates the immutable `vX.Y.Z`
@@ -133,6 +174,15 @@ time:
 .\mvnw.cmd -Dfrostguard.update.manifest.stable=https://updates.example.invalid/stable.json `
   "-Dfrostguard.update.authenticode-publisher=CN=Frostguard Project, O=Frostguard" `
   "-Pwindows-app-image,windows-installer" package
+```
+
+Nightly adds its separate packaging identity and embeds both public endpoints:
+
+```powershell
+.\mvnw.cmd -Dfrostguard.update.manifest.stable=https://example.invalid/stable.json `
+  -Dfrostguard.update.manifest.nightly=https://example.invalid/nightly.json `
+  "-Dfrostguard.update.authenticode-publisher=CN=Frostguard Project, O=Frostguard" `
+  "-Pwindows-app-image,windows-installer,windows-nightly" package
 ```
 
 The checked-in endpoint and publisher defaults are empty, so ordinary local

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -48,7 +48,7 @@ not rebuild or replace its installer.
 
 ## Transitional ZIP promotion
 
-The legacy Stable ZIP workflow promotes an already successful `Daily Windows Bundle` run from
+The legacy Stable ZIP workflow promotes an already successful `Nightly Windows Bundle` run from
 `main`; they do not rebuild a different tree. Run **Stable Windows Release**
 manually with:
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -121,6 +121,13 @@ all mutable databases, configuration, logs, watcher state, and custom tasks
 remain in the selected workspace below `%USERPROFILE%\.frostguard`. The
 installation directory is treated as read-only application content.
 
+The installer offers a checked desktop-shortcut option and a checked launch
+option on its final page. Only the desktop application is exposed in the Start
+menu and on the desktop; the channel-specific Telegram watcher is an internal
+background launcher. Close the desktop application before update or uninstall.
+Maintenance is blocked while it is running rather than leaving locked files and
+a partially removed installation.
+
 Stable and Nightly never share live settings. The first Nightly start can copy
 a one-time Stable snapshot only while Stable and its watcher are closed and
 before Nightly persistence opens. Choosing a fresh start or completing the copy
@@ -137,6 +144,11 @@ This automatically creates and uses `<worktree>\.frostguard-dev\`. Each
 worktree therefore has isolated database, logs, custom tasks, cache, and
 Telegram watcher state. `git clean -xdf` intentionally removes this disposable
 development workspace.
+
+For an additional installed instance of the same channel, select another named
+workspace explicitly, for example `Frostguard.exe --workspace bot-2`. The
+default launch continues to use the `default` workspace and refuses a second
+owner, while each named workspace keeps its own data, ports, locks, and watcher.
 
 For automatic startup through scripts or Task Scheduler:
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -2,10 +2,10 @@
 
 This document summarizes Windows-specific setup for Frostguard.
 
-The [latest Stable Windows bundle](https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip)
-is versioned and remains unchanged until the next Stable release. The
-[latest Nightly](https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip)
-is rebuilt daily from `main`. Git, Git LFS and Maven are needed only when
+The [latest Stable release](https://github.com/Shederator/wosbot/releases/latest)
+provides the tested signed Windows installer. Signed Nightly releases appear in
+the [release history](https://github.com/Shederator/wosbot/releases) as a
+separate product identity. Git, Git LFS, Maven, and a JDK are needed only when
 building from source.
 
 ## Build Requirements
@@ -83,9 +83,20 @@ then run:
 ```
 
 Outputs remain below `packaging/desktop/target`: the directly runnable image is
-at `app-image/Frostguard`, and the installer is under `installers`. Native
+at `app-image/Frostguard`, and the installer is under `installers/stable`. Native
 packaging is opt-in because it is Windows-specific; ordinary `mvn package`
 continues to build and test the platform-neutral reactor.
+
+Add `windows-nightly` to produce `Frostguard Nightly` with a distinct application
+ID, upgrade UUID, install directory, shortcut, workspace channel, and update
+feed:
+
+```powershell
+.\mvnw.cmd "-Pwindows-app-image,windows-installer,windows-nightly" package
+python build-support/verification/verify_app_image.py `
+  "packaging/desktop/target/app-image/Frostguard Nightly" `
+  --channel nightly --product-name "Frostguard Nightly"
+```
 
 ## Runtime Requirements
 
@@ -102,15 +113,19 @@ The application currently packages Windows ADB and Tesseract assets from `tools/
 
 ## Starting Frostguard
 
-After downloading a desktop bundle, extract the complete ZIP into an empty
-folder and double-click `Start Frostguard.bat`. The launcher locates the
-versioned application JAR and reports a clear error if Java 21 is missing.
-
-For a native Frostguard 3.0 build, run the installed `Frostguard.exe` instead.
+After downloading a signed Frostguard 3.0 installer, verify its Windows
+publisher and complete the per-user installation. Run the installed
+`Frostguard.exe` or `Frostguard Nightly.exe`.
 The per-user installer defaults to `%LOCALAPPDATA%\Frostguard`, while
 all mutable databases, configuration, logs, watcher state, and custom tasks
 remain in the selected workspace below `%USERPROFILE%\.frostguard`. The
 installation directory is treated as read-only application content.
+
+Stable and Nightly never share live settings. The first Nightly start can copy
+a one-time Stable snapshot only while Stable and its watcher are closed and
+before Nightly persistence opens. Choosing a fresh start or completing the copy
+is recorded in Nightly; no continuous synchronization or automatic reverse
+migration exists.
 
 For a source build, run from the repository root:
 

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/RuntimeChannel.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/RuntimeChannel.java
@@ -3,12 +3,47 @@ package dev.frostguard.api.runtime;
 import java.util.Locale;
 
 public enum RuntimeChannel {
-    DEVELOPMENT,
-    NIGHTLY,
-    STABLE;
+    DEVELOPMENT("Development", "Frostguard Development", "dev.frostguard.desktop.development"),
+    NIGHTLY("Nightly", "Frostguard Nightly", "dev.frostguard.desktop.nightly"),
+    STABLE("Stable", "Frostguard", "dev.frostguard.desktop");
+
+    private final String displayName;
+    private final String productName;
+    private final String applicationId;
+
+    RuntimeChannel(String displayName, String productName, String applicationId) {
+        this.displayName = displayName;
+        this.productName = productName;
+        this.applicationId = applicationId;
+    }
 
     public String directoryName() {
         return name().toLowerCase(Locale.ROOT);
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    public String productName() {
+        return productName;
+    }
+
+    public String applicationId() {
+        return applicationId;
+    }
+
+    public boolean isPublicRelease() {
+        return this == STABLE || this == NIGHTLY;
+    }
+
+    public RuntimeChannel alternateRelease() {
+        return switch (this) {
+            case STABLE -> NIGHTLY;
+            case NIGHTLY -> STABLE;
+            case DEVELOPMENT -> throw new IllegalStateException(
+                    "Development has no public release-channel counterpart");
+        };
     }
 
     public static RuntimeChannel from(String value) {

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspacePaths.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspacePaths.java
@@ -6,10 +6,12 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.Optional;
 
 public record WorkspacePaths(Path root, RuntimeChannel channel) {
     public static final String WORKSPACE_PROPERTY = "frostguard.workspace";
     public static final String CHANNEL_PROPERTY = "frostguard.channel";
+    public static final String APPLICATION_ID_PROPERTY = "frostguard.application.id";
 
     public WorkspacePaths {
         root = root.toAbsolutePath().normalize();
@@ -30,11 +32,39 @@ public record WorkspacePaths(Path root, RuntimeChannel channel) {
             override = developmentRoot.resolve(".frostguard-dev").toString();
         }
         RuntimeChannel channel = RuntimeChannel.from(configuredChannel);
+        String applicationId = System.getProperty(APPLICATION_ID_PROPERTY, "").trim();
+        if (!applicationId.isEmpty() && !applicationId.equals(channel.applicationId())) {
+            throw new IllegalStateException("Application ID " + applicationId
+                    + " does not match channel " + channel.directoryName());
+        }
         Path root = override == null || override.isBlank()
-                ? Path.of(System.getProperty("user.home"), ".frostguard", "workspaces",
-                        channel.directoryName(), "default")
+                ? userWorkspace(channel, "default")
                 : Path.of(override);
         return new WorkspacePaths(root, channel);
+    }
+
+    public static Path userWorkspace(RuntimeChannel channel, String name) {
+        if (channel == null || !channel.isPublicRelease()) {
+            throw new IllegalArgumentException("Only Stable and Nightly use installed user workspaces");
+        }
+        if (name == null || name.isBlank() || name.equals(".") || name.equals("..")
+                || name.contains("/") || name.contains("\\")) {
+            throw new IllegalArgumentException("Workspace name must be one path segment");
+        }
+        return Path.of(System.getProperty("user.home"), ".frostguard", "workspaces",
+                channel.directoryName(), name).toAbsolutePath().normalize();
+    }
+
+    public Optional<WorkspacePaths> releasePeer(RuntimeChannel targetChannel) {
+        if (!channel.isPublicRelease() || targetChannel == null || !targetChannel.isPublicRelease()
+                || targetChannel == channel) {
+            return Optional.empty();
+        }
+        Path name = root.getFileName();
+        if (name == null || !root.equals(userWorkspace(channel, name.toString()))) {
+            return Optional.empty();
+        }
+        return Optional.of(new WorkspacePaths(userWorkspace(targetChannel, name.toString()), targetChannel));
     }
 
     private static Path findDevelopmentRoot() {

--- a/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
+++ b/modules/api/src/main/java/dev/frostguard/api/runtime/WorkspaceSession.java
@@ -32,7 +32,7 @@ public final class WorkspaceSession implements AutoCloseable {
             }
             if (lock == null) {
                 channel.close();
-                throw new IllegalStateException("Frostguard workspace is already in use: " + paths.root());
+                throw new WorkspaceInUseException(paths);
             }
             System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, paths.root().toString());
             System.setProperty("frostguard.log.dir", paths.logs().toString());
@@ -88,6 +88,19 @@ public final class WorkspaceSession implements AutoCloseable {
         try {
             lockChannel.close();
         } catch (IOException ignored) {
+        }
+    }
+
+    public static final class WorkspaceInUseException extends IllegalStateException {
+        private final WorkspacePaths paths;
+
+        private WorkspaceInUseException(WorkspacePaths paths) {
+            super("Frostguard workspace is already in use: " + paths.root());
+            this.paths = paths;
+        }
+
+        public WorkspacePaths paths() {
+            return paths;
         }
     }
 }

--- a/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
@@ -42,7 +42,10 @@ class WorkspaceSessionTest {
             assertTrue(paths.customTasks().toFile().isDirectory());
             assertTrue(paths.cache().toFile().isDirectory());
             assertTrue(paths.watcher().toFile().isDirectory());
-            assertThrows(IllegalStateException.class, () -> WorkspaceSession.open(paths));
+            WorkspaceSession.WorkspaceInUseException exception = assertThrows(
+                    WorkspaceSession.WorkspaceInUseException.class,
+                    () -> WorkspaceSession.open(paths));
+            assertEquals(paths, exception.paths());
         }
     }
 

--- a/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/runtime/WorkspaceSessionTest.java
@@ -108,6 +108,53 @@ class WorkspaceSessionTest {
         }
     }
 
+    @Test
+    void resolvesOnlyCanonicalInstalledWorkspacesAcrossReleaseChannels() {
+        String oldHome = System.getProperty("user.home");
+        try {
+            System.setProperty("user.home", tempDir.toString());
+            WorkspacePaths stable = new WorkspacePaths(
+                    WorkspacePaths.userWorkspace(RuntimeChannel.STABLE, "Bot 1"), RuntimeChannel.STABLE);
+
+            assertEquals(WorkspacePaths.userWorkspace(RuntimeChannel.NIGHTLY, "Bot 1"),
+                    stable.releasePeer(RuntimeChannel.NIGHTLY).orElseThrow().root());
+            assertTrue(new WorkspacePaths(tempDir.resolve("custom"), RuntimeChannel.STABLE)
+                    .releasePeer(RuntimeChannel.NIGHTLY).isEmpty());
+            assertTrue(stable.releasePeer(RuntimeChannel.DEVELOPMENT).isEmpty());
+        } finally {
+            restore("user.home", oldHome);
+        }
+    }
+
+    @Test
+    void rejectsWorkspaceNamesThatEscapeTheirReleaseChannel() {
+        assertThrows(IllegalArgumentException.class,
+                () -> WorkspacePaths.userWorkspace(RuntimeChannel.STABLE, "."));
+        assertThrows(IllegalArgumentException.class,
+                () -> WorkspacePaths.userWorkspace(RuntimeChannel.STABLE, ".."));
+        assertThrows(IllegalArgumentException.class,
+                () -> WorkspacePaths.userWorkspace(RuntimeChannel.STABLE, "nested/name"));
+    }
+
+    @Test
+    void rejectsAProductIdentityThatDoesNotMatchItsChannel() {
+        String oldChannel = System.getProperty(WorkspacePaths.CHANNEL_PROPERTY);
+        String oldApplicationId = System.getProperty(WorkspacePaths.APPLICATION_ID_PROPERTY);
+        try {
+            System.setProperty(WorkspacePaths.CHANNEL_PROPERTY, "nightly");
+            System.setProperty(WorkspacePaths.APPLICATION_ID_PROPERTY, "dev.frostguard.desktop");
+
+            assertThrows(IllegalStateException.class, WorkspacePaths::current);
+
+            System.setProperty(WorkspacePaths.APPLICATION_ID_PROPERTY,
+                    RuntimeChannel.NIGHTLY.applicationId());
+            assertEquals(RuntimeChannel.NIGHTLY, WorkspacePaths.current().channel());
+        } finally {
+            restore(WorkspacePaths.CHANNEL_PROPERTY, oldChannel);
+            restore(WorkspacePaths.APPLICATION_ID_PROPERTY, oldApplicationId);
+        }
+    }
+
     private static void restore(String property, String value) {
         if (value == null) {
             System.clearProperty(property);

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -840,7 +840,7 @@ public class TaskQueue {
 
     private String resolveAutostartCommand(WorkspacePaths workspace, java.nio.file.Path runtimeCache)
             throws java.io.IOException {
-        String nativeLauncher = System.getProperty(APP_LAUNCHER_PROPERTY, "").trim();
+        String nativeLauncher = packagedApplicationLauncher();
         if (!nativeLauncher.isBlank()) {
             java.nio.file.Path launcher = java.nio.file.Path.of(nativeLauncher).toAbsolutePath().normalize();
             if (java.nio.file.Files.isRegularFile(launcher)) {
@@ -854,6 +854,11 @@ public class TaskQueue {
         return "javaw.exe -D" + WorkspacePaths.WORKSPACE_PROPERTY + "=\"" + workspace.root()
                 + "\" -D" + WorkspacePaths.CHANNEL_PROPERTY + "=" + workspace.channel().directoryName()
                 + " -jar \"" + jar + "\" --autostart";
+    }
+
+    static String packagedApplicationLauncher() {
+        String configured = System.getProperty(APP_LAUNCHER_PROPERTY, "").trim();
+        return configured.isBlank() ? System.getProperty("jpackage.app-path", "").trim() : configured;
     }
 
     static String nativeAutostartLauncherContent(java.nio.file.Path launcher, WorkspacePaths workspace) {

--- a/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueDesktopJarResolutionTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueDesktopJarResolutionTest.java
@@ -55,4 +55,28 @@ class TaskQueueDesktopJarResolutionTest {
         assertTrue(script.contains("set \"FROSTGUARD_CHANNEL=stable\""));
         assertTrue(script.contains("start \"\" \"" + launcher + "\" --autostart"));
     }
+
+    @Test
+    void usesTheJpackageLauncherPathWhenNoExplicitOverrideExists() {
+        String oldConfigured = System.getProperty("frostguard.launcher");
+        String oldJpackage = System.getProperty("jpackage.app-path");
+        try {
+            System.clearProperty("frostguard.launcher");
+            System.setProperty("jpackage.app-path", tempDir.resolve("Frostguard Nightly.exe").toString());
+
+            assertEquals(tempDir.resolve("Frostguard Nightly.exe").toString(),
+                    TaskQueue.packagedApplicationLauncher());
+        } finally {
+            restore("frostguard.launcher", oldConfigured);
+            restore("jpackage.app-path", oldJpackage);
+        }
+    }
+
+    private static void restore(String property, String value) {
+        if (value == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, value);
+        }
+    }
 }

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/ApplicationLifecycle.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/ApplicationLifecycle.java
@@ -18,21 +18,35 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public final class ApplicationLifecycle {
     private static final Logger LOG = LoggerFactory.getLogger(ApplicationLifecycle.class);
     private static final AtomicBoolean SHUTDOWN_ACTIVE = new AtomicBoolean();
+    private static final AtomicBoolean RUNTIME_STARTED = new AtomicBoolean();
     private static final RuntimeShutdownCoordinator COORDINATOR = new RuntimeShutdownCoordinator(List.of(
-            new RuntimeShutdownCoordinator.Step("scheduler", () -> ScheduleService.obtain().haltEngine()),
-            new RuntimeShutdownCoordinator.Step("gift code automation",
+            runtimeStep("scheduler", () -> ScheduleService.obtain().haltEngine()),
+            runtimeStep("gift code automation",
                     () -> GiftCodeAutomationService.getInstance().shutdown()),
-            new RuntimeShutdownCoordinator.Step("Telegram command server",
+            runtimeStep("Telegram command server",
                     () -> TelegramBotService.getInstance().stop()),
-            new RuntimeShutdownCoordinator.Step("custom task loader", () -> CustomTaskService.getInstance().shutdown()),
-            new RuntimeShutdownCoordinator.Step("analytics", () -> AnalyticsService.getInstance().trackAppShutdown()),
-            new RuntimeShutdownCoordinator.Step("persistence", () -> DataStore.getInstance().close()),
-            new RuntimeShutdownCoordinator.Step("ADB", ApplicationLifecycle::terminateAdbProcess),
-            new RuntimeShutdownCoordinator.Step("profile logging", ProfileContextLogger::shutdown),
+            runtimeStep("custom task loader", () -> CustomTaskService.getInstance().shutdown()),
+            runtimeStep("analytics", () -> AnalyticsService.getInstance().trackAppShutdown()),
+            new RuntimeShutdownCoordinator.Step("persistence", DataStore::closeIfInitialized),
+            runtimeStep("ADB", ApplicationLifecycle::terminateAdbProcess),
+            runtimeStep("profile logging", ProfileContextLogger::shutdown),
             new RuntimeShutdownCoordinator.Step("workspace", Main::closeWorkspace)
     ));
 
     private ApplicationLifecycle() {
+    }
+
+    static void markRuntimeStarted() {
+        RUNTIME_STARTED.set(true);
+    }
+
+    private static RuntimeShutdownCoordinator.Step runtimeStep(
+            String name, RuntimeShutdownCoordinator.ShutdownAction action) {
+        return new RuntimeShutdownCoordinator.Step(name, () -> {
+            if (RUNTIME_STARTED.get()) {
+                action.run();
+            }
+        });
     }
 
     public static void stopForUpdate() throws LifecycleException {
@@ -42,7 +56,8 @@ public final class ApplicationLifecycle {
         try {
             COORDINATOR.shutdown();
         } catch (RuntimeShutdownCoordinator.ShutdownException exception) {
-            SHUTDOWN_ACTIVE.set(false);
+            LOG.error("Runtime shutdown for update was incomplete; cancelling installation and exiting: {}",
+                    exception.getMessage());
             throw new LifecycleException(exception.getMessage(), exception);
         }
     }
@@ -62,6 +77,11 @@ public final class ApplicationLifecycle {
     public static void exitAfterUpdateHandoff() {
         Platform.exit();
         System.exit(0);
+    }
+
+    public static void exitAfterCancelledUpdate() {
+        Platform.exit();
+        System.exit(1);
     }
 
     static void runShutdownHook() {

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/ChannelOnboarding.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/ChannelOnboarding.java
@@ -1,0 +1,94 @@
+package dev.frostguard.app.bootstrap;
+
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
+
+import java.io.IOException;
+import java.util.Optional;
+
+final class ChannelOnboarding {
+    private ChannelOnboarding() {
+    }
+
+    static boolean showBeforeStartup() {
+        Optional<WorkspaceSettingsSnapshot> available = WorkspaceSettingsSnapshot.forCurrentNightly();
+        if (available.isEmpty()) {
+            return true;
+        }
+        WorkspaceSettingsSnapshot snapshot = available.orElseThrow();
+        try {
+            if (snapshot.isCompleted() || !snapshot.isTargetFresh()) {
+                return true;
+            }
+            if (!snapshot.hasStableSettings()) {
+                explainFreshNightly(snapshot);
+                return true;
+            }
+            if (!snapshot.sourceIsAvailable()) {
+                return explainBusyStable(snapshot);
+            }
+            return offerStableSnapshot(snapshot);
+        } catch (IOException failure) {
+            showFailure(failure);
+            return false;
+        }
+    }
+
+    private static void explainFreshNightly(WorkspaceSettingsSnapshot snapshot) throws IOException {
+        Alert alert = new Alert(Alert.AlertType.INFORMATION);
+        alert.setTitle("Set up Frostguard Nightly");
+        alert.setHeaderText("Nightly keeps its own settings");
+        alert.setContentText("No Stable workspace was found. Frostguard Nightly will start with new profiles, "
+                + "tasks, schedules, and Telegram settings. Stable remains unchanged.");
+        alert.showAndWait();
+        snapshot.startFresh();
+    }
+
+    private static boolean explainBusyStable(WorkspaceSettingsSnapshot snapshot) throws IOException {
+        ButtonType fresh = new ButtonType("Start fresh", ButtonBar.ButtonData.OK_DONE);
+        ButtonType retryLater = new ButtonType("Exit and retry later", ButtonBar.ButtonData.CANCEL_CLOSE);
+        Alert alert = new Alert(Alert.AlertType.CONFIRMATION, "", fresh, retryLater);
+        alert.setTitle("Set up Frostguard Nightly");
+        alert.setHeaderText("Stable is currently using its settings");
+        alert.setContentText("Close Frostguard Stable and its Telegram watcher, then restart Nightly to copy a "
+                + "safe snapshot. You can also start Nightly with separate, empty settings now.");
+        if (alert.showAndWait().filter(fresh::equals).isPresent()) {
+            snapshot.startFresh();
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean offerStableSnapshot(WorkspaceSettingsSnapshot snapshot) throws IOException {
+        ButtonType copy = new ButtonType("Copy Stable settings", ButtonBar.ButtonData.OK_DONE);
+        ButtonType fresh = new ButtonType("Start fresh", ButtonBar.ButtonData.OTHER);
+        ButtonType cancel = new ButtonType("Exit", ButtonBar.ButtonData.CANCEL_CLOSE);
+        Alert alert = new Alert(Alert.AlertType.CONFIRMATION, "", copy, fresh, cancel);
+        alert.setTitle("Set up Frostguard Nightly");
+        alert.setHeaderText("Nightly keeps an independent copy of your settings");
+        alert.setContentText("Copying creates a one-time snapshot of Stable profiles, tasks, schedules, "
+                + "Telegram configuration, custom tasks, and desktop preferences. Later changes are not "
+                + "synchronized, and Nightly data is never copied back into Stable automatically.");
+        Optional<ButtonType> choice = alert.showAndWait();
+        if (choice.filter(copy::equals).isPresent()) {
+            snapshot.copyFromStable();
+            return true;
+        }
+        if (choice.filter(fresh::equals).isPresent()) {
+            snapshot.startFresh();
+            return true;
+        }
+        return false;
+    }
+
+    private static void showFailure(IOException failure) {
+        Alert alert = new Alert(Alert.AlertType.ERROR);
+        alert.setTitle("Nightly settings setup failed");
+        alert.setHeaderText("Stable settings were not changed");
+        alert.setContentText(failure.getMessage() == null
+                ? "Could not prepare the Nightly workspace. Restart Frostguard Nightly to try again."
+                : failure.getMessage());
+        alert.showAndWait();
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/FXApp.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/FXApp.java
@@ -1,6 +1,7 @@
 package dev.frostguard.app.bootstrap;
 
 import atlantafx.base.theme.PrimerDark;
+import dev.frostguard.api.runtime.WorkspacePaths;
 import dev.frostguard.app.panel.launcher.ILauncherConstants;
 import dev.frostguard.app.panel.launcher.LauncherLayoutController;
 import dev.frostguard.app.panel.misc.GiftCodeAutomationService;
@@ -43,7 +44,12 @@ public class FXApp extends Application {
 
     @Override
     public void start(Stage stage) throws IOException {
-        preferences = Preferences.userRoot().node(FXApp.class.getName());
+        if (!ChannelOnboarding.showBeforeStartup()) {
+            Platform.exit();
+            return;
+        }
+        Main.initializeRuntimeServices(false);
+        preferences = WorkspacePreferences.currentNode("window");
         Application.setUserAgentStylesheet(new PrimerDark().getUserAgentStylesheet());
 
         LauncherLayoutController controller = new LauncherLayoutController(stage);
@@ -77,7 +83,7 @@ public class FXApp extends Application {
         stage.setScene(scene);
         stage.setMinWidth(680);
         stage.setMinHeight(460);
-        stage.setTitle("Frostguard Control Center");
+        stage.setTitle(WorkspacePaths.current().channel().productName() + " Control Center");
         stage.getIcons().add(loadAppIcon());
         WindowResizer.makeResizable(stage);
     }

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
@@ -5,81 +5,125 @@ import org.slf4j.LoggerFactory;
 
 import dev.frostguard.api.runtime.WorkspacePaths;
 import dev.frostguard.api.runtime.WorkspaceSession;
+import dev.frostguard.api.runtime.WorkspaceSession.WorkspaceInUseException;
 import dev.frostguard.engine.service.AnalyticsService;
 import dev.frostguard.tasks.TaskRegistrations;
 
 public class Main {
-	private static final WorkspaceSession WORKSPACE = WorkspaceSession.open(WorkspacePaths.current());
-	private static final Logger logger = LoggerFactory.getLogger(Main.class);
+    private static volatile WorkspaceSession workspace;
 
-	public static void main(String[] args) {
-		try {
-			if (java.util.Arrays.asList(args).contains("--frostguard-native-smoke-test")) {
-				java.nio.file.Files.writeString(
-						WORKSPACE.paths().cache().resolve("native-app-smoke.properties"),
-						"channel=" + WORKSPACE.paths().channel().directoryName() + "\n"
-								+ "applicationId=" + System.getProperty(WorkspacePaths.APPLICATION_ID_PROPERTY, "") + "\n"
-								+ "workspace=" + WORKSPACE.paths().root() + "\n"
-								+ "applicationDir=" + System.getProperty("user.dir") + "\n"
-								+ "appLauncher=" + System.getProperty("jpackage.app-path", "") + "\n",
-						java.nio.charset.StandardCharsets.UTF_8);
-				System.out.println("Frostguard native launcher smoke test passed");
-				System.out.println("channel=" + WORKSPACE.paths().channel().directoryName());
-				System.out.println("workspace=" + WORKSPACE.paths().root());
-				System.out.println("applicationDir=" + System.getProperty("user.dir"));
-				System.out.println("pullRequestBuild="
-						+ System.getProperty("frostguard.update.pullRequestBuild", "false"));
-				WORKSPACE.close();
-				return;
-			}
-			boolean isHeadless = false;
-			for (String arg : args) {
-				if ("--headless".equalsIgnoreCase(arg)) {
-					isHeadless = true;
-					break;
-				}
-			}
-			
-			// 1. Setup environment
-			System.setProperty("logback.statusListenerClass", "ch.qos.logback.core.status.NopStatusListener");
-			java.util.logging.Logger.getLogger("").setLevel(java.util.logging.Level.WARNING);
-			java.util.logging.Logger.getLogger("javafx").setLevel(java.util.logging.Level.SEVERE);
-			java.util.logging.Logger.getLogger("com.sun.javafx").setLevel(java.util.logging.Level.SEVERE);
-			java.util.logging.Logger.getLogger("javax.swing").setLevel(java.util.logging.Level.SEVERE);
+    public static void main(String[] args) {
+        StartupOptions options;
+        WorkspacePaths paths;
+        try {
+            options = StartupOptions.parse(args);
+            paths = options.resolveWorkspace();
+            workspace = WorkspaceSession.open(paths);
+        } catch (WorkspaceInUseException alreadyRunning) {
+            reportWorkspaceInUse(alreadyRunning.paths(), hasHeadlessArgument(args));
+            return;
+        } catch (RuntimeException startupConfigurationFailure) {
+            StartupFailureReporter.report("Frostguard could not start",
+                    startupConfigurationFailure.getMessage(), hasHeadlessArgument(args));
+            return;
+        }
 
-			logger.info("Initializing Frostguard with workspace {}", WORKSPACE.paths().root());
+        configureLoggingNoise();
+        Logger logger = LoggerFactory.getLogger(Main.class);
+        try {
+            if (options.nativeSmokeTest()) {
+                runNativeSmokeTest();
+                closeWorkspace();
+                return;
+            }
 
-			// 2. Setup Shutdown Hook
-			Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-				logger.info("Closing down subsystems.");
-				ApplicationLifecycle.runShutdownHook();
-			}, "frostguard-shutdown"));
+            logger.info("Initializing Frostguard with workspace {}", workspace.paths().root());
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                logger.info("Closing down subsystems.");
+                ApplicationLifecycle.runShutdownHook();
+            }, "frostguard-shutdown"));
 
-			// 3. Delegate to the selected launcher. Graphical startup initializes
-			// services only after Nightly onboarding has completed.
-			if (isHeadless) {
-				initializeRuntimeServices(true);
-				logger.info("Headless application triggered.");
-				HeadlessApp.start(args);
-				Thread.currentThread().join();
-			} else {
-				FXApp.main(args);
-			}
+            if (options.headless()) {
+                initializeRuntimeServices(true);
+                logger.info("Headless application triggered.");
+                HeadlessApp.start(args);
+                Thread.currentThread().join();
+            } else {
+                FXApp.main(args);
+            }
+        } catch (Exception exception) {
+            logger.error("Startup failure: ", exception);
+            ApplicationLifecycle.exitNormally(1);
+        }
+    }
 
-		} catch (Exception e) {
-			logger.error("Startup failure: ", e);
-			ApplicationLifecycle.exitNormally(1);
-		}
-	}
+    private static void reportWorkspaceInUse(WorkspacePaths paths, boolean headless) {
+        String workspaceName = paths.root().getFileName() == null
+                ? paths.root().toString()
+                : paths.root().getFileName().toString();
+        String launcherName = paths.channel().productName() + ".exe";
+        StartupFailureReporter.report(paths.channel().productName() + " is already running",
+                paths.channel().productName() + " already owns workspace \"" + workspaceName + "\"."
+                        + System.lineSeparator() + System.lineSeparator()
+                        + "Close the running instance first, or use a separate workspace:"
+                        + System.lineSeparator() + launcherName + " --workspace <name>",
+                headless);
+    }
 
-	static void initializeRuntimeServices(boolean headless) {
-		ApplicationLifecycle.markRuntimeStarted();
-		try { AnalyticsService.getInstance().initialize(); } catch (Exception ignored) {}
-		TaskRegistrations.initialize();
-		try { AnalyticsService.getInstance().trackAppLaunched(headless); } catch (Exception ignored) {}
-	}
+    private static boolean hasHeadlessArgument(String[] args) {
+        for (String argument : args) {
+            if ("--headless".equalsIgnoreCase(argument)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	static void closeWorkspace() {
-		WORKSPACE.close();
-	}
+    private static void configureLoggingNoise() {
+        System.setProperty("logback.statusListenerClass", "ch.qos.logback.core.status.NopStatusListener");
+        java.util.logging.Logger.getLogger("").setLevel(java.util.logging.Level.WARNING);
+        java.util.logging.Logger.getLogger("javafx").setLevel(java.util.logging.Level.SEVERE);
+        java.util.logging.Logger.getLogger("com.sun.javafx").setLevel(java.util.logging.Level.SEVERE);
+        java.util.logging.Logger.getLogger("javax.swing").setLevel(java.util.logging.Level.SEVERE);
+    }
+
+    private static void runNativeSmokeTest() throws java.io.IOException {
+        WorkspaceSession currentWorkspace = workspace;
+        java.nio.file.Files.writeString(
+                currentWorkspace.paths().cache().resolve("native-app-smoke.properties"),
+                "channel=" + currentWorkspace.paths().channel().directoryName() + "\n"
+                        + "applicationId="
+                        + System.getProperty(WorkspacePaths.APPLICATION_ID_PROPERTY, "") + "\n"
+                        + "workspace=" + currentWorkspace.paths().root() + "\n"
+                        + "applicationDir=" + System.getProperty("user.dir") + "\n"
+                        + "appLauncher=" + System.getProperty("jpackage.app-path", "") + "\n",
+                java.nio.charset.StandardCharsets.UTF_8);
+        System.out.println("Frostguard native launcher smoke test passed");
+        System.out.println("channel=" + currentWorkspace.paths().channel().directoryName());
+        System.out.println("workspace=" + currentWorkspace.paths().root());
+        System.out.println("applicationDir=" + System.getProperty("user.dir"));
+        System.out.println("pullRequestBuild="
+                + System.getProperty("frostguard.update.pullRequestBuild", "false"));
+    }
+
+    static void initializeRuntimeServices(boolean headless) {
+        ApplicationLifecycle.markRuntimeStarted();
+        try {
+            AnalyticsService.getInstance().initialize();
+        } catch (Exception ignored) {
+        }
+        TaskRegistrations.initialize();
+        try {
+            AnalyticsService.getInstance().trackAppLaunched(headless);
+        } catch (Exception ignored) {
+        }
+    }
+
+    static void closeWorkspace() {
+        WorkspaceSession currentWorkspace = workspace;
+        workspace = null;
+        if (currentWorkspace != null) {
+            currentWorkspace.close();
+        }
+    }
 }

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/Main.java
@@ -15,6 +15,14 @@ public class Main {
 	public static void main(String[] args) {
 		try {
 			if (java.util.Arrays.asList(args).contains("--frostguard-native-smoke-test")) {
+				java.nio.file.Files.writeString(
+						WORKSPACE.paths().cache().resolve("native-app-smoke.properties"),
+						"channel=" + WORKSPACE.paths().channel().directoryName() + "\n"
+								+ "applicationId=" + System.getProperty(WorkspacePaths.APPLICATION_ID_PROPERTY, "") + "\n"
+								+ "workspace=" + WORKSPACE.paths().root() + "\n"
+								+ "applicationDir=" + System.getProperty("user.dir") + "\n"
+								+ "appLauncher=" + System.getProperty("jpackage.app-path", "") + "\n",
+						java.nio.charset.StandardCharsets.UTF_8);
 				System.out.println("Frostguard native launcher smoke test passed");
 				System.out.println("channel=" + WORKSPACE.paths().channel().directoryName());
 				System.out.println("workspace=" + WORKSPACE.paths().root());
@@ -47,13 +55,10 @@ public class Main {
 				ApplicationLifecycle.runShutdownHook();
 			}, "frostguard-shutdown"));
 
-			// 3. Initialize Services
-			try { AnalyticsService.getInstance().initialize(); } catch (Exception ignored) {}
-			TaskRegistrations.initialize();
-			try { AnalyticsService.getInstance().trackAppLaunched(isHeadless); } catch (Exception ignored) {}
-
-			// 4. Delegate to appropriate launcher
+			// 3. Delegate to the selected launcher. Graphical startup initializes
+			// services only after Nightly onboarding has completed.
 			if (isHeadless) {
+				initializeRuntimeServices(true);
 				logger.info("Headless application triggered.");
 				HeadlessApp.start(args);
 				Thread.currentThread().join();
@@ -65,6 +70,13 @@ public class Main {
 			logger.error("Startup failure: ", e);
 			ApplicationLifecycle.exitNormally(1);
 		}
+	}
+
+	static void initializeRuntimeServices(boolean headless) {
+		ApplicationLifecycle.markRuntimeStarted();
+		try { AnalyticsService.getInstance().initialize(); } catch (Exception ignored) {}
+		TaskRegistrations.initialize();
+		try { AnalyticsService.getInstance().trackAppLaunched(headless); } catch (Exception ignored) {}
 	}
 
 	static void closeWorkspace() {

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/StartupFailureReporter.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/StartupFailureReporter.java
@@ -1,0 +1,25 @@
+package dev.frostguard.app.bootstrap;
+
+import java.awt.GraphicsEnvironment;
+
+import javax.swing.JOptionPane;
+
+final class StartupFailureReporter {
+    private StartupFailureReporter() {
+    }
+
+    static void report(String title, String message, boolean headless) {
+        if (message == null || message.isBlank()) {
+            message = "An unknown startup error occurred.";
+        }
+        System.err.println(title + ": " + message.replace(System.lineSeparator(), " "));
+        if (headless || GraphicsEnvironment.isHeadless()) {
+            return;
+        }
+        try {
+            JOptionPane.showMessageDialog(null, message, title, JOptionPane.WARNING_MESSAGE);
+        } catch (RuntimeException dialogFailure) {
+            System.err.println("Could not display the startup error dialog: " + dialogFailure.getMessage());
+        }
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/StartupOptions.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/StartupOptions.java
@@ -1,0 +1,58 @@
+package dev.frostguard.app.bootstrap;
+
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+import java.util.Objects;
+
+record StartupOptions(boolean headless, boolean nativeSmokeTest, String workspaceName) {
+    private static final String WORKSPACE_OPTION = "--workspace";
+
+    static StartupOptions parse(String[] args) {
+        Objects.requireNonNull(args, "args");
+        boolean headless = false;
+        boolean nativeSmokeTest = false;
+        String workspaceName = null;
+
+        for (int index = 0; index < args.length; index++) {
+            String argument = args[index];
+            if ("--headless".equalsIgnoreCase(argument)) {
+                headless = true;
+            } else if ("--frostguard-native-smoke-test".equals(argument)) {
+                nativeSmokeTest = true;
+            } else if (WORKSPACE_OPTION.equals(argument)) {
+                if (index + 1 >= args.length || args[index + 1].startsWith("--")) {
+                    throw new IllegalArgumentException("--workspace requires a workspace name");
+                }
+                workspaceName = acceptWorkspaceName(workspaceName, args[++index]);
+            } else if (argument.startsWith(WORKSPACE_OPTION + "=")) {
+                workspaceName = acceptWorkspaceName(
+                        workspaceName, argument.substring((WORKSPACE_OPTION + "=").length()));
+            }
+        }
+        return new StartupOptions(headless, nativeSmokeTest, workspaceName);
+    }
+
+    WorkspacePaths resolveWorkspace() {
+        WorkspacePaths current = WorkspacePaths.current();
+        if (workspaceName == null) {
+            return current;
+        }
+        if (!current.channel().isPublicRelease()) {
+            throw new IllegalArgumentException(
+                    "--workspace is available for installed Stable and Nightly builds only; "
+                            + "development launches already use a worktree-local workspace");
+        }
+        return new WorkspacePaths(
+                WorkspacePaths.userWorkspace(current.channel(), workspaceName), current.channel());
+    }
+
+    private static String acceptWorkspaceName(String current, String candidate) {
+        if (current != null) {
+            throw new IllegalArgumentException("--workspace can be specified only once");
+        }
+        if (candidate == null || candidate.isBlank()) {
+            throw new IllegalArgumentException("--workspace requires a workspace name");
+        }
+        return candidate;
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/WorkspacePreferences.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/WorkspacePreferences.java
@@ -1,0 +1,53 @@
+package dev.frostguard.app.bootstrap;
+
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+
+public final class WorkspacePreferences {
+    private static final String ROOT = "/dev/frostguard/workspaces";
+
+    private WorkspacePreferences() {
+    }
+
+    public static Preferences currentNode(String scope) {
+        return node(WorkspacePaths.current(), scope);
+    }
+
+    static Preferences node(WorkspacePaths workspace, String scope) {
+        if (scope == null || scope.isBlank() || scope.contains("/")) {
+            throw new IllegalArgumentException("Preference scope must be one non-empty node name");
+        }
+        return Preferences.userRoot().node(ROOT)
+                .node(workspace.channel().directoryName())
+                .node(workspace.identity())
+                .node(scope);
+    }
+
+    static void copyAll(WorkspacePaths source, WorkspacePaths target) throws BackingStoreException {
+        Preferences sourceRoot = Preferences.userRoot().node(ROOT)
+                .node(source.channel().directoryName()).node(source.identity());
+        removeAll(target);
+        Preferences targetRoot = Preferences.userRoot().node(ROOT)
+                .node(target.channel().directoryName()).node(target.identity());
+        copyNode(sourceRoot, targetRoot);
+        targetRoot.flush();
+    }
+
+    static void removeAll(WorkspacePaths workspace) throws BackingStoreException {
+        Preferences root = Preferences.userRoot().node(ROOT)
+                .node(workspace.channel().directoryName()).node(workspace.identity());
+        root.removeNode();
+        Preferences.userRoot().flush();
+    }
+
+    private static void copyNode(Preferences source, Preferences target) throws BackingStoreException {
+        for (String key : source.keys()) {
+            target.put(key, source.get(key, ""));
+        }
+        for (String child : source.childrenNames()) {
+            copyNode(source.node(child), target.node(child));
+        }
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/WorkspaceSettingsSnapshot.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/WorkspaceSettingsSnapshot.java
@@ -1,0 +1,316 @@
+package dev.frostguard.app.bootstrap;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.prefs.BackingStoreException;
+
+public final class WorkspaceSettingsSnapshot {
+    private static final String COMPLETED_FILE = "channel-onboarding.properties";
+    private static final String JOURNAL_FILE = "channel-onboarding.in-progress";
+    private static final List<String> DATABASE_SUFFIXES = List.of("", "-wal", "-shm");
+
+    private final WorkspacePaths source;
+    private final WorkspacePaths target;
+
+    public WorkspaceSettingsSnapshot(WorkspacePaths source, WorkspacePaths target) {
+        if (source.channel() != RuntimeChannel.STABLE || target.channel() != RuntimeChannel.NIGHTLY) {
+            throw new IllegalArgumentException("Settings snapshots are supported only from Stable to Nightly");
+        }
+        this.source = source;
+        this.target = target;
+    }
+
+    public static Optional<WorkspaceSettingsSnapshot> forCurrentNightly() {
+        WorkspacePaths current = WorkspacePaths.current();
+        if (current.channel() != RuntimeChannel.NIGHTLY) {
+            return Optional.empty();
+        }
+        return current.releasePeer(RuntimeChannel.STABLE)
+                .map(stable -> new WorkspaceSettingsSnapshot(stable, current));
+    }
+
+    public boolean isCompleted() {
+        return Files.isRegularFile(completedMarker());
+    }
+
+    public boolean hasStableSettings() {
+        return Files.isRegularFile(source.marker()) && Files.isRegularFile(source.database());
+    }
+
+    public boolean isTargetFresh() throws IOException {
+        recoverInterruptedCopy();
+        return !isCompleted()
+                && databaseFiles(target).stream().noneMatch(Files::exists)
+                && directoryIsEmpty(target.config())
+                && directoryIsEmpty(target.customTasks())
+                && !Files.exists(target.watcherConfig());
+    }
+
+    public boolean sourceIsAvailable() throws IOException {
+        if (!hasStableSettings()) {
+            return false;
+        }
+        try (SourceLocks ignored = SourceLocks.acquire(source)) {
+            return true;
+        } catch (WorkspaceBusyException busy) {
+            return false;
+        }
+    }
+
+    public void startFresh() throws IOException {
+        try {
+            WorkspacePreferences.removeAll(target);
+        } catch (BackingStoreException cause) {
+            throw new IOException("Could not reset Nightly desktop preferences", cause);
+        }
+        Files.writeString(completedMarker(), "mode=fresh\nsource=none\n",
+                StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+    }
+
+    public void copyFromStable() throws IOException {
+        if (!isTargetFresh()) {
+            throw new IOException("Nightly settings already exist; first-run copy is no longer safe");
+        }
+        if (!hasStableSettings()) {
+            throw new IOException("No Stable settings are available to copy");
+        }
+
+        Path staging = target.cache().resolve("settings-import-" + UUID.randomUUID());
+        try (SourceLocks ignored = SourceLocks.acquire(source)) {
+            Files.createDirectories(staging);
+            stageFiles(staging);
+            Files.writeString(journal(), "source=" + source.root() + "\n",
+                    StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+            promote(staging);
+            try {
+                WorkspacePreferences.copyAll(source, target);
+            } catch (BackingStoreException cause) {
+                throw new IOException("Could not copy desktop preferences", cause);
+            }
+            Files.deleteIfExists(journal());
+            Files.writeString(completedMarker(), "mode=stable-snapshot\nsource=" + source.root() + "\n",
+                    StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+        } catch (Exception failure) {
+            rollbackImportedFiles();
+            if (failure instanceof IOException ioFailure) {
+                throw ioFailure;
+            }
+            throw new IOException("Could not copy Stable settings", failure);
+        } finally {
+            deleteTree(staging);
+        }
+    }
+
+    private void stageFiles(Path staging) throws IOException {
+        for (Path databaseFile : databaseFiles(source)) {
+            if (Files.isRegularFile(databaseFile)) {
+                Files.copy(databaseFile, staging.resolve(databaseFile.getFileName()),
+                        StandardCopyOption.COPY_ATTRIBUTES);
+            }
+        }
+        copyDirectory(source.config(), staging.resolve("config"));
+        copyDirectory(source.customTasks(), staging.resolve("custom-tasks"));
+        if (Files.isRegularFile(source.watcherConfig())) {
+            Files.createDirectories(staging.resolve("watcher"));
+            Files.copy(source.watcherConfig(), staging.resolve("watcher").resolve(
+                    source.watcherConfig().getFileName()), StandardCopyOption.COPY_ATTRIBUTES);
+        }
+    }
+
+    private void promote(Path staging) throws IOException {
+        for (Path stagedDatabase : databaseFiles(new WorkspacePaths(staging, RuntimeChannel.STABLE))) {
+            if (Files.isRegularFile(stagedDatabase)) {
+                Files.move(stagedDatabase, target.root().resolve(stagedDatabase.getFileName()),
+                        StandardCopyOption.ATOMIC_MOVE);
+            }
+        }
+        moveDirectoryContents(staging.resolve("config"), target.config());
+        moveDirectoryContents(staging.resolve("custom-tasks"), target.customTasks());
+        Path watcherConfig = staging.resolve("watcher").resolve(source.watcherConfig().getFileName());
+        if (Files.isRegularFile(watcherConfig)) {
+            Files.move(watcherConfig, target.watcherConfig(), StandardCopyOption.ATOMIC_MOVE);
+        }
+    }
+
+    private void recoverInterruptedCopy() throws IOException {
+        if (Files.exists(journal()) && !isCompleted()) {
+            rollbackImportedFiles();
+        }
+    }
+
+    private void rollbackImportedFiles() throws IOException {
+        for (Path databaseFile : databaseFiles(target)) {
+            Files.deleteIfExists(databaseFile);
+        }
+        clearDirectory(target.config());
+        clearDirectory(target.customTasks());
+        Files.deleteIfExists(target.watcherConfig());
+        try {
+            WorkspacePreferences.removeAll(target);
+        } catch (BackingStoreException cause) {
+            throw new IOException("Could not roll back desktop preferences", cause);
+        }
+        Files.deleteIfExists(journal());
+        Files.deleteIfExists(completedMarker());
+    }
+
+    private Path completedMarker() {
+        return target.root().resolve(COMPLETED_FILE);
+    }
+
+    private Path journal() {
+        return target.root().resolve(JOURNAL_FILE);
+    }
+
+    private static List<Path> databaseFiles(WorkspacePaths workspace) {
+        List<Path> files = new ArrayList<>();
+        for (String suffix : DATABASE_SUFFIXES) {
+            files.add(Path.of(workspace.database().toString() + suffix));
+        }
+        return files;
+    }
+
+    private static boolean directoryIsEmpty(Path directory) throws IOException {
+        if (!Files.isDirectory(directory)) {
+            return true;
+        }
+        try (var children = Files.list(directory)) {
+            return children.findAny().isEmpty();
+        }
+    }
+
+    private static void copyDirectory(Path source, Path destination) throws IOException {
+        if (!Files.isDirectory(source)) {
+            return;
+        }
+        try (var paths = Files.walk(source)) {
+            for (Path path : paths.toList()) {
+                Path relative = source.relativize(path);
+                Path copy = destination.resolve(relative);
+                if (Files.isDirectory(path)) {
+                    Files.createDirectories(copy);
+                } else {
+                    Files.copy(path, copy, StandardCopyOption.COPY_ATTRIBUTES);
+                }
+            }
+        }
+    }
+
+    private static void moveDirectoryContents(Path source, Path destination) throws IOException {
+        if (!Files.isDirectory(source)) {
+            return;
+        }
+        try (var children = Files.list(source)) {
+            for (Path child : children.toList()) {
+                Files.move(child, destination.resolve(child.getFileName()), StandardCopyOption.ATOMIC_MOVE);
+            }
+        }
+    }
+
+    private static void clearDirectory(Path directory) throws IOException {
+        if (!Files.isDirectory(directory)) {
+            return;
+        }
+        try (var children = Files.list(directory)) {
+            for (Path child : children.toList()) {
+                deleteTree(child);
+            }
+        }
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        if (root == null || !Files.exists(root)) {
+            return;
+        }
+        try (var paths = Files.walk(root)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(path);
+            }
+        }
+    }
+
+    private static final class SourceLocks implements AutoCloseable {
+        private final LockedFile application;
+        private final LockedFile watcher;
+
+        private SourceLocks(LockedFile application, LockedFile watcher) {
+            this.application = application;
+            this.watcher = watcher;
+        }
+
+        static SourceLocks acquire(WorkspacePaths source) throws IOException {
+            LockedFile application = LockedFile.acquire(source.applicationLock());
+            try {
+                return new SourceLocks(application, LockedFile.acquire(source.watcherLock()));
+            } catch (Exception failure) {
+                application.close();
+                throw failure;
+            }
+        }
+
+        @Override
+        public void close() {
+            watcher.close();
+            application.close();
+        }
+    }
+
+    private static final class LockedFile implements AutoCloseable {
+        private final FileChannel channel;
+        private final FileLock lock;
+
+        private LockedFile(FileChannel channel, FileLock lock) {
+            this.channel = channel;
+            this.lock = lock;
+        }
+
+        static LockedFile acquire(Path path) throws IOException {
+            Files.createDirectories(path.getParent());
+            FileChannel channel = FileChannel.open(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            try {
+                FileLock lock;
+                try {
+                    lock = channel.tryLock();
+                } catch (OverlappingFileLockException busy) {
+                    lock = null;
+                }
+                if (lock == null) {
+                    throw new WorkspaceBusyException();
+                }
+                return new LockedFile(channel, lock);
+            } catch (Exception failure) {
+                channel.close();
+                throw failure;
+            }
+        }
+
+        @Override
+        public void close() {
+            try {
+                lock.release();
+            } catch (IOException ignored) {
+            }
+            try {
+                channel.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    private static final class WorkspaceBusyException extends IOException {
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
@@ -49,6 +49,8 @@ import dev.frostguard.app.panel.profile.IProfileObserverInjectable;
 import dev.frostguard.app.panel.profile.ProfileAux;
 import dev.frostguard.app.panel.profile.ProfileManagerLayoutController;
 import dev.frostguard.api.domain.QueueStateData;
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
 import dev.frostguard.engine.listener.StaminaChangeListener;
 import dev.frostguard.engine.service.ConfigService;
 import dev.frostguard.engine.service.ScheduleService;
@@ -720,10 +722,8 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
 
         String version = getVersion();
         int stamina = StaminaService.getServices().getCurrentStamina(currentProfile.getId());
-        String title = String.format("Whiteout Survival Bot v%s - %s [Stamina: %d]",
-                version,
-                currentProfile.getName(),
-                stamina);
+        String title = formatWindowTitle(WorkspacePaths.current().channel(), version,
+                currentProfile.getName(), stamina);
 
         Platform.runLater(() -> {
             stage.setTitle(title);
@@ -731,6 +731,11 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
                 labelWindowTitle.setText(title);
             }
         });
+    }
+
+    static String formatWindowTitle(RuntimeChannel channel, String version, String profileName, int stamina) {
+        return String.format("%s v%s - %s [Stamina: %d]",
+                channel.productName(), version, profileName, stamina);
     }
 
     public void onEngineStateTransition(BotStateData botState) { /* bind */

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerLayoutController.java
@@ -19,6 +19,7 @@ import dev.frostguard.api.configs.TpMessageSeverityEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.ProfileStatusData;
 import dev.frostguard.api.domain.ProfileTagData;
+import dev.frostguard.app.bootstrap.WorkspacePreferences;
 import dev.frostguard.engine.service.LoggingService;
 import dev.frostguard.engine.service.ProfileService;
 import dev.frostguard.engine.service.ScheduleService;
@@ -92,8 +93,7 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 	private final List<String> structuredFilters = new ArrayList<>();
 	private final ContextMenu searchSuggestions = new ContextMenu();
 	private Map<String, String> tagColors = Map.of();
-	private final Preferences savedViewPreferences = Preferences.userNodeForPackage(
-			ProfileManagerLayoutController.class).node("profile-search-views");
+	private final Preferences savedViewPreferences = WorkspacePreferences.currentNode("profile-search-views");
 
 	@FXML
 	private TableView<ProfileAux> tableviewLogMessages;

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/update/ChannelSwitchService.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/update/ChannelSwitchService.java
@@ -1,0 +1,124 @@
+package dev.frostguard.app.panel.update;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+
+import java.awt.Desktop;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+final class ChannelSwitchService {
+    private static final String LAUNCHER_PROPERTY = "frostguard.channel.launcher.";
+    private static final String PAGE_PROPERTY = "frostguard.channel.page.";
+
+    private final Function<String, String> properties;
+    private final Supplier<String> localAppData;
+    private final Launcher launcher;
+    private final PageOpener pageOpener;
+
+    ChannelSwitchService() {
+        this(System::getProperty, () -> System.getenv("LOCALAPPDATA"),
+                executable -> new ProcessBuilder(executable.toString())
+                        .directory(executable.getParent().toFile()).start(),
+                uri -> {
+                    if (!Desktop.isDesktopSupported()) {
+                        throw new IOException("Desktop links are not supported on this system");
+                    }
+                    Desktop.getDesktop().browse(uri);
+                });
+    }
+
+    ChannelSwitchService(Function<String, String> properties, Supplier<String> localAppData,
+                         Launcher launcher, PageOpener pageOpener) {
+        this.properties = properties;
+        this.localAppData = localAppData;
+        this.launcher = launcher;
+        this.pageOpener = pageOpener;
+    }
+
+    Result open(RuntimeChannel target) throws IOException {
+        if (target == null || !target.isPublicRelease()) {
+            throw new IllegalArgumentException("Channel switching supports only Stable and Nightly");
+        }
+        Optional<Path> installed = installedLauncher(target);
+        if (installed.isPresent()) {
+            launcher.launch(installed.orElseThrow());
+            return Result.LAUNCHED_INSTALLED;
+        }
+        URI page = releasePage(target);
+        pageOpener.open(page);
+        return Result.OPENED_RELEASE_PAGE;
+    }
+
+    Optional<Path> installedLauncher(RuntimeChannel target) {
+        String productName = target.productName();
+        String executableName = productName + ".exe";
+        List<Path> candidates = new ArrayList<>();
+
+        String configured = properties.apply(LAUNCHER_PROPERTY + target.directoryName());
+        if (configured != null && !configured.isBlank()) {
+            candidates.add(Path.of(configured));
+        }
+
+        String current = properties.apply("frostguard.launcher");
+        if (current == null || current.isBlank()) {
+            current = properties.apply("jpackage.app-path");
+        }
+        if (current != null && !current.isBlank()) {
+            Path currentLauncher = Path.of(current).toAbsolutePath().normalize();
+            Path currentInstall = currentLauncher.getParent();
+            if (currentInstall != null && currentInstall.getParent() != null) {
+                candidates.add(currentInstall.getParent().resolve(productName).resolve(executableName));
+            }
+        }
+
+        String appData = localAppData.get();
+        if (appData != null && !appData.isBlank()) {
+            candidates.add(Path.of(appData).resolve(productName).resolve(executableName));
+        }
+        return candidates.stream()
+                .map(path -> path.toAbsolutePath().normalize())
+                .filter(Files::isRegularFile)
+                .findFirst();
+    }
+
+    private URI releasePage(RuntimeChannel target) throws IOException {
+        String configured = properties.apply(PAGE_PROPERTY + target.directoryName());
+        if (configured == null || configured.isBlank()) {
+            configured = target == RuntimeChannel.NIGHTLY
+                    ? "https://github.com/Shederator/wosbot/releases"
+                    : "https://github.com/Shederator/wosbot/releases/latest";
+        }
+        URI uri;
+        try {
+            uri = URI.create(configured);
+        } catch (IllegalArgumentException invalid) {
+            throw new IOException("The " + target.displayName() + " release page is invalid", invalid);
+        }
+        if (!"https".equalsIgnoreCase(uri.getScheme()) || uri.getHost() == null) {
+            throw new IOException("The " + target.displayName() + " release page must use HTTPS");
+        }
+        return uri;
+    }
+
+    enum Result {
+        LAUNCHED_INSTALLED,
+        OPENED_RELEASE_PAGE
+    }
+
+    @FunctionalInterface
+    interface Launcher {
+        void launch(Path executable) throws IOException;
+    }
+
+    @FunctionalInterface
+    interface PageOpener {
+        void open(URI page) throws IOException;
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateExitCoordinator.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateExitCoordinator.java
@@ -4,11 +4,13 @@ import dev.frostguard.update.InstallerHandoff;
 
 final class UpdateExitCoordinator {
     private final ShutdownAction shutdown;
-    private final Runnable exit;
+    private final Runnable successfulExit;
+    private final Runnable failedExit;
 
-    UpdateExitCoordinator(ShutdownAction shutdown, Runnable exit) {
+    UpdateExitCoordinator(ShutdownAction shutdown, Runnable successfulExit, Runnable failedExit) {
         this.shutdown = shutdown;
-        this.exit = exit;
+        this.successfulExit = successfulExit;
+        this.failedExit = failedExit;
     }
 
     void execute(InstallerHandoff.HandoffSession session) throws Exception {
@@ -17,9 +19,10 @@ final class UpdateExitCoordinator {
             shutdown.run();
         } catch (Exception exception) {
             session.cancel();
+            failedExit.run();
             throw exception;
         }
-        exit.run();
+        successfulExit.run();
     }
 
     @FunctionalInterface

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateExitCoordinator.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateExitCoordinator.java
@@ -14,9 +14,9 @@ final class UpdateExitCoordinator {
     }
 
     void execute(InstallerHandoff.HandoffSession session) throws Exception {
-        session.authorize();
         try {
             shutdown.run();
+            session.authorize();
         } catch (Exception exception) {
             session.cancel();
             failedExit.run();

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateLayoutController.java
@@ -42,12 +42,17 @@ public final class UpdateLayoutController {
     @FXML private Button buttonCheck;
     @FXML private Button buttonDownloadInstall;
     @FXML private ProgressIndicator progress;
+    @FXML private VBox channelSwitchPane;
+    @FXML private Label labelChannelSwitch;
+    @FXML private Button buttonSwitchChannel;
 
     private final UpdateEndpointResolver endpoints = new UpdateEndpointResolver();
     private final UpdateManager manager = new UpdateManager(
             new WindowsAuthenticodeVerifier(), new WindowsInstallerHandoff());
+    private final ChannelSwitchService channelSwitcher = new ChannelSwitchService();
     private RunningBuild runningBuild;
     private UpdateCandidate candidate;
+    private RuntimeChannel switchTarget;
 
     @FXML
     private void initialize() {
@@ -56,6 +61,7 @@ public final class UpdateLayoutController {
         labelChannel.setText("Channel: " + runningBuild.channel().directoryName());
         setAvailableUpdateVisible(false);
         progress.setVisible(false);
+        configureChannelSwitch();
 
         if (!runningBuild.permitsAutomaticUpdates()) {
             buttonCheck.setDisable(true);
@@ -71,6 +77,33 @@ public final class UpdateLayoutController {
             labelStatus.setText("Automatic installer handoff is currently available on Windows only.");
         } else {
             labelStatus.setText("Check the configured " + runningBuild.channel().directoryName() + " release feed.");
+        }
+    }
+
+    @FXML
+    private void handleSwitchChannel() {
+        if (switchTarget == null) {
+            return;
+        }
+        Alert confirmation = new Alert(Alert.AlertType.CONFIRMATION);
+        confirmation.setTitle("Open Frostguard " + switchTarget.displayName());
+        confirmation.setHeaderText(switchTarget == RuntimeChannel.NIGHTLY
+                ? "Try Frostguard Nightly as a separate installation?"
+                : "Return to Frostguard Stable?");
+        confirmation.setContentText("Stable and Nightly keep separate profiles, tasks, schedules, Telegram "
+                + "settings, and databases. Both can run side by side. A first Nightly launch can copy a "
+                + "one-time Stable snapshot, but later changes are not synchronized.");
+        if (confirmation.showAndWait().filter(ButtonType.OK::equals).isEmpty()) {
+            return;
+        }
+        try {
+            ChannelSwitchService.Result result = channelSwitcher.open(switchTarget);
+            labelStatus.setText(result == ChannelSwitchService.Result.LAUNCHED_INSTALLED
+                    ? "Frostguard " + switchTarget.displayName() + " was launched separately."
+                    : "Opened the Frostguard " + switchTarget.displayName() + " release page.");
+        } catch (Exception failure) {
+            showFailure(new UpdateException("Could not open Frostguard " + switchTarget.displayName()
+                    + ": " + failure.getMessage(), failure));
         }
     }
 
@@ -132,7 +165,9 @@ public final class UpdateLayoutController {
         try {
             session = manager.stageHandoff(prepared, ProcessHandle.current().pid());
             UpdateExitCoordinator coordinator = new UpdateExitCoordinator(
-                    ApplicationLifecycle::stopForUpdate, ApplicationLifecycle::exitAfterUpdateHandoff);
+                    ApplicationLifecycle::stopForUpdate,
+                    ApplicationLifecycle::exitAfterUpdateHandoff,
+                    ApplicationLifecycle::exitAfterCancelledUpdate);
             coordinator.execute(session);
         } catch (Exception exception) {
             if (session != null) {
@@ -172,6 +207,24 @@ public final class UpdateLayoutController {
     private void setAvailableUpdateVisible(boolean visible) {
         availableUpdatePane.setVisible(visible);
         availableUpdatePane.setManaged(visible);
+    }
+
+    private void configureChannelSwitch() {
+        boolean supported = supportsChannelSwitch(runningBuild.channel());
+        channelSwitchPane.setVisible(supported);
+        channelSwitchPane.setManaged(supported);
+        if (!supported) {
+            switchTarget = null;
+            return;
+        }
+        switchTarget = runningBuild.channel().alternateRelease();
+        buttonSwitchChannel.setText(switchTarget == RuntimeChannel.NIGHTLY ? "Try Nightly" : "Return to Stable");
+        labelChannelSwitch.setText("Frostguard " + switchTarget.displayName()
+                + " is a separate application with its own settings and workspace.");
+    }
+
+    static boolean supportsChannelSwitch(RuntimeChannel channel) {
+        return channel != null && channel.isPublicRelease();
     }
 
     static RunningBuild runningBuild() {

--- a/modules/desktop/src/main/resources/layout/UpdateLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/UpdateLayout.fxml
@@ -39,4 +39,11 @@
         <Button fx:id="buttonDownloadInstall" text="Download and install"
                 onAction="#handleDownloadInstall" />
     </VBox>
+
+    <VBox fx:id="channelSwitchPane" spacing="10"
+          style="-fx-background-color: #1b2028; -fx-background-radius: 6; -fx-padding: 16;">
+        <Label text="Release channel" style="-fx-font-size: 16px; -fx-font-weight: bold; -fx-text-fill: #e6edf3;" />
+        <Label fx:id="labelChannelSwitch" wrapText="true" style="-fx-text-fill: #9da7b3;" />
+        <Button fx:id="buttonSwitchChannel" onAction="#handleSwitchChannel" />
+    </VBox>
 </VBox>

--- a/modules/desktop/src/test/java/dev/frostguard/app/bootstrap/StartupOptionsTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/bootstrap/StartupOptionsTest.java
@@ -1,0 +1,92 @@
+package dev.frostguard.app.bootstrap;
+
+import dev.frostguard.api.runtime.WorkspacePaths;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StartupOptionsTest {
+    @TempDir
+    Path tempDir;
+
+    private String previousChannel;
+    private String previousApplicationId;
+    private String previousWorkspace;
+    private String previousUserHome;
+
+    @BeforeEach
+    void configureInstalledStableBuild() {
+        previousChannel = System.getProperty(WorkspacePaths.CHANNEL_PROPERTY);
+        previousApplicationId = System.getProperty(WorkspacePaths.APPLICATION_ID_PROPERTY);
+        previousWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        previousUserHome = System.getProperty("user.home");
+        System.setProperty(WorkspacePaths.CHANNEL_PROPERTY, "stable");
+        System.setProperty(WorkspacePaths.APPLICATION_ID_PROPERTY, "dev.frostguard.desktop");
+        System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        System.setProperty("user.home", tempDir.toString());
+    }
+
+    @AfterEach
+    void restoreRuntimeProperties() {
+        restore(WorkspacePaths.CHANNEL_PROPERTY, previousChannel);
+        restore(WorkspacePaths.APPLICATION_ID_PROPERTY, previousApplicationId);
+        restore(WorkspacePaths.WORKSPACE_PROPERTY, previousWorkspace);
+        restore("user.home", previousUserHome);
+    }
+
+    @Test
+    void keepsTheDefaultInstalledWorkspaceWithoutAnOption() {
+        StartupOptions options = StartupOptions.parse(new String[] {"--autostart"});
+
+        assertFalse(options.headless());
+        assertFalse(options.nativeSmokeTest());
+        assertEquals(tempDir.resolve(".frostguard/workspaces/stable/default").toAbsolutePath(),
+                options.resolveWorkspace().root());
+    }
+
+    @Test
+    void resolvesASeparateNamedInstalledWorkspace() {
+        StartupOptions options = StartupOptions.parse(
+                new String[] {"--headless", "--workspace", "bot-2"});
+
+        assertTrue(options.headless());
+        assertEquals(tempDir.resolve(".frostguard/workspaces/stable/bot-2").toAbsolutePath(),
+                options.resolveWorkspace().root());
+    }
+
+    @Test
+    void acceptsTheEqualsFormAndNativeSmokeFlag() {
+        StartupOptions options = StartupOptions.parse(
+                new String[] {"--workspace=qa", "--frostguard-native-smoke-test"});
+
+        assertTrue(options.nativeSmokeTest());
+        assertEquals("qa", options.workspaceName());
+    }
+
+    @Test
+    void rejectsMissingDuplicateAndUnsafeWorkspaceNames() {
+        assertThrows(IllegalArgumentException.class,
+                () -> StartupOptions.parse(new String[] {"--workspace"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> StartupOptions.parse(new String[] {"--workspace=one", "--workspace", "two"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> StartupOptions.parse(new String[] {"--workspace", "../shared"})
+                        .resolveWorkspace());
+    }
+
+    private static void restore(String property, String value) {
+        if (value == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, value);
+        }
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/bootstrap/WorkspaceSettingsSnapshotTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/bootstrap/WorkspaceSettingsSnapshotTest.java
@@ -1,0 +1,128 @@
+package dev.frostguard.app.bootstrap;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.api.runtime.WorkspaceSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WorkspaceSettingsSnapshotTest {
+    @TempDir
+    Path tempDir;
+
+    private WorkspacePaths stable;
+    private WorkspacePaths nightly;
+
+    @AfterEach
+    void removePreferenceNodes() throws Exception {
+        if (stable != null) {
+            WorkspacePreferences.removeAll(stable);
+        }
+        if (nightly != null) {
+            WorkspacePreferences.removeAll(nightly);
+        }
+    }
+
+    @Test
+    void copiesAClosedStableSnapshotWithoutSharingRuntimeFiles() throws Exception {
+        initializeWorkspaces();
+        Files.writeString(stable.database(), "database");
+        Files.writeString(Path.of(stable.database() + "-wal"), "wal");
+        Files.createDirectories(stable.config().resolve("nested"));
+        Files.writeString(stable.config().resolve("nested/settings.json"), "settings");
+        Files.writeString(stable.customTasks().resolve("task.java"), "task");
+        Files.writeString(stable.watcherConfig(), "token=secret");
+        Files.writeString(stable.logs().resolve("private.log"), "log");
+        Files.writeString(stable.cache().resolve("download.part"), "partial");
+        WorkspacePreferences.node(stable, "window").put("windowX", "42");
+        WorkspacePreferences.node(nightly, "window").put("stale", "remove-me");
+
+        WorkspaceSettingsSnapshot snapshot = new WorkspaceSettingsSnapshot(stable, nightly);
+        assertTrue(snapshot.isTargetFresh());
+        assertTrue(snapshot.sourceIsAvailable());
+        snapshot.copyFromStable();
+
+        assertEquals("database", Files.readString(nightly.database()));
+        assertEquals("wal", Files.readString(Path.of(nightly.database() + "-wal")));
+        assertEquals("settings", Files.readString(nightly.config().resolve("nested/settings.json")));
+        assertEquals("task", Files.readString(nightly.customTasks().resolve("task.java")));
+        assertEquals("token=secret", Files.readString(nightly.watcherConfig()));
+        assertEquals("42", WorkspacePreferences.node(nightly, "window").get("windowX", ""));
+        assertEquals("", WorkspacePreferences.node(nightly, "window").get("stale", ""));
+        assertFalse(Files.exists(nightly.logs().resolve("private.log")));
+        assertFalse(Files.exists(nightly.cache().resolve("download.part")));
+        assertTrue(Files.readString(nightly.marker()).contains("\"channel\": \"nightly\""));
+        assertTrue(snapshot.isCompleted());
+    }
+
+    @Test
+    void refusesToCopyWhileStableOwnsItsWorkspace() throws Exception {
+        initializeWorkspaces();
+        Files.writeString(stable.database(), "database");
+        WorkspaceSettingsSnapshot snapshot = new WorkspaceSettingsSnapshot(stable, nightly);
+
+        try (WorkspaceSession ignored = WorkspaceSession.open(stable)) {
+            assertFalse(snapshot.sourceIsAvailable());
+            assertThrows(IOException.class, snapshot::copyFromStable);
+        }
+        assertTrue(snapshot.isTargetFresh());
+    }
+
+    @Test
+    void neverOverwritesExistingNightlySettings() throws Exception {
+        initializeWorkspaces();
+        Files.writeString(stable.database(), "stable");
+        Files.writeString(nightly.database(), "nightly");
+        WorkspaceSettingsSnapshot snapshot = new WorkspaceSettingsSnapshot(stable, nightly);
+
+        assertFalse(snapshot.isTargetFresh());
+        assertThrows(IOException.class, snapshot::copyFromStable);
+        assertEquals("nightly", Files.readString(nightly.database()));
+    }
+
+    @Test
+    void recordsAnExplicitFreshStartAndDoesNotOfferCopyAgain() throws Exception {
+        initializeWorkspaces();
+        Files.writeString(stable.database(), "stable");
+        WorkspacePreferences.node(nightly, "window").put("stale", "remove-me");
+        WorkspaceSettingsSnapshot snapshot = new WorkspaceSettingsSnapshot(stable, nightly);
+
+        snapshot.startFresh();
+
+        assertTrue(snapshot.isCompleted());
+        assertEquals("", WorkspacePreferences.node(nightly, "window").get("stale", ""));
+        assertThrows(IOException.class, snapshot::copyFromStable);
+    }
+
+    @Test
+    void rollsBackAnInterruptedFirstRunCopyBeforeOfferingItAgain() throws Exception {
+        initializeWorkspaces();
+        Files.writeString(nightly.database(), "partial");
+        Files.writeString(nightly.config().resolve("partial.properties"), "partial");
+        Files.writeString(nightly.root().resolve("channel-onboarding.in-progress"), "source=stable\n");
+        WorkspacePreferences.node(nightly, "window").put("windowX", "13");
+        WorkspaceSettingsSnapshot snapshot = new WorkspaceSettingsSnapshot(stable, nightly);
+
+        assertTrue(snapshot.isTargetFresh());
+        assertFalse(Files.exists(nightly.database()));
+        assertFalse(Files.exists(nightly.config().resolve("partial.properties")));
+        assertEquals("", WorkspacePreferences.node(nightly, "window").get("windowX", ""));
+    }
+
+    private void initializeWorkspaces() {
+        stable = new WorkspacePaths(tempDir.resolve("stable"), RuntimeChannel.STABLE);
+        nightly = new WorkspacePaths(tempDir.resolve("nightly"), RuntimeChannel.NIGHTLY);
+        WorkspaceSession.initializeLayout(stable);
+        WorkspaceSession.initializeLayout(nightly);
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/launcher/LauncherLayoutControllerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/launcher/LauncherLayoutControllerTest.java
@@ -2,6 +2,7 @@ package dev.frostguard.app.panel.launcher;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import dev.frostguard.api.runtime.RuntimeChannel;
 import org.junit.jupiter.api.Test;
 
 class LauncherLayoutControllerTest {
@@ -15,5 +16,15 @@ class LauncherLayoutControllerTest {
     @Test
     void keepsHoursBeyondOneDay() {
         assertEquals("25:00:00", LauncherLayoutController.formatUptime(90_000));
+    }
+
+    @Test
+    void identifiesRuntimeChannelInWindowTitle() {
+        assertEquals("Frostguard v2.1.0 - Main [Stamina: 77]",
+                LauncherLayoutController.formatWindowTitle(RuntimeChannel.STABLE, "2.1.0", "Main", 77));
+        assertEquals("Frostguard Nightly v2.1.0 - Main [Stamina: 77]",
+                LauncherLayoutController.formatWindowTitle(RuntimeChannel.NIGHTLY, "2.1.0", "Main", 77));
+        assertEquals("Frostguard Development v2.1.0 - Main [Stamina: 77]",
+                LauncherLayoutController.formatWindowTitle(RuntimeChannel.DEVELOPMENT, "2.1.0", "Main", 77));
     }
 }

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/update/ChannelSwitchServiceTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/update/ChannelSwitchServiceTest.java
@@ -1,0 +1,61 @@
+package dev.frostguard.app.panel.update;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChannelSwitchServiceTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void launchesAnExplicitlyConfiguredInstalledChannel() throws Exception {
+        Path nightly = Files.createFile(tempDir.resolve("Frostguard Nightly.exe"));
+        Map<String, String> properties = Map.of("frostguard.channel.launcher.nightly", nightly.toString());
+        AtomicReference<Path> launched = new AtomicReference<>();
+        ChannelSwitchService service = new ChannelSwitchService(properties::get, () -> null,
+                launched::set, page -> {
+                    throw new AssertionError("release page must not open");
+                });
+
+        assertEquals(ChannelSwitchService.Result.LAUNCHED_INSTALLED,
+                service.open(RuntimeChannel.NIGHTLY));
+        assertEquals(nightly.toAbsolutePath(), launched.get());
+    }
+
+    @Test
+    void opensThePinnedReleasePageWhenTheOtherChannelIsNotInstalled() throws Exception {
+        Map<String, String> properties = Map.of(
+                "frostguard.channel.page.stable", "https://downloads.example.com/stable");
+        AtomicReference<URI> opened = new AtomicReference<>();
+        ChannelSwitchService service = new ChannelSwitchService(properties::get, () -> null,
+                executable -> {
+                    throw new AssertionError("launcher must not run");
+                }, opened::set);
+
+        assertEquals(ChannelSwitchService.Result.OPENED_RELEASE_PAGE,
+                service.open(RuntimeChannel.STABLE));
+        assertEquals(URI.create("https://downloads.example.com/stable"), opened.get());
+    }
+
+    @Test
+    void rejectsAnUntrustedReleasePageScheme() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("frostguard.channel.page.nightly", "http://downloads.example.com/nightly");
+        ChannelSwitchService service = new ChannelSwitchService(properties::get, () -> null,
+                executable -> { }, page -> { });
+
+        assertThrows(IOException.class, () -> service.open(RuntimeChannel.NIGHTLY));
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateExitCoordinatorTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateExitCoordinatorTest.java
@@ -4,32 +4,33 @@ import dev.frostguard.update.InstallerHandoff;
 import dev.frostguard.update.UpdateException;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class UpdateExitCoordinatorTest {
     @Test
-    void authorizesThenShutsDownAndExits() throws Exception {
-        Session session = new Session();
-        AtomicBoolean shutdown = new AtomicBoolean();
-        AtomicBoolean exited = new AtomicBoolean();
-        UpdateExitCoordinator coordinator = new UpdateExitCoordinator(() -> shutdown.set(true),
-                () -> exited.set(true), () -> { throw new AssertionError("Failure exit should not run"); });
+    void shutsDownThenAuthorizesAndExits() throws Exception {
+        List<String> calls = new ArrayList<>();
+        Session session = new Session(calls);
+        UpdateExitCoordinator coordinator = new UpdateExitCoordinator(() -> calls.add("shutdown"),
+                () -> calls.add("exit"), () -> { throw new AssertionError("Failure exit should not run"); });
 
         coordinator.execute(session);
 
         assertTrue(session.authorized);
-        assertTrue(shutdown.get());
-        assertTrue(exited.get());
         assertFalse(session.cancelled);
+        assertEquals(List.of("shutdown", "authorize", "exit"), calls);
     }
 
     @Test
     void cancelsHandoffAndExitsWhenShutdownFails() {
-        Session session = new Session();
+        Session session = new Session(new ArrayList<>());
         AtomicBoolean failedExit = new AtomicBoolean();
         UpdateExitCoordinator coordinator = new UpdateExitCoordinator(
                 () -> { throw new IllegalStateException("database busy"); },
@@ -37,17 +38,44 @@ class UpdateExitCoordinatorTest {
                 () -> failedExit.set(true));
 
         assertThrows(IllegalStateException.class, () -> coordinator.execute(session));
-        assertTrue(session.authorized);
+        assertFalse(session.authorized);
+        assertTrue(session.cancelled);
+        assertTrue(failedExit.get());
+    }
+
+    @Test
+    void cancelsHandoffAndExitsWhenAuthorizationFails() {
+        Session session = new Session(new ArrayList<>());
+        session.authorizationFailure = new UpdateException("token write failed");
+        AtomicBoolean shutdown = new AtomicBoolean();
+        AtomicBoolean failedExit = new AtomicBoolean();
+        UpdateExitCoordinator coordinator = new UpdateExitCoordinator(
+                () -> shutdown.set(true),
+                () -> { throw new AssertionError("Success exit should not run"); },
+                () -> failedExit.set(true));
+
+        assertThrows(UpdateException.class, () -> coordinator.execute(session));
+        assertTrue(shutdown.get());
         assertTrue(session.cancelled);
         assertTrue(failedExit.get());
     }
 
     private static final class Session implements InstallerHandoff.HandoffSession {
+        private final List<String> calls;
         private boolean authorized;
         private boolean cancelled;
+        private UpdateException authorizationFailure;
+
+        private Session(List<String> calls) {
+            this.calls = calls;
+        }
 
         @Override
         public void authorize() throws UpdateException {
+            calls.add("authorize");
+            if (authorizationFailure != null) {
+                throw authorizationFailure;
+            }
             authorized = true;
         }
 

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateExitCoordinatorTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateExitCoordinatorTest.java
@@ -17,7 +17,7 @@ class UpdateExitCoordinatorTest {
         AtomicBoolean shutdown = new AtomicBoolean();
         AtomicBoolean exited = new AtomicBoolean();
         UpdateExitCoordinator coordinator = new UpdateExitCoordinator(() -> shutdown.set(true),
-                () -> exited.set(true));
+                () -> exited.set(true), () -> { throw new AssertionError("Failure exit should not run"); });
 
         coordinator.execute(session);
 
@@ -28,16 +28,18 @@ class UpdateExitCoordinatorTest {
     }
 
     @Test
-    void cancelsHandoffAndDoesNotExitWhenShutdownFails() {
+    void cancelsHandoffAndExitsWhenShutdownFails() {
         Session session = new Session();
-        AtomicBoolean exited = new AtomicBoolean();
+        AtomicBoolean failedExit = new AtomicBoolean();
         UpdateExitCoordinator coordinator = new UpdateExitCoordinator(
-                () -> { throw new IllegalStateException("database busy"); }, () -> exited.set(true));
+                () -> { throw new IllegalStateException("database busy"); },
+                () -> { throw new AssertionError("Success exit should not run"); },
+                () -> failedExit.set(true));
 
         assertThrows(IllegalStateException.class, () -> coordinator.execute(session));
         assertTrue(session.authorized);
         assertTrue(session.cancelled);
-        assertFalse(exited.get());
+        assertTrue(failedExit.get());
     }
 
     private static final class Session implements InstallerHandoff.HandoffSession {

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateLayoutControllerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateLayoutControllerTest.java
@@ -1,8 +1,11 @@
 package dev.frostguard.app.panel.update;
 
+import dev.frostguard.api.runtime.RuntimeChannel;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class UpdateLayoutControllerTest {
     @Test
@@ -10,5 +13,12 @@ class UpdateLayoutControllerTest {
         assertEquals("512 B", UpdateLayoutController.formatSize(512));
         assertEquals("1.5 KiB", UpdateLayoutController.formatSize(1536));
         assertEquals("273.5 MiB", UpdateLayoutController.formatSize(286_739_610));
+    }
+
+    @Test
+    void offersChannelSwitchingForInstalledAndPrChannelBuilds() {
+        assertTrue(UpdateLayoutController.supportsChannelSwitch(RuntimeChannel.STABLE));
+        assertTrue(UpdateLayoutController.supportsChannelSwitch(RuntimeChannel.NIGHTLY));
+        assertFalse(UpdateLayoutController.supportsChannelSwitch(RuntimeChannel.DEVELOPMENT));
     }
 }

--- a/modules/persistence/src/main/java/dev/frostguard/data/access/DataStore.java
+++ b/modules/persistence/src/main/java/dev/frostguard/data/access/DataStore.java
@@ -27,9 +27,7 @@ public final class DataStore implements AutoCloseable {
 	private static final String PERSISTENCE_UNIT = "frostguardPU";
 	private final EntityManagerFactory emf;
 
-	private static final class Holder {
-		private static final DataStore INSTANCE = new DataStore(Map.of());
-	}
+	private static volatile DataStore instance;
 
 	private DataStore(Map<String, Object> overrides) {
 		try {
@@ -50,7 +48,23 @@ public final class DataStore implements AutoCloseable {
 	}
 
 	public static DataStore getInstance() {
-		return Holder.INSTANCE;
+		DataStore current = instance;
+		if (current != null) {
+			return current;
+		}
+		synchronized (DataStore.class) {
+			if (instance == null) {
+				instance = new DataStore(Map.of());
+			}
+			return instance;
+		}
+	}
+
+	public static void closeIfInitialized() {
+		DataStore current = instance;
+		if (current != null) {
+			current.close();
+		}
 	}
 
 	/**

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateDownloader.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateDownloader.java
@@ -46,7 +46,16 @@ public final class UpdateDownloader {
                     }
                 }
                 long offset = Files.isRegularFile(partial) ? Files.size(partial) : 0L;
-                if (offset > artifact.size()) {
+                if (offset == artifact.size()) {
+                    try {
+                        verifier.verify(partial, artifact);
+                        promote(partial, completed);
+                        return completed;
+                    } catch (UpdateException invalidPartialArtifact) {
+                        Files.delete(partial);
+                        offset = 0L;
+                    }
+                } else if (offset > artifact.size()) {
                     Files.delete(partial);
                     offset = 0L;
                 }

--- a/modules/update/src/test/java/dev/frostguard/update/UpdateDownloaderTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/UpdateDownloaderTest.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.util.HexFormat;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -45,6 +46,41 @@ class UpdateDownloaderTest {
         assertEquals(7L, requestedOffset.get());
         assertArrayEquals(INSTALLER, Files.readAllBytes(result));
         assertFalse(Files.exists(partial));
+    }
+
+    @Test
+    void promotesAlreadyCompletePartialDownloadWithoutAnotherRequest() throws Exception {
+        UpdateCandidate candidate = candidate(INSTALLER, sha256(INSTALLER));
+        Path partial = updateDirectory(candidate).resolve(candidate.artifact().fileName() + ".part");
+        Files.createDirectories(partial.getParent());
+        Files.write(partial, INSTALLER);
+        AtomicBoolean requestAttempted = new AtomicBoolean();
+
+        Path result = new UpdateDownloader((uri, offset) -> {
+            requestAttempted.set(true);
+            return response(416, new byte[0]);
+        }, new ArtifactVerifier()).download(candidate, temp);
+
+        assertFalse(requestAttempted.get());
+        assertArrayEquals(INSTALLER, Files.readAllBytes(result));
+        assertFalse(Files.exists(partial));
+    }
+
+    @Test
+    void restartsACompleteButCorruptPartialDownload() throws Exception {
+        UpdateCandidate candidate = candidate(INSTALLER, sha256(INSTALLER));
+        Path partial = updateDirectory(candidate).resolve(candidate.artifact().fileName() + ".part");
+        Files.createDirectories(partial.getParent());
+        Files.write(partial, "x".repeat(INSTALLER.length).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        AtomicLong requestedOffset = new AtomicLong(-1L);
+
+        Path result = new UpdateDownloader((uri, offset) -> {
+            requestedOffset.set(offset);
+            return response(200, INSTALLER);
+        }, new ArtifactVerifier()).download(candidate, temp);
+
+        assertEquals(0L, requestedOffset.get());
+        assertArrayEquals(INSTALLER, Files.readAllBytes(result));
     }
 
     @Test

--- a/modules/update/src/test/java/dev/frostguard/update/UpdateSelectorTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/UpdateSelectorTest.java
@@ -61,6 +61,22 @@ class UpdateSelectorTest {
         assertThrows(UpdateException.class, () -> selector.select(manifest(), build));
     }
 
+    @Test
+    void nightlyPrereleaseCanUpdateFromNightlyMinimum() throws Exception {
+        String json = ManifestCodecTest.validManifest()
+                .replace("\"channel\": \"stable\"", "\"channel\": \"nightly\"")
+                .replace("\"version\": \"3.0.1\"", "\"version\": \"3.0.0-nightly.20260811.2\"")
+                .replace("\"minimumUpdaterVersion\": \"3.0.0\"",
+                        "\"minimumUpdaterVersion\": \"3.0.0-nightly.0\"")
+                .replace("Frostguard-3.0.1", "Frostguard-3.0.0-nightly.20260811.2");
+        UpdateManifest nightly = codec.read(json.getBytes(StandardCharsets.UTF_8));
+
+        UpdateCandidate candidate = selector.select(nightly,
+                running(RuntimeChannel.NIGHTLY, "3.0.0-nightly.20260811.1", false)).orElseThrow();
+
+        assertEquals(SemanticVersion.parse("3.0.0-nightly.20260811.2"), candidate.version());
+    }
+
     private UpdateManifest manifest() throws Exception {
         return codec.read(ManifestCodecTest.validManifest().getBytes(StandardCharsets.UTF_8));
     }

--- a/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
+++ b/modules/watcher/src/main/java/dev/frostguard/watcher/TelegramWatcher.java
@@ -77,6 +77,7 @@ public class TelegramWatcher {
             loadConfig();
             Files.writeString(workspace.cache().resolve("native-watcher-smoke.properties"),
                     "channel=" + workspace.channel().directoryName() + "\n"
+                            + "applicationId=" + System.getProperty(WorkspacePaths.APPLICATION_ID_PROPERTY, "") + "\n"
                             + "workspace=" + workspace.root() + "\n"
                             + "applicationDir=" + System.getProperty("user.dir") + "\n"
                             + "appLauncher=" + System.getProperty(APP_LAUNCHER_PROPERTY, "") + "\n"

--- a/packaging/desktop/pom.xml
+++ b/packaging/desktop/pom.xml
@@ -16,6 +16,18 @@
     <description>Platform packaging inputs, native application images, and installers</description>
     <packaging>pom</packaging>
 
+    <properties>
+        <frostguard.release.channel>stable</frostguard.release.channel>
+        <frostguard.windows.app-version>${project.version}</frostguard.windows.app-version>
+        <frostguard.product.name>Frostguard</frostguard.product.name>
+        <frostguard.product.identifier>dev.frostguard.desktop</frostguard.product.identifier>
+        <frostguard.product.description>Frostguard automation desktop application</frostguard.product.description>
+        <frostguard.product.install-dir>Frostguard</frostguard.product.install-dir>
+        <frostguard.product.upgrade-uuid>fa0d66f6-1f7d-4da8-9701-88f7b4570797</frostguard.product.upgrade-uuid>
+        <frostguard.channel.page.stable>https://github.com/Shederator/wosbot/releases/latest</frostguard.channel.page.stable>
+        <frostguard.channel.page.nightly>https://github.com/Shederator/wosbot/releases</frostguard.channel.page.nightly>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>dev.frostguard</groupId>
@@ -219,7 +231,7 @@
                                                 else="${java.home}/bin/jpackage">
                                             <os family="windows" />
                                         </condition>
-                                        <delete dir="${project.build.directory}/app-image/Frostguard" />
+                                        <delete dir="${project.build.directory}/app-image/${frostguard.product.name}" />
                                         <mkdir dir="${project.build.directory}/app-image" />
                                         <exec executable="powershell.exe" failonerror="true">
                                             <arg value="-NoProfile" />
@@ -241,13 +253,13 @@
                                             <arg value="--input" />
                                             <arg path="${project.build.directory}/input" />
                                             <arg value="--name" />
-                                            <arg value="Frostguard" />
+                                            <arg value="${frostguard.product.name}" />
                                             <arg value="--app-version" />
-                                            <arg value="${project.version}" />
+                                            <arg value="${frostguard.windows.app-version}" />
                                             <arg value="--vendor" />
                                             <arg value="Frostguard" />
                                             <arg value="--description" />
-                                            <arg value="Frostguard automation desktop application" />
+                                            <arg value="${frostguard.product.description}" />
                                             <arg value="--icon" />
                                             <arg path="${project.build.directory}/jpackage/Frostguard.ico" />
                                             <arg value="--main-jar" />
@@ -257,15 +269,21 @@
                                             <arg value="--java-options" />
                                             <arg value="--enable-native-access=ALL-UNNAMED" />
                                             <arg value="--java-options" />
-                                            <arg value="-Dfrostguard.channel=stable" />
+                                            <arg value="-Dfrostguard.channel=${frostguard.release.channel}" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Dfrostguard.application.id=${frostguard.product.identifier}" />
                                             <arg value="--java-options" />
                                             <arg value="-Dfrostguard.update.pullRequestBuild=${frostguard.pull-request-build}" />
                                             <arg value="--java-options" />
                                             <arg value="-Dfrostguard.update.manifest.stable=${frostguard.update.manifest.stable}" />
                                             <arg value="--java-options" />
-                                            <arg value="-Duser.dir=$APPDIR" />
+                                            <arg value="-Dfrostguard.update.manifest.nightly=${frostguard.update.manifest.nightly}" />
                                             <arg value="--java-options" />
-                                            <arg value="-Dfrostguard.launcher=$APPDIR/../Frostguard.exe" />
+                                            <arg value="-Dfrostguard.channel.page.stable=${frostguard.channel.page.stable}" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Dfrostguard.channel.page.nightly=${frostguard.channel.page.nightly}" />
+                                            <arg value="--java-options" />
+                                            <arg value="-Duser.dir=$APPDIR" />
                                             <arg value="--java-options" />
                                             <arg value="-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe" />
                                             <arg value="--add-launcher" />
@@ -306,28 +324,28 @@
                                                 else="${java.home}/bin/jpackage">
                                             <os family="windows" />
                                         </condition>
-                                        <delete dir="${project.build.directory}/installers" />
-                                        <mkdir dir="${project.build.directory}/installers" />
+                                        <delete dir="${project.build.directory}/installers/${frostguard.release.channel}" />
+                                        <mkdir dir="${project.build.directory}/installers/${frostguard.release.channel}" />
                                         <exec executable="${jpackage.executable}" failonerror="true">
                                             <arg value="--verbose" />
                                             <arg value="--type" />
                                             <arg value="exe" />
                                             <arg value="--dest" />
-                                            <arg path="${project.build.directory}/installers" />
+                                            <arg path="${project.build.directory}/installers/${frostguard.release.channel}" />
                                             <arg value="--name" />
-                                            <arg value="Frostguard" />
+                                            <arg value="${frostguard.product.name}" />
                                             <arg value="--app-version" />
-                                            <arg value="${project.version}" />
+                                            <arg value="${frostguard.windows.app-version}" />
                                             <arg value="--vendor" />
                                             <arg value="Frostguard" />
                                             <arg value="--description" />
-                                            <arg value="Frostguard automation desktop application" />
+                                            <arg value="${frostguard.product.description}" />
                                             <arg value="--app-image" />
-                                            <arg path="${project.build.directory}/app-image/Frostguard" />
+                                            <arg path="${project.build.directory}/app-image/${frostguard.product.name}" />
                                             <!-- Nested per-user install paths can trigger inconsistent WiX
                                                  directory validation (JDK-8226534). -->
                                             <arg value="--install-dir" />
-                                            <arg value="Frostguard" />
+                                            <arg value="${frostguard.product.install-dir}" />
                                             <arg value="--win-per-user-install" />
                                             <arg value="--win-dir-chooser" />
                                             <arg value="--win-menu" />
@@ -335,7 +353,7 @@
                                             <arg value="Frostguard" />
                                             <arg value="--win-shortcut-prompt" />
                                             <arg value="--win-upgrade-uuid" />
-                                            <arg value="fa0d66f6-1f7d-4da8-9701-88f7b4570797" />
+                                            <arg value="${frostguard.product.upgrade-uuid}" />
                                         </exec>
                                     </target>
                                 </configuration>
@@ -344,6 +362,18 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>windows-nightly</id>
+            <properties>
+                <frostguard.release.channel>nightly</frostguard.release.channel>
+                <frostguard.product.name>Frostguard Nightly</frostguard.product.name>
+                <frostguard.product.identifier>dev.frostguard.desktop.nightly</frostguard.product.identifier>
+                <frostguard.product.description>Frostguard Nightly automation desktop application</frostguard.product.description>
+                <frostguard.product.install-dir>Frostguard Nightly</frostguard.product.install-dir>
+                <frostguard.product.upgrade-uuid>51ac745d-78e4-4d89-a36d-1c38b87598b3</frostguard.product.upgrade-uuid>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/packaging/desktop/pom.xml
+++ b/packaging/desktop/pom.xml
@@ -23,6 +23,7 @@
         <frostguard.product.identifier>dev.frostguard.desktop</frostguard.product.identifier>
         <frostguard.product.description>Frostguard automation desktop application</frostguard.product.description>
         <frostguard.product.install-dir>Frostguard</frostguard.product.install-dir>
+        <frostguard.watcher.name>FrostguardWatcher</frostguard.watcher.name>
         <frostguard.product.upgrade-uuid>fa0d66f6-1f7d-4da8-9701-88f7b4570797</frostguard.product.upgrade-uuid>
         <frostguard.channel.page.stable>https://github.com/Shederator/wosbot/releases/latest</frostguard.channel.page.stable>
         <frostguard.channel.page.nightly>https://github.com/Shederator/wosbot/releases</frostguard.channel.page.nightly>
@@ -174,6 +175,7 @@
                                     <filtering>true</filtering>
                                     <includes>
                                         <include>Frostguard-Watcher.properties</include>
+                                        <include>main.wxs</include>
                                     </includes>
                                 </resource>
                             </resources>
@@ -285,9 +287,9 @@
                                             <arg value="--java-options" />
                                             <arg value="-Duser.dir=$APPDIR" />
                                             <arg value="--java-options" />
-                                            <arg value="-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe" />
+                                            <arg value="-Dfrostguard.watcher.launcher=$APPDIR/../${frostguard.watcher.name}.exe" />
                                             <arg value="--add-launcher" />
-                                            <arg value="FrostguardWatcher=${project.build.directory}/jpackage/Frostguard-Watcher.properties" />
+                                            <arg value="${frostguard.watcher.name}=${project.build.directory}/jpackage/Frostguard-Watcher.properties" />
                                         </exec>
                                     </target>
                                 </configuration>
@@ -342,6 +344,8 @@
                                             <arg value="${frostguard.product.description}" />
                                             <arg value="--app-image" />
                                             <arg path="${project.build.directory}/app-image/${frostguard.product.name}" />
+                                            <arg value="--resource-dir" />
+                                            <arg path="${project.build.directory}/jpackage" />
                                             <!-- Nested per-user install paths can trigger inconsistent WiX
                                                  directory validation (JDK-8226534). -->
                                             <arg value="--install-dir" />
@@ -351,6 +355,7 @@
                                             <arg value="--win-menu" />
                                             <arg value="--win-menu-group" />
                                             <arg value="Frostguard" />
+                                            <arg value="--win-shortcut" />
                                             <arg value="--win-shortcut-prompt" />
                                             <arg value="--win-upgrade-uuid" />
                                             <arg value="${frostguard.product.upgrade-uuid}" />
@@ -372,6 +377,7 @@
                 <frostguard.product.identifier>dev.frostguard.desktop.nightly</frostguard.product.identifier>
                 <frostguard.product.description>Frostguard Nightly automation desktop application</frostguard.product.description>
                 <frostguard.product.install-dir>Frostguard Nightly</frostguard.product.install-dir>
+                <frostguard.watcher.name>FrostguardNightlyWatcher</frostguard.watcher.name>
                 <frostguard.product.upgrade-uuid>51ac745d-78e4-4d89-a36d-1c38b87598b3</frostguard.product.upgrade-uuid>
             </properties>
         </profile>

--- a/packaging/desktop/src/main/windows/Frostguard-Watcher.properties
+++ b/packaging/desktop/src/main/windows/Frostguard-Watcher.properties
@@ -1,4 +1,4 @@
 main-jar=frostguard-watcher-${project.version}.jar
 main-class=dev.frostguard.watcher.TelegramWatcher
 description=Frostguard Telegram Watcher
-java-options=--enable-native-access=ALL-UNNAMED -Dfrostguard.channel=stable -Dfrostguard.update.pullRequestBuild=${frostguard.pull-request-build} "-Duser.dir=$APPDIR" "-Dfrostguard.launcher=$APPDIR/../Frostguard.exe" "-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe"
+java-options=--enable-native-access=ALL-UNNAMED -Dfrostguard.channel=${frostguard.release.channel} -Dfrostguard.application.id=${frostguard.product.identifier} -Dfrostguard.update.pullRequestBuild=${frostguard.pull-request-build} "-Duser.dir=$APPDIR" "-Dfrostguard.launcher=$APPDIR/../${frostguard.product.name}.exe" "-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe"

--- a/packaging/desktop/src/main/windows/Frostguard-Watcher.properties
+++ b/packaging/desktop/src/main/windows/Frostguard-Watcher.properties
@@ -1,4 +1,6 @@
 main-jar=frostguard-watcher-${project.version}.jar
 main-class=dev.frostguard.watcher.TelegramWatcher
 description=Frostguard Telegram Watcher
-java-options=--enable-native-access=ALL-UNNAMED -Dfrostguard.channel=${frostguard.release.channel} -Dfrostguard.application.id=${frostguard.product.identifier} -Dfrostguard.update.pullRequestBuild=${frostguard.pull-request-build} "-Duser.dir=$APPDIR" "-Dfrostguard.launcher=$APPDIR/../${frostguard.product.name}.exe" "-Dfrostguard.watcher.launcher=$APPDIR/../FrostguardWatcher.exe"
+java-options=--enable-native-access=ALL-UNNAMED -Dfrostguard.channel=${frostguard.release.channel} -Dfrostguard.application.id=${frostguard.product.identifier} -Dfrostguard.update.pullRequestBuild=${frostguard.pull-request-build} "-Duser.dir=$APPDIR" "-Dfrostguard.launcher=$APPDIR/../${frostguard.product.name}.exe" "-Dfrostguard.watcher.launcher=$APPDIR/../${frostguard.watcher.name}.exe"
+win-menu=false
+win-shortcut=false

--- a/packaging/desktop/src/main/windows/main.wxs
+++ b/packaging/desktop/src/main/windows/main.wxs
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+
+  <?ifdef JpIsSystemWide ?>
+    <?define JpInstallScope="perMachine"?>
+  <?else?>
+    <?define JpInstallScope="perUser"?>
+  <?endif?>
+
+  <?define JpProductLanguage=1033 ?>
+  <?define JpInstallerVersion=200 ?>
+  <?define JpCompressedMsi=yes ?>
+
+  <?include $(var.JpConfigDir)/overrides.wxi ?>
+
+  <?ifdef JpAllowUpgrades ?>
+    <?define JpUpgradeVersionOnlyDetectUpgrade="no"?>
+  <?else?>
+    <?define JpUpgradeVersionOnlyDetectUpgrade="yes"?>
+  <?endif?>
+  <?ifdef JpAllowDowngrades ?>
+    <?define JpUpgradeVersionOnlyDetectDowngrade="no"?>
+  <?else?>
+    <?define JpUpgradeVersionOnlyDetectDowngrade="yes"?>
+  <?endif?>
+
+  <Product
+    Id="$(var.JpProductCode)"
+    Name="$(var.JpAppName)"
+    Language="$(var.JpProductLanguage)"
+    Version="$(var.JpAppVersion)"
+    Manufacturer="$(var.JpAppVendor)"
+    UpgradeCode="$(var.JpProductUpgradeCode)">
+
+    <Package
+      Description="$(var.JpAppDescription)"
+      Manufacturer="$(var.JpAppVendor)"
+      InstallerVersion="$(var.JpInstallerVersion)"
+      Compressed="$(var.JpCompressedMsi)"
+      InstallScope="$(var.JpInstallScope)" Platform="x64"
+    />
+
+    <Media Id="1" Cabinet="Data.cab" EmbedCab="yes" />
+
+    <Upgrade Id="$(var.JpProductUpgradeCode)">
+      <UpgradeVersion
+        OnlyDetect="$(var.JpUpgradeVersionOnlyDetectUpgrade)"
+        Property="JP_UPGRADABLE_FOUND"
+        Maximum="$(var.JpAppVersion)"
+        MigrateFeatures="yes"
+        IncludeMaximum="$(var.JpUpgradeVersionOnlyDetectUpgrade)" />
+      <UpgradeVersion
+        OnlyDetect="$(var.JpUpgradeVersionOnlyDetectDowngrade)"
+        Property="JP_DOWNGRADABLE_FOUND"
+        Minimum="$(var.JpAppVersion)"
+        MigrateFeatures="yes"
+        IncludeMinimum="$(var.JpUpgradeVersionOnlyDetectDowngrade)" />
+    </Upgrade>
+
+    <?ifndef JpAllowUpgrades ?>
+    <CustomAction Id="JpDisallowUpgrade" Error="!(loc.DisallowUpgradeErrorMessage)" />
+    <?endif?>
+    <?ifndef JpAllowDowngrades ?>
+    <CustomAction Id="JpDisallowDowngrade" Error="!(loc.DowngradeErrorMessage)" />
+    <?endif?>
+
+    <Binary Id="JpCaDll" SourceFile="wixhelper.dll"/>
+    <CustomAction Id="JpFindRelatedProducts" BinaryKey="JpCaDll" DllEntry="FindRelatedProductsEx" />
+
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch $(var.JpAppName)" />
+    <CustomAction Id="JpSetLaunchTarget" Property="WixShellExecTarget"
+                  Value="[INSTALLDIR]$(var.JpAppName).exe" />
+    <CustomAction Id="JpLaunchApplication" BinaryKey="WixCA"
+                  DllEntry="WixShellExec" Impersonate="yes" />
+
+    <util:CloseApplication Id="JpDetectRunningApplication"
+                           Target="$(var.JpAppName).exe"
+                           Property="JP_FROSTGUARD_RUNNING"
+                           RebootPrompt="no" />
+    <Condition Message="Close $(var.JpAppName) before installing, updating, or uninstalling it.">
+      NOT JP_FROSTGUARD_RUNNING
+    </Condition>
+
+    <CustomAction Id="JpStopWatcher" Directory="TARGETDIR" Execute="immediate"
+                  ExeCommand="&quot;[SystemFolder]taskkill.exe&quot; /F /IM &quot;${frostguard.watcher.name}.exe&quot;"
+                  Return="ignore" Impersonate="yes" />
+
+    <Directory Id="TARGETDIR" Name="SourceDir"/>
+
+    <Feature Id="DefaultFeature" Title="!(loc.MainFeatureTitle)" Level="1">
+      <ComponentGroupRef Id="Shortcuts"/>
+      <ComponentGroupRef Id="Files"/>
+      <ComponentGroupRef Id="FileAssociations"/>
+    </Feature>
+
+    <CustomAction Id="JpSetARPINSTALLLOCATION" Property="ARPINSTALLLOCATION" Value="[INSTALLDIR]" />
+    <CustomAction Id="JpSetARPCOMMENTS" Property="ARPCOMMENTS" Value="$(var.JpAppDescription)" />
+    <CustomAction Id="JpSetARPCONTACT" Property="ARPCONTACT" Value="$(var.JpAppVendor)" />
+    <CustomAction Id="JpSetARPSIZE" Property="ARPSIZE" Value="$(var.JpAppSizeKb)" />
+
+    <?ifdef JpHelpURL ?>
+      <CustomAction Id="JpSetARPHELPLINK" Property="ARPHELPLINK" Value="$(var.JpHelpURL)" />
+    <?endif?>
+
+    <?ifdef JpAboutURL ?>
+      <CustomAction Id="JpSetARPURLINFOABOUT" Property="ARPURLINFOABOUT" Value="$(var.JpAboutURL)" />
+    <?endif?>
+
+    <?ifdef JpUpdateURL ?>
+      <CustomAction Id="JpSetARPURLUPDATEINFO" Property="ARPURLUPDATEINFO" Value="$(var.JpUpdateURL)" />
+    <?endif?>
+
+    <?ifdef JpIcon ?>
+    <Property Id="ARPPRODUCTICON" Value="JpARPPRODUCTICON"/>
+    <Icon Id="JpARPPRODUCTICON" SourceFile="$(var.JpIcon)"/>
+    <?endif?>
+
+    <UIRef Id="JpUI"/>
+    <UI>
+      <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
+               Value="JpSetLaunchTarget" Order="1">
+        WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT Installed
+      </Publish>
+      <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction"
+               Value="JpLaunchApplication" Order="2">
+        WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT Installed
+      </Publish>
+    </UI>
+
+    <InstallExecuteSequence>
+      <Custom Action="JpSetARPINSTALLLOCATION" After="CostFinalize">Not Installed</Custom>
+      <Custom Action="JpSetARPCOMMENTS" After="CostFinalize">Not Installed</Custom>
+      <Custom Action="JpSetARPCONTACT" After="CostFinalize">Not Installed</Custom>
+      <Custom Action="JpSetARPSIZE" After="CostFinalize">Not Installed</Custom>
+      <?ifdef JpHelpURL ?>
+        <Custom Action="JpSetARPHELPLINK" After="CostFinalize">Not Installed</Custom>
+      <?endif?>
+      <?ifdef JpAboutURL ?>
+        <Custom Action="JpSetARPURLINFOABOUT" After="CostFinalize">Not Installed</Custom>
+      <?endif?>
+      <?ifdef JpUpdateURL ?>
+        <Custom Action="JpSetARPURLUPDATEINFO" After="CostFinalize">Not Installed</Custom>
+      <?endif?>
+
+      <?ifndef JpAllowUpgrades ?>
+      <Custom Action="JpDisallowUpgrade" After="JpFindRelatedProducts">JP_UPGRADABLE_FOUND</Custom>
+      <?endif?>
+      <?ifndef JpAllowDowngrades ?>
+      <Custom Action="JpDisallowDowngrade" After="JpFindRelatedProducts">JP_DOWNGRADABLE_FOUND</Custom>
+      <?endif?>
+      <Custom Action="WixCloseApplications" Before="LaunchConditions">1</Custom>
+      <Custom Action="JpStopWatcher" Before="InstallValidate">
+        Installed OR JP_UPGRADABLE_FOUND OR JP_DOWNGRADABLE_FOUND
+      </Custom>
+      <RemoveExistingProducts Before="CostInitialize"/>
+      <Custom Action="JpFindRelatedProducts" After="FindRelatedProducts"/>
+    </InstallExecuteSequence>
+
+    <InstallUISequence>
+      <Custom Action="JpFindRelatedProducts" After="FindRelatedProducts"/>
+      <Custom Action="WixCloseApplications" Before="LaunchConditions">1</Custom>
+    </InstallUISequence>
+
+  </Product>
+</Wix>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<revision>2.1.0</revision>
 		<frostguard.pull-request-build>false</frostguard.pull-request-build>
 		<frostguard.update.manifest.stable></frostguard.update.manifest.stable>
+		<frostguard.update.manifest.nightly></frostguard.update.manifest.nightly>
 		<frostguard.update.authenticode-publisher></frostguard.update.authenticode-publisher>
 
 		<!-- JDK baseline -->


### PR DESCRIPTION
## Summary

- add distinct Stable and Nightly Windows product identities, install locations, launchers, workspaces, settings, and update feeds
- offer a guarded one-time Stable-to-Nightly settings snapshot on first Nightly start
- add in-app channel switching and channel-specific window titles
- add a signed channel-release workflow with monotonic Windows installer versions and manifest publication only after installer verification
- allow Nightly prerelease builds to satisfy the updater compatibility floor and update to newer Nightlies
- cancel installer handoff and terminate cleanly if runtime shutdown is incomplete, avoiding a partially stopped unlocked process
- separate read-only pull-request CI from scheduled/manual Nightly publication
- build and verify both channel variants in native Windows pull-request CI
- report a clear already-running message on a second same-workspace launch and support explicit isolated instances with `--workspace <name>`
- keep the channel-specific watcher internal instead of exposing it as a Start-menu or desktop application
- offer a default-checked desktop shortcut and a default-checked launch-after-install option
- refuse install, update, or uninstall before mutation while the matching Frostguard desktop process is still running, and stop only that channel's watcher during maintenance

## Why

Stable and Nightly must coexist on one Windows system without sharing mutable state or replacing each other's installation. Users can try Nightly safely, optionally copy an initial Stable snapshot, and return to Stable without ongoing synchronization.

The installer lifecycle guard fixes the observed half-uninstall where Windows removed Frostguard from Installed Apps while its locked program directory and runnable process remained.

This is the final implementation slice of #130 and is intentionally stacked on #162.

Closes #163

## Validation

Automated on rebased commit `9a0db93`:

- full `mvnw.cmd package`: 316 tests passed, 0 failures, 0 errors, 0 skipped
- verification/release/notification Python suites: 138 tests passed
- `git diff --check` passed
- Stable and Nightly `jpackage` application images built locally and passed structural and launcher/watcher smoke verification
- a second headless Stable launch against an already locked default workspace exited through the controlled path without starting another process
- Stable and Nightly EXE installers compiled locally with WiX 3.14.1
- compiled MSI inspection confirmed that the running-app detector executes before `LaunchConditions`, launch-after-install is checked by default, the desktop shortcut is checked by default, and only the main Frostguard launcher receives shortcuts
- completed `.part` downloads are verified and promoted locally without an invalid end-of-file Range request; corrupt full-size partials restart from byte zero
- installer handoff authorization is written only after scheduler, persistence, workspace, and remaining runtime shutdown steps succeed
- final GitHub checks passed: read-only Linux CI in 1m34s and native Stable/Nightly installer verification in 5m57s; no Nightly publisher ran for the pull request

Manual Windows evidence from the earlier PR installers:

- Stable and Nightly installed as separate registered applications and ran concurrently
- both held separate workspace locks and wrote separate databases and logs
- one-time Stable-to-Nightly snapshot completed; later Nightly writes did not modify Stable
- Gather completed from each channel in sequence without workspace or lock errors
- uninstalling Nightly removed only its registration and program directory while Stable kept running and both workspaces remained
- reinstalling Nightly reused its prior workspace without repeating onboarding
- a reset developer machine started with zero Frostguard registrations, program directories, or data home; Stable first launch created only the Stable installation and workspace
- Stable settings persisted across a normal close and restart
- Nightly refused to copy while Stable held its workspace, exited without creating a database or completion marker, and copied successfully only after Stable closed
- the copied Nightly workspace had its own database, marker, lock, and processes; subsequent Nightly-only changes did not appear in Stable
- the equivalent pre-rebase `0ad9b14` Stable CI installer offered the expected default-checked desktop shortcut and launch-after-install options
- a second default-workspace launch showed the explicit already-running message instead of `Failed to launch JVM`
- uninstall while Frostguard was running aborted before deregistration or file removal; after Frostguard closed, uninstall completed normally

## Risks

- production signing, real installer upgrade/handoff, interrupted-update recovery, and clean-VM validation require release credentials and a second signed build
- portable distributions and non-Windows platforms remain follow-up work



