### PR TITLE
fix(update): preserve PowerShell handoff script

### DIFF
--- a/modules/update/src/main/java/dev/frostguard/update/WindowsInstallerHandoff.java
+++ b/modules/update/src/main/java/dev/frostguard/update/WindowsInstallerHandoff.java
@@ -1,9 +1,11 @@
 package dev.frostguard.update;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -56,9 +58,7 @@ public final class WindowsInstallerHandoff implements InstallerHandoff {
         if (installDirectory == null) {
             throw new UpdateException("Frostguard restart launcher has no installation directory");
         }
-        List<String> command = List.of(
-                "powershell.exe", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden",
-                "-ExecutionPolicy", "Bypass", "-Command", HANDOFF_SCRIPT);
+        List<String> command = createPowerShellCommand(HANDOFF_SCRIPT);
         String tokenValue = UUID.randomUUID().toString();
         Path tokenPath = installer.resolveSibling(installer.getFileName() + ".handoff-ready");
         try {
@@ -194,6 +194,14 @@ public final class WindowsInstallerHandoff implements InstallerHandoff {
                 TOKEN_PATH_ENV,
                 TOKEN_VALUE_ENV,
                 INSTALL_DIR_ENV);
+    }
+
+    static List<String> createPowerShellCommand(String script) {
+        String encodedScript = Base64.getEncoder().encodeToString(
+                script.getBytes(StandardCharsets.UTF_16LE));
+        return List.of(
+                "powershell.exe", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden",
+                "-ExecutionPolicy", "Bypass", "-EncodedCommand", encodedScript);
     }
 
     @FunctionalInterface

--- a/modules/update/src/test/java/dev/frostguard/update/WindowsInstallerHandoffTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/WindowsInstallerHandoffTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class WindowsInstallerHandoffTest {
     @TempDir
@@ -33,7 +37,8 @@ class WindowsInstallerHandoffTest {
                 installer, 4242L, launcher, workspace);
 
         assertTrue(command.get().contains("Hidden"));
-        String script = command.get().getLast();
+        assertTrue(command.get().contains("-EncodedCommand"));
+        String script = decodeScript(command.get());
         assertTrue(script.contains("Get-Process -Id $targetPid"));
         assertTrue(script.contains("Start-Process -FilePath 'msiexec.exe'"));
         assertTrue(script.contains("'/i'"));
@@ -55,11 +60,29 @@ class WindowsInstallerHandoffTest {
         assertEquals(workspace.toAbsolutePath().normalize().toString(),
                 environment.get().get(WindowsInstallerHandoff.WORKSPACE_ENV));
         Path token = Path.of(environment.get().get(WindowsInstallerHandoff.TOKEN_PATH_ENV));
-        assertTrue(command.get().getLast().contains("TOKEN_PATH"));
+        assertTrue(script.contains("TOKEN_PATH"));
         session.authorize();
         assertEquals(environment.get().get(WindowsInstallerHandoff.TOKEN_VALUE_ENV), Files.readString(token));
         session.cancel();
         assertTrue(Files.notExists(token));
+    }
+
+    @Test
+    void preservesQuotedMultilineScriptThroughWindowsProcessCreation() throws Exception {
+        assumeTrue(System.getProperty("os.name", "").toLowerCase().contains("win"));
+        String script = """
+                $value = "quoted value"
+                [Console]::Out.Write($value)
+                """;
+
+        Process process = new ProcessBuilder(WindowsInstallerHandoff.createPowerShellCommand(script))
+                .redirectErrorStream(true)
+                .start();
+
+        assertTrue(process.waitFor(10, TimeUnit.SECONDS));
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertEquals(0, process.exitValue());
+        assertEquals("quoted value", output);
     }
 
     @Test
@@ -98,5 +121,12 @@ class WindowsInstallerHandoffTest {
 
         assertThrows(UpdateException.class,
                 () -> handoff.stage(installer, 10L, launcher, workspace));
+    }
+
+    private static String decodeScript(java.util.List<String> command) {
+        int encodedCommand = command.indexOf("-EncodedCommand");
+        assertTrue(encodedCommand >= 0);
+        byte[] scriptBytes = Base64.getDecoder().decode(command.get(encodedCommand + 1));
+        return new String(scriptBytes, StandardCharsets.UTF_16LE);
     }
 }


### PR DESCRIPTION
## Summary

- launch the hidden Windows installer waiter through PowerShell `-EncodedCommand`
- encode the multiline script as UTF-16LE Base64 before crossing the Java/Windows process boundary
- add a Windows process-level regression test with multiline, double-quoted PowerShell input

## Why

The live Nightly `.4 -> .5` update downloaded and verified the exact MSI and Frostguard shut down cleanly, but Windows Installer never started. Java `ProcessBuilder` passed the multiline script through `powershell.exe -Command`; embedded double quotes were stripped during Windows command-line construction, so PowerShell exited with parser errors before consuming the handoff token.

The event timestamps confirmed the waiter exited 270 ms before the authorization token was created. The same failure was reproduced locally through the Java process boundary.

## User impact

Automatic installed updates can hand off to the passive MSI instead of closing Frostguard and then appearing to do nothing.

Relates to #165.

## Validation

- `.\mvnw.cmd -pl modules/update -am test` — 49 tests passed with no failures, errors, or skips
- `.\mvnw.cmd package` — full reactor build passed
- the complete production handoff script stayed alive while waiting for a live dummy parent when launched through the encoded command
- the new Windows-only regression test starts real `powershell.exe` and verifies that multiline double-quoted input survives process creation

## Risks

The fixed handoff has not yet completed a live installed Frostguard update. The currently installed Nightly `.4` contains the broken waiter and therefore needs one manual bridge installation before a subsequent automatic update can validate the corrected path.
