### PR TITLE
fix(release): resolve drafts from release listings

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -287,11 +287,17 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
               throw "Draft release creation failed"
           }
-          $releaseJson = gh api "repos/$($env:GITHUB_REPOSITORY)/releases/tags/$($env:TAG)"
+          $releasesJson = gh api "repos/$($env:GITHUB_REPOSITORY)/releases?per_page=100"
           if ($LASTEXITCODE -ne 0) {
-              throw "Draft release could not be resolved"
+              throw "Draft releases could not be listed"
           }
-          $release = $releaseJson | ConvertFrom-Json
+          $releases = $releasesJson | ConvertFrom-Json
+          $matchingReleases = @($releases |
+              Where-Object { $_.tag_name -ceq $env:TAG })
+          if ($matchingReleases.Count -ne 1 -or -not $matchingReleases[0].draft) {
+              throw "Draft release could not be resolved uniquely"
+          }
+          $release = $matchingReleases[0]
           $assetName = [IO.Path]::GetFileName($env:INSTALLER)
           $matchingAssets = @($release.assets | Where-Object { $_.name -ceq $assetName })
           if ($matchingAssets.Count -ne 1) {

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -138,6 +138,9 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("Where-Object { $_.name -ceq $assetName }", workflow)
         self.assertNotIn('--jq ".assets[]', workflow)
         self.assertNotIn("gh release view updates-nightly", workflow)
+        self.assertNotIn("releases/tags/$($env:TAG)", workflow)
+        self.assertGreaterEqual(
+            workflow.count("Where-Object { $_.tag_name -ceq $env:TAG }"), 2)
         self.assertIn("gh release upload updates-nightly $env:MANIFEST", workflow)
         self.assertIn("Remove an abandoned draft release", workflow)
         self.assertIn('gh api --method DELETE `', workflow)


### PR DESCRIPTION
## Summary

- resolve the newly created draft from GitHub's authenticated release listing
- require exactly one matching draft before inspecting its installer asset
- prevent future use of the tag endpoint for an unpublished draft

## Why

Windows Channel Release run [31546315383](https://github.com/Shederator/wosbot/actions/runs/31546315383) passed identity, native packaging, smoke testing, installer preparation, and draft creation. GitHub then returned 404 for `/releases/tags/{tag}` because draft releases do not have Git tag refs until publication.

The already verified ID-based cleanup uses the authenticated release list and removed the draft successfully. Draft verification now uses the same API semantics.

Related to #165.

## Validation

- `python -m unittest discover -s build-support/verification -p "test_*.py"` — 36 tests passed
- `python build-support/verification/check_workflow_python.py .github/workflows` — all three inline Python snippets compile
- regression contract requires list-based draft selection and forbids the draft tag endpoint
- `git diff --check` passed

## Risks

The real channel workflow still needs to be rerun after merge. Cleanup passed in the failed run and no draft, tag, or public candidate release remains.
