### PR TITLE
fix(windows): preserve trusted Nightly launchers

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "21.0.12+8.0"
           cache: maven
 
       - name: Install WiX Toolset 3
@@ -225,8 +225,18 @@ jobs:
           PRODUCT_NAME: ${{ steps.identity.outputs.product_name }}
         run: |
           $image = "packaging/desktop/target/app-image/$($env:PRODUCT_NAME)"
-          python build-support/verification/verify_app_image.py $image `
-              --channel $env:CHANNEL --product-name $env:PRODUCT_NAME
+          $verificationArgs = @(
+              $image, '--channel', $env:CHANNEL, '--product-name', $env:PRODUCT_NAME
+          )
+          if ($env:CHANNEL -eq 'nightly') {
+              $verificationArgs += @(
+                  '--expected-desktop-launcher-sha256',
+                  '5c728d3662d64c428d003874f6d62b798bbbe329f595b2b15a2ab5ab1fd1faa9',
+                  '--expected-watcher-launcher-sha256',
+                  '9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209'
+              )
+          }
+          python build-support/verification/verify_app_image.py @verificationArgs
           powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
               -File build-support/verification/smoke_test_app_image.ps1 `
               -ImagePath $image -Channel $env:CHANNEL -ProductName $env:PRODUCT_NAME

--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "21.0.12+8.0"
           cache: maven
 
       # JDK 21 jpackage invokes the WiX 3 candle/light toolchain for an MSI.
@@ -117,6 +117,8 @@ jobs:
           "packaging/desktop/target/app-image/Frostguard Nightly"
           --channel nightly
           --product-name "Frostguard Nightly"
+          --expected-desktop-launcher-sha256 5c728d3662d64c428d003874f6d62b798bbbe329f595b2b15a2ab5ab1fd1faa9
+          --expected-watcher-launcher-sha256 9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209
 
       - name: Smoke test Nightly launchers and workspace isolation
         shell: pwsh

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -41,6 +41,7 @@ class ChannelPackagingTest(unittest.TestCase):
 
         self.assertIn("name: Windows Installers", installers)
         self.assertIn("Build and smoke-test Stable and Nightly installers", installers)
+        self.assertIn('java-version: "21.0.12+8.0"', installers)
 
     def test_stable_and_nightly_use_distinct_durable_windows_identities(self):
         root = ET.parse(REPO_ROOT / "packaging/desktop/pom.xml").getroot()
@@ -71,6 +72,10 @@ class ChannelPackagingTest(unittest.TestCase):
             self.assertEqual(value, nightly[key])
         self.assertNotEqual(stable["frostguard.product.upgrade-uuid"],
                             nightly["frostguard.product.upgrade-uuid"])
+        self.assertEqual("${frostguard.windows.app-version}",
+                         stable["frostguard.windows.launcher-version"])
+        self.assertEqual("26.8.12004",
+                         nightly["frostguard.windows.launcher-version"])
 
         pom = (REPO_ROOT / "packaging/desktop/pom.xml").read_text(encoding="utf-8")
         for contract in (
@@ -93,6 +98,14 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("msi", installer_arguments)
         self.assertNotIn("exe", installer_arguments)
         self.assertIn("--win-shortcut", installer_arguments)
+
+        app_image_arguments = [
+            argument.attrib["value"]
+            for argument in root.findall(
+                ".//m:profile[m:id='windows-app-image']//m:arg[@value]", NS)
+        ]
+        self.assertIn("${frostguard.windows.launcher-version}", app_image_arguments)
+        self.assertIn("${frostguard.windows.app-version}", installer_arguments)
 
     def test_installer_exposes_only_product_shortcuts_and_guards_running_apps(self):
         watcher = (REPO_ROOT / "packaging/desktop/src/main/windows/"
@@ -119,6 +132,8 @@ class ChannelPackagingTest(unittest.TestCase):
 
     def test_release_publishes_project_signed_manifest_after_installer_verification(self):
         workflow = (REPO_ROOT / ".github/workflows/signed-windows-channel-release.yml").read_text(
+            encoding="utf-8")
+        installers = (REPO_ROOT / ".github/workflows/windows-native-package.yml").read_text(
             encoding="utf-8")
         ordered_steps = (
             "Prepare immutable installer and verify optional Authenticode",
@@ -153,6 +168,13 @@ class ChannelPackagingTest(unittest.TestCase):
             workflow.count("Where-Object { $_.tag_name -ceq $env:TAG }"), 2)
         self.assertIn("gh release upload updates-nightly $env:MANIFEST", workflow)
         self.assertIn("Remove an abandoned draft release", workflow)
+        self.assertIn('java-version: "21.0.12+8.0"', workflow)
+        for launcher_hash in (
+            "5c728d3662d64c428d003874f6d62b798bbbe329f595b2b15a2ab5ab1fd1faa9",
+            "9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209",
+        ):
+            self.assertIn(launcher_hash, installers)
+            self.assertIn(launcher_hash, workflow)
         self.assertIn('gh api --method DELETE `', workflow)
         self.assertIn('releases/$($release.id)', workflow)
         self.assertNotIn("--cleanup-tag --yes", workflow)

--- a/build-support/verification/test_verify_app_image.py
+++ b/build-support/verification/test_verify_app_image.py
@@ -70,6 +70,17 @@ class VerifyAppImageTest(unittest.TestCase):
     def test_accepts_complete_image(self):
         self.assertEqual([], verify_app_image.inspect_image(self.image))
 
+    def test_rejects_changed_pinned_launcher_hash(self):
+        problems = verify_app_image.inspect_image(
+            self.image, expected_desktop_launcher_sha256="0" * 64)
+        self.assertTrue(any("Frostguard.exe SHA-256 changed" in item for item in problems))
+
+    def test_accepts_matching_pinned_launcher_hash(self):
+        launcher = self.image / "Frostguard.exe"
+        expected = __import__("hashlib").sha256(launcher.read_bytes()).hexdigest()
+        self.assertEqual([], verify_app_image.inspect_image(
+            self.image, expected_desktop_launcher_sha256=expected))
+
     def test_rejects_missing_bundled_runtime(self):
         (self.image / "runtime/bin/server/jvm.dll").unlink()
         self.assertTrue(any("jvm.dll" in item for item in verify_app_image.inspect_image(self.image)))

--- a/build-support/verification/verify_app_image.py
+++ b/build-support/verification/verify_app_image.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import base64
 import binascii
+import hashlib
 import re
 import zipfile
 from pathlib import Path
@@ -47,7 +48,9 @@ def _read_properties(content: str) -> dict[str, str]:
 
 
 def inspect_image(
-        image: Path, channel: str = "stable", product_name: str = "Frostguard"
+        image: Path, channel: str = "stable", product_name: str = "Frostguard",
+        expected_desktop_launcher_sha256: str = "",
+        expected_watcher_launcher_sha256: str = "",
 ) -> list[str]:
     problems: list[str] = []
     if not image.is_dir():
@@ -69,6 +72,18 @@ def inspect_image(
     for required in required_files:
         if required not in files:
             problems.append(f"Application image is missing {required}")
+
+    for relative, expected_hash in (
+        (f"{product_name}.exe", expected_desktop_launcher_sha256),
+        (f"{watcher_name}.exe", expected_watcher_launcher_sha256),
+    ):
+        if not expected_hash or relative not in files:
+            continue
+        actual_hash = hashlib.sha256(files[relative].read_bytes()).hexdigest()
+        if actual_hash != expected_hash:
+            problems.append(
+                f"{relative} SHA-256 changed: expected {expected_hash}, got {actual_hash}"
+            )
 
     runtime_jars = [name for name in files if re.match(r"^app/lib/[^/]+\.jar$", name)]
     if len(runtime_jars) < MINIMUM_RUNTIME_JARS:
@@ -196,8 +211,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("image", type=Path)
     parser.add_argument("--channel", choices=("stable", "nightly"), default="stable")
     parser.add_argument("--product-name", default="Frostguard")
+    parser.add_argument("--expected-desktop-launcher-sha256", default="")
+    parser.add_argument("--expected-watcher-launcher-sha256", default="")
     args = parser.parse_args(argv)
-    problems = inspect_image(args.image, args.channel, args.product_name)
+    problems = inspect_image(
+        args.image,
+        args.channel,
+        args.product_name,
+        args.expected_desktop_launcher_sha256,
+        args.expected_watcher_launcher_sha256,
+    )
     if problems:
         for problem in problems:
             print(f"::error::{problem}")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -274,6 +274,14 @@ the Java/JAR paths retained only as the source and transitional-ZIP fallback.
 Native packaging is opt-in through Maven profiles so the normal reactor build
 stays platform-neutral.
 
+The Nightly MSI product version remains monotonic for Windows Installer, while
+the unchanged native bootstrap launchers retain the last known-good launcher
+file version until Authenticode signing is enabled. This keeps their bytes and
+Smart App Control reputation stable across Java-only Nightly updates. The
+application reports its release version from packaged build metadata, not from
+the bootstrap file version. A bootstrap, icon, or JDK change still requires a
+new launcher identity and must pass the Windows signing/reputation gate.
+
 The watcher launcher is channel-specific internal infrastructure and does not
 receive Start-menu or desktop shortcuts. The installer exposes only the desktop
 launcher, optionally creates its desktop shortcut, and can launch it from the

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -44,6 +44,14 @@ and leaves the current installation untouched. A failed installer upgrade uses
 Windows Installer rollback, attempts to reopen the retained application, and
 shows an update failure instead of silently claiming success.
 
+Until release binaries have an Authenticode publisher, Java-only Nightly
+updates keep the native desktop and watcher bootstrap files byte-identical so
+an already accepted launcher does not lose Smart App Control reputation merely
+because the MSI product version increased. The MSI version still increases for
+every release, and Frostguard displays the version embedded in its application
+JAR. Changes to the bootstrap, icon, or packaged JDK require a new Windows
+reputation decision; Authenticode signing remains the durable solution.
+
 Recommended installs:
 
 ```powershell

--- a/packaging/desktop/pom.xml
+++ b/packaging/desktop/pom.xml
@@ -19,6 +19,7 @@
     <properties>
         <frostguard.release.channel>stable</frostguard.release.channel>
         <frostguard.windows.app-version>${project.version}</frostguard.windows.app-version>
+        <frostguard.windows.launcher-version>${frostguard.windows.app-version}</frostguard.windows.launcher-version>
         <frostguard.product.name>Frostguard</frostguard.product.name>
         <frostguard.product.identifier>dev.frostguard.desktop</frostguard.product.identifier>
         <frostguard.product.description>Frostguard automation desktop application</frostguard.product.description>
@@ -257,7 +258,7 @@
                                             <arg value="--name" />
                                             <arg value="${frostguard.product.name}" />
                                             <arg value="--app-version" />
-                                            <arg value="${frostguard.windows.app-version}" />
+                                            <arg value="${frostguard.windows.launcher-version}" />
                                             <arg value="--vendor" />
                                             <arg value="Frostguard" />
                                             <arg value="--description" />
@@ -373,6 +374,9 @@
             <id>windows-nightly</id>
             <properties>
                 <frostguard.release.channel>nightly</frostguard.release.channel>
+                <!-- Keep the unchanged bootstrap byte-identical while releases are
+                     project-signed but do not yet have an Authenticode publisher. -->
+                <frostguard.windows.launcher-version>26.8.12004</frostguard.windows.launcher-version>
                 <frostguard.product.name>Frostguard Nightly</frostguard.product.name>
                 <frostguard.product.identifier>dev.frostguard.desktop.nightly</frostguard.product.identifier>
                 <frostguard.product.description>Frostguard Nightly automation desktop application</frostguard.product.description>


### PR DESCRIPTION
## Summary

- separate the monotonically increasing MSI product version from the unchanged Nightly bootstrap file version
- pin Windows packaging to Temurin `21.0.12+8.0`, the exact JDK used for the known-good `.4` launchers
- fail both PR packaging and authenticated Nightly publication if the desktop or watcher launcher hash drifts
- document the temporary bootstrap-reputation contract until Authenticode is available

## Why

Nightly `.6` installed successfully, but enforced Smart App Control blocked its unsigned native launcher. Local Code Integrity events identify `Frostguard Nightly.exe` with signing level zero as the blocked file. Under the same policy, the extracted `.4` launcher starts successfully.

The `.4` and `.6` launchers are both unsigned, have the same size, and differ by only four bytes: the embedded Windows file version changed from `26.8.12004` to `26.8.12006`. Microsoft documents that unsigned files cannot inherit publisher reputation and must establish reputation for every new hash.

The native bootstrap does not contain the Frostguard application version or Java code. The MSI retains its increasing Windows Installer version, while Frostguard continues to report the release version from packaged JAR metadata.

Relates to #165.

## Validation

- `python -m unittest build-support.verification.test_verify_app_image build-support.verification.test_channel_packaging build-support.release.test_windows_installer_version` — 21 tests passed
- `.\mvnw.cmd package` — full reactor build passed
- enforced Smart App Control allowed the `.4` launcher and blocked `.6` with Code Integrity events 3033/3077
- binary comparison found exactly four changed launcher bytes, all caused by the embedded file-version change
- local app-image generation confirmed the launcher-version and MSI-version properties are independent

## Risks

The expected launcher hashes still require confirmation on GitHub's pinned Windows packaging runner; CI fails closed if they do not reproduce exactly. This is an interim compatibility measure, not a replacement for Authenticode. A future bootstrap, icon, or JDK update intentionally requires new launcher hashes and a renewed Windows trust decision.
