### PR TITLE
feat(update): authenticate releases with project key

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -1,4 +1,4 @@
-name: Signed Windows Channel Release
+name: Windows Channel Release
 
 on:
   workflow_dispatch:
@@ -23,12 +23,12 @@ on:
 permissions: {}
 
 concurrency:
-  group: signed-windows-${{ inputs.channel }}-release
+  group: windows-${{ inputs.channel }}-release
   cancel-in-progress: false
 
 jobs:
   release:
-    name: Sign and publish ${{ inputs.channel }} Windows release
+    name: Authenticate and publish ${{ inputs.channel }} Windows release
     if: github.ref == 'refs/heads/main'
     runs-on: windows-latest
     timeout-minutes: 75
@@ -39,7 +39,6 @@ jobs:
       CHANNEL: ${{ inputs.channel }}
       VERSION: ${{ inputs.version }}
       MINIMUM_UPDATER_VERSION: ${{ inputs.minimum_updater_version }}
-      AUTHENTICODE_PUBLISHER: ${{ secrets.FROSTGUARD_AUTHENTICODE_PUBLISHER }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -82,9 +81,6 @@ jobs:
           if ($env:CHANNEL -eq 'stable' -and $env:VERSION.Contains('-')) {
               throw "Stable releases must not use a prerelease version"
           }
-          if ([string]::IsNullOrWhiteSpace($env:AUTHENTICODE_PUBLISHER)) {
-              throw "FROSTGUARD_AUTHENTICODE_PUBLISHER is not configured"
-          }
           $manifestName = "frostguard-$($env:CHANNEL)-manifest.json"
           $feedTag = if ($env:CHANNEL -eq 'nightly') {
               if (gh release view updates-nightly --repo $env:GITHUB_REPOSITORY 2>$null) {
@@ -101,7 +97,17 @@ jobs:
                   $previousManifest = Join-Path $env:RUNNER_TEMP "previous-$manifestName"
                   gh api "repos/$($env:GITHUB_REPOSITORY)/releases/assets/$assetId" `
                       -H "Accept: application/octet-stream" > $previousManifest
-                  $previousVersion = (Get-Content -Raw -LiteralPath $previousManifest |
+                  $previousEnvelope = Get-Content -Raw -LiteralPath $previousManifest | ConvertFrom-Json
+                  $projectKey = Get-Content -Raw `
+                      modules/update/src/main/resources/dev/frostguard/update/project-update-key.properties `
+                      | ConvertFrom-StringData
+                  if ($previousEnvelope.envelopeVersion -ne 1 -or
+                      $previousEnvelope.algorithm -cne 'Ed25519' -or
+                      $previousEnvelope.keyId -cne $projectKey.keyId) {
+                      throw "Previous update feed is not a supported project-signed manifest"
+                  }
+                  $payloadBytes = [Convert]::FromBase64String($previousEnvelope.payload)
+                  $previousVersion = ([Text.Encoding]::UTF8.GetString($payloadBytes) |
                       ConvertFrom-Json).version
               }
           }
@@ -132,16 +138,27 @@ jobs:
               throw "Immutable release $tag already exists"
           }
 
-      - name: Import release-signing certificate
+      - name: Configure optional Authenticode certificate
         id: certificate
         env:
           SIGNING_CERTIFICATE_BASE64: ${{ secrets.FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
           SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
+          AUTHENTICODE_PUBLISHER: ${{ secrets.FROSTGUARD_AUTHENTICODE_PUBLISHER }}
         shell: pwsh
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:SIGNING_CERTIFICATE_BASE64) -or
-              [string]::IsNullOrWhiteSpace($env:SIGNING_CERTIFICATE_PASSWORD)) {
-              throw "Windows signing certificate secrets are not configured"
+          $configuredCount = @(
+              $env:SIGNING_CERTIFICATE_BASE64,
+              $env:SIGNING_CERTIFICATE_PASSWORD,
+              $env:AUTHENTICODE_PUBLISHER
+          ).Where({ -not [string]::IsNullOrWhiteSpace($_) }).Count
+          if ($configuredCount -eq 0) {
+              "enabled=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+              "publisher=" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+              Write-Output "Authenticode is not configured; project signing remains mandatory."
+              exit 0
+          }
+          if ($configuredCount -ne 3) {
+              throw "Authenticode certificate, password, and publisher must be configured together"
           }
           $certificatePath = Join-Path $env:RUNNER_TEMP "frostguard-release-signing.pfx"
           [IO.File]::WriteAllBytes($certificatePath,
@@ -157,12 +174,16 @@ jobs:
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "path=$certificatePath" | Out-File `
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "publisher=$($certificate.Subject)" | Out-File `
+              -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Build channel application image and installer
         shell: pwsh
         env:
           WINDOWS_VERSION: ${{ steps.identity.outputs.windows_version }}
           EXTRA_PROFILE: ${{ steps.identity.outputs.profile }}
+          AUTHENTICODE_PUBLISHER: ${{ steps.certificate.outputs.publisher }}
         run: |
           $mavenArgs = $env:MAVEN_ARGS -split " "
           $profiles = "windows-app-image,windows-installer$($env:EXTRA_PROFILE)"
@@ -187,12 +208,14 @@ jobs:
               -File build-support/verification/smoke_test_app_image.ps1 `
               -ImagePath $image -Channel $env:CHANNEL -ProductName $env:PRODUCT_NAME
 
-      - name: Sign and verify immutable installer
+      - name: Prepare immutable installer and verify optional Authenticode
         id: installer
         shell: pwsh
         env:
           IMMUTABLE_NAME: ${{ steps.identity.outputs.installer_name }}
           CERTIFICATE_THUMBPRINT: ${{ steps.certificate.outputs.thumbprint }}
+          AUTHENTICODE_ENABLED: ${{ steps.certificate.outputs.enabled }}
+          AUTHENTICODE_PUBLISHER: ${{ steps.certificate.outputs.publisher }}
         run: |
           $source = @(Get-ChildItem "packaging/desktop/target/installers/$($env:CHANNEL)" `
               -Filter '*.exe' -File)
@@ -201,22 +224,26 @@ jobs:
           }
           $installer = Join-Path $env:RUNNER_TEMP $env:IMMUTABLE_NAME
           Copy-Item -LiteralPath $source[0].FullName -Destination $installer
-          $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" `
-              -Recurse -Filter signtool.exe | Where-Object FullName -Match '\\x64\\' `
-              | Sort-Object FullName -Descending | Select-Object -First 1
-          if ($null -eq $signtool) {
-              throw "Windows SDK signtool.exe was not found"
-          }
-          & $signtool.FullName sign /sha1 $env:CERTIFICATE_THUMBPRINT /fd SHA256 `
-              /td SHA256 /tr http://timestamp.digicert.com $installer
-          & $signtool.FullName verify /pa /v $installer
-          if ($LASTEXITCODE -ne 0) {
-              throw "Authenticode verification failed"
-          }
-          $signature = Get-AuthenticodeSignature -LiteralPath $installer
-          if ($signature.Status -ne 'Valid' -or
-              $signature.SignerCertificate.Subject -cne $env:AUTHENTICODE_PUBLISHER) {
-              throw "Signed installer does not match the pinned publisher"
+          if ($env:AUTHENTICODE_ENABLED -eq 'true') {
+              $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" `
+                  -Recurse -Filter signtool.exe | Where-Object FullName -Match '\\x64\\' `
+                  | Sort-Object FullName -Descending | Select-Object -First 1
+              if ($null -eq $signtool) {
+                  throw "Windows SDK signtool.exe was not found"
+              }
+              & $signtool.FullName sign /sha1 $env:CERTIFICATE_THUMBPRINT /fd SHA256 `
+                  /td SHA256 /tr http://timestamp.digicert.com $installer
+              & $signtool.FullName verify /pa /v $installer
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Authenticode verification failed"
+              }
+              $signature = Get-AuthenticodeSignature -LiteralPath $installer
+              if ($signature.Status -ne 'Valid' -or
+                  $signature.SignerCertificate.Subject -cne $env:AUTHENTICODE_PUBLISHER) {
+                  throw "Signed installer does not match the pinned publisher"
+              }
+          } else {
+              Write-Warning "Installer has no Windows verified publisher; the project-signed manifest is the trust root."
           }
           "path=$installer" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
@@ -250,7 +277,7 @@ jobs:
           "download_url=$($parts[1])" | Out-File `
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-      - name: Generate update manifest from the signed installer
+      - name: Generate and project-sign update manifest
         id: manifest
         shell: pwsh
         env:
@@ -258,16 +285,35 @@ jobs:
           INSTALLER_URL: ${{ steps.draft.outputs.download_url }}
           MANIFEST_NAME: ${{ steps.identity.outputs.manifest_name }}
           TAG: ${{ steps.identity.outputs.tag }}
+          AUTHENTICODE_PUBLISHER: ${{ steps.certificate.outputs.publisher }}
+          FROSTGUARD_UPDATE_SIGNING_PRIVATE_KEY_BASE64: ${{ secrets.FROSTGUARD_UPDATE_SIGNING_PRIVATE_KEY_BASE64 }}
         run: |
           $manifest = Join-Path $env:RUNNER_TEMP $env:MANIFEST_NAME
+          $payload = Join-Path $env:RUNNER_TEMP "payload-$($env:MANIFEST_NAME)"
           $publishedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
           $releaseNotes = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/tag/$($env:TAG)"
-          python build-support/release/write_update_manifest.py `
-              --channel $env:CHANNEL --version $env:VERSION `
-              --minimum-updater-version $env:MINIMUM_UPDATER_VERSION `
-              --published-at $publishedAt --release-notes-url $releaseNotes `
-              --installer-url $env:INSTALLER_URL --installer $env:INSTALLER `
-              --publisher $env:AUTHENTICODE_PUBLISHER --output $manifest
+          $manifestArgs = @(
+              '--channel', $env:CHANNEL, '--version', $env:VERSION,
+              '--minimum-updater-version', $env:MINIMUM_UPDATER_VERSION,
+              '--published-at', $publishedAt, '--release-notes-url', $releaseNotes,
+              '--installer-url', $env:INSTALLER_URL, '--installer', $env:INSTALLER,
+              '--output', $payload
+          )
+          if (-not [string]::IsNullOrWhiteSpace($env:AUTHENTICODE_PUBLISHER)) {
+              $manifestArgs += @('--publisher', $env:AUTHENTICODE_PUBLISHER)
+          }
+          python build-support/release/write_update_manifest.py @manifestArgs
+          if ([string]::IsNullOrWhiteSpace($env:FROSTGUARD_UPDATE_SIGNING_PRIVATE_KEY_BASE64)) {
+              throw "FROSTGUARD_UPDATE_SIGNING_PRIVATE_KEY_BASE64 is not configured"
+          }
+          java -cp modules/update/target/classes dev.frostguard.update.ProjectManifestSigner `
+              sign $payload $manifest
+          $verificationClasspath = "modules/update/target/classes;modules/api/target/classes;packaging/desktop/target/input/lib/*"
+          java -cp $verificationClasspath dev.frostguard.update.ProjectManifestSigner verify $manifest
+          if ($LASTEXITCODE -ne 0) {
+              throw "Project-signed update manifest verification failed"
+          }
+          Remove-Item -LiteralPath $payload -Force
           "path=$manifest" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Publish immutable release and channel manifest last
@@ -285,7 +331,7 @@ jobs:
               if (-not (gh release view updates-nightly --repo $env:GITHUB_REPOSITORY 2>$null)) {
                   gh release create updates-nightly --repo $env:GITHUB_REPOSITORY `
                       --target $env:GITHUB_SHA --title "Frostguard Nightly update feed" `
-                      --notes "The manifest asset is replaced only after a signed immutable Nightly release is verified." `
+                      --notes "The manifest asset is replaced only after an authenticated immutable Nightly release is verified." `
                       --prerelease
               }
               gh release upload updates-nightly $env:MANIFEST --repo $env:GITHUB_REPOSITORY --clobber
@@ -303,10 +349,10 @@ jobs:
               gh release delete $env:TAG --repo $env:GITHUB_REPOSITORY --cleanup-tag --yes
           }
 
-      - name: Upload signed release evidence
+      - name: Upload authenticated release evidence
         uses: actions/upload-artifact@v4
         with:
-          name: frostguard-${{ inputs.channel }}-${{ inputs.version }}-signed-release
+          name: frostguard-${{ inputs.channel }}-${{ inputs.version }}-authenticated-release
           path: |
             ${{ steps.installer.outputs.path }}
             ${{ steps.manifest.outputs.path }}

--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -84,7 +84,7 @@ jobs:
             exit 1
           fi
           if (( ${VERSION%%.*} >= 3 )); then
-            echo "::error::Frostguard 3.x must use Signed Windows Channel Release; the legacy ZIP workflow cannot publish an installed Stable identity."
+            echo "::error::Frostguard 3.x must use Windows Channel Release; the legacy ZIP workflow cannot publish an installed Stable identity."
             exit 1
           fi
           project_version="$(./mvnw -B --no-transfer-progress -q help:evaluate -Dexpression=project.version -DforceStdout)"

--- a/README.md
+++ b/README.md
@@ -218,12 +218,14 @@ Stable and Nightly use separate, self-contained Windows applications. Git,
 Maven, and a separately installed Java runtime are not required.
 
 - **[Latest Stable release](https://github.com/Shederator/wosbot/releases/latest)**
-- **[Signed Nightly releases](https://github.com/Shederator/wosbot/releases)**
+- **[Nightly releases](https://github.com/Shederator/wosbot/releases)**
 
 After choosing a build:
 
 1. Download the Windows x64 EXE for the desired channel.
-2. Verify the Frostguard publisher shown by Windows and run the installer.
+2. Confirm the download is from the official `Shederator/wosbot` release and
+   run the installer. A Windows **Unknown publisher** warning is currently
+   expected.
 3. Start **Frostguard** or **Frostguard Nightly** from its shortcut.
 4. Open **Configuration** and select your emulator's command-line controller.
 

--- a/build-support/release/test_write_update_manifest.py
+++ b/build-support/release/test_write_update_manifest.py
@@ -36,7 +36,28 @@ class WriteUpdateManifestTest(unittest.TestCase):
             self.assertEqual(16, manifest["artifacts"]["windows-x64"]["size"])
             self.assertEqual(64, len(manifest["artifacts"]["windows-x64"]["sha256"]))
             self.assertEqual("3.0.0-nightly.0", manifest["minimumUpdaterVersion"])
+            self.assertEqual("CN=Frostguard Project, O=Frostguard",
+                             manifest["artifacts"]["windows-x64"]["signature"]["publisher"])
             self.assertEqual(manifest, json.loads(output.read_text(encoding="utf-8")))
+
+    def test_omits_optional_authenticode_requirement(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            installer = root / "Frostguard-3.0.1-windows-x64.exe"
+            installer.write_bytes(b"unsigned but project-authenticated")
+
+            manifest = write_manifest(
+                channel="stable",
+                version="3.0.1",
+                minimum_updater_version="3.0.0",
+                published_at="2026-08-12T00:00:00Z",
+                release_notes_url="https://example.com/releases/3.0.1",
+                installer_url=f"https://example.com/releases/3.0.1/{installer.name}",
+                installer=installer,
+                output=root / "manifest.json",
+            )
+
+            self.assertNotIn("signature", manifest["artifacts"]["windows-x64"])
 
     def test_rejects_mutable_or_cross_channel_inputs(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/build-support/release/write_update_manifest.py
+++ b/build-support/release/write_update_manifest.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Create a schema-1 Frostguard update manifest from a signed installer."""
+"""Create a schema-1 Frostguard update payload from an immutable installer."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ SEMANTIC_VERSION = re.compile(
 def write_manifest(
         *, channel: str, version: str, minimum_updater_version: str,
         published_at: str, release_notes_url: str, installer_url: str,
-        installer: Path, publisher: str, output: Path) -> dict:
+        installer: Path, output: Path, publisher: str = "") -> dict:
     if channel not in {"stable", "nightly"}:
         raise ValueError("channel must be stable or nightly")
     for value, label in ((version, "version"),
@@ -46,9 +46,6 @@ def write_manifest(
         raise ValueError("installer URL must end with the exact installer file name")
     if version not in installer.name:
         raise ValueError("installer file name must contain the immutable release version")
-    if not publisher.strip():
-        raise ValueError("Authenticode publisher must not be blank")
-
     manifest = {
         "schemaVersion": 1,
         "channel": channel,
@@ -64,13 +61,14 @@ def write_manifest(
                 "url": installer_url,
                 "sha256": hashlib.sha256(installer.read_bytes()).hexdigest(),
                 "size": installer.stat().st_size,
-                "signature": {
-                    "type": "authenticode",
-                    "publisher": publisher.strip(),
-                },
             }
         },
     }
+    if publisher.strip():
+        manifest["artifacts"]["windows-x64"]["signature"] = {
+            "type": "authenticode",
+            "publisher": publisher.strip(),
+        }
     output.parent.mkdir(parents=True, exist_ok=True)
     temporary = output.with_suffix(output.suffix + ".tmp")
     temporary.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
@@ -87,7 +85,7 @@ def main() -> int:
     parser.add_argument("--release-notes-url", required=True)
     parser.add_argument("--installer-url", required=True)
     parser.add_argument("--installer", required=True, type=Path)
-    parser.add_argument("--publisher", required=True)
+    parser.add_argument("--publisher", default="")
     parser.add_argument("--output", required=True, type=Path)
     args = parser.parse_args()
     write_manifest(

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -115,18 +115,21 @@ class ChannelPackagingTest(unittest.TestCase):
         ):
             self.assertIn(contract, installer)
 
-    def test_signed_release_publishes_manifest_after_signed_installer_verification(self):
+    def test_release_publishes_project_signed_manifest_after_installer_verification(self):
         workflow = (REPO_ROOT / ".github/workflows/signed-windows-channel-release.yml").read_text(
             encoding="utf-8")
         ordered_steps = (
-            "Sign and verify immutable installer",
+            "Prepare immutable installer and verify optional Authenticode",
             "Create draft release and verify uploaded installer",
-            "Generate update manifest from the signed installer",
+            "Generate and project-sign update manifest",
             "Publish immutable release and channel manifest last",
         )
         positions = [workflow.index(step) for step in ordered_steps]
         self.assertEqual(sorted(positions), positions)
+        self.assertIn("FROSTGUARD_UPDATE_SIGNING_PRIVATE_KEY_BASE64", workflow)
+        self.assertIn("ProjectManifestSigner", workflow)
         self.assertIn("FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_BASE64", workflow)
+        self.assertIn("Configure optional Authenticode certificate", workflow)
         self.assertIn("Get-AuthenticodeSignature", workflow)
         self.assertIn("windows_installer_version.py", workflow)
         self.assertIn("gh release upload updates-nightly $env:MANIFEST", workflow)
@@ -134,7 +137,7 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("--cleanup-tag --yes", workflow)
         legacy_stable = (REPO_ROOT / ".github/workflows/stable-windows-release.yml").read_text(
             encoding="utf-8")
-        self.assertIn("Frostguard 3.x must use Signed Windows Channel Release", legacy_stable)
+        self.assertIn("Frostguard 3.x must use Windows Channel Release", legacy_stable)
 
 
 if __name__ == "__main__":

--- a/build-support/verification/test_verify_app_image.py
+++ b/build-support/verification/test_verify_app_image.py
@@ -41,6 +41,11 @@ class VerifyAppImageTest(unittest.TestCase):
                 verify_app_image.BUILD_METADATA,
                 "pullRequestBuild=false\nauthenticodePublisher=CN=Frostguard Project, O=Frostguard\n",
             )
+        with zipfile.ZipFile(self.image / "app/lib/frostguard-update-3.0.0.jar", "w") as update_jar:
+            update_jar.writestr(
+                verify_app_image.UPDATE_KEY,
+                verify_app_image.REPO_UPDATE_KEY.read_text(encoding="utf-8"),
+            )
         common_options = "\n".join((
             "java-options=-Dfrostguard.channel=stable",
             "java-options=-Dfrostguard.application.id=dev.frostguard.desktop",
@@ -98,6 +103,25 @@ class VerifyAppImageTest(unittest.TestCase):
     def test_rejects_desktop_jar_without_embedded_identity(self):
         (self.image / "app/frostguard-desktop-3.0.0.jar").write_bytes(b"not a jar")
         self.assertTrue(any("no valid embedded PR-build" in item
+                            for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_update_jar_without_project_key(self):
+        with zipfile.ZipFile(
+                self.image / "app/lib/frostguard-update-3.0.0.jar", "w"
+        ) as update_jar:
+            update_jar.writestr("placeholder", "missing key")
+        self.assertTrue(any("project update key" in item
+                            for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_update_jar_with_unexpected_project_key(self):
+        with zipfile.ZipFile(
+                self.image / "app/lib/frostguard-update-3.0.0.jar", "w"
+        ) as update_jar:
+            update_jar.writestr(
+                verify_app_image.UPDATE_KEY,
+                "keyId=untrusted\npublicKey=MCowBQYDK2VwAyEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n",
+            )
+        self.assertTrue(any("unexpected project update key" in item
                             for item in verify_app_image.inspect_image(self.image)))
 
     def test_rejects_runtime_data(self):

--- a/build-support/verification/verify_app_image.py
+++ b/build-support/verification/verify_app_image.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
 import re
 import zipfile
 from pathlib import Path
@@ -24,6 +26,24 @@ FORBIDDEN_NAMES = {
     "telegram-watcher.properties",
 }
 BUILD_METADATA = "dev/frostguard/app/frostguard-build.properties"
+UPDATE_KEY = "dev/frostguard/update/project-update-key.properties"
+REPO_UPDATE_KEY = (
+    Path(__file__).resolve().parents[2]
+    / "modules/update/src/main/resources"
+    / UPDATE_KEY
+)
+
+
+def _read_properties(content: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in content.splitlines():
+        if not line or line.lstrip().startswith("#"):
+            continue
+        key, separator, value = line.partition("=")
+        if not separator or not key or key in values:
+            return {}
+        values[key] = value
+    return values
 
 
 def inspect_image(
@@ -133,6 +153,33 @@ def inspect_image(
                         )
         except (KeyError, UnicodeDecodeError, zipfile.BadZipFile):
             problems.append("Desktop JAR has no valid embedded PR-build update identity")
+
+    update_jars = [
+        path for name, path in files.items()
+        if re.match(r"^app/lib/frostguard-update-[^/]+\.jar$", name)
+    ]
+    if len(update_jars) == 1:
+        try:
+            with zipfile.ZipFile(update_jars[0]) as update_jar:
+                embedded_key = update_jar.read(UPDATE_KEY).decode("utf-8")
+            expected_key = REPO_UPDATE_KEY.read_text(encoding="utf-8")
+            key_values = _read_properties(embedded_key)
+            expected_values = _read_properties(expected_key)
+            public_key = base64.b64decode(
+                key_values.get("publicKey", ""), validate=True
+            )
+            if (set(key_values) != {"keyId", "publicKey"}
+                    or not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}",
+                                        key_values.get("keyId", ""))
+                    or len(public_key) != 44
+                    or not public_key.startswith(bytes.fromhex("302a300506032b6570032100"))
+                    or key_values != expected_values):
+                problems.append("Update module has an invalid or unexpected project update key")
+        except (KeyError, UnicodeDecodeError, binascii.Error, ValueError,
+                OSError, zipfile.BadZipFile):
+            problems.append("Update module has no valid embedded project update key")
+    elif len(update_jars) > 1:
+        problems.append("Application image contains multiple update modules")
 
     for relative in files:
         path = Path(relative)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,10 +70,13 @@ Do not put game task business logic in `modules/desktop`; do not put UI concepts
 `modules/update` owns the platform-neutral update trust boundary:
 
 - strict schema-versioned manifest parsing;
+- Ed25519 verification of the exact manifest payload against the project public
+  key embedded in every eligible build;
 - semantic-version, channel, operating-system, and architecture selection;
 - restart-safe downloads below the selected workspace cache;
 - byte-size and SHA-256 verification;
-- a build-pinned Windows Authenticode identity and token-authorized external handoff.
+- optional build-pinned Windows Authenticode verification and token-authorized
+  external handoff.
 
 The desktop module owns presentation and runtime shutdown. Update code does not
 depend on JavaFX, persistence, scheduling, or GitHub APIs. Development and
@@ -293,6 +296,12 @@ Frostguard authorizes the staged waiter, stops queues and workspace-owned
 services, closes SQLite and the workspace lock, and exits. A failed shutdown
 cancels the authorization, and the waiter cannot start the installer while the
 Frostguard PID is alive. Frostguard never replaces its own running files.
+
+The release feed is a signed envelope whose Ed25519 signature covers the exact
+manifest bytes. The embedded project public key is the primary update trust
+root. The manifest then binds the immutable installer URL, filename, size, and
+SHA-256. Authenticode is an additional check when a release build embeds a
+publisher identity; it is not required for project-signed releases.
 
 `modules/watcher` builds a separate shaded watcher jar.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,18 +8,21 @@ required emulator, and building the project from source on Windows.
 | Build | Use it when | Download |
 |:------|:------------|:---------|
 | Stable | You want a tested, versioned build that changes only with a release | [Latest Stable release](https://github.com/Shederator/wosbot/releases/latest) |
-| Nightly | You want the latest signed preview without replacing Stable | [Nightly releases](https://github.com/Shederator/wosbot/releases) |
+| Nightly | You want the latest authenticated preview without replacing Stable | [Nightly releases](https://github.com/Shederator/wosbot/releases) |
 | PR build | You want to test one or more open pull requests | Run `/build-pr` in Discord `#request-a-build` |
 
-Stable and Nightly use self-contained, signed Windows installers and do not
-require a separately installed Java runtime. Nightly may contain unfinished
-changes; PR builds additionally contain unmerged code and continue to use the
-temporary ZIP format.
+Stable and Nightly use self-contained Windows installers and do not require a
+separately installed Java runtime. Their automatic update feeds are signed by
+the Frostguard project. The installers currently have no Windows verified
+publisher, so Windows may show an **Unknown publisher** or SmartScreen warning.
+Nightly may contain unfinished changes; PR builds additionally contain
+unmerged code and continue to use the temporary ZIP format.
 
 ## Install a downloaded build
 
 1. Open the desired release and download its Windows x64 EXE installer.
-2. Confirm that Windows reports the expected Frostguard publisher before running it.
+2. Confirm that the download comes from the official `Shederator/wosbot`
+   GitHub release. A Windows publisher identity is not currently expected.
 3. Choose whether to create a desktop shortcut and complete the per-user
    installation. The final page starts `Frostguard` or `Frostguard Nightly` by
    default; clear the checkbox if you do not want to launch it yet.
@@ -159,12 +162,14 @@ python build-support/verification/verify_app_image.py `
 Nightly uses its own application ID, upgrade UUID, installation directory,
 shortcut, launcher identity, workspace channel, and update feed.
 
-Signed Stable and Nightly builds expose a channel-specific update feed in
+Stable and Nightly release builds expose a channel-specific update feed in
 **Config > Updates**. Development and pull-request builds cannot install from
-release feeds. Frostguard accepts an update only after the manifest identity,
-download size, SHA-256, and Windows Authenticode signer all match. The current
-public ZIP feeds are not used by this updater; automatic installer updates stay
-disabled in ordinary local and PR builds.
+release feeds. Frostguard first verifies the project Ed25519 signature over the
+manifest, then requires the manifest identity, immutable download, size, and
+SHA-256 to match. A Windows Authenticode signer is checked in addition when the
+build and manifest declare one. The current public ZIP feeds are not used by
+this updater; automatic installer updates stay disabled in ordinary local and
+PR builds.
 
 ### Run a source build
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,6 +1,6 @@
 # Releases
 
-Frostguard publishes signed installed releases for Stable and Nightly plus
+Frostguard publishes authenticated installed releases for Stable and Nightly plus
 temporary ZIP builds for pull-request testing. The existing daily and Stable
 ZIP workflows remain transitional until #155 separates validation from public
 Nightly publication.
@@ -11,9 +11,9 @@ Nightly publication.
 | Daily `nightly` | Testers | Replaced daily | Update the daily download, no mass mention |
 | PR test `pr-test-*` | Requester/testers | Temporary | Reply only to the requester |
 
-## Signed installed releases
+## Authenticated installed releases
 
-Run **Signed Windows Channel Release** manually from `main`. It requires a
+Run **Windows Channel Release** manually from `main`. It requires a
 semantic version, the target `stable` or `nightly` identity, and the minimum
 supported updater version. Stable versions use `X.Y.Z`; Nightly versions use an
 immutable prerelease such as `3.1.0-nightly.20260811.1`.
@@ -24,18 +24,24 @@ Windows identity from `YYYYMMDD.N`; for example, the Nightly above uses
 `26.8.11001`. Use the current date and a sequence from 1 through 999, increasing
 the sequence for additional Nightlies on the same day.
 
-The workflow requires these repository secrets:
+The workflow always requires
+`FROSTGUARD_UPDATE_SIGNING_PRIVATE_KEY_BASE64`: the Base64-encoded PKCS#8
+Ed25519 private key matching the public key committed in
+`modules/update/src/main/resources/dev/frostguard/update/project-update-key.properties`.
+Keep a second, access-controlled backup of the private key because GitHub
+Actions secrets cannot be exported again.
 
-- `FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_BASE64` — the PFX encoded as Base64;
-- `FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_PASSWORD` — the PFX password;
-- `FROSTGUARD_AUTHENTICODE_PUBLISHER` — the exact certificate subject embedded
-  into the application and required by every update manifest.
+Authenticode is optional. Configure all three of
+`FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_BASE64`,
+`FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_PASSWORD`, and
+`FROSTGUARD_AUTHENTICODE_PUBLISHER`, or leave all three unset. A partial
+configuration fails the release.
 
 Stable and Nightly use different application IDs, upgrade UUIDs, install
 directories, shortcuts, workspaces, and feeds. The workflow builds and smokes
-the selected identity, signs the installer, verifies the exact subject,
-uploads and re-downloads the immutable installer, derives its final size and
-SHA-256, and publishes the manifest last. Stable exposes its manifest through
+the selected identity, optionally Authenticode-signs the installer, uploads and
+re-downloads the immutable installer, derives its final size and SHA-256,
+project-signs the manifest, verifies it, and publishes it last. Stable exposes its manifest through
 the latest immutable release; Nightly points `updates-nightly` at an installer
 stored in an immutable `nightly-<version>` release.
 
@@ -57,7 +63,7 @@ manually with:
   `main` after the intended release commit.
 
 This workflow rejects Frostguard 3.x. Installed 3.x releases must use the
-signed channel workflow so an unsigned ZIP can never become the latest Stable
+authenticated channel workflow so an unsigned ZIP can never become the latest Stable
 product accidentally.
 
 The workflow pins the run's exact commit, downloads its versioned artifact,
@@ -130,9 +136,28 @@ public download.
 
 ## Native installer update contract
 
-The Frostguard 3.0 updater uses one immutable HTTPS manifest per channel. Do
-not publish a manifest until its installer has been built, Authenticode-signed,
-uploaded, and smoke-tested. Signing credentials remain outside the repository.
+The Frostguard 3.0 updater uses one project-signed manifest envelope per
+channel. Do not publish an envelope until its installer has been built,
+uploaded to an immutable HTTPS URL, and smoke-tested. The public verification
+key is part of the application; the private signing key remains outside the
+repository.
+
+### Signed envelope 1
+
+```json
+{
+  "envelopeVersion": 1,
+  "algorithm": "Ed25519",
+  "keyId": "frostguard-update-2026-01",
+  "payload": "<Base64 of the exact UTF-8 schema-1 manifest bytes>",
+  "signature": "<Base64 Ed25519 signature over those exact bytes>"
+}
+```
+
+The updater rejects an unsigned raw manifest, an unknown envelope field,
+algorithm, or key ID, invalid Base64, and any payload whose signature does not
+verify against the embedded project key. It parses and selects an artifact only
+after signature verification.
 
 ### Manifest schema 1
 
@@ -151,28 +176,25 @@ uploaded, and smoke-tested. Signing credentials remain outside the repository.
       "fileName": "Frostguard-3.0.1-windows-x64.exe",
       "url": "https://example.invalid/releases/3.0.1/Frostguard-3.0.1-windows-x64.exe",
       "sha256": "<64 lowercase hexadecimal characters>",
-      "size": 123456789,
-      "signature": {
-        "type": "authenticode",
-        "publisher": "<exact certificate subject>"
-      }
+      "size": 123456789
     }
   }
 }
 ```
 
-Unknown fields, unsupported schemas, mutable filenames, insecure URLs, and
-Windows artifacts without an Authenticode publisher are rejected. Calculate
-the hash and size after signing because Authenticode changes the file.
+Unknown fields, unsupported schemas, mutable filenames, and insecure URLs are
+rejected. If Authenticode is configured, the artifact additionally carries a
+`signature` object with type `authenticode` and the exact certificate subject.
+Calculate the hash and size after optional Authenticode signing because signing
+changes the file.
 
 ### Build inputs
 
-Embed the Stable endpoint and exact trusted certificate subject at packaging
-time:
+Embed the Stable endpoint at packaging time. The project verification key is a
+versioned source resource and is always included in release builds:
 
 ```powershell
 .\mvnw.cmd -Dfrostguard.update.manifest.stable=https://updates.example.invalid/stable.json `
-  "-Dfrostguard.update.authenticode-publisher=CN=Frostguard Project, O=Frostguard" `
   "-Pwindows-app-image,windows-installer" package
 ```
 
@@ -181,29 +203,55 @@ Nightly adds its separate packaging identity and embeds both public endpoints:
 ```powershell
 .\mvnw.cmd -Dfrostguard.update.manifest.stable=https://example.invalid/stable.json `
   -Dfrostguard.update.manifest.nightly=https://example.invalid/nightly.json `
-  "-Dfrostguard.update.authenticode-publisher=CN=Frostguard Project, O=Frostguard" `
   "-Pwindows-app-image,windows-installer,windows-nightly" package
 ```
 
-The checked-in endpoint and publisher defaults are empty, so ordinary local
-builds cannot contact or trust a release feed accidentally. PR packaging also
-embeds `frostguard.update.pullRequestBuild=true`. Development builds, PR builds,
-and builds without a pinned publisher cannot update even if someone supplies a
-manifest URL manually. The manifest publisher must match the value embedded in
-the application JAR before its installer can be downloaded or executed.
+The checked-in endpoint defaults are empty, so ordinary local builds cannot
+contact a release feed accidentally. PR packaging also embeds
+`frostguard.update.pullRequestBuild=true`. Development and PR builds cannot
+update even if someone supplies a manifest URL manually. Release builds trust
+only envelopes signed by the project key embedded in their update module. If a
+build also pins an Authenticode publisher, the manifest and downloaded
+installer must match it exactly.
 
 ### Publication order
 
 1. Build and smoke-test the native application image.
 2. Build the channel-specific installer with its stable upgrade identity.
-3. Authenticode-sign the final installer outside the repository.
-4. Verify the signature and exact certificate subject on Windows.
-5. Calculate the final byte size and SHA-256.
-6. Upload the installer to an immutable versioned HTTPS URL.
-7. Publish the manifest atomically as the final step.
+3. Optionally Authenticode-sign the final installer and verify its exact subject.
+4. Calculate the final byte size and SHA-256.
+5. Upload and re-download the installer at its immutable versioned HTTPS URL.
+6. Generate the schema-1 payload from that verified file.
+7. Ed25519-sign the exact payload and verify the resulting envelope.
+8. Publish the signed envelope atomically as the final step.
 
-Never publish a PR artifact, unsigned installer, mutable rolling filename, or
-manifest whose artifact has not completed the same verification sequence.
+Never publish a PR artifact, unsigned manifest payload, mutable installer
+filename, or envelope whose artifact has not completed the same verification
+sequence.
+
+### Key lifecycle
+
+Generate a replacement pair with
+`ProjectManifestSigner generate <private-output> <public-output>`. Restrict the
+private file to release maintainers, keep an offline backup, place its Base64
+value in the repository secret, and commit only the Base64 X.509 public key with
+a new key ID. Never commit, log, upload as an artifact, or place the private key
+in a workflow variable that is printed.
+
+Rotation is staged. First publish an old-key-signed bridge release whose
+application embeds the new public key. Keep the old private key and old bridge
+release available while supported installations move through it. Only then
+replace the repository secret and publish envelopes with the new key ID. With
+the current single-key client, installations that skip the bridge cannot trust
+the new feed and must install a current release manually. Supporting overlapping
+keys is the follow-up if seamless emergency rotation is required.
+
+If the private key is lost, restore it from the offline backup; the GitHub
+secret cannot be read back. If compromise is suspected, stop channel
+publication, remove or replace the Actions secret, preserve release evidence,
+and prepare a bridge release and manual recovery instructions before resuming.
+Adding a Windows code-signing certificate later is additive: configure the
+three Authenticode secrets above; the signed-envelope format does not change.
 
 ### Runtime and recovery
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -3,7 +3,7 @@
 This document summarizes Windows-specific setup for Frostguard.
 
 The [latest Stable release](https://github.com/Shederator/wosbot/releases/latest)
-provides the tested signed Windows installer. Signed Nightly releases appear in
+provides the tested Windows installer. Authenticated Nightly releases appear in
 the [release history](https://github.com/Shederator/wosbot/releases) as a
 separate product identity. Git, Git LFS, Maven, and a JDK are needed only when
 building from source.
@@ -25,15 +25,15 @@ identity has a configured release manifest. The update flow:
 1. selects only a newer artifact for the running channel, Windows, and x64;
 2. shows the version, release notes, channel, and size before confirmation;
 3. downloads below the selected workspace's `cache\updates` directory;
-4. verifies the declared size, SHA-256, and exact Authenticode signer;
+4. verifies the project Ed25519 signature, declared size, SHA-256, and any
+   configured Authenticode signer;
 5. stops scheduling and workspace services, closes SQLite, and releases the
    workspace lock;
 6. exits before an external waiter launches the installer.
 
-Development and PR-test packages cannot use automatic release updates. An
-unsigned installer is never handed off. Public automatic updates remain
-disabled until the release workflow can provide signed Frostguard 3.0
-installers and atomically promoted manifests.
+Development and PR-test packages cannot use automatic release updates. A
+release whose manifest is not validly signed by the embedded project key is
+never handed off. Authenticode remains an optional additional check.
 
 Interrupted downloads remain `.part` files and resume when the server supports
 byte ranges. A failed size, hash, or signature check prevents installer handoff
@@ -113,9 +113,10 @@ The application currently packages Windows ADB and Tesseract assets from `tools/
 
 ## Starting Frostguard
 
-After downloading a signed Frostguard 3.0 installer, verify its Windows
-publisher and complete the per-user installation. Run the installed
-`Frostguard.exe` or `Frostguard Nightly.exe`.
+After downloading a Frostguard 3.0 installer from the official GitHub release,
+complete the per-user installation. The installer currently has no Windows
+verified publisher, so an **Unknown publisher** or SmartScreen warning is
+expected. Run the installed `Frostguard.exe` or `Frostguard Nightly.exe`.
 The per-user installer defaults to `%LOCALAPPDATA%\Frostguard`, while
 all mutable databases, configuration, logs, watcher state, and custom tasks
 remain in the selected workspace below `%USERPROFILE%\.frostguard`. The

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateLayoutController.java
@@ -6,6 +6,7 @@ import dev.frostguard.app.BuildMetadata;
 import dev.frostguard.app.bootstrap.ApplicationLifecycle;
 import dev.frostguard.update.InstallerHandoff;
 import dev.frostguard.update.PreparedUpdate;
+import dev.frostguard.update.ProjectUpdateKey;
 import dev.frostguard.update.RunningBuild;
 import dev.frostguard.update.SemanticVersion;
 import dev.frostguard.update.UpdateCandidate;
@@ -70,7 +71,7 @@ public final class UpdateLayoutController {
             } else if (runningBuild.channel() == RuntimeChannel.DEVELOPMENT) {
                 labelStatus.setText("Development builds do not use release update feeds.");
             } else {
-                labelStatus.setText("This build has no pinned release-signing identity.");
+                labelStatus.setText("This build has no valid pinned project update key.");
             }
         } else if (runningBuild.platform().operatingSystem() != UpdatePlatform.OperatingSystem.WINDOWS) {
             buttonCheck.setDisable(true);
@@ -127,11 +128,12 @@ public final class UpdateLayoutController {
         confirmation.setHeaderText("Install Frostguard " + candidate.version() + "?");
         confirmation.setContentText("Channel: " + candidate.channel().directoryName() + "\n"
                 + "Download: " + formatSize(candidate.artifact().size()) + "\n\n"
-                + "Frostguard will stop automation, close its workspace, exit, and then launch the signed installer.");
+                + "Frostguard will verify the project-signed release, stop automation, close its workspace, "
+                + "exit, and then launch the installer. Windows may show an unknown-publisher warning.");
         if (confirmation.showAndWait().filter(ButtonType.OK::equals).isEmpty()) {
             return;
         }
-        setBusy(true, "Downloading and verifying the signed installer...");
+        setBusy(true, "Downloading and verifying the authenticated installer...");
         runAsync(() -> manager.prepare(candidate, WorkspacePaths.current().cache()), this::beginHandoff);
     }
 
@@ -234,7 +236,7 @@ public final class UpdateLayoutController {
         BuildMetadata metadata = BuildMetadata.current();
         return new RunningBuild(SemanticVersion.parse(version), SemanticVersion.parse(version),
                 WorkspacePaths.current().channel(), UpdatePlatform.current(),
-                metadata.pullRequestBuild(), metadata.authenticodePublisher());
+                metadata.pullRequestBuild(), ProjectUpdateKey.current(), metadata.authenticodePublisher());
     }
 
     static String formatSize(long bytes) {

--- a/modules/update/src/main/java/dev/frostguard/update/ManifestClient.java
+++ b/modules/update/src/main/java/dev/frostguard/update/ManifestClient.java
@@ -10,21 +10,21 @@ import java.time.Duration;
 public final class ManifestClient {
     private static final int MAX_MANIFEST_BYTES = 1024 * 1024;
     private final HttpClient client;
-    private final ManifestCodec codec;
+    private final SignedManifestCodec codec;
 
     public ManifestClient() {
         this(HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .followRedirects(HttpClient.Redirect.NORMAL)
-                .build(), new ManifestCodec());
+                .build(), new SignedManifestCodec());
     }
 
-    ManifestClient(HttpClient client, ManifestCodec codec) {
+    ManifestClient(HttpClient client, SignedManifestCodec codec) {
         this.client = client;
         this.codec = codec;
     }
 
-    public UpdateManifest fetch(URI uri) throws UpdateException {
+    public UpdateManifest fetch(URI uri, ManifestVerificationKey trustedKey) throws UpdateException {
         requireHttps(uri);
         HttpRequest request = HttpRequest.newBuilder(uri)
                 .timeout(Duration.ofSeconds(20))
@@ -45,7 +45,7 @@ public final class ManifestClient {
             if (body.length > MAX_MANIFEST_BYTES) {
                 throw new UpdateException("Manifest exceeds the 1 MiB safety limit");
             }
-            return codec.read(body);
+            return codec.read(body, trustedKey);
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
             throw new UpdateException("Manifest request was interrupted", exception);

--- a/modules/update/src/main/java/dev/frostguard/update/ManifestCodec.java
+++ b/modules/update/src/main/java/dev/frostguard/update/ManifestCodec.java
@@ -76,9 +76,9 @@ public final class ManifestCodec {
         HexFormat.of().parseHex(hash);
         if (platform.operatingSystem() == UpdatePlatform.OperatingSystem.WINDOWS) {
             SignatureRequirement signature = artifact.signature();
-            if (signature == null || !"authenticode".equalsIgnoreCase(signature.type())
-                    || required(signature.publisher(), "Authenticode publisher").isBlank()) {
-                throw new IllegalArgumentException("Windows artifacts require an Authenticode publisher");
+            if (signature != null && (!"authenticode".equalsIgnoreCase(signature.type())
+                    || required(signature.publisher(), "Authenticode publisher").isBlank())) {
+                throw new IllegalArgumentException("Windows Authenticode requirement is invalid");
             }
         }
     }

--- a/modules/update/src/main/java/dev/frostguard/update/ManifestVerificationKey.java
+++ b/modules/update/src/main/java/dev/frostguard/update/ManifestVerificationKey.java
@@ -1,0 +1,42 @@
+package dev.frostguard.update;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.regex.Pattern;
+
+public record ManifestVerificationKey(String keyId, String publicKeyBase64) {
+    private static final Pattern KEY_ID = Pattern.compile("[a-z0-9][a-z0-9._-]{0,63}");
+
+    public ManifestVerificationKey {
+        keyId = keyId == null ? "" : keyId.trim();
+        publicKeyBase64 = publicKeyBase64 == null ? "" : publicKeyBase64.trim();
+    }
+
+    public boolean isUsable() {
+        try {
+            decodePublicKey();
+            return isValidKeyId(keyId);
+        } catch (UpdateException exception) {
+            return false;
+        }
+    }
+
+    PublicKey decodePublicKey() throws UpdateException {
+        if (!isValidKeyId(keyId)) {
+            throw new UpdateException("Pinned update-signing key ID is invalid");
+        }
+        try {
+            byte[] encoded = Base64.getDecoder().decode(publicKeyBase64);
+            return KeyFactory.getInstance("Ed25519").generatePublic(new X509EncodedKeySpec(encoded));
+        } catch (IllegalArgumentException | GeneralSecurityException exception) {
+            throw new UpdateException("Pinned update-signing public key is invalid", exception);
+        }
+    }
+
+    static boolean isValidKeyId(String value) {
+        return value != null && KEY_ID.matcher(value).matches();
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/ProjectManifestSigner.java
+++ b/modules/update/src/main/java/dev/frostguard/update/ProjectManifestSigner.java
@@ -1,0 +1,102 @@
+package dev.frostguard.update;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+
+public final class ProjectManifestSigner {
+    static final String PRIVATE_KEY_ENV = "FROSTGUARD_UPDATE_SIGNING_PRIVATE_KEY_BASE64";
+
+    private ProjectManifestSigner() {
+    }
+
+    public static void main(String[] arguments) throws Exception {
+        if (arguments.length == 3 && "sign".equals(arguments[0])) {
+            String privateKey = System.getenv(PRIVATE_KEY_ENV);
+            if (privateKey == null || privateKey.isBlank()) {
+                throw new IllegalArgumentException(PRIVATE_KEY_ENV + " is not configured");
+            }
+            byte[] payload = Files.readAllBytes(Path.of(arguments[1]));
+            byte[] envelope = sign(payload, ProjectUpdateKey.current().keyId(), privateKey);
+            writeNew(Path.of(arguments[2]), envelope);
+            return;
+        }
+        if (arguments.length == 3 && "generate".equals(arguments[0])) {
+            generate(Path.of(arguments[1]), Path.of(arguments[2]));
+            return;
+        }
+        if (arguments.length == 2 && "verify".equals(arguments[0])) {
+            UpdateManifest manifest = new SignedManifestCodec().read(
+                    Files.readAllBytes(Path.of(arguments[1])), ProjectUpdateKey.current());
+            System.out.println("Verified project-signed " + manifest.channel()
+                    + " manifest for " + manifest.version());
+            return;
+        }
+        throw new IllegalArgumentException("Usage: sign <manifest-payload> <signed-envelope> "
+                + "or verify <signed-envelope> or generate <private-key-output> <public-key-output>");
+    }
+
+    static byte[] sign(byte[] payload, String keyId, String privateKeyBase64) throws GeneralSecurityException {
+        if (payload == null || payload.length == 0) {
+            throw new IllegalArgumentException("Manifest payload must not be empty");
+        }
+        if (!ManifestVerificationKey.isValidKeyId(keyId)) {
+            throw new IllegalArgumentException("Update-signing key ID is invalid");
+        }
+        byte[] encodedPrivateKey = Base64.getDecoder().decode(privateKeyBase64.trim());
+        PrivateKey privateKey = KeyFactory.getInstance("Ed25519")
+                .generatePrivate(new PKCS8EncodedKeySpec(encodedPrivateKey));
+        Signature signer = Signature.getInstance("Ed25519");
+        signer.initSign(privateKey);
+        signer.update(payload);
+        String envelope = """
+                {
+                  "envelopeVersion": 1,
+                  "algorithm": "Ed25519",
+                  "keyId": "%s",
+                  "payload": "%s",
+                  "signature": "%s"
+                }
+                """.formatted(
+                keyId,
+                Base64.getEncoder().encodeToString(payload),
+                Base64.getEncoder().encodeToString(signer.sign()));
+        return envelope.getBytes(StandardCharsets.UTF_8);
+    }
+
+    static void generate(Path privateKeyOutput, Path publicKeyOutput) throws GeneralSecurityException, IOException {
+        if (privateKeyOutput.toAbsolutePath().normalize()
+                .equals(publicKeyOutput.toAbsolutePath().normalize())) {
+            throw new IllegalArgumentException("Private and public key outputs must be different");
+        }
+        if (Files.exists(privateKeyOutput)) {
+            throw new FileAlreadyExistsException(privateKeyOutput.toString());
+        }
+        if (Files.exists(publicKeyOutput)) {
+            throw new FileAlreadyExistsException(publicKeyOutput.toString());
+        }
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("Ed25519");
+        KeyPair keyPair = generator.generateKeyPair();
+        writeNew(privateKeyOutput, Base64.getEncoder().encode(keyPair.getPrivate().getEncoded()));
+        writeNew(publicKeyOutput, Base64.getEncoder().encode(keyPair.getPublic().getEncoded()));
+    }
+
+    private static void writeNew(Path output, byte[] content) throws IOException {
+        Path parent = output.toAbsolutePath().normalize().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        Files.write(output, content, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/ProjectUpdateKey.java
+++ b/modules/update/src/main/java/dev/frostguard/update/ProjectUpdateKey.java
@@ -1,0 +1,36 @@
+package dev.frostguard.update;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public final class ProjectUpdateKey {
+    private static final String RESOURCE = "/dev/frostguard/update/project-update-key.properties";
+
+    private ProjectUpdateKey() {
+    }
+
+    public static ManifestVerificationKey current() {
+        return Holder.INSTANCE;
+    }
+
+    static ManifestVerificationKey read(InputStream input) {
+        if (input == null) {
+            return new ManifestVerificationKey("", "");
+        }
+        Properties properties = new Properties();
+        try (input) {
+            properties.load(input);
+        } catch (IOException exception) {
+            return new ManifestVerificationKey("", "");
+        }
+        return new ManifestVerificationKey(
+                properties.getProperty("keyId", ""),
+                properties.getProperty("publicKey", ""));
+    }
+
+    private static final class Holder {
+        private static final ManifestVerificationKey INSTANCE = read(
+                ProjectUpdateKey.class.getResourceAsStream(RESOURCE));
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/RunningBuild.java
+++ b/modules/update/src/main/java/dev/frostguard/update/RunningBuild.java
@@ -8,16 +8,18 @@ public record RunningBuild(
         RuntimeChannel channel,
         UpdatePlatform platform,
         boolean pullRequestBuild,
+        ManifestVerificationKey manifestKey,
         String authenticodePublisher) {
 
     public RunningBuild {
         if (version == null || updaterVersion == null || channel == null || platform == null) {
             throw new IllegalArgumentException("Running build identity is incomplete");
         }
+        manifestKey = manifestKey == null ? new ManifestVerificationKey("", "") : manifestKey;
         authenticodePublisher = authenticodePublisher == null ? "" : authenticodePublisher.trim();
     }
 
     public boolean permitsAutomaticUpdates() {
-        return channel != RuntimeChannel.DEVELOPMENT && !pullRequestBuild && !authenticodePublisher.isBlank();
+        return channel != RuntimeChannel.DEVELOPMENT && !pullRequestBuild && manifestKey.isUsable();
     }
 }

--- a/modules/update/src/main/java/dev/frostguard/update/SignedManifestCodec.java
+++ b/modules/update/src/main/java/dev/frostguard/update/SignedManifestCodec.java
@@ -1,0 +1,79 @@
+package dev.frostguard.update;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.Signature;
+import java.util.Base64;
+
+public final class SignedManifestCodec {
+    static final int SUPPORTED_ENVELOPE_VERSION = 1;
+    private static final int MAX_PAYLOAD_BYTES = 512 * 1024;
+    private static final String ALGORITHM = "Ed25519";
+
+    private final ObjectMapper mapper = new ObjectMapper()
+            .enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION)
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+    private final ManifestCodec manifestCodec;
+
+    public SignedManifestCodec() {
+        this(new ManifestCodec());
+    }
+
+    SignedManifestCodec(ManifestCodec manifestCodec) {
+        this.manifestCodec = manifestCodec;
+    }
+
+    public UpdateManifest read(byte[] envelopeJson, ManifestVerificationKey trustedKey) throws UpdateException {
+        if (trustedKey == null || !trustedKey.isUsable()) {
+            throw new UpdateException("This build has no valid pinned update-signing key");
+        }
+        try {
+            SignedManifestEnvelope envelope = mapper.readValue(envelopeJson, SignedManifestEnvelope.class);
+            validateEnvelope(envelope, trustedKey);
+            byte[] payload = decode(envelope.payload(), "payload");
+            if (payload.length == 0 || payload.length > MAX_PAYLOAD_BYTES) {
+                throw new IllegalArgumentException("signed manifest payload size is invalid");
+            }
+            byte[] signatureBytes = decode(envelope.signature(), "signature");
+            Signature verifier = Signature.getInstance(ALGORITHM);
+            verifier.initVerify(trustedKey.decodePublicKey());
+            verifier.update(payload);
+            if (!verifier.verify(signatureBytes)) {
+                throw new IllegalArgumentException("signed manifest signature is invalid");
+            }
+            return manifestCodec.read(payload);
+        } catch (IOException | GeneralSecurityException | IllegalArgumentException exception) {
+            throw new UpdateException("Signed update manifest is invalid: " + exception.getMessage(), exception);
+        }
+    }
+
+    private static void validateEnvelope(SignedManifestEnvelope envelope, ManifestVerificationKey trustedKey) {
+        if (envelope.envelopeVersion() != SUPPORTED_ENVELOPE_VERSION) {
+            throw new IllegalArgumentException("unsupported signed-manifest envelope version "
+                    + envelope.envelopeVersion());
+        }
+        if (!ALGORITHM.equals(envelope.algorithm())) {
+            throw new IllegalArgumentException("signed manifest must use Ed25519");
+        }
+        if (!trustedKey.keyId().equals(envelope.keyId())) {
+            throw new IllegalArgumentException("signed manifest key ID does not match this build");
+        }
+        if (envelope.payload() == null || envelope.payload().isBlank()
+                || envelope.signature() == null || envelope.signature().isBlank()) {
+            throw new IllegalArgumentException("signed manifest payload and signature are required");
+        }
+    }
+
+    private static byte[] decode(String value, String label) {
+        try {
+            return Base64.getDecoder().decode(value);
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException("signed manifest " + label + " is not valid Base64", exception);
+        }
+    }
+}

--- a/modules/update/src/main/java/dev/frostguard/update/SignedManifestEnvelope.java
+++ b/modules/update/src/main/java/dev/frostguard/update/SignedManifestEnvelope.java
@@ -1,0 +1,9 @@
+package dev.frostguard.update;
+
+record SignedManifestEnvelope(
+        int envelopeVersion,
+        String algorithm,
+        String keyId,
+        String payload,
+        String signature) {
+}

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateManager.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateManager.java
@@ -27,7 +27,7 @@ public final class UpdateManager {
     }
 
     public Optional<UpdateCandidate> check(URI manifestUri, RunningBuild running) throws UpdateException {
-        return exclusive(() -> selector.select(manifests.fetch(manifestUri), running));
+        return exclusive(() -> selector.select(manifests.fetch(manifestUri, running.manifestKey()), running));
     }
 
     public PreparedUpdate prepare(UpdateCandidate candidate, Path workspaceCache) throws UpdateException {

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateSelector.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateSelector.java
@@ -35,10 +35,13 @@ public final class UpdateSelector {
         if (!artifactPlatform.equals(running.platform())) {
             throw new UpdateException("Selected artifact platform does not match the running application");
         }
-        String manifestPublisher = artifact.signature() == null ? null : artifact.signature().publisher();
-        if (manifestPublisher == null || !running.authenticodePublisher()
-                .equalsIgnoreCase(manifestPublisher.trim())) {
-            throw new UpdateException("Manifest signer does not match the publisher pinned in this build");
+        String pinnedPublisher = running.authenticodePublisher();
+        String manifestPublisher = artifact.signature() == null ? "" : artifact.signature().publisher().trim();
+        if (!pinnedPublisher.isBlank() || !manifestPublisher.isBlank()) {
+            if (pinnedPublisher.isBlank() || manifestPublisher.isBlank()
+                    || !pinnedPublisher.equalsIgnoreCase(manifestPublisher)) {
+                throw new UpdateException("Manifest Authenticode publisher does not match this build");
+            }
         }
         return Optional.of(new UpdateCandidate(manifestChannel, release, Instant.parse(manifest.publishedAt()),
                 URI.create(manifest.releaseNotesUrl()), artifactPlatform, artifact));

--- a/modules/update/src/main/java/dev/frostguard/update/WindowsAuthenticodeVerifier.java
+++ b/modules/update/src/main/java/dev/frostguard/update/WindowsAuthenticodeVerifier.java
@@ -29,9 +29,12 @@ public final class WindowsAuthenticodeVerifier implements InstallerTrustVerifier
         if (!Files.isRegularFile(installer)) {
             throw new UpdateException("Verified installer does not exist: " + installer);
         }
-        if (requirement == null || !"authenticode".equalsIgnoreCase(requirement.type())
+        if (requirement == null) {
+            return;
+        }
+        if (!"authenticode".equalsIgnoreCase(requirement.type())
                 || requirement.publisher() == null || requirement.publisher().isBlank()) {
-            throw new UpdateException("Windows update is missing its Authenticode trust requirement");
+            throw new UpdateException("Windows update has an invalid Authenticode trust requirement");
         }
         try {
             CommandRunner.CommandResult result = runner.run(List.of(

--- a/modules/update/src/main/resources/dev/frostguard/update/project-update-key.properties
+++ b/modules/update/src/main/resources/dev/frostguard/update/project-update-key.properties
@@ -1,0 +1,2 @@
+keyId=frostguard-update-2026-01
+publicKey=MCowBQYDK2VwAyEAHxJ25bg5LZZ//BfZJ2DaW9ch43spaq/vs+wB2fqLHIQ=

--- a/modules/update/src/test/java/dev/frostguard/update/ManifestCodecTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/ManifestCodecTest.java
@@ -45,9 +45,19 @@ class ManifestCodecTest {
     }
 
     @Test
-    void rejectsUnsignedWindowsArtifact() {
+    void acceptsProjectAuthenticatedWindowsArtifactWithoutAuthenticode() throws Exception {
+        UpdateManifest manifest = codec.read(validUnsignedManifest().getBytes(StandardCharsets.UTF_8));
+        assertEquals(null, manifest.artifacts().get("windows-x64").signature());
+    }
+
+    @Test
+    void rejectsInvalidOptionalAuthenticodeRequirement() {
         String json = validManifest().replace("\"type\": \"authenticode\"", "\"type\": \"none\"");
         assertThrows(UpdateException.class, () -> codec.read(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    static String validUnsignedManifest() {
+        return validManifest().replaceAll(",\\s*\"signature\"\\s*:\\s*\\{[^}]+}", "");
     }
 
     static String validManifest() {

--- a/modules/update/src/test/java/dev/frostguard/update/ProjectManifestSignerTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/ProjectManifestSignerTest.java
@@ -1,0 +1,44 @@
+package dev.frostguard.update;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProjectManifestSignerTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void producesRuntimeCompatibleEnvelope() throws Exception {
+        byte[] payload = ManifestCodecTest.validUnsignedManifest().getBytes(StandardCharsets.UTF_8);
+        byte[] envelope = ProjectManifestSigner.sign(
+                payload, TestManifestKeys.KEY_ID, TestManifestKeys.privateKey());
+
+        UpdateManifest manifest = new SignedManifestCodec().read(envelope, TestManifestKeys.trustedKey());
+        assertEquals("3.0.1", manifest.version());
+    }
+
+    @Test
+    void generatesNonOverwritingEd25519KeyPair() throws Exception {
+        Path privateKey = temp.resolve("private.txt");
+        Path publicKey = temp.resolve("public.txt");
+        ProjectManifestSigner.generate(privateKey, publicKey);
+
+        ManifestVerificationKey key = new ManifestVerificationKey("generated-test-key",
+                Files.readString(publicKey));
+        byte[] payload = ManifestCodecTest.validUnsignedManifest().getBytes(StandardCharsets.UTF_8);
+        byte[] envelope = ProjectManifestSigner.sign(payload, key.keyId(), Files.readString(privateKey));
+        assertTrue(key.isUsable());
+        assertEquals("3.0.1", new SignedManifestCodec().read(envelope, key).version());
+        assertThrows(FileAlreadyExistsException.class,
+                () -> ProjectManifestSigner.generate(privateKey, publicKey));
+    }
+}

--- a/modules/update/src/test/java/dev/frostguard/update/ProjectUpdateKeyTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/ProjectUpdateKeyTest.java
@@ -1,0 +1,24 @@
+package dev.frostguard.update;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProjectUpdateKeyTest {
+    @Test
+    void readsCommittedPublicTrustAnchor() {
+        ManifestVerificationKey expected = TestManifestKeys.trustedKey();
+        String properties = "keyId=" + expected.keyId() + "\npublicKey=" + expected.publicKeyBase64();
+        ManifestVerificationKey actual = ProjectUpdateKey.read(new ByteArrayInputStream(
+                properties.getBytes(StandardCharsets.UTF_8)));
+
+        assertEquals(expected, actual);
+        assertTrue(actual.isUsable());
+        assertFalse(ProjectUpdateKey.read(null).isUsable());
+    }
+}

--- a/modules/update/src/test/java/dev/frostguard/update/SignedManifestCodecTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/SignedManifestCodecTest.java
@@ -1,0 +1,75 @@
+package dev.frostguard.update;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SignedManifestCodecTest {
+    private final SignedManifestCodec codec = new SignedManifestCodec();
+    private final byte[] payload = ManifestCodecTest.validUnsignedManifest()
+            .getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    void verifiesEnvelopeBeforeParsingManifest() throws Exception {
+        UpdateManifest manifest = codec.read(TestManifestKeys.signedEnvelope(payload),
+                TestManifestKeys.trustedKey());
+
+        assertEquals("3.0.1", manifest.version());
+    }
+
+    @Test
+    void rejectsModifiedPayloadAndSignature() throws Exception {
+        String envelope = new String(TestManifestKeys.signedEnvelope(payload), StandardCharsets.UTF_8);
+        String encodedPayload = Base64.getEncoder().encodeToString(payload);
+        String modifiedPayload = Base64.getEncoder().encodeToString(
+                ManifestCodecTest.validUnsignedManifest().replace("3.0.1", "3.0.2")
+                        .getBytes(StandardCharsets.UTF_8));
+        assertThrows(UpdateException.class, () -> codec.read(
+                envelope.replace(encodedPayload, modifiedPayload).getBytes(StandardCharsets.UTF_8),
+                TestManifestKeys.trustedKey()));
+
+        String signatureField = envelope.substring(envelope.indexOf("\"signature\": \"") + 14);
+        String signature = signatureField.substring(0, signatureField.indexOf('"'));
+        String damaged = (signature.charAt(0) == 'A' ? "B" : "A") + signature.substring(1);
+        byte[] damagedEnvelope = envelope.replace(signature, damaged).getBytes(StandardCharsets.UTF_8);
+        assertThrows(UpdateException.class, () -> codec.read(
+                damagedEnvelope, TestManifestKeys.trustedKey()));
+    }
+
+    @Test
+    void rejectsWrongKeyAndKeyId() throws Exception {
+        byte[] envelope = TestManifestKeys.signedEnvelope(payload);
+        var other = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        ManifestVerificationKey wrongKey = new ManifestVerificationKey(TestManifestKeys.KEY_ID,
+                Base64.getEncoder().encodeToString(other.getPublic().getEncoded()));
+        assertThrows(UpdateException.class, () -> codec.read(envelope, wrongKey));
+
+        ManifestVerificationKey wrongId = new ManifestVerificationKey("frostguard-test-2",
+                TestManifestKeys.trustedKey().publicKeyBase64());
+        assertThrows(UpdateException.class, () -> codec.read(envelope, wrongId));
+    }
+
+    @Test
+    void rejectsMalformedUnsignedOrUnknownEnvelopeData() throws Exception {
+        String envelope = new String(TestManifestKeys.signedEnvelope(payload), StandardCharsets.UTF_8);
+        assertThrows(UpdateException.class, () -> codec.read(payload, TestManifestKeys.trustedKey()));
+        assertThrows(UpdateException.class, () -> codec.read(
+                envelope.replace("\"algorithm\": \"Ed25519\"", "\"algorithm\": \"RSA\"")
+                        .getBytes(StandardCharsets.UTF_8), TestManifestKeys.trustedKey()));
+        assertThrows(UpdateException.class, () -> codec.read(
+                envelope.replace("\"payload\": \"", "\"extra\": true, \"payload\": \"")
+                        .getBytes(StandardCharsets.UTF_8), TestManifestKeys.trustedKey()));
+        assertThrows(UpdateException.class, () -> codec.read(
+                envelope.replace("\"algorithm\": \"Ed25519\"",
+                                "\"algorithm\": \"Ed25519\", \"algorithm\": \"Ed25519\"")
+                        .getBytes(StandardCharsets.UTF_8), TestManifestKeys.trustedKey()));
+        assertThrows(UpdateException.class, () -> codec.read(
+                envelope.replaceFirst("\"payload\": \"[^\"]+\"", "\"payload\": \"%%%\"")
+                        .getBytes(StandardCharsets.UTF_8), TestManifestKeys.trustedKey()));
+    }
+}

--- a/modules/update/src/test/java/dev/frostguard/update/TestManifestKeys.java
+++ b/modules/update/src/test/java/dev/frostguard/update/TestManifestKeys.java
@@ -1,0 +1,35 @@
+package dev.frostguard.update;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+
+final class TestManifestKeys {
+    static final String KEY_ID = "frostguard-test-1";
+    private static final KeyPair KEY_PAIR = generate();
+
+    private TestManifestKeys() {
+    }
+
+    static ManifestVerificationKey trustedKey() {
+        return new ManifestVerificationKey(KEY_ID,
+                Base64.getEncoder().encodeToString(KEY_PAIR.getPublic().getEncoded()));
+    }
+
+    static String privateKey() {
+        return Base64.getEncoder().encodeToString(KEY_PAIR.getPrivate().getEncoded());
+    }
+
+    static byte[] signedEnvelope(byte[] payload) throws GeneralSecurityException {
+        return ProjectManifestSigner.sign(payload, KEY_ID, privateKey());
+    }
+
+    private static KeyPair generate() {
+        try {
+            return KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        } catch (GeneralSecurityException exception) {
+            throw new ExceptionInInitializerError(exception);
+        }
+    }
+}

--- a/modules/update/src/test/java/dev/frostguard/update/UpdateSelectorTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/UpdateSelectorTest.java
@@ -34,10 +34,20 @@ class UpdateSelectorTest {
     }
 
     @Test
-    void buildWithoutPinnedPublisherCannotUpdate() throws Exception {
+    void buildWithoutPinnedProjectKeyCannotUpdate() throws Exception {
         RunningBuild build = new RunningBuild(SemanticVersion.parse("3.0.0"), SemanticVersion.parse("3.0.0"),
-                RuntimeChannel.STABLE, windowsX64(), false, "");
+                RuntimeChannel.STABLE, windowsX64(), false, new ManifestVerificationKey("", ""), "");
         assertFalse(selector.select(manifest(), build).isPresent());
+    }
+
+    @Test
+    void selectsProjectAuthenticatedReleaseWithoutAuthenticode() throws Exception {
+        UpdateManifest manifest = codec.read(
+                ManifestCodecTest.validUnsignedManifest().getBytes(StandardCharsets.UTF_8));
+        RunningBuild build = new RunningBuild(SemanticVersion.parse("3.0.0"), SemanticVersion.parse("3.0.0"),
+                RuntimeChannel.STABLE, windowsX64(), false, TestManifestKeys.trustedKey(), "");
+
+        assertEquals(SemanticVersion.parse("3.0.1"), selector.select(manifest, build).orElseThrow().version());
     }
 
     @Test
@@ -57,7 +67,7 @@ class UpdateSelectorTest {
     @Test
     void rejectsUpdaterBelowManifestMinimum() throws Exception {
         RunningBuild build = new RunningBuild(SemanticVersion.parse("2.9.0"), SemanticVersion.parse("2.9.0"),
-                RuntimeChannel.STABLE, windowsX64(), false, TRUSTED_PUBLISHER);
+                RuntimeChannel.STABLE, windowsX64(), false, TestManifestKeys.trustedKey(), TRUSTED_PUBLISHER);
         assertThrows(UpdateException.class, () -> selector.select(manifest(), build));
     }
 
@@ -83,7 +93,7 @@ class UpdateSelectorTest {
 
     private static RunningBuild running(RuntimeChannel channel, String version, boolean pullRequest) {
         return new RunningBuild(SemanticVersion.parse(version), SemanticVersion.parse(version),
-                channel, windowsX64(), pullRequest, TRUSTED_PUBLISHER);
+                channel, windowsX64(), pullRequest, TestManifestKeys.trustedKey(), TRUSTED_PUBLISHER);
     }
 
     static UpdatePlatform windowsX64() {

--- a/modules/update/src/test/java/dev/frostguard/update/WindowsAuthenticodeVerifierTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/WindowsAuthenticodeVerifierTest.java
@@ -25,6 +25,17 @@ class WindowsAuthenticodeVerifierTest {
     }
 
     @Test
+    void acceptsProjectAuthenticatedInstallerWhenAuthenticodeIsNotRequired() throws Exception {
+        Path installer = Files.writeString(temp.resolve("project-signed-installer.exe"), "test");
+        WindowsAuthenticodeVerifier verifier = new WindowsAuthenticodeVerifier(
+                (command, environment, timeout) -> {
+                    throw new AssertionError("PowerShell should not run without an Authenticode requirement");
+                });
+
+        assertDoesNotThrow(() -> verifier.verify(installer, null));
+    }
+
+    @Test
     void rejectsUnsignedInstaller() throws Exception {
         Path installer = Files.writeString(temp.resolve("installer.exe"), "test");
         WindowsAuthenticodeVerifier verifier = new WindowsAuthenticodeVerifier(


### PR DESCRIPTION
## Summary

- verify strict Ed25519-signed update-manifest envelopes before parsing or artifact selection
- bind each accepted installer to its immutable URL, filename, byte size, and SHA-256
- project-sign and re-verify Stable/Nightly manifests in the Windows release workflow
- keep Authenticode optional and additive, with packaging checks for the embedded project key
- document first-install Windows warnings plus signing-key backup, rotation, and recovery

## Why

Automatic updates must not depend on Windows Store registration or a purchased code-signing certificate. A project-owned signing key gives Frostguard an authenticated update chain now, while preserving a clean path to add Authenticode later without changing the manifest protocol.

Closes #166.

## Validation

- `.\mvnw.cmd package` — full reactor passed
- `.\mvnw.cmd -pl modules/desktop -am test` — affected desktop reactor passed
- `.\mvnw.cmd -pl modules/update -am test` — 18 API and 46 update tests passed
- `python -m unittest discover -s build-support/verification -p "test_*.py"` — 36 tests passed
- `python -m unittest discover -s build-support/release -p "test_*.py"` — 44 tests passed
- production release key completed a local payload generation, signing, and runtime verification round trip
- `git diff --check` passed

## Risks

- The first manually downloaded installer still has no Windows verified publisher, so SmartScreen or an **Unknown publisher** warning remains expected.
- The real Windows channel publication job can only be exercised after this workflow is available on `main`.
- The current client trusts one project key at a time. Rotation uses a bridge release; overlapping-key support remains a future hardening option.
