### PR TITLE
fix(update): apply Windows upgrades without setup wizard

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,7 +76,7 @@ Do not put game task business logic in `modules/desktop`; do not put UI concepts
 - restart-safe downloads below the selected workspace cache;
 - byte-size and SHA-256 verification;
 - optional build-pinned Windows Authenticode verification and token-authorized
-  external handoff.
+  external handoff with passive installer execution and workspace-aware restart.
 
 The desktop module owns presentation and runtime shutdown. Update code does not
 depend on JavaFX, persistence, scheduling, or GitHub APIs. Development and
@@ -291,11 +291,18 @@ The installed desktop exposes update controls only for eligible Stable or
 Nightly builds. A selected installer is downloaded to
 `<workspace>/cache/updates/<channel>/<version>`, verified, and passed to a
 hidden PowerShell waiter. The waiter requires a one-time authorization token
-and waits for the Frostguard PID to disappear before starting the installer.
+and waits for the Frostguard PID to disappear before starting the same published
+installer in passive, no-restart mode. It pins `INSTALLDIR` to the running
+launcher's parent so upgrades retain a user-selected installation directory.
 Frostguard authorizes the staged waiter, stops queues and workspace-owned
 services, closes SQLite and the workspace lock, and exits. A failed shutdown
 cancels the authorization, and the waiter cannot start the installer while the
-Frostguard PID is alive. Frostguard never replaces its own running files.
+Frostguard PID is alive. After a successful Windows Installer exit, the waiter
+restarts the channel launcher with the same workspace environment. Installer
+failure relies on MSI rollback, relaunches the retained application when
+possible, and presents the failure instead of reporting success. Manually
+downloaded installers remain interactive. Frostguard never replaces its own
+running files.
 
 The release feed is a signed envelope whose Ed25519 signature covers the exact
 manifest bytes. The embedded project public key is the primary update trust

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -169,7 +169,10 @@ manifest, then requires the manifest identity, immutable download, size, and
 SHA-256 to match. A Windows Authenticode signer is checked in addition when the
 build and manifest declare one. The current public ZIP feeds are not used by
 this updater; automatic installer updates stay disabled in ordinary local and
-PR builds.
+PR builds. After confirmation, an in-app update closes Frostguard, applies the
+same published EXE with compact progress but without the first-install wizard,
+and reopens the same channel and workspace. Running a downloaded installer
+manually remains interactive.
 
 ### Run a source build
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -29,7 +29,10 @@ identity has a configured release manifest. The update flow:
    configured Authenticode signer;
 5. stops scheduling and workspace services, closes SQLite, and releases the
    workspace lock;
-6. exits before an external waiter launches the installer.
+6. exits before an external waiter applies the installer with compact Windows
+   progress and no setup decisions;
+7. preserves the current installation directory and restarts the same channel
+   and workspace after Windows Installer reports success.
 
 Development and PR-test packages cannot use automatic release updates. A
 release whose manifest is not validly signed by the embedded project key is
@@ -37,7 +40,9 @@ never handed off. Authenticode remains an optional additional check.
 
 Interrupted downloads remain `.part` files and resume when the server supports
 byte ranges. A failed size, hash, or signature check prevents installer handoff
-and leaves the current installation untouched.
+and leaves the current installation untouched. A failed installer upgrade uses
+Windows Installer rollback, attempts to reopen the retained application, and
+shows an update failure instead of silently claiming success.
 
 Recommended installs:
 

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/update/UpdateLayoutController.java
@@ -28,6 +28,8 @@ import javafx.scene.layout.VBox;
 
 import java.awt.Desktop;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
@@ -124,12 +126,13 @@ public final class UpdateLayoutController {
             return;
         }
         Alert confirmation = new Alert(Alert.AlertType.CONFIRMATION);
-        confirmation.setTitle("Install Frostguard update");
-        confirmation.setHeaderText("Install Frostguard " + candidate.version() + "?");
+        confirmation.setTitle("Update Frostguard");
+        confirmation.setHeaderText("Download Frostguard " + candidate.version() + " and restart?");
         confirmation.setContentText("Channel: " + candidate.channel().directoryName() + "\n"
                 + "Download: " + formatSize(candidate.artifact().size()) + "\n\n"
                 + "Frostguard will verify the project-signed release, stop automation, close its workspace, "
-                + "exit, and then launch the installer. Windows may show an unknown-publisher warning.");
+                + "apply the update with a compact Windows progress window, and restart this workspace. "
+                + "Windows may show an unknown-publisher warning.");
         if (confirmation.showAndWait().filter(ButtonType.OK::equals).isEmpty()) {
             return;
         }
@@ -162,10 +165,11 @@ public final class UpdateLayoutController {
     }
 
     private void beginHandoff(PreparedUpdate prepared) {
-        labelStatus.setText("Installer verified. Stopping Frostguard safely...");
+        labelStatus.setText("Update verified. Restarting Frostguard to apply it...");
         InstallerHandoff.HandoffSession session = null;
         try {
-            session = manager.stageHandoff(prepared, ProcessHandle.current().pid());
+            session = manager.stageHandoff(prepared, ProcessHandle.current().pid(),
+                    currentNativeLauncher(), WorkspacePaths.current().root());
             UpdateExitCoordinator coordinator = new UpdateExitCoordinator(
                     ApplicationLifecycle::stopForUpdate,
                     ApplicationLifecycle::exitAfterUpdateHandoff,
@@ -177,6 +181,18 @@ public final class UpdateLayoutController {
             }
             showFailure(exception);
         }
+    }
+
+    static Path currentNativeLauncher() throws UpdateException {
+        String configured = System.getProperty("jpackage.app-path", "").trim();
+        if (configured.isEmpty()) {
+            throw new UpdateException("The installed Frostguard launcher could not be resolved");
+        }
+        Path launcher = Path.of(configured).toAbsolutePath().normalize();
+        if (!Files.isRegularFile(launcher)) {
+            throw new UpdateException("The installed Frostguard launcher does not exist: " + launcher);
+        }
+        return launcher;
     }
 
     private <T> void runAsync(Callable<T> operation, Consumer<T> success) {

--- a/modules/desktop/src/main/resources/layout/UpdateLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/UpdateLayout.fxml
@@ -36,7 +36,7 @@
                style="-fx-font-size: 16px; -fx-font-weight: bold; -fx-text-fill: #e6edf3;" />
         <Label fx:id="labelArtifactDetails" style="-fx-text-fill: #9da7b3;" />
         <Hyperlink fx:id="linkReleaseNotes" text="Release notes" onAction="#openReleaseNotes" />
-        <Button fx:id="buttonDownloadInstall" text="Download and install"
+        <Button fx:id="buttonDownloadInstall" text="Download and restart"
                 onAction="#handleDownloadInstall" />
     </VBox>
 

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateLayoutControllerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/update/UpdateLayoutControllerTest.java
@@ -1,13 +1,22 @@
 package dev.frostguard.app.panel.update;
 
 import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.update.UpdateException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class UpdateLayoutControllerTest {
+    @TempDir
+    Path tempDir;
+
     @Test
     void formatsInstallerSizesForReview() {
         assertEquals("512 B", UpdateLayoutController.formatSize(512));
@@ -20,5 +29,24 @@ class UpdateLayoutControllerTest {
         assertTrue(UpdateLayoutController.supportsChannelSwitch(RuntimeChannel.STABLE));
         assertTrue(UpdateLayoutController.supportsChannelSwitch(RuntimeChannel.NIGHTLY));
         assertFalse(UpdateLayoutController.supportsChannelSwitch(RuntimeChannel.DEVELOPMENT));
+    }
+
+    @Test
+    void resolvesOnlyAnExistingNativeLauncherForUpdateRestart() throws Exception {
+        String previous = System.getProperty("jpackage.app-path");
+        Path launcher = Files.writeString(tempDir.resolve("Frostguard Nightly.exe"), "test");
+        try {
+            System.setProperty("jpackage.app-path", launcher.toString());
+            assertEquals(launcher.toAbsolutePath(), UpdateLayoutController.currentNativeLauncher());
+
+            System.setProperty("jpackage.app-path", tempDir.resolve("missing.exe").toString());
+            assertThrows(UpdateException.class, UpdateLayoutController::currentNativeLauncher);
+        } finally {
+            if (previous == null) {
+                System.clearProperty("jpackage.app-path");
+            } else {
+                System.setProperty("jpackage.app-path", previous);
+            }
+        }
     }
 }

--- a/modules/update/src/main/java/dev/frostguard/update/InstallerHandoff.java
+++ b/modules/update/src/main/java/dev/frostguard/update/InstallerHandoff.java
@@ -3,7 +3,8 @@ package dev.frostguard.update;
 import java.nio.file.Path;
 
 public interface InstallerHandoff {
-    HandoffSession stage(Path installer, long parentPid) throws UpdateException;
+    HandoffSession stage(Path installer, long parentPid, Path restartLauncher, Path workspaceRoot)
+            throws UpdateException;
 
     interface HandoffSession {
         void authorize() throws UpdateException;

--- a/modules/update/src/main/java/dev/frostguard/update/UpdateManager.java
+++ b/modules/update/src/main/java/dev/frostguard/update/UpdateManager.java
@@ -38,8 +38,10 @@ public final class UpdateManager {
         });
     }
 
-    public InstallerHandoff.HandoffSession stageHandoff(PreparedUpdate update, long parentPid) throws UpdateException {
-        return exclusive(() -> handoff.stage(update.installer(), parentPid));
+    public InstallerHandoff.HandoffSession stageHandoff(
+            PreparedUpdate update, long parentPid, Path restartLauncher, Path workspaceRoot) throws UpdateException {
+        return exclusive(() -> handoff.stage(
+                update.installer(), parentPid, restartLauncher, workspaceRoot));
     }
 
     public boolean isOperationActive() {

--- a/modules/update/src/main/java/dev/frostguard/update/WindowsInstallerHandoff.java
+++ b/modules/update/src/main/java/dev/frostguard/update/WindowsInstallerHandoff.java
@@ -13,16 +13,10 @@ public final class WindowsInstallerHandoff implements InstallerHandoff {
     static final String PID_ENV = "FROSTGUARD_UPDATE_PARENT_PID";
     static final String TOKEN_PATH_ENV = "FROSTGUARD_UPDATE_TOKEN_PATH";
     static final String TOKEN_VALUE_ENV = "FROSTGUARD_UPDATE_TOKEN_VALUE";
-    private static final String HANDOFF_SCRIPT = "$targetPid = [int]$env:" + PID_ENV + "; "
-            + "$deadline = [DateTime]::UtcNow.AddMinutes(5); "
-            + "while ((Get-Process -Id $targetPid -ErrorAction SilentlyContinue) -and "
-            + "[DateTime]::UtcNow -lt $deadline) { Start-Sleep -Milliseconds 200 }; "
-            + "if (Get-Process -Id $targetPid -ErrorAction SilentlyContinue) { exit 2 }; "
-            + "if (-not (Test-Path -LiteralPath $env:" + TOKEN_PATH_ENV + ")) { exit 3 }; "
-            + "$token = Get-Content -Raw -LiteralPath $env:" + TOKEN_PATH_ENV + "; "
-            + "if ($token -ne $env:" + TOKEN_VALUE_ENV + ") { exit 4 }; "
-            + "Remove-Item -LiteralPath $env:" + TOKEN_PATH_ENV + " -Force; "
-            + "Start-Process -FilePath $env:" + INSTALLER_ENV;
+    static final String RESTART_LAUNCHER_ENV = "FROSTGUARD_UPDATE_RESTART_LAUNCHER";
+    static final String INSTALL_DIR_ENV = "FROSTGUARD_UPDATE_INSTALL_DIR";
+    static final String WORKSPACE_ENV = "FROSTGUARD_WORKSPACE";
+    private static final String HANDOFF_SCRIPT = createHandoffScript();
 
     private final DetachedProcessStarter processStarter;
 
@@ -39,12 +33,24 @@ public final class WindowsInstallerHandoff implements InstallerHandoff {
     }
 
     @Override
-    public HandoffSession stage(Path installer, long parentPid) throws UpdateException {
+    public HandoffSession stage(Path installer, long parentPid, Path restartLauncher, Path workspaceRoot)
+            throws UpdateException {
         if (!Files.isRegularFile(installer)) {
             throw new UpdateException("Installer handoff target does not exist: " + installer);
         }
         if (parentPid <= 0) {
             throw new UpdateException("Installer handoff requires a valid Frostguard process ID");
+        }
+        if (!Files.isRegularFile(restartLauncher)) {
+            throw new UpdateException("Frostguard restart launcher does not exist: " + restartLauncher);
+        }
+        if (!Files.isDirectory(workspaceRoot)) {
+            throw new UpdateException("Frostguard restart workspace does not exist: " + workspaceRoot);
+        }
+        Path normalizedLauncher = restartLauncher.toAbsolutePath().normalize();
+        Path installDirectory = normalizedLauncher.getParent();
+        if (installDirectory == null) {
+            throw new UpdateException("Frostguard restart launcher has no installation directory");
         }
         List<String> command = List.of(
                 "powershell.exe", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden",
@@ -60,7 +66,10 @@ public final class WindowsInstallerHandoff implements InstallerHandoff {
                 INSTALLER_ENV, installer.toAbsolutePath().normalize().toString(),
                 PID_ENV, Long.toString(parentPid),
                 TOKEN_PATH_ENV, tokenPath.toAbsolutePath().normalize().toString(),
-                TOKEN_VALUE_ENV, tokenValue);
+                TOKEN_VALUE_ENV, tokenValue,
+                RESTART_LAUNCHER_ENV, normalizedLauncher.toString(),
+                INSTALL_DIR_ENV, installDirectory.toString(),
+                WORKSPACE_ENV, workspaceRoot.toAbsolutePath().normalize().toString());
         try {
             processStarter.start(command, environment);
         } catch (IOException exception) {
@@ -93,6 +102,92 @@ public final class WindowsInstallerHandoff implements InstallerHandoff {
                 }
             }
         };
+    }
+
+    private static String createHandoffScript() {
+        return """
+                $ErrorActionPreference = 'Stop'
+                $parentExited = $false
+                $targetPid = [int]$env:%1$s
+                $restartLauncher = $env:%2$s
+                $installerPath = $env:%3$s
+                $tokenPath = $env:%4$s
+                $tokenValue = $env:%5$s
+                $installDirectory = $env:%6$s
+
+                function Start-Frostguard {
+                    @('Env:%1$s', 'Env:%2$s', 'Env:%3$s', 'Env:%4$s', 'Env:%5$s', 'Env:%6$s') |
+                        ForEach-Object { Remove-Item -LiteralPath $_ -ErrorAction SilentlyContinue }
+                    if (-not (Test-Path -LiteralPath $restartLauncher)) {
+                        throw 'The Frostguard restart launcher was not found.'
+                    }
+                    Start-Process -FilePath $restartLauncher
+                }
+
+                function Show-UpdateFailure {
+                    param([string]$Details)
+                    try {
+                        Add-Type -AssemblyName PresentationFramework
+                        [System.Windows.MessageBox]::Show(
+                            "Frostguard could not complete the update.`n`n$Details",
+                            'Frostguard update failed',
+                            [System.Windows.MessageBoxButton]::OK,
+                            [System.Windows.MessageBoxImage]::Error) | Out-Null
+                    } catch {
+                    }
+                }
+
+                try {
+                    $deadline = [DateTime]::UtcNow.AddMinutes(5)
+                    while ((Get-Process -Id $targetPid -ErrorAction SilentlyContinue) -and
+                            [DateTime]::UtcNow -lt $deadline) {
+                        Start-Sleep -Milliseconds 200
+                    }
+                    if (Get-Process -Id $targetPid -ErrorAction SilentlyContinue) {
+                        throw 'Frostguard did not exit before the update timeout.'
+                    }
+                    $parentExited = $true
+                    if (-not (Test-Path -LiteralPath $tokenPath)) {
+                        throw 'The update handoff was not authorized.'
+                    }
+                    $token = Get-Content -Raw -LiteralPath $tokenPath
+                    if ($token -ne $tokenValue) {
+                        throw 'The update handoff authorization was invalid.'
+                    }
+                    Remove-Item -LiteralPath $tokenPath -Force
+
+                    $installArguments = @(
+                        '/passive',
+                        '/norestart',
+                        ('INSTALLDIR="{0}"' -f $installDirectory)
+                    )
+                    $installerProcess = Start-Process -FilePath $installerPath `
+                        -ArgumentList $installArguments -Wait -PassThru
+                    if (@(0, 3010) -notcontains $installerProcess.ExitCode) {
+                        throw "Windows Installer exited with code $($installerProcess.ExitCode). " +
+                            'The previous installation was restored.'
+                    }
+                    Start-Frostguard
+                    exit 0
+                } catch {
+                    $failureDetails = $_.Exception.Message
+                    if ($parentExited) {
+                        try {
+                            Start-Frostguard
+                        } catch {
+                            $failureDetails += "`nFrostguard could not be restarted: $($_.Exception.Message)"
+                        }
+                    }
+                    Show-UpdateFailure -Details $failureDetails
+                    exit 1
+                }
+                """.formatted(
+                PID_ENV,
+                RESTART_LAUNCHER_ENV,
+                INSTALLER_ENV,
+                TOKEN_PATH_ENV,
+                TOKEN_VALUE_ENV,
+                INSTALL_DIR_ENV);
     }
 
     @FunctionalInterface

--- a/modules/update/src/test/java/dev/frostguard/update/WindowsInstallerHandoffTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/WindowsInstallerHandoffTest.java
@@ -19,6 +19,9 @@ class WindowsInstallerHandoffTest {
     @Test
     void startsHiddenWaiterWithInstallerAndParentIdentity() throws Exception {
         Path installer = Files.writeString(temp.resolve("Frostguard-3.0.1.exe"), "test");
+        Path installDirectory = Files.createDirectory(temp.resolve("installed Frostguard"));
+        Path launcher = Files.writeString(installDirectory.resolve("Frostguard.exe"), "test");
+        Path workspace = Files.createDirectory(temp.resolve("workspace"));
         AtomicReference<java.util.List<String>> command = new AtomicReference<>();
         AtomicReference<java.util.Map<String, String>> environment = new AtomicReference<>();
         WindowsInstallerHandoff handoff = new WindowsInstallerHandoff((actualCommand, actualEnvironment) -> {
@@ -26,13 +29,28 @@ class WindowsInstallerHandoffTest {
             environment.set(actualEnvironment);
         });
 
-        InstallerHandoff.HandoffSession session = handoff.stage(installer, 4242L);
+        InstallerHandoff.HandoffSession session = handoff.stage(
+                installer, 4242L, launcher, workspace);
 
         assertTrue(command.get().contains("Hidden"));
-        assertTrue(command.get().getLast().contains("Get-Process -Id $targetPid"));
+        String script = command.get().getLast();
+        assertTrue(script.contains("Get-Process -Id $targetPid"));
+        assertTrue(script.contains("'/passive'"));
+        assertTrue(script.contains("'/norestart'"));
+        assertTrue(script.contains("INSTALLDIR=\"{0}\""));
+        assertTrue(script.contains("-Wait -PassThru"));
+        assertTrue(script.contains("@(0, 3010)"));
+        assertTrue(script.contains("The Frostguard restart launcher was not found"));
+        assertTrue(script.contains("Start-Frostguard"));
         assertEquals("4242", environment.get().get(WindowsInstallerHandoff.PID_ENV));
         assertEquals(installer.toAbsolutePath().normalize().toString(),
                 environment.get().get(WindowsInstallerHandoff.INSTALLER_ENV));
+        assertEquals(launcher.toAbsolutePath().normalize().toString(),
+                environment.get().get(WindowsInstallerHandoff.RESTART_LAUNCHER_ENV));
+        assertEquals(installDirectory.toAbsolutePath().normalize().toString(),
+                environment.get().get(WindowsInstallerHandoff.INSTALL_DIR_ENV));
+        assertEquals(workspace.toAbsolutePath().normalize().toString(),
+                environment.get().get(WindowsInstallerHandoff.WORKSPACE_ENV));
         Path token = Path.of(environment.get().get(WindowsInstallerHandoff.TOKEN_PATH_ENV));
         assertTrue(command.get().getLast().contains("TOKEN_PATH"));
         session.authorize();
@@ -46,15 +64,22 @@ class WindowsInstallerHandoffTest {
         WindowsInstallerHandoff handoff = new WindowsInstallerHandoff((command, environment) -> {
             throw new AssertionError("Waiter should not start");
         });
-        assertThrows(UpdateException.class, () -> handoff.stage(temp.resolve("missing.exe"), 10L));
+        Path installer = temp.resolve("missing.exe");
+        Path launcher = temp.resolve("missing-launcher.exe");
+        assertThrows(UpdateException.class,
+                () -> handoff.stage(installer, 10L, launcher, temp));
     }
 
     @Test
     void reportsWaiterLaunchFailure() throws Exception {
         Path installer = Files.writeString(temp.resolve("Frostguard-3.0.1.exe"), "test");
+        Path installDirectory = Files.createDirectory(temp.resolve("installed"));
+        Path launcher = Files.writeString(installDirectory.resolve("Frostguard.exe"), "test");
+        Path workspace = Files.createDirectory(temp.resolve("workspace"));
         WindowsInstallerHandoff handoff = new WindowsInstallerHandoff((command, environment) -> {
             throw new IOException("blocked");
         });
-        assertThrows(UpdateException.class, () -> handoff.stage(installer, 10L));
+        assertThrows(UpdateException.class,
+                () -> handoff.stage(installer, 10L, launcher, workspace));
     }
 }


### PR DESCRIPTION
## Summary

- run authenticated in-app Windows upgrades through the published jpackage EXE with passive progress and no setup decisions
- preserve the running launcher's installation directory and restart the same channel and workspace after MSI success
- recover by reopening the retained application and showing an explicit error when the installer fails
- keep manually downloaded installers interactive and update the user/developer documentation

## Why

The authenticated updater previously launched the verified installer without upgrade arguments. The full first-install wizard therefore asked for the installation directory again and warned that the existing folder already existed, making a successful update feel like a manual reinstall.

This is a follow-up to #171 and part of the Windows release gate in #165.

## Validation

- `.\mvnw.cmd package` — 327 tests, 0 failures, 0 errors, 0 skipped
- `.\mvnw.cmd -pl modules\update,modules\desktop -am test` — passed
- `python -m unittest discover -s build-support/verification -p "test_*.py"` — 36 tests passed
- `python build-support/verification/check_workflow_python.py .github/workflows` — all 3 snippets compiled
- `git diff --check` — passed
- generated PowerShell handoff parsed with the Windows PowerShell AST parser — 0 syntax errors
- OpenJDK 21 source inspection confirms the jpackage EXE forwards command-line arguments to MSI and uses `INSTALLDIR` for the application directory

## Risks

The passive EXE invocation, same-path replacement, and automatic same-workspace restart still need live verification with the next Nightly update (`.2` to `.3`). Real MSI failure and rejection recovery also remain live-unverified; the previous authenticated `.1` to `.2` update verified download integrity, safe shutdown, database retention, Nightly restart, and Stable isolation, but used the old interactive installer handoff.
