### PR TITLE
fix(taskbuilder): repair node metadata editing and flow persistence

### DIFF
--- a/modules/api/pom.xml
+++ b/modules/api/pom.xml
@@ -33,5 +33,16 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!--
+			Test-only: pins the persisted JSON shape of the task-builder domain
+			types here, where they are defined. Production code keeps depending
+			on the annotations alone.
+		-->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/modules/api/src/main/java/dev/frostguard/api/domain/AutomationBlueprint.java
+++ b/modules/api/src/main/java/dev/frostguard/api/domain/AutomationBlueprint.java
@@ -1,5 +1,9 @@
 package dev.frostguard.api.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -7,14 +11,37 @@ import java.util.List;
  * Defines a complete user-created automation workflow. Contains an ordered
  * sequence of {@link AutomationStep} entries that execute in series when
  * the custom routine runs. Designed for JSON serialization for save/load/share.
+ *
+ * <p>Persistence binds to the private fields only, for the reasons documented
+ * on {@link AutomationStep}: the legacy accessor shims kept here would
+ * otherwise duplicate every value under a second name in the saved file.
+ * {@link JsonAlias} still accepts the historical key spellings on read.</p>
  */
+@JsonAutoDetect(
+        fieldVisibility = JsonAutoDetect.Visibility.ANY,
+        getterVisibility = JsonAutoDetect.Visibility.NONE,
+        isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+        setterVisibility = JsonAutoDetect.Visibility.NONE,
+        creatorVisibility = JsonAutoDetect.Visibility.NONE)
 public class AutomationBlueprint {
 
+    @JsonAlias("name")
     private String title;
+
+    @JsonAlias("description")
     private String notes;
+
+    @JsonAlias("startLocation")
     private String initialScreen; // HOME, WORLD, ANY
+
+    @JsonAlias("nodes")
+    @JsonSetter(nulls = Nulls.SKIP)
     private List<AutomationStep> steps;
+
+    @JsonAlias("createdAt")
     private long createdEpochMs;
+
+    @JsonAlias("updatedAt")
     private long modifiedEpochMs;
 
     public AutomationBlueprint() {
@@ -70,7 +97,11 @@ public class AutomationBlueprint {
     public void setInitialScreen(String screen) { this.initialScreen = screen; }
 
     public List<AutomationStep> getSteps() { return steps; }
-    public void setSteps(List<AutomationStep> steps) { this.steps = steps; }
+
+    /** Replaces the step list, treating a null list as an empty flow. */
+    public void setSteps(List<AutomationStep> steps) {
+        this.steps = steps != null ? steps : new ArrayList<>();
+    }
 
     public long getCreatedEpochMs() { return createdEpochMs; }
     public void setCreatedEpochMs(long ms) { this.createdEpochMs = ms; }

--- a/modules/api/src/main/java/dev/frostguard/api/domain/AutomationStep.java
+++ b/modules/api/src/main/java/dev/frostguard/api/domain/AutomationStep.java
@@ -1,5 +1,9 @@
 package dev.frostguard.api.domain;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import dev.frostguard.api.configs.FlowStepKind;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,21 +24,55 @@ import java.util.Map;
  *   <li><b>TEMPLATE_SEARCH</b> — templatePath, threshold, grayscale, tlX, brX</li>
  *   <li><b>NAVIGATE</b> — location</li>
  * </ul>
+ *
+ * <h3>JSON mapping</h3>
+ * <p>Persistence binds to the private fields only. This class also exposes
+ * legacy accessor shims ({@code getParams}, {@code getNextNodeId}, …) and
+ * derived read-only views ({@code getSummary}, {@code isBranching}, …). Were
+ * Jackson allowed to auto-detect those methods, every stored value would be
+ * written two or three times under different names and each derived getter
+ * would be invoked while writing — so one failing getter aborts the write
+ * midway and leaves a truncated, unparseable document on disk. Field-only
+ * visibility keeps the saved file canonical and makes future helper methods
+ * inert by default instead of silently joining the output. {@link JsonAlias}
+ * still accepts the historical key spellings when reading older files.</p>
  */
+@JsonAutoDetect(
+        fieldVisibility = JsonAutoDetect.Visibility.ANY,
+        getterVisibility = JsonAutoDetect.Visibility.NONE,
+        isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+        setterVisibility = JsonAutoDetect.Visibility.NONE,
+        creatorVisibility = JsonAutoDetect.Visibility.NONE)
 public class AutomationStep {
     public static final String PARAM_NODE_NAME = "nodeName";
     public static final int NODE_NAME_MAX_LENGTH = 30;
 
+    @JsonAlias("id")
     private int stepId;
+
+    @JsonAlias("type")
     private FlowStepKind kind;
+
+    @JsonAlias("params")
+    @JsonSetter(nulls = Nulls.SKIP)
     private Map<String, String> attributes;
+
+    @JsonAlias("executed")
     private boolean completed;
 
+    @JsonAlias("canvasX")
     private double layoutX;
+
+    @JsonAlias("canvasY")
     private double layoutY;
 
+    @JsonAlias("nextNodeId")
     private int successorId  = -1;
+
+    @JsonAlias("nextNodeFalseId")
     private int alternateId  = -1;
+
+    @JsonAlias("lastOcrResult")
     private String lastReadValue = null;
 
     /** Creates a blank step with an empty attribute map. */
@@ -69,9 +107,33 @@ public class AutomationStep {
     /* ---- attributes ---- */
 
     public Map<String, String> getAttributes()                { return attributes; }
-    public void setAttributes(Map<String, String> attrs)      { this.attributes = attrs; }
 
-    public void putAttribute(String key, String value)  { attributes.put(key, value); }
+    /**
+     * Replaces the attribute map, copying the supplied entries so the step
+     * never aliases a caller-owned map and never holds a null map. A stored
+     * node name is re-sanitized on the way in, because attribute maps also
+     * arrive from hand-edited files.
+     */
+    public void setAttributes(Map<String, String> attrs) {
+        Map<String, String> replacement = new HashMap<>();
+        if (attrs != null) {
+            replacement.putAll(attrs);
+        }
+        this.attributes = replacement;
+        if (replacement.containsKey(PARAM_NODE_NAME)) {
+            setNodeName(replacement.get(PARAM_NODE_NAME));
+        }
+    }
+
+    /** Stores an attribute, keeping the node name sanitized and readable. */
+    public void putAttribute(String key, String value) {
+        if (PARAM_NODE_NAME.equals(key)) {
+            setNodeName(value);
+        } else {
+            attributes.put(key, value);
+        }
+    }
+
     public String getAttribute(String key)              { return attributes.get(key); }
 
     public String getNodeName() {
@@ -221,7 +283,7 @@ public class AutomationStep {
     public FlowStepKind getType()               { return kind; }
     public void setType(FlowStepKind type)      { this.kind = type; }
     public Map<String, String> getParams()      { return attributes; }
-    public void setParams(Map<String, String> p){ this.attributes = p; }
+    public void setParams(Map<String, String> p){ setAttributes(p); }
     public void setParam(String k, String v)    { putAttribute(k, v); }
     public String getParam(String k)            { return getAttribute(k); }
     public int getParamAsInt(String k, int d)   { return readIntAttribute(k, d); }
@@ -276,7 +338,7 @@ public class AutomationStep {
                         && getAttribute("brX") != null;
                 String suffix    = (gs ? " GS" : "")
                         + (bounded ? " [area]" : " [full]");
-                yield String.format("Find: %s @%s\\% %s",
+                yield String.format("Find: %s @%s%% %s",
                         tplPath, threshold, suffix);
             }
 

--- a/modules/api/src/test/java/dev/frostguard/api/domain/AutomationBlueprintSerializationTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/domain/AutomationBlueprintSerializationTest.java
@@ -1,0 +1,184 @@
+package dev.frostguard.api.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import dev.frostguard.api.configs.FlowStepKind;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Locks the persisted shape of a task-builder flow.
+ *
+ * <p>Both domain types keep legacy accessor shims and derived read-only views
+ * alongside their canonical accessors. When Jackson auto-detected those
+ * methods, every value was written two or three times under different names and
+ * each derived getter ran during the write — so one failing getter aborted
+ * serialization mid-document and left a truncated, unparseable file behind.
+ * These tests pin the canonical key set, prove the file stays parseable, and
+ * prove that flows saved by older builds still load.</p>
+ */
+class AutomationBlueprintSerializationTest {
+
+    /** Mirrors the mapper configuration used by the task-builder service. */
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper()
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    private AutomationBlueprint sampleFlow() {
+        AutomationBlueprint blueprint = new AutomationBlueprint("dead_shot");
+        blueprint.setStartLocation("HOME");
+
+        AutomationStep find = new AutomationStep(0, FlowStepKind.TEMPLATE_SEARCH);
+        find.setNodeName("search deal");
+        find.setParam("templatePath", "HOME_DEALS_BUTTON");
+        find.setParam("threshold", "90");
+        blueprint.addNode(find);
+
+        AutomationStep wait = new AutomationStep(0, FlowStepKind.WAIT);
+        wait.setNodeName("wait for panel");
+        wait.setParam("durationMs", "1500");
+        blueprint.addNode(wait);
+
+        return blueprint;
+    }
+
+    /**
+     * The reported symptom: saving a flow containing a template-search node
+     * produced a file that stopped mid-object.
+     */
+    @Test
+    void savesAFlowWithATemplateSearchNodeAsCompleteParseableJson() throws Exception {
+        String json = mapper.writeValueAsString(sampleFlow());
+
+        JsonNode parsed = mapper.readTree(json);
+
+        assertEquals("dead_shot", parsed.path("title").asText());
+        assertEquals(2, parsed.path("steps").size());
+    }
+
+    @Test
+    void writesOnlyCanonicalStepKeys() throws Exception {
+        JsonNode step = mapper.readTree(mapper.writeValueAsString(sampleFlow()))
+                .path("steps").path(0);
+
+        List<String> actual = new java.util.ArrayList<>();
+        step.fieldNames().forEachRemaining(actual::add);
+        java.util.Collections.sort(actual);
+
+        assertEquals(List.of("alternateId", "attributes", "completed", "kind",
+                        "lastReadValue", "layoutX", "layoutY", "stepId", "successorId"),
+                actual);
+    }
+
+    @Test
+    void writesOnlyCanonicalBlueprintKeys() throws Exception {
+        JsonNode parsed = mapper.readTree(mapper.writeValueAsString(sampleFlow()));
+
+        List<String> actual = new java.util.ArrayList<>();
+        parsed.fieldNames().forEachRemaining(actual::add);
+        java.util.Collections.sort(actual);
+
+        assertEquals(List.of("createdEpochMs", "initialScreen", "modifiedEpochMs",
+                        "notes", "steps", "title"),
+                actual);
+    }
+
+    /**
+     * Derived, computed accessors must never be invoked while writing: that is
+     * what let a single failing getter corrupt the whole document.
+     */
+    @Test
+    void neverWritesDerivedOrComputedViews() throws Exception {
+        String json = mapper.writeValueAsString(sampleFlow());
+
+        for (String derived : List.of("\"summary\"", "\"branching\"", "\"region\"",
+                "\"successor\"", "\"alternate\"", "\"attributeCount\"", "\"nextStepId\"")) {
+            assertFalse(json.contains(derived), "derived view leaked into the saved file: " + derived);
+        }
+    }
+
+    @Test
+    void preservesNodeMetadataAcrossASaveAndReload() throws Exception {
+        AutomationBlueprint reloaded =
+                mapper.readValue(mapper.writeValueAsString(sampleFlow()), AutomationBlueprint.class);
+
+        assertEquals("dead_shot", reloaded.getTitle());
+        assertEquals("HOME", reloaded.getInitialScreen());
+        assertEquals(2, reloaded.getSteps().size());
+        assertEquals("search deal", reloaded.getSteps().get(0).getNodeName());
+        assertEquals(FlowStepKind.TEMPLATE_SEARCH, reloaded.getSteps().get(0).getKind());
+        assertEquals("HOME_DEALS_BUTTON", reloaded.getSteps().get(0).getParam("templatePath"));
+        assertEquals("wait for panel", reloaded.getSteps().get(1).getNodeName());
+    }
+
+    /** Flows saved by earlier builds used the duplicated legacy key spellings. */
+    @Test
+    void loadsFlowsSavedWithLegacyKeyNames() throws Exception {
+        String legacy = """
+                {
+                  "name": "legacy flow",
+                  "description": "notes",
+                  "startLocation": "WORLD",
+                  "createdAt": 111,
+                  "updatedAt": 222,
+                  "nodes": [ {
+                    "id": 7,
+                    "type": "WAIT",
+                    "params": { "durationMs": "500", "nodeName": "pause" },
+                    "executed": true,
+                    "canvasX": 12.0,
+                    "canvasY": 34.0,
+                    "nextNodeId": 9,
+                    "nextNodeFalseId": -1,
+                    "lastOcrResult": "read"
+                  } ]
+                }
+                """;
+
+        AutomationBlueprint blueprint = mapper.readValue(legacy, AutomationBlueprint.class);
+        AutomationStep step = blueprint.getSteps().get(0);
+
+        assertEquals("legacy flow", blueprint.getTitle());
+        assertEquals("notes", blueprint.getNotes());
+        assertEquals("WORLD", blueprint.getInitialScreen());
+        assertEquals(111, blueprint.getCreatedEpochMs());
+        assertEquals(222, blueprint.getModifiedEpochMs());
+        assertEquals(7, step.getStepId());
+        assertEquals(FlowStepKind.WAIT, step.getKind());
+        assertEquals("500", step.getParam("durationMs"));
+        assertEquals("pause", step.getNodeName());
+        assertTrue(step.isCompleted());
+        assertEquals(12.0, step.getLayoutX());
+        assertEquals(34.0, step.getLayoutY());
+        assertEquals(9, step.getSuccessorId());
+        assertEquals(-1, step.getAlternateId());
+        assertEquals("read", step.getLastReadValue());
+    }
+
+    /** A hand-edited file may spell a collection as null; that must not crash the editor. */
+    @Test
+    void treatsExplicitNullCollectionsAsEmpty() throws Exception {
+        AutomationBlueprint blueprint =
+                mapper.readValue("{\"title\":\"t\",\"steps\":null}", AutomationBlueprint.class);
+        AutomationStep step =
+                mapper.readValue("{\"stepId\":1,\"attributes\":null}", AutomationStep.class);
+
+        assertNotNull(blueprint.getSteps());
+        assertTrue(blueprint.getSteps().isEmpty());
+        assertNotNull(step.getAttributes());
+        assertTrue(step.getAttributes().isEmpty());
+    }
+}

--- a/modules/api/src/test/java/dev/frostguard/api/domain/AutomationStepTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/domain/AutomationStepTest.java
@@ -1,0 +1,92 @@
+package dev.frostguard.api.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.frostguard.api.configs.FlowStepKind;
+import org.junit.jupiter.api.Test;
+
+class AutomationStepTest {
+
+    /**
+     * A malformed conversion in the TEMPLATE_SEARCH branch threw
+     * {@code IllegalFormatFlagsException}, which broke every caller of the
+     * summary: the editor could not render a template-search card, and
+     * serialization aborted part-way through writing the saved flow.
+     */
+    @Test
+    void summarizesTemplateSearchWithoutFailingOnThePercentLiteral() {
+        AutomationStep step = new AutomationStep(1, FlowStepKind.TEMPLATE_SEARCH);
+
+        assertEquals("Find: ? @90%  [full]", step.describeBriefly());
+    }
+
+    @Test
+    void summarizesTemplateSearchWithConfiguredTemplateAndRegion() {
+        AutomationStep step = new AutomationStep(1, FlowStepKind.TEMPLATE_SEARCH);
+        step.setParam("templatePath", "HOME_DEALS_BUTTON");
+        step.setParam("threshold", "85");
+        step.setParam("grayscale", "true");
+        step.setParam("tlX", "10");
+        step.setParam("brX", "40");
+
+        assertEquals("Find: HOME_DEALS_BUTTON @85%  GS [area]", step.describeBriefly());
+    }
+
+    /** Every kind must produce a summary; none may throw. */
+    @Test
+    void summarizesEveryStepKind() {
+        for (FlowStepKind kind : FlowStepKind.values()) {
+            AutomationStep step = new AutomationStep(1, kind);
+
+            String summary = step.describeBriefly();
+
+            assertNotNull(summary, "no summary for " + kind);
+            assertTrue(!summary.isBlank(), "blank summary for " + kind);
+        }
+    }
+
+    @Test
+    void sanitizesNodeNameForReadableSavedMetadata() {
+        AutomationStep step = new AutomationStep(1, FlowStepKind.WAIT);
+
+        step.setNodeName("  first line\nsecond line with too much detail  ");
+
+        assertEquals("first line second line with to", step.getNodeName());
+        assertEquals("first line second line with to", step.getParam(AutomationStep.PARAM_NODE_NAME));
+    }
+
+    /** A node name written straight into the attribute map is still sanitized. */
+    @Test
+    void sanitizesNodeNameSuppliedThroughTheAttributeMap() {
+        AutomationStep step = new AutomationStep(1, FlowStepKind.WAIT);
+
+        step.setParams(java.util.Map.of(AutomationStep.PARAM_NODE_NAME, "  raw\nname  "));
+
+        assertEquals("raw name", step.getNodeName());
+    }
+
+    /** Replacing the attribute map must not alias the caller's map. */
+    @Test
+    void copiesSuppliedAttributesInsteadOfAliasingThem() {
+        AutomationStep step = new AutomationStep(1, FlowStepKind.WAIT);
+        java.util.Map<String, String> supplied = new java.util.HashMap<>();
+        supplied.put("durationMs", "500");
+
+        step.setAttributes(supplied);
+        supplied.put("durationMs", "999");
+
+        assertEquals("500", step.getParam("durationMs"));
+    }
+
+    @Test
+    void treatsNullAttributesAsAnEmptyMap() {
+        AutomationStep step = new AutomationStep(1, FlowStepKind.WAIT);
+
+        step.setAttributes(null);
+
+        assertNotNull(step.getAttributes());
+        assertTrue(step.getAttributes().isEmpty());
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
@@ -40,9 +40,6 @@ public class TaskBuilderService {
 
     private static final Logger logger = LoggerFactory.getLogger(TaskBuilderService.class);
 
-    /** Sentinel prefix used for user-selected custom template files. */
-    private static final String FILE_PREFIX = "file://";
-
     private final EmulatorController emuManager;
     private final Path customTasksDir;
     private final ObjectMapper mapper;
@@ -385,7 +382,7 @@ public class TaskBuilderService {
 
             // Execute the search with retries
             ImageSearchResultData result = null;
-            boolean isCustomFile = templateName.startsWith(FILE_PREFIX);
+            boolean isCustomFile = TemplatePathResolver.isFileReference(templateName);
 
             for (int attempt = 1; attempt <= maxAttempts; attempt++) {
                 result = isCustomFile
@@ -437,8 +434,7 @@ public class TaskBuilderService {
     private ImageSearchResultData searchCustomTemplate(String templateName, boolean grayscale,
                                                        boolean hasArea, PointData topLeft, PointData bottomRight,
                                                        double thresholdPct) {
-        String absolutePath = templateName.substring(FILE_PREFIX.length());
-        String method = grayscale ? "Grayscale" : "";
+        String absolutePath = TemplatePathResolver.resolveFileReference(templateName);
 
         if (hasArea) {
             return grayscale

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TaskCodeGenerator.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TaskCodeGenerator.java
@@ -22,8 +22,6 @@ import java.util.stream.Collectors;
  */
 public class TaskCodeGenerator {
 
-    private static final String CUSTOM_TPL_SCHEME = "file://";
-
     // ── Helpers ───────────────────────────────────────────────────────
 
     /** Returns whitespace for the requested nesting depth (1 = 4 spaces). */
@@ -73,6 +71,7 @@ public class TaskCodeGenerator {
         out.append("import dev.frostguard.engine.helper.TemplateSearchHelper;\n");
         out.append("import dev.frostguard.engine.schedule.DelayedTask;\n");
         out.append("import dev.frostguard.engine.schedule.LaunchPoint;\n");
+        out.append("import dev.frostguard.engine.service.TemplatePathResolver;\n");
         out.append("import java.time.LocalDateTime;\n\n");
     }
 
@@ -294,7 +293,7 @@ public class TaskCodeGenerator {
         String tmpl = node.getParam("templatePath");
         if (tmpl == null) tmpl = "GAME_HOME_FURNACE";
 
-        boolean customFile  = tmpl.startsWith(CUSTOM_TPL_SCHEME);
+        boolean customFile  = TemplatePathResolver.isFileReference(tmpl);
         int     threshold   = node.getParamAsInt("threshold", 90);
         int     maxAttempts = node.getParamAsInt("maxAttempts", 1);
         int     delayMs     = node.getParamAsInt("delayMs", 300);
@@ -343,16 +342,23 @@ public class TaskCodeGenerator {
                                    int threshold, boolean mono, boolean bounded,
                                    String tlXs, String tlYs, String brXs, String brYs) {
         String i6 = indent(6);
-        String path   = tmpl.substring(CUSTOM_TPL_SCHEME.length()).replace("\\", "\\\\");
         String method = mono ? "locatePatternMonoFromFile" : "locatePatternFromFile";
 
+        // Emit the stored reference and resolve it at run time, so a task
+        // generated on one machine still finds its template on another.
         out.append(i6).append(var).append(" = emuManager.").append(method)
-           .append("(EMULATOR_NUMBER, \"").append(path).append("\", ");
+           .append("(EMULATOR_NUMBER, TemplatePathResolver.resolveFileReference(\"")
+           .append(escapeJavaString(tmpl)).append("\"), ");
         if (bounded) {
             out.append("new PointData(").append(tlXs).append(", ").append(tlYs).append("), ");
             out.append("new PointData(").append(brXs).append(", ").append(brYs).append("), ");
         }
         out.append(threshold).append(");\n");
+    }
+
+    /** Escapes a value for embedding in a generated Java string literal. */
+    private String escapeJavaString(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     private void writeEnumSearch(StringBuilder out, String tmpl, String var,

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TemplatePathResolver.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TemplatePathResolver.java
@@ -1,0 +1,159 @@
+package dev.frostguard.engine.service;
+
+import dev.frostguard.api.runtime.WorkspacePaths;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Resolves the {@code templatePath} attribute of a task-builder
+ * {@code TEMPLATE_SEARCH} step to something the vision layer can load.
+ *
+ * <p>The attribute holds either a {@code TemplatesEnum} constant name or a
+ * reference to an image file. File references reach the resolver in three
+ * shapes, and all three must keep working:</p>
+ * <ul>
+ *   <li>the {@value #FILE_PREFIX} sentinel the template picker writes, which
+ *       carries an absolute path;</li>
+ *   <li>a bundled asset path such as {@code templates/deals/event_tab.png},
+ *       which the packaged application stages next to the launcher;</li>
+ *   <li>a relative path a shared task file brought from another machine.</li>
+ * </ul>
+ *
+ * <p>Relative references are matched against the known installation roots
+ * rather than the process working directory alone: a launcher that starts the
+ * application from an unrelated directory would otherwise break every shared
+ * task. The first existing candidate wins, and when none exists the
+ * working-directory candidate is returned so the vision layer reports the path
+ * the operator actually configured.</p>
+ */
+public final class TemplatePathResolver {
+
+    /** Sentinel prefix the template picker stores for operator-chosen files. */
+    public static final String FILE_PREFIX = "file://";
+
+    /**
+     * Overrides the primary lookup root. Set by tests, and available as an
+     * escape hatch when an installation stages assets outside the launcher
+     * directory.
+     */
+    public static final String ROOT_PROPERTY = "frostguard.templates.root";
+
+    private static final Pattern WINDOWS_ABSOLUTE = Pattern.compile("^[A-Za-z]:[\\\\/].*");
+
+    private TemplatePathResolver() {
+    }
+
+    /**
+     * Whether the stored value names an image file rather than a
+     * {@code TemplatesEnum} constant.
+     *
+     * <p>Enum constants are upper-snake-case identifiers, so any path
+     * separator, drive letter, or explicit sentinel marks a file reference.</p>
+     */
+    public static boolean isFileReference(String templatePath) {
+        if (templatePath == null || templatePath.isBlank()) {
+            return false;
+        }
+        String value = templatePath.trim();
+        return value.startsWith(FILE_PREFIX)
+                || value.indexOf('/') >= 0
+                || value.indexOf('\\') >= 0
+                || WINDOWS_ABSOLUTE.matcher(value).matches();
+    }
+
+    /**
+     * Converts a file reference into an absolute filesystem path.
+     *
+     * @param templatePath the stored {@code templatePath} attribute
+     * @return an absolute, normalized path for the vision layer to read
+     * @throws IllegalArgumentException when the reference is blank or unusable
+     */
+    public static String resolveFileReference(String templatePath) {
+        if (templatePath == null || templatePath.isBlank()) {
+            throw new IllegalArgumentException("Template path is blank");
+        }
+
+        String value = templatePath.trim();
+        if (value.startsWith(FILE_PREFIX)) {
+            value = value.substring(FILE_PREFIX.length()).trim();
+        }
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException("Template path is blank after the " + FILE_PREFIX + " prefix");
+        }
+
+        // Bundled assets are addressed as classpath resources ("/templates/x.png")
+        // elsewhere; on disk they are staged without the leading separator.
+        if (value.startsWith("/templates/") || value.startsWith("\\templates\\")) {
+            value = value.substring(1);
+        }
+
+        Path candidate = toPath(value);
+        if (candidate.isAbsolute()) {
+            return candidate.normalize().toString();
+        }
+
+        Path fallback = null;
+        for (Path root : lookupRoots()) {
+            Path resolved = root.resolve(candidate).normalize();
+            if (Files.isRegularFile(resolved)) {
+                return resolved.toString();
+            }
+            if (fallback == null) {
+                fallback = resolved;
+            }
+        }
+        return fallback != null
+                ? fallback.toString()
+                : candidate.toAbsolutePath().normalize().toString();
+    }
+
+    private static Path toPath(String value) {
+        try {
+            return Paths.get(value);
+        } catch (InvalidPathException ex) {
+            throw new IllegalArgumentException("Template path is not a valid file path: " + value, ex);
+        }
+    }
+
+    /** Installation roots to probe for a relative template reference, in order. */
+    private static List<Path> lookupRoots() {
+        List<Path> roots = new ArrayList<>();
+        addRoot(roots, System.getProperty(ROOT_PROPERTY));
+        addRoot(roots, System.getProperty("user.dir"));
+        addRoot(roots, launcherDirectory());
+        try {
+            WorkspacePaths workspace = WorkspacePaths.current();
+            addRoot(roots, workspace.root().toString());
+            addRoot(roots, workspace.customTasks().toString());
+        } catch (RuntimeException ex) {
+            // A misconfigured workspace must not stop absolute or
+            // working-directory references from resolving.
+        }
+        return roots;
+    }
+
+    /** Directory holding the packaged launcher, when running from an install. */
+    private static String launcherDirectory() {
+        String launcher = System.getProperty("jpackage.app-path", "").trim();
+        if (launcher.isEmpty()) {
+            return null;
+        }
+        Path parent = toPath(launcher).toAbsolutePath().getParent();
+        return parent != null ? parent.toString() : null;
+    }
+
+    private static void addRoot(List<Path> roots, String rawRoot) {
+        if (rawRoot == null || rawRoot.isBlank()) {
+            return;
+        }
+        Path root = Paths.get(rawRoot).toAbsolutePath().normalize();
+        if (!roots.contains(root)) {
+            roots.add(root);
+        }
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
@@ -1,11 +1,14 @@
 package dev.frostguard.engine.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -48,11 +51,69 @@ class TaskBuilderServiceTest {
             assertEquals("Pause before bag", loaded.getNodes().get(0).getNodeName());
             assertEquals("1", service.getActiveEmulatorNumber());
         } finally {
-            if (originalWorkspace == null) {
-                System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
-            } else {
-                System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, originalWorkspace);
+            restoreWorkspace(originalWorkspace);
+        }
+    }
+
+    /**
+     * Saving a flow that contained a template-search node used to abort
+     * part-way through writing and leave an unparseable file on disk, so the
+     * flow could never be reopened. The whole save/reload cycle is exercised
+     * here through the service, exactly as the editor drives it.
+     */
+    @Test
+    void savesAndReloadsAFlowContainingATemplateSearchNode() throws Exception {
+        String originalWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+        try {
+            TaskBuilderService service = new TaskBuilderService();
+            service.startSession("Dead Shot", "0");
+
+            AutomationStep find = new AutomationStep(1, FlowStepKind.TEMPLATE_SEARCH);
+            find.setNodeName("search deal");
+            find.setParam("templatePath", "HOME_DEALS_BUTTON");
+            find.setParam("threshold", "90");
+            service.addNode(find);
+
+            AutomationStep wait = new AutomationStep(2, FlowStepKind.WAIT);
+            wait.setNodeName("wait for panel");
+            wait.setParam("durationMs", "1500");
+            service.addNode(wait);
+
+            Path builderFile = tempDir.resolve("custom-tasks").resolve("dead_shot.json");
+            TaskBuilderService.CustomTaskSaveResult saved =
+                    service.saveCurrentTaskToCustomTasks("Dead Shot", builderFile);
+
+            String builderJson = Files.readString(saved.builderFile());
+            JsonNode parsed = new ObjectMapper().readTree(builderJson);
+            assertEquals("Dead Shot", parsed.path("title").asText());
+            assertEquals(2, parsed.path("steps").size());
+            assertEquals("search deal",
+                    parsed.path("steps").path(0).path("attributes").path("nodeName").asText());
+
+            // Legacy duplicate spellings must not reappear in the saved file.
+            for (String legacyKey : new String[] {"\"id\"", "\"type\"", "\"params\"",
+                    "\"canvasX\"", "\"nextNodeId\"", "\"summary\"", "\"nodes\""}) {
+                assertFalse(builderJson.contains(legacyKey),
+                        "legacy key leaked into the saved file: " + legacyKey);
             }
+
+            AutomationBlueprint reloaded = service.loadDefinition(saved.builderFile().toFile(), "0");
+            assertEquals(2, reloaded.getNodes().size());
+            assertEquals(FlowStepKind.TEMPLATE_SEARCH, reloaded.getNodes().get(0).getKind());
+            assertEquals("search deal", reloaded.getNodes().get(0).getNodeName());
+            assertEquals("HOME_DEALS_BUTTON", reloaded.getNodes().get(0).getParam("templatePath"));
+            assertEquals("wait for panel", reloaded.getNodes().get(1).getNodeName());
+        } finally {
+            restoreWorkspace(originalWorkspace);
+        }
+    }
+
+    private void restoreWorkspace(String originalWorkspace) {
+        if (originalWorkspace == null) {
+            System.clearProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        } else {
+            System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, originalWorkspace);
         }
     }
 }

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/TaskCodeGeneratorTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/TaskCodeGeneratorTest.java
@@ -1,0 +1,68 @@
+package dev.frostguard.engine.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.frostguard.api.configs.FlowStepKind;
+import dev.frostguard.api.domain.AutomationBlueprint;
+import dev.frostguard.api.domain.AutomationStep;
+import org.junit.jupiter.api.Test;
+
+class TaskCodeGeneratorTest {
+
+    private String generateFor(String templatePath) {
+        AutomationBlueprint blueprint = new AutomationBlueprint("Find Deals");
+        AutomationStep step = new AutomationStep(0, FlowStepKind.TEMPLATE_SEARCH);
+        step.setParam("templatePath", templatePath);
+        blueprint.addNode(step);
+
+        return new TaskCodeGenerator().generate(blueprint, "find_deals", "Find Deals");
+    }
+
+    /**
+     * Baking the absolute path of the authoring machine into the generated task
+     * made the task unusable anywhere else. The generated code now stores the
+     * reference and resolves it at run time.
+     */
+    @Test
+    void resolvesFileTemplatesAtRunTimeInsteadOfHardCodingTheAuthoringPath() {
+        String source = generateFor("templates/deals/event_tab.png");
+
+        assertTrue(source.contains("import dev.frostguard.engine.service.TemplatePathResolver;"),
+                "generated task must import the resolver");
+        assertTrue(source.contains("TemplatePathResolver.resolveFileReference(\"templates/deals/event_tab.png\")"),
+                "generated task must resolve the stored reference at run time");
+    }
+
+    @Test
+    void escapesWindowsSeparatorsInGeneratedStringLiterals() {
+        String source = generateFor(TemplatePathResolver.FILE_PREFIX + "C:\\ops\\tpl.png");
+
+        assertTrue(source.contains("resolveFileReference(\"file://C:\\\\ops\\\\tpl.png\")"),
+                "backslashes must be escaped for the Java literal");
+    }
+
+    /** Enum-backed templates keep using the bundled classpath assets. */
+    @Test
+    void keepsUsingEnumTemplatesForBundledAssets() {
+        String source = generateFor("HOME_DEALS_BUTTON");
+
+        assertTrue(source.contains("TemplatesEnum.HOME_DEALS_BUTTON"));
+        assertFalse(source.contains("resolveFileReference"),
+                "enum templates must not be routed through the file resolver");
+    }
+
+    /** A node name is emitted as a comment so generated code stays readable. */
+    @Test
+    void carriesNodeNamesIntoTheGeneratedSourceAsComments() {
+        AutomationBlueprint blueprint = new AutomationBlueprint("Wait Flow");
+        AutomationStep step = new AutomationStep(0, FlowStepKind.WAIT);
+        step.setNodeName("pause before bag");
+        step.setParam("durationMs", "250");
+        blueprint.addNode(step);
+
+        String source = new TaskCodeGenerator().generate(blueprint, "wait_flow", "Wait Flow");
+
+        assertTrue(source.contains("// pause before bag"));
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/TemplatePathResolverTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/TemplatePathResolverTest.java
@@ -1,0 +1,107 @@
+package dev.frostguard.engine.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TemplatePathResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    @AfterEach
+    void clearRootOverride() {
+        System.clearProperty(TemplatePathResolver.ROOT_PROPERTY);
+    }
+
+    @Test
+    void treatsTemplateEnumConstantsAsEnumNamesNotFiles() {
+        assertFalse(TemplatePathResolver.isFileReference("HOME_DEALS_BUTTON"));
+        assertFalse(TemplatePathResolver.isFileReference("GAME_HOME_FURNACE"));
+    }
+
+    @Test
+    void treatsBlankOrMissingValuesAsEnumNames() {
+        assertFalse(TemplatePathResolver.isFileReference(null));
+        assertFalse(TemplatePathResolver.isFileReference("  "));
+    }
+
+    @Test
+    void recognisesEveryShapeOfFileReference() {
+        assertTrue(TemplatePathResolver.isFileReference("file:///home/op/tpl.png"));
+        assertTrue(TemplatePathResolver.isFileReference("templates/deals/event_tab.png"));
+        assertTrue(TemplatePathResolver.isFileReference("/opt/frostguard/tpl.png"));
+        assertTrue(TemplatePathResolver.isFileReference("C:\\Users\\op\\tpl.png"));
+        assertTrue(TemplatePathResolver.isFileReference("templates\\deals\\event_tab.png"));
+    }
+
+    @Test
+    void keepsAbsolutePathsFromThePickerUnchanged() {
+        Path absolute = tempDir.resolve("chosen.png").toAbsolutePath();
+
+        String resolved = TemplatePathResolver.resolveFileReference(
+                TemplatePathResolver.FILE_PREFIX + absolute);
+
+        assertEquals(absolute.normalize().toString(), resolved);
+    }
+
+    /**
+     * A shared task ships a relative template path. It must resolve against the
+     * installation root rather than whichever directory launched the process.
+     */
+    @Test
+    void resolvesRelativeReferenceAgainstTheInstallationRoot() throws Exception {
+        Path template = tempDir.resolve("templates").resolve("deals").resolve("event_tab.png");
+        Files.createDirectories(template.getParent());
+        Files.writeString(template, "png");
+        System.setProperty(TemplatePathResolver.ROOT_PROPERTY, tempDir.toString());
+
+        String resolved = TemplatePathResolver.resolveFileReference("templates/deals/event_tab.png");
+
+        assertEquals(template.toAbsolutePath().normalize().toString(), resolved);
+    }
+
+    /**
+     * Bundled assets are addressed as classpath resources ("/templates/…")
+     * elsewhere; on disk the same asset is staged without the leading separator.
+     */
+    @Test
+    void resolvesClasspathStyleBundledAssetPaths() throws Exception {
+        Path template = tempDir.resolve("templates").resolve("event_tab.png");
+        Files.createDirectories(template.getParent());
+        Files.writeString(template, "png");
+        System.setProperty(TemplatePathResolver.ROOT_PROPERTY, tempDir.toString());
+
+        String resolved = TemplatePathResolver.resolveFileReference("/templates/event_tab.png");
+
+        assertEquals(template.toAbsolutePath().normalize().toString(), resolved);
+    }
+
+    /** An unresolvable reference still reports a concrete path for the log. */
+    @Test
+    void returnsAnAbsoluteCandidateWhenNoRootHoldsTheTemplate() {
+        System.setProperty(TemplatePathResolver.ROOT_PROPERTY, tempDir.toString());
+
+        String resolved = TemplatePathResolver.resolveFileReference("templates/absent.png");
+
+        assertEquals(tempDir.resolve("templates").resolve("absent.png")
+                .toAbsolutePath().normalize().toString(), resolved);
+    }
+
+    @Test
+    void rejectsBlankReferences() {
+        assertThrows(IllegalArgumentException.class,
+                () -> TemplatePathResolver.resolveFileReference(null));
+        assertThrows(IllegalArgumentException.class,
+                () -> TemplatePathResolver.resolveFileReference("   "));
+        assertThrows(IllegalArgumentException.class,
+                () -> TemplatePathResolver.resolveFileReference(TemplatePathResolver.FILE_PREFIX));
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/taskbuilder/TaskBuilderLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/taskbuilder/TaskBuilderLayoutController.java
@@ -12,6 +12,7 @@ import dev.frostguard.engine.service.BranchEvaluator;
 import dev.frostguard.engine.service.ProfileService;
 import dev.frostguard.engine.service.TaskBuilderService;
 import dev.frostguard.engine.service.TaskCodeGenerator;
+import dev.frostguard.engine.service.TemplatePathResolver;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.event.ActionEvent;
@@ -105,7 +106,7 @@ public class TaskBuilderLayoutController {
     @FXML private TextField templateOffsetXField, templateOffsetYField;
 
     /** Sentinel prefix stored in templatePath param to distinguish custom file paths from TemplatesEnum names. */
-    private static final String CUSTOM_TEMPLATE_PREFIX = "file://";
+    private static final String CUSTOM_TEMPLATE_PREFIX = TemplatePathResolver.FILE_PREFIX;
     // ===== Preview Column (right) =====
     @FXML private VBox rightPanel;
 
@@ -1605,15 +1606,20 @@ public class TaskBuilderLayoutController {
                 if (templatePropsBox != null) {
                     templatePropsBox.setVisible(true); templatePropsBox.setManaged(true);
                     String curTpl = node.getParam("templatePath");
-                    if (curTpl != null && curTpl.startsWith(CUSTOM_TEMPLATE_PREFIX)) {
-                        // Custom file path — add to combo dynamically if not present
+                    if (TemplatePathResolver.isFileReference(curTpl)) {
+                        // File-backed template (operator-chosen or bundled with a
+                        // shared task) — add to the combo dynamically if absent.
                         if (!templateComboBox.getItems().contains(curTpl)) {
                             templateComboBox.getItems().add(curTpl);
                         }
                         templateComboBox.setValue(curTpl);
-                        String fname = Paths.get(curTpl.substring(CUSTOM_TEMPLATE_PREFIX.length())).getFileName().toString();
+                        boolean picked = curTpl.startsWith(CUSTOM_TEMPLATE_PREFIX);
+                        String shown = picked
+                                ? curTpl.substring(CUSTOM_TEMPLATE_PREFIX.length())
+                                : curTpl;
                         if (templateCustomPathLabel != null) {
-                            templateCustomPathLabel.setText("📁 Custom: " + fname);
+                            templateCustomPathLabel.setText("📁 " + (picked ? "Custom: " : "Package: ")
+                                    + Paths.get(shown).getFileName());
                             templateCustomPathLabel.setVisible(true);
                             templateCustomPathLabel.setManaged(true);
                         }

--- a/modules/desktop/src/main/resources/layout/TaskBuilderLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/TaskBuilderLayout.fxml
@@ -145,6 +145,14 @@
                         <padding><Insets top="8" bottom="8"/></padding>
                     </Separator>
 
+                    <!-- Shared node metadata: applies to every node kind -->
+                    <FlowPane hgap="14" vgap="10" alignment="CENTER_LEFT">
+                        <padding><Insets bottom="10"/></padding>
+                        <Label text="Node name:" styleClass="tb-props-label"/>
+                        <TextField fx:id="nodeNameField" promptText="Optional display name"
+                                   prefWidth="240" styleClass="tb-text-field"/>
+                    </FlowPane>
+
                     <!-- TAP properties -->
                     <VBox fx:id="tapPropsBox" spacing="10" visible="false" managed="false">
                         <FlowPane hgap="14" vgap="10" alignment="CENTER_LEFT">

--- a/modules/desktop/src/test/java/dev/frostguard/app/arch/FxmlControllerBindingTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/arch/FxmlControllerBindingTest.java
@@ -1,0 +1,299 @@
+package dev.frostguard.app.arch;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Structural conformance between JavaFX controllers and the FXML documents they
+ * drive.
+ *
+ * <p>Controllers in this application are attached with
+ * {@code FXMLLoader.setController(...)} instead of an {@code fx:controller}
+ * attribute, so the loader silently leaves an {@code @FXML} field null when the
+ * matching {@code fx:id} is absent from the document. Nothing fails at build
+ * time and nothing fails at load time: the control is simply missing from the
+ * screen, and every guarded use of the field becomes a no-op. That is exactly
+ * how the Task Builder shipped without a node-name input while the controller
+ * read from and wrote to {@code nodeNameField}.</p>
+ *
+ * <p>These checks compare each {@code XxxLayout.fxml} with its
+ * {@code XxxLayoutController} by naming convention — the same convention
+ * {@code LauncherLayoutController#loadNode} uses to resolve documents at
+ * runtime — and enforce both directions of the contract:</p>
+ * <ul>
+ *   <li>every {@code @FXML} field has a matching {@code fx:id}, so injection
+ *       cannot silently yield null;</li>
+ *   <li>every {@code on*="#handler"} reference resolves to a controller method,
+ *       so document loading cannot fail at runtime.</li>
+ * </ul>
+ *
+ * <p>Source text is parsed rather than reflection or a live {@code FXMLLoader}
+ * because the assertions must hold on headless CI agents, where no JavaFX
+ * toolkit is available to realize a scene graph.</p>
+ */
+class FxmlControllerBindingTest {
+
+    /**
+     * Controls that predate these checks and are declared in a controller but
+     * absent from its document. Each one is read through an explicit null guard,
+     * so the screens work as shipped; they are recorded here so the checks can
+     * be strict about anything new without bundling unrelated UI changes into a
+     * bug fix. Removing an entry means adding the control to the document or
+     * dropping the field.
+     */
+    private static final Set<String> KNOWN_UNBOUND_FIELDS = Set.of(
+            "AllianceLayout#hboxAutojoinQueues",
+            "AllianceLayout#textfieldAutojoinQueues",
+            "ExpertsLayout#troopOptionsVBox",
+            "LauncherLayout#logoSurvival",
+            "LauncherLayout#logoWhiteout",
+            "ShopLayout#labelPeriod",
+            "TaskBuilderLayout#zoomLabel");
+
+    private static final Pattern FX_ID = Pattern.compile("fx:id\\s*=\\s*\"([^\"]+)\"");
+    private static final Pattern EVENT_HANDLER = Pattern.compile("\\bon[A-Z]\\w*\\s*=\\s*\"#(\\w+)\"");
+    private static final Pattern FXML_ANNOTATION = Pattern.compile("@FXML\\b");
+    private static final Pattern SUPERCLASS = Pattern.compile("\\bclass\\s+\\w+\\s+extends\\s+(\\w+)");
+    private static final Pattern BLOCK_COMMENT = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
+    private static final Pattern LINE_COMMENT = Pattern.compile("//[^\\n]*");
+    private static final Pattern GENERICS = Pattern.compile("<[^<>]*(?:<[^<>]*>)?[^<>]*>");
+    private static final Pattern MODIFIERS = Pattern.compile("\\b(?:private|public|protected|final|static|transient)\\b|@\\w+");
+    private static final Pattern IDENTIFIER = Pattern.compile("\\w+");
+
+    private static Path layoutDirectory;
+    private static Map<String, Path> controllerSources;
+
+    @BeforeAll
+    static void locateSources() throws IOException {
+        Path root = Path.of("").toAbsolutePath();
+        while (root != null && !Files.isDirectory(root.resolve("modules/desktop"))) {
+            root = root.getParent();
+        }
+        assertNotNull(root, "Could not locate the repository root from the working directory");
+
+        layoutDirectory = root.resolve("modules/desktop/src/main/resources/layout");
+        assertTrue(Files.isDirectory(layoutDirectory), "Missing layout directory: " + layoutDirectory);
+
+        controllerSources = new HashMap<>();
+        try (Stream<Path> sources = Files.walk(root.resolve("modules/desktop/src/main/java"))) {
+            sources.filter(path -> path.getFileName().toString().endsWith(".java"))
+                    .forEach(path -> {
+                        String fileName = path.getFileName().toString();
+                        controllerSources.put(fileName.substring(0, fileName.length() - ".java".length()), path);
+                    });
+        }
+        assertTrue(controllerSources.containsKey("TaskBuilderLayoutController"),
+                "Controller sources were not indexed");
+    }
+
+    /**
+     * A field the loader never injects is the failure mode this suite exists
+     * for: the screen renders without the control and every use of the field
+     * turns into a silent no-op.
+     */
+    @Test
+    void everyInjectedControlExistsInItsDocument() throws IOException {
+        List<String> offenders = new ArrayList<>();
+        int comparedDocuments = 0;
+
+        for (Path document : documents()) {
+            Path controller = controllerFor(document);
+            if (controller == null) {
+                continue;
+            }
+            comparedDocuments++;
+
+            String documentName = documentName(document);
+            Set<String> declaredIds = matches(FX_ID, Files.readString(document));
+            for (String field : injectedFieldNames(controller)) {
+                if (declaredIds.contains(field)) {
+                    continue;
+                }
+                String reference = documentName + "#" + field;
+                if (KNOWN_UNBOUND_FIELDS.contains(reference)) {
+                    continue;
+                }
+                offenders.add(reference);
+            }
+        }
+
+        assertTrue(comparedDocuments >= 30,
+                "Expected the naming convention to pair most documents, paired only " + comparedDocuments);
+        assertEquals(List.of(), new ArrayList<>(new TreeSet<>(offenders)),
+                "These @FXML fields have no matching fx:id, so FXMLLoader leaves them null. "
+                        + "Add the control to the document or remove the field.");
+    }
+
+    /**
+     * The node-name input that issue #136 reported as missing. Pinned by name so
+     * a future document edit cannot quietly drop it again.
+     */
+    @Test
+    void taskBuilderDocumentDeclaresTheNodeNameInput() throws IOException {
+        Set<String> declaredIds = matches(FX_ID, Files.readString(layoutDirectory.resolve("TaskBuilderLayout.fxml")));
+        assertTrue(declaredIds.contains("nodeNameField"),
+                "TaskBuilderLayout.fxml must declare nodeNameField so node names can be edited");
+    }
+
+    /**
+     * The opposite mismatch is louder — an unresolved handler makes
+     * {@code FXMLLoader.load} throw — but it still escapes compilation, so it is
+     * checked here too.
+     */
+    @Test
+    void everyDocumentEventHandlerResolvesToAControllerMethod() throws IOException {
+        List<String> offenders = new ArrayList<>();
+
+        for (Path document : documents()) {
+            Path controller = controllerFor(document);
+            if (controller == null) {
+                continue;
+            }
+
+            String controllerText = controllerHierarchyText(controller);
+            for (String handler : matches(EVENT_HANDLER, Files.readString(document))) {
+                if (!Pattern.compile("\\b" + Pattern.quote(handler) + "\\s*\\(").matcher(controllerText).find()) {
+                    offenders.add(documentName(document) + "#" + handler);
+                }
+            }
+        }
+
+        assertEquals(List.of(), new ArrayList<>(new TreeSet<>(offenders)),
+                "These document handlers have no controller method, so FXMLLoader.load fails at runtime.");
+    }
+
+    /**
+     * The allowlist is a temporary record, not a place to park new defects, so it
+     * may not name a control that is now bound or a document that no longer
+     * exists.
+     */
+    @Test
+    void allowlistOnlyNamesControlsThatAreStillUnbound() throws IOException {
+        List<String> stale = new ArrayList<>();
+
+        for (String reference : new TreeSet<>(KNOWN_UNBOUND_FIELDS)) {
+            String documentName = reference.substring(0, reference.indexOf('#'));
+            String field = reference.substring(reference.indexOf('#') + 1);
+            Path document = layoutDirectory.resolve(documentName + ".fxml");
+            if (!Files.isRegularFile(document)) {
+                stale.add(reference + " (document no longer exists)");
+            } else if (matches(FX_ID, Files.readString(document)).contains(field)) {
+                stale.add(reference + " (now bound)");
+            }
+        }
+
+        assertEquals(List.of(), stale,
+                "Remove these entries from KNOWN_UNBOUND_FIELDS; the checks now cover them.");
+    }
+
+    private static List<Path> documents() throws IOException {
+        try (Stream<Path> files = Files.list(layoutDirectory)) {
+            return files.filter(path -> path.getFileName().toString().endsWith(".fxml")).sorted().toList();
+        }
+    }
+
+    private static String documentName(Path document) {
+        String fileName = document.getFileName().toString();
+        return fileName.substring(0, fileName.length() - ".fxml".length());
+    }
+
+    private static Path controllerFor(Path document) {
+        return controllerSources.get(documentName(document) + "Controller");
+    }
+
+    /** Concatenates a controller with its superclasses so inherited members count as declared. */
+    private static String controllerHierarchyText(Path controller) throws IOException {
+        StringBuilder combined = new StringBuilder();
+        Path current = controller;
+        Set<Path> visited = new LinkedHashSet<>();
+        while (current != null && visited.add(current)) {
+            String text = Files.readString(current);
+            combined.append(text).append('\n');
+            Matcher superclass = SUPERCLASS.matcher(text);
+            current = superclass.find() ? controllerSources.get(superclass.group(1)) : null;
+        }
+        return combined.toString();
+    }
+
+    /**
+     * Collects the names of {@code @FXML} fields, including inherited ones and
+     * the comma-separated groups this codebase uses (for example
+     * {@code private CheckBox checkBoxChests, checkBoxTriumph;}). Annotated
+     * methods are skipped: they are event handlers, not injected controls.
+     */
+    private static Set<String> injectedFieldNames(Path controller) throws IOException {
+        Set<String> names = new LinkedHashSet<>();
+        Path current = controller;
+        Set<Path> visited = new LinkedHashSet<>();
+
+        while (current != null && visited.add(current)) {
+            String text = Files.readString(current);
+            names.addAll(injectedFieldNames(stripComments(text)));
+            Matcher superclass = SUPERCLASS.matcher(text);
+            current = superclass.find() ? controllerSources.get(superclass.group(1)) : null;
+        }
+        return names;
+    }
+
+    private static Set<String> injectedFieldNames(String source) {
+        Set<String> names = new LinkedHashSet<>();
+        Matcher annotation = FXML_ANNOTATION.matcher(source);
+
+        while (annotation.find()) {
+            String remainder = source.substring(annotation.end());
+            int terminator = remainder.indexOf(';');
+            int bodyStart = remainder.indexOf('{');
+            if (terminator < 0 || (bodyStart >= 0 && bodyStart < terminator)) {
+                continue;
+            }
+            String declaration = remainder.substring(0, terminator);
+            if (declaration.indexOf('(') >= 0) {
+                continue;
+            }
+
+            declaration = GENERICS.matcher(MODIFIERS.matcher(declaration).replaceAll("")).replaceAll("").trim();
+            String[] typeAndNames = declaration.split("\\s+", 2);
+            if (typeAndNames.length < 2) {
+                continue;
+            }
+            for (String candidate : typeAndNames[1].split(",")) {
+                String name = candidate.split("=")[0].replace("[]", "").trim();
+                if (IDENTIFIER.matcher(name).matches()) {
+                    names.add(name);
+                }
+            }
+        }
+        return names;
+    }
+
+    private static String stripComments(String source) {
+        return LINE_COMMENT.matcher(BLOCK_COMMENT.matcher(source).replaceAll("")).replaceAll("");
+    }
+
+    private static Set<String> matches(Pattern pattern, String text) {
+        Set<String> values = new LinkedHashSet<>();
+        Matcher matcher = pattern.matcher(text);
+        while (matcher.find()) {
+            values.add(matcher.group(1));
+        }
+        return values;
+    }
+}


### PR DESCRIPTION
Fixes the Task Builder faults reported in #136 and supersedes #137, which targeted the pre-3.0 `fg-*/` tree and no longer merges after the `modules/*/` restructure.

## What was broken

Three independent defects produced the reported symptoms.

**1. No way to name a node.** `TaskBuilderLayoutController` declares `@FXML private TextField nodeNameField` and reads/writes it in five places, but `TaskBuilderLayout.fxml` never declared the matching `fx:id`. Controllers here are attached with `FXMLLoader.setController(...)` rather than an `fx:controller` attribute, so the loader left the field null, the input never rendered, and every guarded use became a silent no-op.

**2. Saved flows were truncated and would not reload.** Two faults compounded:

- `AutomationStep.describeBriefly()` used `"Find: %s @%s\% %s"`. `java.util.Formatter` rejects `\%` with `IllegalFormatFlagsException: Flags = ' '`.
- Jackson auto-detected the legacy display shims (`getSummary()`, `getDisplayName()`, …) on both domain types, so every file carried duplicate keys — and serializing a Find Image node called `getSummary()`, which threw.

The exception surfaced mid-write, so Jackson aborted after emitting a partial document. Reproduced against real Jackson 2.17.2:

```
WRITE THREW: JsonMappingException: Flags = ' ' (through reference chain:
  AutomationBlueprint["steps"]->ArrayList[1]->AutomationStep["summary"])
bytes=1468 ... PARSE FAILED: Unexpected end-of-input: expected close marker for Object
```

That truncation is the "missing closing brackets" in the issue, and it is why a flow containing a Find Image node appeared to vanish.

**3. Custom template paths were not portable.** `file://` references resolved against the process working directory, so a flow authored in the workspace broke once the packaged launcher started from elsewhere.

## Changes

- **Format string** → `"Find: %s @%s%% %s"`.
- **Field-based mapping** via `@JsonAutoDetect` on `AutomationStep` and `AutomationBlueprint`, so derived views stay out of the JSON. Chose this over annotating each shim with `@JsonIgnore` (the approach in #137): new helper methods are inert by default instead of silently widening the format.
- **Back-compatible reads** with `@JsonAlias` on every renamed field, so existing task files still load.
- **Collection safety** — `@JsonSetter(nulls = Nulls.SKIP)` plus defensive copies in `setAttributes`, `putAttribute`, and `setSteps`.
- **`nodeNameField`** added to the shared node metadata row in `TaskBuilderLayout.fxml`.
- **`TemplatePathResolver`** extracted; it probes the known roots in order, and generated Java now resolves at runtime instead of baking in an absolute path. Removes the duplicated `file://` constants and a dead local in `TaskBuilderService`.

## Regression coverage

`FxmlControllerBindingTest` closes the class of defect behind fault 1 — the one nothing in the build could catch. It pairs each layout with its controller by naming convention and asserts both directions: every `@FXML` field has a matching `fx:id`, and every `on*="#handler"` resolves to a method. Source text is parsed rather than loading a scene graph so it runs headless on CI.

Five controls predate the check and are read through explicit null guards; they are allowlisted, with a companion assertion that fails once any becomes bound, so the list cannot quietly absorb new breakage. Fixing them would mean unrelated UI changes in a bug fix.

**Verified by mutation** — reverting only the `fx:id` reproduces the original bug and the suite rejects it:

```
FxmlControllerBindingTest.everyInjectedControlExistsInItsDocument:140
  expected: <[]> but was: <[TaskBuilderLayout#nodeNameField]>
FxmlControllerBindingTest.taskBuilderDocumentDeclaresTheNodeNameInput:152
  TaskBuilderLayout.fxml must declare nodeNameField ==> expected: <true> but was: <false>
```

Serialization tests pin the canonical key sets, so a future accessor cannot widen the on-disk format unnoticed.

## Testing

| Module | Result |
| --- | --- |
| `modules/api` | 32 tests, all pass |
| `modules/automation` | 148 tests, 0 failures |
| `modules/desktop` | all pass, including the 4 new binding checks |

Two pre-existing environmental limitations are unrelated to this change and reproduce identically on a clean `main` checkout:

- 4 OCR errors from a missing `tesseract` native library (135 → 148 tests with these changes; same 4 errors before and after).
- `BearTrapTimerDateTimeUxTest` calls `Platform.startup()` and needs a display.

**Evidence level:** all three root causes reproduced and confirmed fixed by automated tests; the FXML guard additionally verified by mutation. Not exercised against a live emulator — the end-to-end save/reload path is covered by `TaskBuilderServiceTest` round-trip assertions rather than a running device.

Closes #136
