### PR TITLE
fix(update): publish direct MSI upgrades

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -152,7 +152,7 @@ jobs:
               product_name = $productName
               profile = $profile
               tag = $tag
-              installer_name = "$assetPrefix-$($env:VERSION)-windows-x64.exe"
+              installer_name = "$assetPrefix-$($env:VERSION)-windows-x64.msi"
               manifest_name = $manifestName
           }.GetEnumerator() | ForEach-Object {
               "$($_.Key)=$($_.Value)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
@@ -241,7 +241,7 @@ jobs:
           AUTHENTICODE_PUBLISHER: ${{ steps.certificate.outputs.publisher }}
         run: |
           $source = @(Get-ChildItem "packaging/desktop/target/installers/$($env:CHANNEL)" `
-              -Filter '*.exe' -File)
+              -Filter '*.msi' -File)
           if ($source.Count -ne 1) {
               throw "Expected exactly one unsigned installer, found $($source.Count)"
           }
@@ -304,7 +304,7 @@ jobs:
               throw "Uploaded installer could not be resolved"
           }
           $asset = $matchingAssets[0]
-          $downloaded = Join-Path $env:RUNNER_TEMP "uploaded-installer.exe"
+          $downloaded = Join-Path $env:RUNNER_TEMP "uploaded-installer.msi"
           gh api "repos/$($env:GITHUB_REPOSITORY)/releases/assets/$($asset.id)" `
               -H "Accept: application/octet-stream" > $downloaded
           if ($LASTEXITCODE -ne 0) {

--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -50,7 +50,7 @@ jobs:
           java-version: "21"
           cache: maven
 
-      # JDK 21 jpackage invokes the WiX 3 candle/light toolchain for an EXE.
+      # JDK 21 jpackage invokes the WiX 3 candle/light toolchain for an MSI.
       # Pinning the Chocolatey package prevents an incompatible WiX major from
       # silently changing the installer build underneath this workflow.
       - name: Install WiX Toolset 3
@@ -94,7 +94,7 @@ jobs:
         shell: pwsh
         run: |
           $installers = @(Get-ChildItem -LiteralPath packaging/desktop/target/installers/stable `
-              -Filter "Frostguard-*.exe" -File)
+              -Filter "Frostguard-*.msi" -File)
           if ($installers.Count -ne 1) {
               throw "Expected exactly one versioned installer, found $($installers.Count)"
           }
@@ -131,7 +131,7 @@ jobs:
         shell: pwsh
         run: |
           $installers = @(Get-ChildItem -LiteralPath packaging/desktop/target/installers/nightly `
-              -Filter "Frostguard Nightly-*.exe" -File)
+              -Filter "Frostguard Nightly-*.msi" -File)
           if ($installers.Count -ne 1) {
               throw "Expected exactly one versioned Nightly installer, found $($installers.Count)"
           }

--- a/build-support/release/test_write_update_manifest.py
+++ b/build-support/release/test_write_update_manifest.py
@@ -17,7 +17,7 @@ class WriteUpdateManifestTest(unittest.TestCase):
     def test_writes_hash_size_identity_and_channel_after_installer_exists(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            installer = root / "Frostguard-Nightly-3.1.0-nightly.20260811.1-windows-x64.exe"
+            installer = root / "Frostguard-Nightly-3.1.0-nightly.20260811.1-windows-x64.msi"
             installer.write_bytes(b"signed-installer")
             output = root / "manifest.json"
 
@@ -43,7 +43,7 @@ class WriteUpdateManifestTest(unittest.TestCase):
     def test_omits_optional_authenticode_requirement(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            installer = root / "Frostguard-3.0.1-windows-x64.exe"
+            installer = root / "Frostguard-3.0.1-windows-x64.msi"
             installer.write_bytes(b"unsigned but project-authenticated")
 
             manifest = write_manifest(
@@ -62,7 +62,7 @@ class WriteUpdateManifestTest(unittest.TestCase):
     def test_rejects_mutable_or_cross_channel_inputs(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            installer = root / "Frostguard-latest.exe"
+            installer = root / "Frostguard-latest.msi"
             installer.write_bytes(b"installer")
             common = dict(
                 channel="stable",
@@ -70,7 +70,7 @@ class WriteUpdateManifestTest(unittest.TestCase):
                 minimum_updater_version="3.0.0",
                 published_at="2026-08-11T14:00:00Z",
                 release_notes_url="https://example.com/release",
-                installer_url="https://example.com/Frostguard-latest.exe",
+                installer_url="https://example.com/Frostguard-latest.msi",
                 installer=installer,
                 publisher="CN=Frostguard",
                 output=root / "manifest.json",
@@ -78,6 +78,24 @@ class WriteUpdateManifestTest(unittest.TestCase):
 
             with self.assertRaises(ValueError):
                 write_manifest(**common)
+
+    def test_rejects_exe_wrapper(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            installer = root / "Frostguard-3.0.1-windows-x64.exe"
+            installer.write_bytes(b"wrapper")
+
+            with self.assertRaisesRegex(ValueError, "MSI package"):
+                write_manifest(
+                    channel="stable",
+                    version="3.0.1",
+                    minimum_updater_version="3.0.0",
+                    published_at="2026-08-12T00:00:00Z",
+                    release_notes_url="https://example.com/releases/3.0.1",
+                    installer_url=f"https://example.com/releases/3.0.1/{installer.name}",
+                    installer=installer,
+                    output=root / "manifest.json",
+                )
 
 
 if __name__ == "__main__":

--- a/build-support/release/write_update_manifest.py
+++ b/build-support/release/write_update_manifest.py
@@ -42,6 +42,8 @@ def write_manifest(
             raise ValueError(f"{label} must use HTTPS")
     if not installer.is_file() or installer.stat().st_size <= 0:
         raise ValueError("installer must be a non-empty file")
+    if installer.suffix.lower() != ".msi":
+        raise ValueError("Windows installer must be an MSI package")
     if Path(urlparse(installer_url).path).name != installer.name:
         raise ValueError("installer URL must end with the exact installer file name")
     if version not in installer.name:

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -90,6 +90,8 @@ class ChannelPackagingTest(unittest.TestCase):
             for argument in root.findall(
                 ".//m:profile[m:id='windows-installer']//m:arg[@value]", NS)
         ]
+        self.assertIn("msi", installer_arguments)
+        self.assertNotIn("exe", installer_arguments)
         self.assertIn("--win-shortcut", installer_arguments)
 
     def test_installer_exposes_only_product_shortcuts_and_guards_running_apps(self):
@@ -131,6 +133,8 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_BASE64", workflow)
         self.assertIn("Configure optional Authenticode certificate", workflow)
         self.assertIn("Get-AuthenticodeSignature", workflow)
+        self.assertIn('installer_name = "$assetPrefix-$($env:VERSION)-windows-x64.msi"', workflow)
+        self.assertIn("-Filter '*.msi' -File", workflow)
         self.assertIn("windows_installer_version.py", workflow)
         self.assertIn("gh release list --repo $env:GITHUB_REPOSITORY", workflow)
         self.assertIn("if ($releaseTags -contains $tag)", workflow)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -260,7 +260,7 @@ with `./mvnw javafx:run`; its versioned JAR is not a standalone distribution.
 - packaging inputs staged under `packaging/desktop/target/input`
 - Windows application images: `packaging/desktop/target/app-image/Frostguard`
   and `app-image/Frostguard Nightly`
-- Windows installers: versioned EXEs under
+- Windows installers: versioned MSI packages under
   `packaging/desktop/target/installers/<channel>`
 - ADB/Tesseract files staged from `tools/`
 - custom task examples staged from root `examples/custom-tasks/`
@@ -290,9 +290,11 @@ and automatic Nightly-to-Stable migration are not supported.
 The installed desktop exposes update controls only for eligible Stable or
 Nightly builds. A selected installer is downloaded to
 `<workspace>/cache/updates/<channel>/<version>`, verified, and passed to a
-hidden PowerShell waiter. The waiter requires a one-time authorization token
-and waits for the Frostguard PID to disappear before starting the same published
-installer in passive, no-restart mode. It pins `INSTALLDIR` to the running
+hidden PowerShell waiter. Windows releases publish the MSI package directly;
+the jpackage EXE bootstrap wrapper is not part of the update contract. The
+waiter requires a one-time authorization token and waits for the Frostguard PID
+to disappear before invoking `msiexec` for the same published MSI in passive,
+no-restart mode. It pins `INSTALLDIR` to the running
 launcher's parent so upgrades retain a user-selected installation directory.
 Frostguard authorizes the staged waiter, stops queues and workspace-owned
 services, closes SQLite and the workspace lock, and exits. A failed shutdown

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ unmerged code and continue to use the temporary ZIP format.
 
 ## Install a downloaded build
 
-1. Open the desired release and download its Windows x64 EXE installer.
+1. Open the desired release and download its Windows x64 MSI installer.
 2. Confirm that the download comes from the official `Shederator/wosbot`
    GitHub release. A Windows publisher identity is not currently expected.
 3. Choose whether to create a desktop shortcut and complete the per-user
@@ -170,7 +170,7 @@ SHA-256 to match. A Windows Authenticode signer is checked in addition when the
 build and manifest declare one. The current public ZIP feeds are not used by
 this updater; automatic installer updates stay disabled in ordinary local and
 PR builds. After confirmation, an in-app update closes Frostguard, applies the
-same published EXE with compact progress but without the first-install wizard,
+same published MSI with compact progress but without the first-install wizard,
 and reopens the same channel and workspace. Running a downloaded installer
 manually remains interactive.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -142,6 +142,12 @@ uploaded to an immutable HTTPS URL, and smoke-tested. The public verification
 key is part of the application; the private signing key remains outside the
 repository.
 
+Windows release artifacts are direct MSI packages. Do not switch the feed back
+to jpackage's EXE bootstrap wrapper: installed Frostguard invokes Windows
+Installer directly, and existing schema-1 clients can use an MSI artifact
+without a manifest-format migration. Authenticode signing remains additive and
+can be applied to the final MSI later.
+
 ### Signed envelope 1
 
 ```json
@@ -173,8 +179,8 @@ after signature verification.
     "windows-x64": {
       "operatingSystem": "windows",
       "architecture": "x64",
-      "fileName": "Frostguard-3.0.1-windows-x64.exe",
-      "url": "https://example.invalid/releases/3.0.1/Frostguard-3.0.1-windows-x64.exe",
+      "fileName": "Frostguard-3.0.1-windows-x64.msi",
+      "url": "https://example.invalid/releases/3.0.1/Frostguard-3.0.1-windows-x64.msi",
       "sha256": "<64 lowercase hexadecimal characters>",
       "size": 123456789
     }

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -14,7 +14,7 @@ building from source.
 - Java JDK 21 or newer.
 - Git and Git LFS.
 
-WiX Toolset 3.14.1 is required only when producing the native EXE installer.
+WiX Toolset 3.14.1 is required only when producing the native MSI installer.
 Running an installed native build does not require a separately installed JDK.
 
 ## Native application updates
@@ -79,7 +79,7 @@ python build-support/verification/verify_app_image.py packaging/desktop/target/a
 powershell -ExecutionPolicy Bypass -File build-support/verification/smoke_test_app_image.ps1 -ImagePath packaging/desktop/target/app-image/Frostguard
 ```
 
-To build both the application image and a versioned per-user EXE installer,
+To build both the application image and a versioned per-user MSI installer,
 install WiX Toolset 3.14.1, ensure `candle.exe` and `light.exe` are on `PATH`,
 then run:
 

--- a/modules/update/src/main/java/dev/frostguard/update/ManifestCodec.java
+++ b/modules/update/src/main/java/dev/frostguard/update/ManifestCodec.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.HexFormat;
+import java.util.Locale;
 import java.util.Map;
 
 public final class ManifestCodec {
@@ -75,6 +76,9 @@ public final class ManifestCodec {
         }
         HexFormat.of().parseHex(hash);
         if (platform.operatingSystem() == UpdatePlatform.OperatingSystem.WINDOWS) {
+            if (!fileName.toLowerCase(Locale.ROOT).endsWith(".msi")) {
+                throw new IllegalArgumentException("Windows update artifact must be an MSI package");
+            }
             SignatureRequirement signature = artifact.signature();
             if (signature != null && (!"authenticode".equalsIgnoreCase(signature.type())
                     || required(signature.publisher(), "Authenticode publisher").isBlank())) {

--- a/modules/update/src/main/java/dev/frostguard/update/WindowsInstallerHandoff.java
+++ b/modules/update/src/main/java/dev/frostguard/update/WindowsInstallerHandoff.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -37,6 +38,9 @@ public final class WindowsInstallerHandoff implements InstallerHandoff {
             throws UpdateException {
         if (!Files.isRegularFile(installer)) {
             throw new UpdateException("Installer handoff target does not exist: " + installer);
+        }
+        if (!installer.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".msi")) {
+            throw new UpdateException("Windows update handoff requires an MSI package");
         }
         if (parentPid <= 0) {
             throw new UpdateException("Installer handoff requires a valid Frostguard process ID");
@@ -157,11 +161,13 @@ public final class WindowsInstallerHandoff implements InstallerHandoff {
                     Remove-Item -LiteralPath $tokenPath -Force
 
                     $installArguments = @(
+                        '/i',
+                        ('"{0}"' -f $installerPath),
                         '/passive',
                         '/norestart',
                         ('INSTALLDIR="{0}"' -f $installDirectory)
                     )
-                    $installerProcess = Start-Process -FilePath $installerPath `
+                    $installerProcess = Start-Process -FilePath 'msiexec.exe' `
                         -ArgumentList $installArguments -Wait -PassThru
                     if (@(0, 3010) -notcontains $installerProcess.ExitCode) {
                         throw "Windows Installer exited with code $($installerProcess.ExitCode). " +

--- a/modules/update/src/test/java/dev/frostguard/update/ManifestCodecTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/ManifestCodecTest.java
@@ -16,7 +16,7 @@ class ManifestCodecTest {
 
         assertEquals(1, manifest.schemaVersion());
         assertEquals("stable", manifest.channel());
-        assertEquals("Frostguard-3.0.1-windows-x64.exe",
+        assertEquals("Frostguard-3.0.1-windows-x64.msi",
                 manifest.artifacts().get("windows-x64").fileName());
     }
 
@@ -40,7 +40,13 @@ class ManifestCodecTest {
 
     @Test
     void rejectsMutableOrMismatchedArtifactName() {
-        String json = validManifest().replace("Frostguard-3.0.1-windows-x64.exe", "Frostguard-latest.exe");
+        String json = validManifest().replace("Frostguard-3.0.1-windows-x64.msi", "Frostguard-latest.msi");
+        assertThrows(UpdateException.class, () -> codec.read(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void rejectsWindowsExeWrapper() {
+        String json = validManifest().replace("windows-x64.msi", "windows-x64.exe");
         assertThrows(UpdateException.class, () -> codec.read(json.getBytes(StandardCharsets.UTF_8)));
     }
 
@@ -73,8 +79,8 @@ class ManifestCodecTest {
                     "windows-x64": {
                       "operatingSystem": "windows",
                       "architecture": "x64",
-                      "fileName": "Frostguard-3.0.1-windows-x64.exe",
-                      "url": "https://example.com/releases/3.0.1/Frostguard-3.0.1-windows-x64.exe",
+                      "fileName": "Frostguard-3.0.1-windows-x64.msi",
+                      "url": "https://example.com/releases/3.0.1/Frostguard-3.0.1-windows-x64.msi",
                       "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                       "size": 123,
                       "signature": {"type": "authenticode", "publisher": "CN=Frostguard Project, O=Frostguard"}

--- a/modules/update/src/test/java/dev/frostguard/update/UpdateDownloaderTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/UpdateDownloaderTest.java
@@ -143,8 +143,8 @@ class UpdateDownloaderTest {
 
     private static UpdateCandidate candidate(byte[] bytes, String hash) {
         UpdateArtifact artifact = new UpdateArtifact("windows", "x64",
-                "Frostguard-3.0.1-windows-x64.exe",
-                "https://example.com/releases/3.0.1/Frostguard-3.0.1-windows-x64.exe",
+                "Frostguard-3.0.1-windows-x64.msi",
+                "https://example.com/releases/3.0.1/Frostguard-3.0.1-windows-x64.msi",
                 hash, bytes.length, new SignatureRequirement("authenticode", "CN=Frostguard Project, O=Frostguard"));
         return new UpdateCandidate(RuntimeChannel.STABLE, SemanticVersion.parse("3.0.1"),
                 java.time.Instant.parse("2026-08-10T04:00:00Z"), URI.create("https://example.com/releases/3.0.1"),

--- a/modules/update/src/test/java/dev/frostguard/update/WindowsAuthenticodeVerifierTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/WindowsAuthenticodeVerifierTest.java
@@ -15,7 +15,7 @@ class WindowsAuthenticodeVerifierTest {
 
     @Test
     void acceptsValidExpectedPublisher() throws Exception {
-        Path installer = Files.writeString(temp.resolve("installer.exe"), "test");
+        Path installer = Files.writeString(temp.resolve("installer.msi"), "test");
         WindowsAuthenticodeVerifier verifier = new WindowsAuthenticodeVerifier(
                 (command, environment, timeout) -> new CommandRunner.CommandResult(
                         0, "Valid\tCN=Frostguard Project, O=Frostguard"));
@@ -26,7 +26,7 @@ class WindowsAuthenticodeVerifierTest {
 
     @Test
     void acceptsProjectAuthenticatedInstallerWhenAuthenticodeIsNotRequired() throws Exception {
-        Path installer = Files.writeString(temp.resolve("project-signed-installer.exe"), "test");
+        Path installer = Files.writeString(temp.resolve("project-signed-installer.msi"), "test");
         WindowsAuthenticodeVerifier verifier = new WindowsAuthenticodeVerifier(
                 (command, environment, timeout) -> {
                     throw new AssertionError("PowerShell should not run without an Authenticode requirement");
@@ -37,7 +37,7 @@ class WindowsAuthenticodeVerifierTest {
 
     @Test
     void rejectsUnsignedInstaller() throws Exception {
-        Path installer = Files.writeString(temp.resolve("installer.exe"), "test");
+        Path installer = Files.writeString(temp.resolve("installer.msi"), "test");
         WindowsAuthenticodeVerifier verifier = new WindowsAuthenticodeVerifier(
                 (command, environment, timeout) -> new CommandRunner.CommandResult(0, "NotSigned\t"));
 
@@ -47,7 +47,7 @@ class WindowsAuthenticodeVerifierTest {
 
     @Test
     void rejectsUnexpectedPublisher() throws Exception {
-        Path installer = Files.writeString(temp.resolve("installer.exe"), "test");
+        Path installer = Files.writeString(temp.resolve("installer.msi"), "test");
         WindowsAuthenticodeVerifier verifier = new WindowsAuthenticodeVerifier(
                 (command, environment, timeout) -> new CommandRunner.CommandResult(0, "Valid\tCN=Someone Else"));
 
@@ -61,7 +61,7 @@ class WindowsAuthenticodeVerifierTest {
                 (command, environment, timeout) -> {
                     throw new AssertionError("PowerShell should not run");
                 });
-        assertThrows(UpdateException.class, () -> verifier.verify(temp.resolve("missing.exe"),
+        assertThrows(UpdateException.class, () -> verifier.verify(temp.resolve("missing.msi"),
                 new SignatureRequirement("authenticode", "Frostguard Project")));
     }
 }

--- a/modules/update/src/test/java/dev/frostguard/update/WindowsInstallerHandoffTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/WindowsInstallerHandoffTest.java
@@ -18,7 +18,7 @@ class WindowsInstallerHandoffTest {
 
     @Test
     void startsHiddenWaiterWithInstallerAndParentIdentity() throws Exception {
-        Path installer = Files.writeString(temp.resolve("Frostguard-3.0.1.exe"), "test");
+        Path installer = Files.writeString(temp.resolve("Frostguard-3.0.1.msi"), "test");
         Path installDirectory = Files.createDirectory(temp.resolve("installed Frostguard"));
         Path launcher = Files.writeString(installDirectory.resolve("Frostguard.exe"), "test");
         Path workspace = Files.createDirectory(temp.resolve("workspace"));
@@ -35,6 +35,9 @@ class WindowsInstallerHandoffTest {
         assertTrue(command.get().contains("Hidden"));
         String script = command.get().getLast();
         assertTrue(script.contains("Get-Process -Id $targetPid"));
+        assertTrue(script.contains("Start-Process -FilePath 'msiexec.exe'"));
+        assertTrue(script.contains("'/i'"));
+        assertTrue(script.contains("('\"{0}\"' -f $installerPath)"));
         assertTrue(script.contains("'/passive'"));
         assertTrue(script.contains("'/norestart'"));
         assertTrue(script.contains("INSTALLDIR=\"{0}\""));
@@ -64,7 +67,7 @@ class WindowsInstallerHandoffTest {
         WindowsInstallerHandoff handoff = new WindowsInstallerHandoff((command, environment) -> {
             throw new AssertionError("Waiter should not start");
         });
-        Path installer = temp.resolve("missing.exe");
+        Path installer = temp.resolve("missing.msi");
         Path launcher = temp.resolve("missing-launcher.exe");
         assertThrows(UpdateException.class,
                 () -> handoff.stage(installer, 10L, launcher, temp));
@@ -72,13 +75,27 @@ class WindowsInstallerHandoffTest {
 
     @Test
     void reportsWaiterLaunchFailure() throws Exception {
-        Path installer = Files.writeString(temp.resolve("Frostguard-3.0.1.exe"), "test");
+        Path installer = Files.writeString(temp.resolve("Frostguard-3.0.1.msi"), "test");
         Path installDirectory = Files.createDirectory(temp.resolve("installed"));
         Path launcher = Files.writeString(installDirectory.resolve("Frostguard.exe"), "test");
         Path workspace = Files.createDirectory(temp.resolve("workspace"));
         WindowsInstallerHandoff handoff = new WindowsInstallerHandoff((command, environment) -> {
             throw new IOException("blocked");
         });
+        assertThrows(UpdateException.class,
+                () -> handoff.stage(installer, 10L, launcher, workspace));
+    }
+
+    @Test
+    void rejectsExeWrapperBeforeStartingWaiter() throws Exception {
+        Path installer = Files.writeString(temp.resolve("Frostguard-3.0.1.exe"), "test");
+        Path installDirectory = Files.createDirectory(temp.resolve("installed-exe"));
+        Path launcher = Files.writeString(installDirectory.resolve("Frostguard.exe"), "test");
+        Path workspace = Files.createDirectory(temp.resolve("workspace-exe"));
+        WindowsInstallerHandoff handoff = new WindowsInstallerHandoff((command, environment) -> {
+            throw new AssertionError("Waiter should not start for an EXE wrapper");
+        });
+
         assertThrows(UpdateException.class,
                 () -> handoff.stage(installer, 10L, launcher, workspace));
     }

--- a/packaging/desktop/pom.xml
+++ b/packaging/desktop/pom.xml
@@ -331,7 +331,7 @@
                                         <exec executable="${jpackage.executable}" failonerror="true">
                                             <arg value="--verbose" />
                                             <arg value="--type" />
-                                            <arg value="exe" />
+                                            <arg value="msi" />
                                             <arg value="--dest" />
                                             <arg path="${project.build.directory}/installers/${frostguard.release.channel}" />
                                             <arg value="--name" />


### PR DESCRIPTION
## Summary

- publish Stable and Nightly Windows releases as direct MSI packages instead of jpackage EXE bootstrap wrappers
- require MSI artifacts in release manifest generation and runtime validation
- invoke `msiexec` explicitly for passive in-app upgrades while preserving the current installation directory and workspace restart
- update packaging verification and contributor/release documentation for the MSI contract

## Why

Smart App Control blocks the unsigned jpackage EXE bootstrap wrapper before its embedded MSI can run. The exact unsigned MSI extracted from the blocked Nightly passed Windows Config CI and completed an isolated administrative installation.

Publishing that MSI directly removes the blocked outer layer without changing Frostguard's project-owned Ed25519 trust model. Existing Nightly `.2` clients accept an MSI artifact, providing the bridge to the first direct-MSI release. Later MSI-to-MSI updates use explicit passive Windows Installer execution.

Part of #165. The release-gate issue remains open for the live `.2` to direct-MSI candidate upgrade and subsequent MSI-to-MSI verification.

## Validation

- `.\mvnw.cmd package` — 329 tests, 0 failures/errors/skips
- all 11 `build-support/**/test_*.py` suites passed
- Windows Installers run #31555064407 passed Stable and Nightly jpackage/WiX builds, application-image verification, launcher/workspace smoke tests, MSI boundary checks, and artifact uploads
- downloaded Nightly MSI from run #31555064407 completed isolated `msiexec /a` with exit code 0 and produced 883 files
- MSI metadata verified as `Frostguard Nightly`, version `2.1.0`, upgrade code `{51AC745D-78E4-4D89-A36D-1C38B87598B3}`
- `git diff --check origin/main...HEAD` passed

## Risks

- The current installed Nightly `.2` bridge launches the first MSI through Windows file association, so that one transition remains interactive. Once the direct-MSI build is installed, later updates use explicit passive `msiexec` handoff.
- The real project-signed `.2 → .4` update and one subsequent MSI-to-MSI update remain live release-gate checks.
- Authenticode is still optional and currently unconfigured; project-signed manifest verification remains the updater trust root.