### PR TITLE
test(update): cover release recovery paths

### DIFF
--- a/modules/update/src/test/java/dev/frostguard/update/UpdateDownloaderTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/UpdateDownloaderTest.java
@@ -16,6 +16,7 @@ import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.util.HexFormat;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -125,6 +126,50 @@ class UpdateDownloaderTest {
     }
 
     @Test
+    void resumesAfterInterruptedTransfer() throws Exception {
+        UpdateCandidate candidate = candidate(INSTALLER, sha256(INSTALLER));
+        AtomicInteger requestCount = new AtomicInteger();
+        AtomicLong resumedOffset = new AtomicLong(-1L);
+        DownloadTransport transport = (uri, offset) -> {
+            if (requestCount.getAndIncrement() == 0) {
+                return response(200, new InputStream() {
+                    private int position;
+
+                    @Override
+                    public int read() throws IOException {
+                        if (position == 7) {
+                            throw new IOException("connection reset");
+                        }
+                        return position < INSTALLER.length ? INSTALLER[position++] : -1;
+                    }
+                });
+            }
+            resumedOffset.set(offset);
+            return response(206, java.util.Arrays.copyOfRange(INSTALLER, (int) offset, INSTALLER.length));
+        };
+        UpdateDownloader downloader = new UpdateDownloader(transport, new ArtifactVerifier());
+
+        assertThrows(UpdateException.class, () -> downloader.download(candidate, temp));
+        Path result = downloader.download(candidate, temp);
+
+        assertEquals(7L, resumedOffset.get());
+        assertArrayEquals(INSTALLER, Files.readAllBytes(result));
+    }
+
+    @Test
+    void rejectsDeclaredSizeMismatchWithoutPromotingArtifact() throws Exception {
+        byte[] truncated = java.util.Arrays.copyOf(INSTALLER, INSTALLER.length - 1);
+        UpdateCandidate candidate = candidate(INSTALLER, sha256(INSTALLER));
+        UpdateDownloader downloader = new UpdateDownloader((uri, offset) -> response(200, truncated),
+                new ArtifactVerifier());
+
+        assertThrows(UpdateException.class, () -> downloader.download(candidate, temp));
+
+        assertFalse(Files.exists(updateDirectory(candidate).resolve(candidate.artifact().fileName())));
+        assertFalse(Files.exists(updateDirectory(candidate).resolve(candidate.artifact().fileName() + ".part")));
+    }
+
+    @Test
     void rejectsConcurrentDownloadLock() throws Exception {
         UpdateCandidate candidate = candidate(INSTALLER, sha256(INSTALLER));
         Path lockPath = updateDirectory(candidate).resolve(candidate.artifact().fileName() + ".lock");
@@ -152,8 +197,12 @@ class UpdateDownloaderTest {
     }
 
     private static DownloadTransport.Response response(int status, byte[] body) {
+        return response(status, new ByteArrayInputStream(body));
+    }
+
+    private static DownloadTransport.Response response(int status, InputStream body) {
         return new DownloadTransport.Response() {
-            private final InputStream input = new ByteArrayInputStream(body);
+            private final InputStream input = body;
 
             @Override
             public int statusCode() {

--- a/modules/update/src/test/java/dev/frostguard/update/WindowsInstallerHandoffTest.java
+++ b/modules/update/src/test/java/dev/frostguard/update/WindowsInstallerHandoffTest.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -86,6 +87,48 @@ class WindowsInstallerHandoffTest {
     }
 
     @Test
+    void restartsExistingInstallationWhenWindowsInstallerFails() throws Exception {
+        assumeTrue(System.getProperty("os.name", "").toLowerCase().contains("win"));
+        Path installer = Files.writeString(temp.resolve("Frostguard-broken.msi"), "not an MSI package");
+        Path installDirectory = Files.createDirectory(temp.resolve("installed Frostguard"));
+        Path restartMarker = temp.resolve("restart-marker.txt");
+        Path launcher = Files.writeString(installDirectory.resolve("Frostguard.cmd"),
+                "@echo off\r\n>\"" + restartMarker + "\" echo restarted\r\n");
+        Path workspace = Files.createDirectory(temp.resolve("workspace"));
+        Path persistedData = Files.writeString(workspace.resolve("frostguard.db"), "existing profile data");
+        Path fakeSystemTools = Files.createDirectory(temp.resolve("fake-system-tools"));
+        Files.copy(Path.of(System.getenv("SystemRoot"), "System32", "where.exe"),
+                fakeSystemTools.resolve("msiexec.exe"));
+        Process parent = new ProcessBuilder("powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
+                "Start-Sleep -Milliseconds 750").start();
+        AtomicReference<Process> waiter = new AtomicReference<>();
+        AtomicReference<Map<String, String>> handoffEnvironment = new AtomicReference<>();
+        WindowsInstallerHandoff handoff = new WindowsInstallerHandoff((command, environment) -> {
+            String testScript = decodeScript(command).replace(
+                    "Show-UpdateFailure -Details $failureDetails",
+                    "[Console]::Error.WriteLine($failureDetails)");
+            ProcessBuilder builder = new ProcessBuilder(WindowsInstallerHandoff.createPowerShellCommand(testScript))
+                    .redirectErrorStream(true);
+            builder.environment().putAll(environment);
+            builder.environment().put("PATH", fakeSystemTools + ";" + builder.environment().get("PATH"));
+            handoffEnvironment.set(environment);
+            waiter.set(builder.start());
+        });
+
+        InstallerHandoff.HandoffSession session = handoff.stage(installer, parent.pid(), launcher, workspace);
+        session.authorize();
+
+        assertTrue(waiter.get().waitFor(20, TimeUnit.SECONDS));
+        assertEquals(1, waiter.get().exitValue());
+        waitForFile(restartMarker);
+        assertEquals("restarted", Files.readString(restartMarker).trim());
+        assertEquals("existing profile data", Files.readString(persistedData));
+        assertTrue(Files.notExists(Path.of(handoffEnvironment.get().get(WindowsInstallerHandoff.TOKEN_PATH_ENV))));
+        String output = new String(waiter.get().getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertTrue(output.contains("Windows Installer exited with code"), output);
+    }
+
+    @Test
     void rejectsInvalidInputsBeforeStartingWaiter() {
         WindowsInstallerHandoff handoff = new WindowsInstallerHandoff((command, environment) -> {
             throw new AssertionError("Waiter should not start");
@@ -128,5 +171,13 @@ class WindowsInstallerHandoffTest {
         assertTrue(encodedCommand >= 0);
         byte[] scriptBytes = Base64.getDecoder().decode(command.get(encodedCommand + 1));
         return new String(scriptBytes, StandardCharsets.UTF_16LE);
+    }
+
+    private static void waitForFile(Path file) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (Files.notExists(file) && System.nanoTime() < deadline) {
+            Thread.sleep(50);
+        }
+        assertTrue(Files.isRegularFile(file), "Restart launcher was not executed");
     }
 }


### PR DESCRIPTION
## Summary

- prove interrupted installer downloads resume from the retained partial file
- prove declared-size mismatches are rejected without promoting an artifact
- execute the real Windows handoff script against a failing installer process and verify the retained launcher restarts
- verify the existing workspace data remains unchanged during installer failure recovery

## Why

Issue #165 requires explicit recovery evidence before Frostguard 3.0 Stable promotion. The implementation already handled these paths, but interrupted transfer, size rejection, and post-exit installer failure recovery were not all directly exercised.

## Validation

- `./mvnw.cmd -pl modules/update -am test` — 52 tests passed
- `./mvnw.cmd package` — 364 tests passed; desktop package built
- `git diff --check` — passed
- Windows-specific integration test executed locally on Windows 11

## Risks

The failure-path integration test replaces `msiexec.exe` only through the child process's temporary `PATH`; it never invokes or changes the installed Frostguard product.

Closes the remaining automated recovery-evidence gap in #165.
