### PR TITLE
docs(release): point users to Frostguard 3 installers

### DIFF
--- a/.github/workflows/refresh-stable-discord.yml
+++ b/.github/workflows/refresh-stable-discord.yml
@@ -30,8 +30,21 @@ jobs:
           tag="$(jq -r '.tag_name' <<< "${release}")"
           version="${tag#v}"
           release_url="$(jq -r '.html_url' <<< "${release}")"
-          asset="frostguard-windows-desktop-bundle.zip"
-          download_url="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/${asset}"
+          asset="Frostguard-${version}-windows-x64.msi"
+          download_url="$(jq -r --arg asset "${asset}" \
+            '[.assets[] | select(.name == $asset) | .browser_download_url] | if length == 1 then .[0] else empty end' \
+            <<< "${release}")"
+          if [[ -z "${download_url}" ]]; then
+            echo "::error::Latest Stable does not contain exactly one ${asset}."
+            exit 1
+          fi
+          code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
+            --fail --retry 12 --retry-delay 5 --retry-all-errors \
+            -r 0-1023 "${download_url}" || true)"
+          if [[ "${code}" != "200" && "${code}" != "206" ]]; then
+            echo "::error::Stable installer URL returned HTTP ${code}."
+            exit 1
+          fi
           archive_url="https://github.com/${GITHUB_REPOSITORY}/releases"
 
           python3 build-support/notifications/stable_release_notify.py \

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Maven, and a separately installed Java runtime are not required.
 
 After choosing a build:
 
-1. Download the Windows x64 EXE for the desired channel.
+1. Download the Windows x64 MSI for the desired channel.
 2. Confirm the download is from the official `Shederator/wosbot` release and
    run the installer. A Windows **Unknown publisher** warning is currently
    expected.
@@ -234,16 +234,16 @@ After choosing a build:
 > side. The first Nightly start can copy a one-time Stable snapshot; changes are
 > not synchronized afterward.
 
-See the **[complete installation guide](docs/installation.md)** for Java,
-emulator and game settings.
+See the **[complete installation guide](docs/installation.md)** for emulator,
+game, and source-development settings.
 
 ### 🧪 Test pull requests
 
 Request a temporary build of one or more open pull requests with `/build-pr` in
 the Discord `#request-a-build` channel.
 
-PR builds use the same Windows bundle format as Stable and Nightly, but contain
-unmerged code and expire automatically.
+PR builds remain temporary ZIP bundles rather than installed release-channel
+products. They contain unmerged code and expire automatically.
 
 ### 🛠️ Build from source
 

--- a/build-support/notifications/stable_release_notify.py
+++ b/build-support/notifications/stable_release_notify.py
@@ -19,9 +19,9 @@ def build_payload(args: argparse.Namespace) -> dict:
         "A tested, versioned build that changes only when a new Stable is published.\n\n"
         f"**[⬇️ Download Frostguard {args.version} for Windows]"
         f"({args.download_url})**\n\n"
-        "Extract the complete archive and use the included Frostguard launcher. "
-        "Java 21 or newer is "
-        f"required.\n\n[📋 Release notes]({args.release_url})"
+        "Run the self-contained per-user MSI installer; a separate Java "
+        "installation is not required. Windows may currently show an Unknown "
+        f"publisher warning.\n\n[📋 Release notes]({args.release_url})"
         f" • [🗂️ Previous stable releases]({args.archive_url})"
     )
     return {

--- a/build-support/notifications/test_stable_release_notify.py
+++ b/build-support/notifications/test_stable_release_notify.py
@@ -13,9 +13,9 @@ WEBHOOK = "https://discord.com/api/webhooks/123456789/abcdefTOKEN-value_x"
 class StablePayloadTest(unittest.TestCase):
     def args(self):
         return notify.parse_args([
-            "--version", "2.1.0",
-            "--download-url", "https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip",
-            "--release-url", "https://github.com/Shederator/wosbot/releases/tag/v2.1.0",
+            "--version", "3.0.0",
+            "--download-url", "https://github.com/Shederator/wosbot/releases/download/v3.0.0/Frostguard-3.0.0-windows-x64.msi",
+            "--release-url", "https://github.com/Shederator/wosbot/releases/tag/v3.0.0",
             "--archive-url", "https://github.com/Shederator/wosbot/releases",
             "--message-id", "1533506274472235099",
             "--dry-run",
@@ -28,25 +28,26 @@ class StablePayloadTest(unittest.TestCase):
 
     def test_contains_only_stable_release_facts(self):
         text = str(notify.build_payload(self.args()))
-        self.assertIn("2.1.0", text)
-        self.assertIn("included Frostguard launcher", text)
-        self.assertIn("releases/latest/download", text)
+        self.assertIn("3.0.0", text)
+        self.assertIn("self-contained per-user MSI installer", text)
+        self.assertIn("Frostguard-3.0.0-windows-x64.msi", text)
+        self.assertIn("separate Java installation is not required", text)
         self.assertIn("Previous stable releases", text)
         self.assertNotIn("recommended", text.lower())
         self.assertNotIn("commit", text.lower())
 
     def test_names_the_maintained_stable_download(self):
         title = notify.build_payload(self.args())["embeds"][0]["title"]
-        self.assertEqual("✅ Frostguard Stable 2.1.0", title)
+        self.assertEqual("✅ Frostguard Stable 3.0.0", title)
 
     def test_existing_stable_message_uses_patch(self):
         os.environ["FG_STABLE_TEST_WEBHOOK"] = WEBHOOK
         try:
             with mock.patch.object(notify, "post") as sender:
                 code = notify.main([
-                    "--version", "2.1.0",
-                    "--download-url", "https://github.com/a/releases/latest/download/a.zip",
-                    "--release-url", "https://github.com/a/releases/tag/v2.1.0",
+                    "--version", "3.0.0",
+                    "--download-url", "https://github.com/a/releases/download/v3.0.0/a.msi",
+                    "--release-url", "https://github.com/a/releases/tag/v3.0.0",
                     "--archive-url", "https://github.com/a/releases",
                     "--webhook-env", "FG_STABLE_TEST_WEBHOOK",
                     "--message-id", "1533506274472235099",

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -193,6 +193,16 @@ class ChannelPackagingTest(unittest.TestCase):
             encoding="utf-8")
         self.assertIn("Frostguard 3.x must use Windows Channel Release", legacy_stable)
 
+    def test_stable_discord_refresh_resolves_the_versioned_msi(self):
+        workflow = (REPO_ROOT / ".github/workflows/refresh-stable-discord.yml").read_text(
+            encoding="utf-8")
+
+        self.assertIn('asset="Frostguard-${version}-windows-x64.msi"', workflow)
+        self.assertIn(".browser_download_url", workflow)
+        self.assertIn("does not contain exactly one ${asset}", workflow)
+        self.assertIn("Stable installer URL returned HTTP", workflow)
+        self.assertNotIn("frostguard-windows-desktop-bundle.zip", workflow)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -117,9 +117,10 @@ mvnw.cmd package
 ```
 
 The build writes module artifacts below their respective `target` directories
-and the transitional desktop bundle ZIP below `packaging/desktop/target`. End
-users should extract the ZIP and launch `Start Frostguard.bat`; individual
-module JARs are not standalone distributions.
+and a transitional desktop bundle ZIP below `packaging/desktop/target`. That ZIP
+is used for temporary PR testing and is not the installed Stable/Nightly product.
+End users should use the published MSI installer; individual module JARs are not
+standalone distributions.
 
 ### Build the native Windows package
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,14 +1,15 @@
 # Releases
 
-Frostguard publishes authenticated installed releases for Stable and Nightly plus
-temporary ZIP builds for pull-request testing. The existing daily and Stable
-ZIP workflows remain transitional until #155 separates validation from public
-Nightly publication.
+Frostguard publishes project-authenticated installed releases for Stable and
+Nightly plus temporary ZIP builds for pull-request testing. A legacy rolling
+Nightly ZIP remains available while its maintained download channel is retired;
+it is not an automatic-update source.
 
 | Type | Audience | Lifetime | Discord notification |
 |---|---|---|---|
 | Stable `vX.Y.Z` | Regular users | Permanent | Update the maintained Stable message |
-| Daily `nightly` | Testers | Replaced daily | Update the daily download, no mass mention |
+| Nightly `nightly-X.Y.Z-nightly.*` | Testers | Permanent prerelease | Release history; in-app Nightly feed |
+| Legacy daily `nightly` ZIP | Testers | Replaced daily | Maintained legacy download, no mass mention |
 | PR test `pr-test-*` | Requester/testers | Temporary | Reply only to the requester |
 
 ## Authenticated installed releases
@@ -99,25 +100,25 @@ in place; GitHub Releases remains the permanent release history.
 ```text
 📥 Frostguard Downloads
 
-Stable — versioned
-A tested build that changes only when a new Stable is published:
-https://github.com/Shederator/wosbot/releases/latest/download/frostguard-windows-desktop-bundle.zip
+Stable — versioned installer
+A tested, self-contained Windows build that changes only with a Stable release:
+https://github.com/Shederator/wosbot/releases/latest
 
-Nightly — testing
-The newest automated development build. It may contain unfinished changes:
-https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip
+Nightly — authenticated previews
+Immutable Windows installer previews with their own app and settings:
+https://github.com/Shederator/wosbot/releases
 
-Extract the complete archive and use the included Frostguard launcher.
-Java 21 or newer is required.
+Download the Windows x64 MSI from the selected release. The installer includes
+Java. A Windows Unknown publisher or SmartScreen warning is currently expected.
 ```
 
-The Stable URL is deliberately a direct, version-independent asset URL. GitHub
-redirects it to the asset on the latest non-prerelease release. Store the
-webhook-owned card ID in `DISCORD_STABLE_MESSAGE_ID`. A Stable promotion updates
-the card automatically; `Refresh Stable Discord Message` repairs it manually
-from GitHub's Latest release when necessary.
+The Stable guide links to GitHub's Latest release because the immutable MSI
+filename contains its version. Store the webhook-owned card ID in
+`DISCORD_STABLE_MESSAGE_ID`. Run `Refresh Stable Discord Message` after a Stable
+promotion; it resolves and verifies the exact versioned MSI from Latest before
+updating the maintained card.
 
-### Nightly message
+### Legacy Nightly ZIP message
 
 ```text
 Latest Nightly — Frostguard <version>
@@ -134,8 +135,8 @@ Extract the complete archive and use the included Frostguard launcher.
 Java 21 or newer is required.
 ```
 
-The URL is deliberately version-independent. Do not post a new Discord message
-for every daily build. Store the webhook-owned message ID in the repository
+This legacy ZIP URL is deliberately version-independent. Do not post a new
+Discord message for every daily build. Store the webhook-owned message ID in the repository
 variable `DISCORD_DAILY_MESSAGE_ID`; successful builds edit that message. Show
 at most five linked first-parent changes since the previous Nightly and collapse
 older entries into a count.


### PR DESCRIPTION
## Summary

- point Windows users to the published self-contained MSI instead of stale EXE/ZIP instructions
- distinguish authenticated installed Nightlies from the intentionally retained legacy daily ZIP
- resolve the exact versioned Stable MSI from GitHub's Latest release before refreshing Discord
- update the maintained Stable message to describe bundled Java and the current Unknown publisher warning accurately

## Why

Frostguard 3.0.0 is now the public Stable release, but several user-facing and release-operator paths still described the transitional ZIP or an EXE wrapper. The Stable Discord refresh also constructed a ZIP URL that does not exist on `v3.0.0`.

## Validation

- 61 notification tests passed
- 47 release tests passed
- 39 verification tests passed
- `git diff --check` passed
- the public `v3.0.0` release independently resolves exactly one `Frostguard-3.0.0-windows-x64.msi`

## Risks

The legacy daily Nightly ZIP remains documented as legacy and is not removed here; the previously deferred download-channel consolidation remains separate from the Frostguard 3 Stable release gate.

Completes the public guidance and maintained-message portion of #130 and #165.
