### PR TITLE
fix(windows): preserve Stable launcher reputation

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -235,6 +235,13 @@ jobs:
                   '--expected-watcher-launcher-sha256',
                   '9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209'
               )
+          } else {
+              $verificationArgs += @(
+                  '--expected-desktop-launcher-sha256',
+                  '06610c6684f6323edf915a713d6a29cbc488d49f044685b80eabcfb1f7ca0a53',
+                  '--expected-watcher-launcher-sha256',
+                  'ed6a92c9e42bf4b205c669771bef4cbcd9e4d8674678f89cf944f965922f714e'
+              )
           }
           python build-support/verification/verify_app_image.py @verificationArgs
           powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `

--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -16,6 +16,17 @@ on:
       - ".github/workflows/windows-native-package.yml"
       - ".github/workflows/signed-windows-channel-release.yml"
   workflow_dispatch:
+    inputs:
+      stable_candidate_version:
+        description: "Unpublished Stable application SemVer (must be a prerelease)"
+        required: true
+        default: "3.0.0-rc.1"
+        type: string
+      stable_candidate_windows_version:
+        description: "Numeric MSI version below the final Stable version"
+        required: true
+        default: "2.99.1"
+        type: string
 
 permissions:
   contents: read
@@ -63,11 +74,35 @@ jobs:
           }
           $wixBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Validate optional Stable release candidate identity
+        if: github.event_name == 'workflow_dispatch'
+        shell: pwsh
+        env:
+          CANDIDATE_VERSION: ${{ inputs.stable_candidate_version }}
+          CANDIDATE_WINDOWS_VERSION: ${{ inputs.stable_candidate_windows_version }}
+        run: |
+          python build-support/release/windows_installer_version.py `
+              --channel stable --version $env:CANDIDATE_VERSION `
+              --candidate-windows-version $env:CANDIDATE_WINDOWS_VERSION
+          if ($LASTEXITCODE -ne 0) {
+              throw "Stable release candidate identity is invalid"
+          }
+
       - name: Build Stable application image and installer
         shell: pwsh
+        env:
+          CANDIDATE_VERSION: ${{ inputs.stable_candidate_version }}
+          CANDIDATE_WINDOWS_VERSION: ${{ inputs.stable_candidate_windows_version }}
         run: |
           $mavenArgs = $env:MAVEN_ARGS -split " "
-          & .\mvnw.cmd @mavenArgs "-Dfrostguard.pull-request-build=true" `
+          $candidateArgs = @()
+          if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
+              $candidateArgs += @(
+                  "-Drevision=$($env:CANDIDATE_VERSION)",
+                  "-Dfrostguard.windows.app-version=$($env:CANDIDATE_WINDOWS_VERSION)"
+              )
+          }
+          & .\mvnw.cmd @mavenArgs @candidateArgs "-Dfrostguard.pull-request-build=true" `
               "-Pwindows-app-image,windows-installer" package
 
       - name: Test the application-image verifier
@@ -81,6 +116,8 @@ jobs:
         run: >-
           python build-support/verification/verify_app_image.py
           packaging/desktop/target/app-image/Frostguard
+          --expected-desktop-launcher-sha256 06610c6684f6323edf915a713d6a29cbc488d49f044685b80eabcfb1f7ca0a53
+          --expected-watcher-launcher-sha256 ed6a92c9e42bf4b205c669771bef4cbcd9e4d8674678f89cf944f965922f714e
 
       - name: Smoke test Stable launchers and workspace isolation
         shell: pwsh
@@ -103,6 +140,29 @@ jobs:
           }
           "path=$($installers[0].FullName)" | Out-File `
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Upload Stable application image
+        uses: actions/upload-artifact@v4
+        with:
+          name: frostguard-stable-windows-app-image
+          path: packaging/desktop/target/app-image/Frostguard
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload Stable installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: frostguard-stable-windows-installer
+          path: ${{ steps.stable-installer.outputs.path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+      - name: Reset packaging output before Nightly build
+        shell: pwsh
+        run: |
+          $mavenArgs = $env:MAVEN_ARGS -split " "
+          & .\mvnw.cmd @mavenArgs -pl packaging/desktop clean
 
       - name: Build Nightly application image and installer
         shell: pwsh
@@ -142,23 +202,6 @@ jobs:
           }
           "path=$($installers[0].FullName)" | Out-File `
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-
-      - name: Upload native application image
-        uses: actions/upload-artifact@v4
-        with:
-          name: frostguard-stable-windows-app-image
-          path: packaging/desktop/target/app-image/Frostguard
-          if-no-files-found: error
-          retention-days: 14
-
-      - name: Upload Windows installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: frostguard-stable-windows-installer
-          path: ${{ steps.stable-installer.outputs.path }}
-          if-no-files-found: error
-          compression-level: 0
-          retention-days: 14
 
       - name: Upload Nightly application image
         uses: actions/upload-artifact@v4

--- a/build-support/release/test_windows_installer_version.py
+++ b/build-support/release/test_windows_installer_version.py
@@ -8,7 +8,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from windows_installer_version import require_newer_version, windows_installer_version  # noqa: E402
+from windows_installer_version import (  # noqa: E402
+    require_newer_version,
+    stable_candidate_windows_version,
+    windows_installer_version,
+)
 
 
 class WindowsInstallerVersionTest(unittest.TestCase):
@@ -47,6 +51,21 @@ class WindowsInstallerVersionTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             require_newer_version(
                 "nightly", "3.0.0-nightly.20260812.1", "3.1.0-nightly.20260811.1")
+
+    def test_accepts_numeric_stable_candidate_version_below_final_release(self):
+        self.assertEqual("2.99.1", stable_candidate_windows_version(
+            "3.0.0-rc.1", "2.99.1"))
+
+    def test_rejects_invalid_or_non_upgradable_stable_candidate_versions(self):
+        for version, windows_version in (
+                ("3.0.0", "2.99.1"),
+                ("3.0.0-01", "2.99.1"),
+                ("3.0.0-rc.1", "3.0.0"),
+                ("3.0.0-rc.1", "2.256.1"),
+                ("3.0.0-rc.1", "2.99")):
+            with self.subTest(version=version, windows_version=windows_version):
+                with self.assertRaises(ValueError):
+                    stable_candidate_windows_version(version, windows_version)
 
 
 if __name__ == "__main__":

--- a/build-support/release/windows_installer_version.py
+++ b/build-support/release/windows_installer_version.py
@@ -12,6 +12,11 @@ NIGHTLY_VERSION = re.compile(
     r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
     r"-nightly\.(\d{8})\.(0|[1-9]\d*)$"
 )
+STABLE_CANDIDATE_VERSION = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"-(?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*))*$"
+)
 
 
 def windows_installer_version(channel: str, version: str) -> str:
@@ -27,6 +32,21 @@ def require_newer_version(channel: str, version: str, previous_version: str) -> 
         raise ValueError(
             f"Windows installer version {'.'.join(map(str, current))} must be newer than "
             f"{'.'.join(map(str, previous))}")
+
+
+def stable_candidate_windows_version(version: str, windows_version: str) -> str:
+    candidate = STABLE_CANDIDATE_VERSION.fullmatch(version)
+    if candidate is None:
+        raise ValueError("Stable candidate version must be a semantic prerelease")
+    windows = STABLE_VERSION.fullmatch(windows_version)
+    if windows is None:
+        raise ValueError("Stable candidate Windows version must use X.Y.Z")
+    candidate_fields = tuple(int(candidate.group(index)) for index in range(1, 4))
+    windows_fields = tuple(int(value) for value in windows.groups())
+    _validate_windows_fields(windows_fields)
+    if windows_fields >= candidate_fields:
+        raise ValueError("Stable candidate Windows version must remain below the final Stable version")
+    return ".".join(str(value) for value in windows_fields)
 
 
 def _release_order(channel: str, version: str) -> tuple[int, ...]:
@@ -71,11 +91,20 @@ def main() -> int:
     parser.add_argument("--channel", required=True, choices=("stable", "nightly"))
     parser.add_argument("--version", required=True)
     parser.add_argument("--previous-version")
+    parser.add_argument("--candidate-windows-version")
     args = parser.parse_args()
     try:
-        if args.previous_version:
+        if args.candidate_windows_version:
+            if args.channel != "stable":
+                raise ValueError("Candidate Windows versions are available only for Stable")
+            if args.previous_version:
+                raise ValueError("Candidate and previous versions cannot be validated together")
+            print(stable_candidate_windows_version(args.version, args.candidate_windows_version))
+        elif args.previous_version:
             require_newer_version(args.channel, args.version, args.previous_version)
-        print(windows_installer_version(args.channel, args.version))
+            print(windows_installer_version(args.channel, args.version))
+        else:
+            print(windows_installer_version(args.channel, args.version))
     except ValueError as failure:
         parser.error(str(failure))
     return 0

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -72,7 +72,7 @@ class ChannelPackagingTest(unittest.TestCase):
             self.assertEqual(value, nightly[key])
         self.assertNotEqual(stable["frostguard.product.upgrade-uuid"],
                             nightly["frostguard.product.upgrade-uuid"])
-        self.assertEqual("${frostguard.windows.app-version}",
+        self.assertEqual("2.1.0",
                          stable["frostguard.windows.launcher-version"])
         self.assertEqual("26.8.12004",
                          nightly["frostguard.windows.launcher-version"])
@@ -170,11 +170,22 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("Remove an abandoned draft release", workflow)
         self.assertIn('java-version: "21.0.12+8.0"', workflow)
         for launcher_hash in (
+            "06610c6684f6323edf915a713d6a29cbc488d49f044685b80eabcfb1f7ca0a53",
+            "ed6a92c9e42bf4b205c669771bef4cbcd9e4d8674678f89cf944f965922f714e",
             "5c728d3662d64c428d003874f6d62b798bbbe329f595b2b15a2ab5ab1fd1faa9",
             "9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209",
         ):
             self.assertIn(launcher_hash, installers)
             self.assertIn(launcher_hash, workflow)
+        self.assertIn("stable_candidate_version", installers)
+        self.assertIn("stable_candidate_windows_version", installers)
+        self.assertIn("--candidate-windows-version", installers)
+        stable_upload = installers.index("Upload Stable installer")
+        packaging_reset = installers.index("Reset packaging output before Nightly build")
+        nightly_build = installers.index("Build Nightly application image and installer")
+        self.assertLess(stable_upload, packaging_reset)
+        self.assertLess(packaging_reset, nightly_build)
+        self.assertIn("-pl packaging/desktop clean", installers)
         self.assertIn('gh api --method DELETE `', workflow)
         self.assertIn('releases/$($release.id)', workflow)
         self.assertNotIn("--cleanup-tag --yes", workflow)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -52,6 +52,22 @@ immutable release intact and keep the previous rolling manifest active. Recover
 by verifying and promoting the manifest asset from that immutable release; do
 not rebuild or replace its installer.
 
+### Unpublished Stable release candidates
+
+Before promoting a new Stable major or minor version, manually run **Windows
+Installers** with a prerelease application version such as `3.0.0-rc.1` and a
+numeric Windows Installer version below the final release, such as `2.99.1`.
+The workflow validates that ordering, builds with release updates disabled,
+verifies the pinned Stable launcher hashes, smoke-tests the image, and uploads
+the MSI only as a short-lived Actions artifact. It does not create a GitHub
+Release or change `releases/latest`.
+
+Use the artifact to prove a real upgrade from the current Stable installation.
+The candidate's numeric MSI version must be newer than the installed Stable but
+lower than the final release, so the final `3.0.0` installer can still upgrade
+it. The application displays the prerelease version from its JAR independently
+of the numeric MSI version.
+
 ## Transitional ZIP promotion
 
 The legacy Stable ZIP workflow promotes an already successful `Nightly Windows Bundle` run from

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -44,13 +44,13 @@ and leaves the current installation untouched. A failed installer upgrade uses
 Windows Installer rollback, attempts to reopen the retained application, and
 shows an update failure instead of silently claiming success.
 
-Until release binaries have an Authenticode publisher, Java-only Nightly
-updates keep the native desktop and watcher bootstrap files byte-identical so
-an already accepted launcher does not lose Smart App Control reputation merely
-because the MSI product version increased. The MSI version still increases for
-every release, and Frostguard displays the version embedded in its application
-JAR. Changes to the bootstrap, icon, or packaged JDK require a new Windows
-reputation decision; Authenticode signing remains the durable solution.
+Until release binaries have an Authenticode publisher, Java-only Stable and
+Nightly updates keep their native desktop and watcher bootstrap files
+byte-identical to the already accepted Stable 2.1.0 and Nightly 26.8.12004
+launchers. The MSI version still increases for every release, and Frostguard
+displays the version embedded in its application JAR. Changes to the bootstrap,
+icon, or packaged JDK require a new Windows reputation decision; Authenticode
+signing remains the durable solution.
 
 Recommended installs:
 

--- a/packaging/desktop/pom.xml
+++ b/packaging/desktop/pom.xml
@@ -19,7 +19,9 @@
     <properties>
         <frostguard.release.channel>stable</frostguard.release.channel>
         <frostguard.windows.app-version>${project.version}</frostguard.windows.app-version>
-        <frostguard.windows.launcher-version>${frostguard.windows.app-version}</frostguard.windows.launcher-version>
+        <!-- Keep the unchanged bootstrap byte-identical while releases are
+             project-signed but do not yet have an Authenticode publisher. -->
+        <frostguard.windows.launcher-version>2.1.0</frostguard.windows.launcher-version>
         <frostguard.product.name>Frostguard</frostguard.product.name>
         <frostguard.product.identifier>dev.frostguard.desktop</frostguard.product.identifier>
         <frostguard.product.description>Frostguard automation desktop application</frostguard.product.description>


### PR DESCRIPTION
## Summary

- keep Stable's unchanged native desktop and watcher bootstrap byte-identical to the Smart App Control-accepted 2.1.0 launchers
- enforce the known Stable hashes in both pull-request packaging and the protected channel release workflow
- add a validated, non-publishing Stable release-candidate build with independent application and numeric MSI versions
- upload Stable evidence and reset only desktop packaging output before building Nightly, preventing cross-version artifacts from leaking between identities

## Why

Unsigned jpackage launchers receive a new Windows reputation decision when their embedded file version changes. Nightly already preserves its accepted bootstrap, but Stable still tied the launcher version to every MSI release and could therefore become blocked during the 3.0 upgrade.

The release gate also had no safe way to create a correctly versioned Stable candidate: ordinary PR installers remained at 2.1.0, while the authenticated Stable workflow would immediately publish the candidate as GitHub Latest. The new manual Windows Installers inputs build an update-disabled Actions artifact such as application `3.0.0-rc.1` with MSI `2.99.1`, which can upgrade 2.1.0 while remaining below final 3.0.0.

Part of #165 and follow-up release-gate work for #130.

## Validation

- `mvnw.cmd package`: 361 tests, 0 failures/errors/skips
- `python -m unittest discover -s build-support/verification -p 'test_*.py' -v`: 38 tests passed
- `python -m unittest discover -s build-support/release -p 'test_*.py' -v`: 47 tests passed
- [Windows RC run 31599524431](https://github.com/Shederator/wosbot/actions/runs/31599524431): complete Stable and Nightly builds, pinned hashes, image smoke tests, workspace isolation, MSI boundaries, and artifact uploads passed
- independently extracted RC confirms app `3.0.0-rc.1`, MSI `2.99.1`, Stable UpgradeCode `{FA0D66F6-1F7D-4DA8-9701-88F7B4570797}`, update-disabled identity, and exact accepted desktop/watcher hashes
- live Windows upgrade from installed Stable 2.1.0 passed: Windows Installer status 0, old product replaced by 2.99.1, same Stable workspace/profile and scheduled task activity retained, no Code Integrity block, and concurrent launch with installed Nightly `.8` succeeded

## Risks

- the pinned unsigned bootstrap is a temporary reputation bridge; native launcher, icon, or packaged-JDK changes still require a new Windows reputation decision until Authenticode is configured
- this PR does not publish Stable 3.0
- explicit failure/recovery scenarios in #165 remain separate release-gate evidence
