### PR TITLE
fix(release): sign canonical installer download URL

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -314,7 +314,9 @@ jobs:
               (Get-FileHash $env:INSTALLER -Algorithm SHA256).Hash) {
               throw "Uploaded installer hash does not match the signed source"
           }
-          "download_url=$($asset.browser_download_url)" | Out-File `
+          $publicInstallerUrl = "https://github.com/$($env:GITHUB_REPOSITORY)" +
+              "/releases/download/$($env:TAG)/$assetName"
+          "download_url=$publicInstallerUrl" | Out-File `
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Generate and project-sign update manifest

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -137,6 +137,12 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertNotIn("if (gh release view", workflow)
         self.assertIn("Where-Object { $_.name -ceq $assetName }", workflow)
         self.assertNotIn('--jq ".assets[]', workflow)
+        self.assertIn(
+            '"https://github.com/$($env:GITHUB_REPOSITORY)" +', workflow)
+        self.assertIn(
+            '"/releases/download/$($env:TAG)/$assetName"', workflow)
+        self.assertIn('"download_url=$publicInstallerUrl"', workflow)
+        self.assertNotIn("$asset.browser_download_url", workflow)
         self.assertNotIn("gh release view updates-nightly", workflow)
         self.assertNotIn("releases/tags/$($env:TAG)", workflow)
         self.assertGreaterEqual(


### PR DESCRIPTION
## Summary

- build the signed installer URL from the immutable release tag and exact uploaded asset name
- retain the API-backed download and SHA-256 comparison of the draft asset before signing
- add a workflow contract regression that rejects GitHub's draft-only `browser_download_url`

## Why

The first project-signed Nightly published a valid signature, installer hash,
and size, but its manifest embedded GitHub's temporary `untagged-*` draft asset
URL. That URL returned HTTP 404 after publication. The broken rolling manifest
has been removed and Nightly `.1` is marked withdrawn.

The canonical `/releases/download/<tag>/<asset>` URL is stable after the draft
is published and still binds the manifest to the exact immutable tag and asset.

Relates to #165.

## Validation

- `python -m unittest discover -s build-support/verification -p "test_*.py"` — 36 tests passed
- `python build-support/verification/check_workflow_python.py .github/workflows` — all 3 inline snippets compiled
- `git diff --check` — passed
- independent `.1` investigation reproduced HTTP 404 for the signed `untagged-*` URL while its project signature, installer hash, and size verified

## Risks

The canonical URL construction is statically verified here. Its real public
availability will be independently checked against the replacement `.2`
Nightly after this PR merges.
