### PR TITLE
chore(release): clarify permanent channel links

### DIFF
--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -1,25 +1,16 @@
-name: Nightly Windows Bundle
+name: Legacy Windows Bundle Candidate
 
 on:
-  schedule:
-    - cron: "17 3 * * *"
   workflow_dispatch:
-    inputs:
-      recreate_discord_message:
-        description: "Post a new maintained Nightly below Stable and retire the old message"
-        required: false
-        default: false
-        type: boolean
 
-# `contents: write` is needed to publish the rolling `nightly` release that the
-# Discord message links to. An Actions artifact URL requires a signed-in GitHub
-# account with access to this repository, so it is useless as a "downloadable"
-# link for testers in a Discord channel.
+# Frostguard 3 uses the authenticated native channel workflow. This manual-only
+# build remains available solely as an input for an intentional legacy 2.x ZIP
+# promotion; it never publishes a rolling release or updates Discord.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: nightly-windows-bundle-${{ github.ref }}
+  group: legacy-windows-bundle-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -29,7 +20,7 @@ env:
 
 jobs:
   build-windows-bundle:
-    name: Build and publish nightly Windows bundle
+    name: Build legacy Windows bundle candidate
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -199,188 +190,3 @@ jobs:
           path: "**/target/surefire-reports/*.xml"
           if-no-files-found: ignore
           retention-days: 7
-
-      # A rolling prerelease gives the Discord message a stable, public,
-      # login-free download URL. This workflow only runs from the default
-      # branch on its schedule or through an explicit manual dispatch.
-      - name: Publish the rolling nightly release
-        id: release
-        if: success() && github.ref == 'refs/heads/main'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ZIP_PATH: ${{ steps.bundle.outputs.path }}
-          VERSION: ${{ steps.version.outputs.version }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          # The asset is uploaded under a FIXED name, not the versioned one. The
-          # download URL contains the asset filename, so a versioned name would
-          # silently change the link on every version bump and break every
-          # message already posted to the channel.
-          asset="frostguard-windows-desktop-bundle.zip"
-          staged="$(dirname "${ZIP_PATH}")/${asset}"
-          cp "${ZIP_PATH}" "${staged}"
-
-          notes="$(printf '%s\n' \
-            "Automated Windows desktop bundle for Frostguard \`${VERSION}\`." \
-            "" \
-            "Built from \`${GITHUB_SHA}\` on $(date -u '+%Y-%m-%d %H:%M UTC')." \
-            "Verified: bundle structure, manifest classpath and launch smoke test." \
-            "" \
-            "**Install:** extract the complete ZIP, then double-click" \
-            "\`Start Frostguard.bat\`" \
-            "(Java 21+ required)." \
-            "" \
-            "This tag is replaced by every nightly build; it is not a stable release.")"
-
-          # Recreate the release from scratch each night. `gh release edit
-          # --target` does NOT move an existing tag, so editing in place would
-          # leave the `nightly` tag pinned to the first commit it was ever cut
-          # from while the notes claimed a newer SHA. --cleanup-tag removes the
-          # tag too, so the recreated one points at this build.
-          previous_sha=""
-          if gh release view nightly >/dev/null 2>&1; then
-            previous_sha="$(gh api \
-              "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
-              --jq '.target_commitish')"
-          fi
-          changes="$(python3 build-support/release/nightly_changes.py \
-            --repository "${GITHUB_REPOSITORY}" \
-            --previous "${previous_sha}" \
-            --current "${GITHUB_SHA}")"
-
-          notes="${notes}
-
-          ## Changes since the previous Nightly
-
-          ${changes}"
-
-          if [[ -n "${previous_sha}" ]]; then
-            gh release delete nightly --yes --cleanup-tag
-          fi
-
-          # Creating the release with the asset in the same call means there is
-          # never a window where the tag exists but the download 404s.
-          gh release create nightly "${staged}" \
-            --title "Nightly build ${VERSION}" \
-            --notes "${notes}" \
-            --prerelease \
-            --target "${GITHUB_SHA}"
-
-          # Read the URL back from the API instead of predicting it. A predicted
-          # URL is exactly how a 404 gets posted to the channel: if the upload
-          # landed under a different name, or not at all, this fails here rather
-          # than in Discord.
-          # `browser_download_url` straight from the REST API is unambiguous,
-          # unlike gh's `url` JSON field which is the API URL for some versions.
-          url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
-            --jq ".assets[] | select(.name == \"${asset}\") | .browser_download_url")"
-          if [[ -z "${url}" ]]; then
-            echo "::error::Asset ${asset} is not attached to the nightly release."
-            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
-              --jq '.assets[].name'
-            exit 1
-          fi
-
-          # Prove the link actually serves the file before it is advertised.
-          # A release asset redirects to a signed CDN URL, so follow redirects.
-          # GitHub's release API can expose the asset before its CDN download
-          # route has propagated. Treat the initial 404 as retryable.
-          code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
-            --fail --retry 12 --retry-delay 5 --retry-all-errors \
-            -r 0-1023 "${url}" || true)"
-          if [[ "${code}" != "200" && "${code}" != "206" ]]; then
-            echo "::error::Download URL ${url} returned HTTP ${code}."
-            exit 1
-          fi
-
-          echo "download_url=${url}" >> "${GITHUB_OUTPUT}"
-          {
-            echo "changes<<FROSTGUARD_CHANGES"
-            printf '%s\n' "${changes}"
-            echo "FROSTGUARD_CHANGES"
-          } >> "${GITHUB_OUTPUT}"
-          echo "Published and verified ${asset} at ${url} (HTTP ${code})"
-
-      # Keep one maintained Nightly message instead of adding one post per run.
-      # Failures remain visible in Actions and never overwrite the last working
-      # public download.
-      - name: Update the Nightly Discord message
-        id: discord
-        if: success() && github.ref == 'refs/heads/main'
-        continue-on-error: true
-        env:
-          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
-          DISCORD_DAILY_MESSAGE_ID: ${{ vars.DISCORD_DAILY_MESSAGE_ID }}
-          # A commit message is attacker-controlled text. Interpolating it
-          # straight into the `run:` block would let `$(...)` or a backtick in a
-          # commit subject execute on the runner, with the webhook secret in
-          # scope. Passing it through the environment keeps it inert data.
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          JOB_STATUS: ${{ job.status }}
-          BUNDLE_NAME: ${{ steps.metrics.outputs.bundle_name }}
-          BUNDLE_BYTES: ${{ steps.metrics.outputs.bundle_bytes }}
-          JAR_COUNT: ${{ steps.metrics.outputs.jar_count }}
-          TEST_COUNT: ${{ steps.metrics.outputs.test_count }}
-          DOWNLOAD_URL: ${{ steps.release.outputs.download_url }}
-          NIGHTLY_CHANGES: ${{ steps.release.outputs.changes }}
-          VERSION: ${{ steps.version.outputs.version }}
-          RECREATE_DISCORD_MESSAGE: ${{ inputs.recreate_discord_message || false }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          # `head_commit` only exists on push events. The nightly is a
-          # `schedule` run, which is precisely the case that matters most, so
-          # read the subject out of the checkout when the payload has none.
-          COMMIT_MESSAGE="${COMMIT_MESSAGE:-}"
-          if [[ -z "${COMMIT_MESSAGE}" ]]; then
-            COMMIT_MESSAGE="$(git log -1 --pretty=%s || true)"
-          fi
-
-          discord_target=(--message-id "${DISCORD_DAILY_MESSAGE_ID}")
-          if [[ "${RECREATE_DISCORD_MESSAGE}" == "true" ]]; then
-            discord_target=(--message-id-output "${GITHUB_OUTPUT}")
-          fi
-
-          python3 build-support/notifications/discord_notify.py \
-            --status "${JOB_STATUS,,}" \
-            --version "${VERSION}" \
-            --bundle-name "${BUNDLE_NAME}" \
-            --bundle-bytes "${BUNDLE_BYTES:-0}" \
-            --jar-count "${JAR_COUNT:-0}" \
-            --test-count "${TEST_COUNT:-0}" \
-            --download-url "${DOWNLOAD_URL}" \
-            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            --run-number "${GITHUB_RUN_NUMBER}" \
-            --repository "${GITHUB_REPOSITORY}" \
-            --branch "${GITHUB_REF_NAME}" \
-            --trigger "${GITHUB_EVENT_NAME}" \
-            --commit "${GITHUB_SHA}" \
-            --commit-message "${COMMIT_MESSAGE}" \
-            --actor "${GITHUB_ACTOR}" \
-            --changes "${NIGHTLY_CHANGES}" \
-            "${discord_target[@]}"
-
-      - name: Delete the superseded Discord message
-        if: >-
-          success() &&
-          github.ref == 'refs/heads/main' &&
-          inputs.recreate_discord_message &&
-          steps.discord.outcome == 'success'
-        env:
-          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
-          OLD_MESSAGE_ID: ${{ vars.DISCORD_DAILY_MESSAGE_ID }}
-          NEW_MESSAGE_ID: ${{ steps.discord.outputs.message_id }}
-        run: |
-          set -euo pipefail
-          if [[ ! "${OLD_MESSAGE_ID}" =~ ^[0-9]+$ ||
-                ! "${NEW_MESSAGE_ID}" =~ ^[0-9]+$ ||
-                "${OLD_MESSAGE_ID}" == "${NEW_MESSAGE_ID}" ]]; then
-            echo "::error::Refusing to delete an invalid or current Discord message ID."
-            exit 1
-          fi
-          curl --fail --silent --show-error \
-            --request DELETE \
-            "${DISCORD_NIGHTLY_WEBHOOK_URL%/}/messages/${OLD_MESSAGE_ID}"

--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -1,6 +1,8 @@
 name: Windows Channel Release
 
 on:
+  schedule:
+    - cron: "17 3 * * *"
   workflow_dispatch:
     inputs:
       channel:
@@ -23,12 +25,12 @@ on:
 permissions: {}
 
 concurrency:
-  group: windows-${{ inputs.channel }}-release
+  group: windows-${{ github.event_name == 'schedule' && 'nightly' || inputs.channel }}-release
   cancel-in-progress: false
 
 jobs:
   release:
-    name: Authenticate and publish ${{ inputs.channel }} Windows release
+    name: Authenticate and publish ${{ github.event_name == 'schedule' && 'nightly' || inputs.channel }} Windows release
     if: github.ref == 'refs/heads/main'
     runs-on: windows-latest
     timeout-minutes: 75
@@ -36,9 +38,9 @@ jobs:
       contents: write
     env:
       MAVEN_ARGS: "-B --no-transfer-progress -Dstyle.color=never"
-      CHANNEL: ${{ inputs.channel }}
-      VERSION: ${{ inputs.version }}
-      MINIMUM_UPDATER_VERSION: ${{ inputs.minimum_updater_version }}
+      REQUESTED_CHANNEL: ${{ inputs.channel }}
+      REQUESTED_VERSION: ${{ inputs.version }}
+      REQUESTED_MINIMUM_UPDATER_VERSION: ${{ inputs.minimum_updater_version }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -68,6 +70,104 @@ jobs:
           }
           $wixBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Resolve manual or scheduled release identity
+        shell: pwsh
+        run: |
+          $channel = $env:REQUESTED_CHANNEL
+          $version = $env:REQUESTED_VERSION
+          $minimumUpdaterVersion = $env:REQUESTED_MINIMUM_UPDATER_VERSION
+          if ($env:GITHUB_EVENT_NAME -eq 'schedule') {
+              $channel = 'nightly'
+              $version = ''
+              $minimumUpdaterVersion = '3.0.0-nightly.0'
+          }
+          if ($channel -notin @('stable', 'nightly')) {
+              throw "Release channel must be stable or nightly"
+          }
+
+          $manifestName = "frostguard-$channel-manifest.json"
+          $previousVersion = ''
+          $feedReleases = @()
+          if ($channel -eq 'nightly') {
+              foreach ($feedTag in @('nightly', 'updates-nightly')) {
+                  $feedJson = gh api `
+                      "repos/$($env:GITHUB_REPOSITORY)/releases/tags/$feedTag" 2>$null
+                  if ($LASTEXITCODE -eq 0) {
+                      $feedReleases += ,($feedJson | ConvertFrom-Json)
+                  }
+              }
+          } else {
+              $feedJson = gh api "repos/$($env:GITHUB_REPOSITORY)/releases/latest" 2>$null
+              if ($LASTEXITCODE -eq 0) {
+                  $feedReleases += ,($feedJson | ConvertFrom-Json)
+              }
+          }
+
+          foreach ($feedRelease in $feedReleases) {
+              $manifestAssets = @($feedRelease.assets |
+                  Where-Object { $_.name -ceq $manifestName })
+              if ($manifestAssets.Count -gt 1) {
+                  throw "Update feed contains duplicate $manifestName assets"
+              }
+              if ($manifestAssets.Count -eq 0) {
+                  continue
+              }
+              $previousManifest = Join-Path $env:RUNNER_TEMP "previous-$manifestName"
+              gh api "repos/$($env:GITHUB_REPOSITORY)/releases/assets/$($manifestAssets[0].id)" `
+                  -H "Accept: application/octet-stream" > $previousManifest
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Previous update manifest could not be downloaded"
+              }
+              $previousEnvelope = Get-Content -Raw -LiteralPath $previousManifest |
+                  ConvertFrom-Json
+              $projectKey = Get-Content -Raw `
+                  modules/update/src/main/resources/dev/frostguard/update/project-update-key.properties `
+                  | ConvertFrom-StringData
+              if ($previousEnvelope.envelopeVersion -ne 1 -or
+                  $previousEnvelope.algorithm -cne 'Ed25519' -or
+                  $previousEnvelope.keyId -cne $projectKey.keyId) {
+                  throw "Previous update feed is not a supported project-signed manifest"
+              }
+              $payloadBytes = [Convert]::FromBase64String($previousEnvelope.payload)
+              $previousVersion = ([Text.Encoding]::UTF8.GetString($payloadBytes) |
+                  ConvertFrom-Json).version
+              break
+          }
+
+          if ($env:GITHUB_EVENT_NAME -eq 'schedule') {
+              $versionArgs = @('--date', (Get-Date).ToUniversalTime().ToString('yyyyMMdd'))
+              if ([string]::IsNullOrWhiteSpace($previousVersion)) {
+                  $latestTag = gh api "repos/$($env:GITHUB_REPOSITORY)/releases/latest" `
+                      --jq '.tag_name'
+                  if ($LASTEXITCODE -ne 0 -or $latestTag -notmatch '^v(\d+\.\d+\.\d+)$') {
+                      throw "A scheduled Nightly needs an existing Stable base version"
+                  }
+                  $versionArgs += @('--base-version', $Matches[1])
+              } else {
+                  $versionArgs += @('--previous-version', $previousVersion)
+              }
+              $version = python build-support/release/next_nightly_version.py @versionArgs
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Could not derive the next scheduled Nightly version"
+              }
+              $version = $version.Trim()
+          }
+          if ([string]::IsNullOrWhiteSpace($version)) {
+              throw "A manual release requires a version"
+          }
+          if ([string]::IsNullOrWhiteSpace($minimumUpdaterVersion)) {
+              throw "A release requires a minimum updater version"
+          }
+          @{
+              CHANNEL = $channel
+              VERSION = $version
+              MINIMUM_UPDATER_VERSION = $minimumUpdaterVersion
+              PREVIOUS_VERSION = $previousVersion
+          }.GetEnumerator() | ForEach-Object {
+              "$($_.Key)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV `
+                  -Encoding utf8 -Append
+          }
+
       - name: Validate immutable release identity
         id: identity
         shell: pwsh
@@ -87,53 +187,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
               throw "Could not list existing releases"
           }
-          $feedTag = if ($env:CHANNEL -eq 'nightly') {
-              if ($releaseTags -contains 'updates-nightly') {
-                  'updates-nightly'
-              }
-          } else {
-              $latestStable = @(gh release list --repo $env:GITHUB_REPOSITORY `
-                  --exclude-drafts --exclude-pre-releases --limit 1 `
-                  --json tagName --jq '.[].tagName')
-              if ($LASTEXITCODE -ne 0) {
-                  throw "Could not resolve the latest Stable release"
-              }
-              $latestStable | Select-Object -First 1
-          }
-          $previousVersion = $null
-          if (-not [string]::IsNullOrWhiteSpace($feedTag)) {
-              $feedReleaseJson = gh api `
-                  "repos/$($env:GITHUB_REPOSITORY)/releases/tags/$feedTag"
-              if ($LASTEXITCODE -ne 0) {
-                  throw "Previous update feed could not be resolved"
-              }
-              $feedRelease = $feedReleaseJson | ConvertFrom-Json
-              $manifestAssets = @($feedRelease.assets |
-                  Where-Object { $_.name -ceq $manifestName })
-              if ($manifestAssets.Count -gt 1) {
-                  throw "Previous update feed contains duplicate manifest assets"
-              }
-              if ($manifestAssets.Count -eq 1) {
-                  $previousManifest = Join-Path $env:RUNNER_TEMP "previous-$manifestName"
-                  gh api "repos/$($env:GITHUB_REPOSITORY)/releases/assets/$($manifestAssets[0].id)" `
-                      -H "Accept: application/octet-stream" > $previousManifest
-                  if ($LASTEXITCODE -ne 0) {
-                      throw "Previous update manifest could not be downloaded"
-                  }
-                  $previousEnvelope = Get-Content -Raw -LiteralPath $previousManifest | ConvertFrom-Json
-                  $projectKey = Get-Content -Raw `
-                      modules/update/src/main/resources/dev/frostguard/update/project-update-key.properties `
-                      | ConvertFrom-StringData
-                  if ($previousEnvelope.envelopeVersion -ne 1 -or
-                      $previousEnvelope.algorithm -cne 'Ed25519' -or
-                      $previousEnvelope.keyId -cne $projectKey.keyId) {
-                      throw "Previous update feed is not a supported project-signed manifest"
-                  }
-                  $payloadBytes = [Convert]::FromBase64String($previousEnvelope.payload)
-                  $previousVersion = ([Text.Encoding]::UTF8.GetString($payloadBytes) |
-                      ConvertFrom-Json).version
-              }
-          }
+          $previousVersion = $env:PREVIOUS_VERSION
           $versionArgs = @('--channel', $env:CHANNEL, '--version', $env:VERSION)
           if (-not [string]::IsNullOrWhiteSpace($previousVersion)) {
               $versionArgs += @('--previous-version', $previousVersion)
@@ -145,9 +199,11 @@ jobs:
           $windowsVersion = $windowsVersion.Trim()
           $productName = if ($env:CHANNEL -eq 'nightly') { 'Frostguard Nightly' } else { 'Frostguard' }
           $profile = if ($env:CHANNEL -eq 'nightly') { ',windows-nightly' } else { '' }
-          $tag = if ($env:CHANNEL -eq 'nightly') { "nightly-$($env:VERSION)" } else { "v$($env:VERSION)" }
+          $tag = "v$($env:VERSION)"
           $assetPrefix = if ($env:CHANNEL -eq 'nightly') { 'Frostguard-Nightly' } else { 'Frostguard' }
           @{
+              channel = $env:CHANNEL
+              version = $env:VERSION
               windows_version = $windowsVersion
               product_name = $productName
               profile = $profile
@@ -211,7 +267,7 @@ jobs:
           $mavenArgs = $env:MAVEN_ARGS -split " "
           $profiles = "windows-app-image,windows-installer$($env:EXTRA_PROFILE)"
           $stableManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/latest/download/frostguard-stable-manifest.json"
-          $nightlyManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/download/updates-nightly/frostguard-nightly-manifest.json"
+          $nightlyManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/download/nightly/frostguard-nightly-manifest.json"
           & .\mvnw.cmd @mavenArgs "-Drevision=$($env:VERSION)" `
               "-Dfrostguard.windows.app-version=$($env:WINDOWS_VERSION)" `
               "-Dfrostguard.update.authenticode-publisher=$($env:AUTHENTICODE_PUBLISHER)" `
@@ -295,7 +351,11 @@ jobs:
           INSTALLER: ${{ steps.installer.outputs.path }}
         run: |
           $title = if ($env:CHANNEL -eq 'nightly') {
-              "Frostguard Nightly $($env:VERSION)"
+              if ($env:VERSION -notmatch '^\d+\.\d+\.\d+-nightly\.(\d{4})(\d{2})(\d{2})\.(\d+)$') {
+                  throw "Nightly title requires X.Y.Z-nightly.YYYYMMDD.N"
+              }
+              "Frostguard $($env:VERSION.Split('-')[0]) Nightly - " +
+                  "$($Matches[1])-$($Matches[2])-$($Matches[3]) #$($Matches[4])"
           } else {
               "Frostguard $($env:VERSION)"
           }
@@ -401,20 +461,111 @@ jobs:
               if ($LASTEXITCODE -ne 0) {
                   throw "Could not list releases before Nightly feed promotion"
               }
-              if (-not ($releaseTags -contains 'updates-nightly')) {
-                  gh release create updates-nightly --repo $env:GITHUB_REPOSITORY `
-                      --target $env:GITHUB_SHA --title "Frostguard Nightly update feed" `
-                      --notes "The manifest asset is replaced only after an authenticated immutable Nightly release is verified." `
-                      --prerelease
+              $immutableUrl = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/tag/$($env:TAG)"
+              $channelUrl = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/tag/nightly"
+              $channelNotes = @"
+          Permanent Frostguard Nightly channel.
+
+          **Current build:** [$($env:VERSION)]($immutableUrl)
+
+          Download the Windows x64 MSI from that immutable release. This rolling
+          channel contains only the project-signed update manifest used to select
+          and verify the current installer.
+
+          Stable: https://github.com/$($env:GITHUB_REPOSITORY)/releases/latest
+          "@
+              if (-not ($releaseTags -contains 'nightly')) {
+                  gh release create nightly --repo $env:GITHUB_REPOSITORY `
+                      --target $env:GITHUB_SHA --title "Frostguard Nightly - Latest" `
+                      --notes $channelNotes --prerelease
                   if ($LASTEXITCODE -ne 0) {
-                      throw "Nightly update feed could not be created"
+                      throw "Permanent Nightly channel could not be created"
+                  }
+              } else {
+                  $rollingJson = gh api `
+                      "repos/$($env:GITHUB_REPOSITORY)/releases/tags/nightly"
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "Permanent Nightly channel could not be resolved"
                   }
               }
-              gh release upload updates-nightly $env:MANIFEST --repo $env:GITHUB_REPOSITORY --clobber
-              if ($LASTEXITCODE -ne 0) {
-                  throw "Nightly update manifest could not be promoted"
+
+              # Builds through .8 use this old endpoint. Promote the new manifest
+              # there first so they can cross the one-release migration bridge.
+              if ($releaseTags -contains 'updates-nightly') {
+                  gh release edit updates-nightly --repo $env:GITHUB_REPOSITORY `
+                      --title "Frostguard Nightly - Compatibility Feed" `
+                      --notes "Temporary feed for Nightly builds through .8. New builds use the permanent nightly channel." `
+                      --prerelease
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "Compatibility Nightly metadata could not be updated"
+                  }
+                  gh release upload updates-nightly $env:MANIFEST `
+                      --repo $env:GITHUB_REPOSITORY --clobber
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "Compatibility Nightly manifest could not be promoted"
+                  }
               }
+              gh release upload nightly $env:MANIFEST --repo $env:GITHUB_REPOSITORY --clobber
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Permanent Nightly manifest could not be promoted"
+              }
+              $rollingJson = gh api `
+                  "repos/$($env:GITHUB_REPOSITORY)/releases/tags/nightly"
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Permanent Nightly channel could not be resolved after promotion"
+              }
+              $rolling = $rollingJson | ConvertFrom-Json
+              foreach ($asset in @($rolling.assets |
+                  Where-Object { $_.name -cne 'frostguard-nightly-manifest.json' })) {
+                  gh api --method DELETE `
+                      "repos/$($env:GITHUB_REPOSITORY)/releases/assets/$($asset.id)"
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "Legacy Nightly asset $($asset.name) could not be retired"
+                  }
+              }
+              gh release edit nightly --repo $env:GITHUB_REPOSITORY `
+                  --title "Frostguard Nightly - Latest" --notes $channelNotes `
+                  --prerelease
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Permanent Nightly channel metadata could not be updated"
+              }
+              gh api --method PATCH `
+                  "repos/$($env:GITHUB_REPOSITORY)/git/refs/tags/nightly" `
+                  -f sha=$env:GITHUB_SHA -F force=true | Out-Null
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Permanent Nightly tag could not be moved to the current build"
+              }
+              "channel_url=$channelUrl" | Out-File -FilePath $env:GITHUB_OUTPUT `
+                  -Encoding utf8 -Append
+              "release_url=$immutableUrl" | Out-File -FilePath $env:GITHUB_OUTPUT `
+                  -Encoding utf8 -Append
           }
+
+      - name: Update the maintained Nightly Discord message
+        if: always() && env.CHANNEL == 'nightly'
+        continue-on-error: true
+        env:
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          DISCORD_DAILY_MESSAGE_ID: ${{ vars.DISCORD_DAILY_MESSAGE_ID }}
+          JOB_STATUS: ${{ job.status }}
+          INSTALLER_URL: ${{ steps.draft.outputs.download_url }}
+          RELEASE_URL: ${{ steps.publish.outputs.release_url }}
+          CHANNEL_URL: ${{ steps.publish.outputs.channel_url }}
+          TAG: ${{ steps.identity.outputs.tag }}
+        shell: pwsh
+        run: |
+          $notificationArgs = @(
+              '--status', $env:JOB_STATUS.ToLowerInvariant(),
+              '--version', $env:VERSION,
+              '--download-url', $env:INSTALLER_URL,
+              '--release-url', $env:RELEASE_URL,
+              '--channel-url', $env:CHANNEL_URL,
+              '--run-url', "$($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)",
+              '--run-number', $env:GITHUB_RUN_NUMBER,
+              '--repository', $env:GITHUB_REPOSITORY,
+              '--message-id', $env:DISCORD_DAILY_MESSAGE_ID
+          )
+          python build-support/notifications/discord_notify.py @notificationArgs
 
       - name: Remove an abandoned draft release
         if: failure() && steps.draft.outcome != 'skipped'
@@ -440,7 +591,7 @@ jobs:
       - name: Upload authenticated release evidence
         uses: actions/upload-artifact@v4
         with:
-          name: frostguard-${{ inputs.channel }}-${{ inputs.version }}-authenticated-release
+          name: frostguard-${{ steps.identity.outputs.channel }}-${{ steps.identity.outputs.version }}-authenticated-release
           path: |
             ${{ steps.installer.outputs.path }}
             ${{ steps.manifest.outputs.path }}

--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       daily_run_id:
-        description: "Successful Nightly Windows Bundle run ID from main"
+        description: "Successful Legacy Windows Bundle Candidate run ID from main"
         required: true
         type: string
 
@@ -55,7 +55,7 @@ jobs:
             exit 1
           fi
           if [[ "${workflow}" != ".github/workflows/daily-windows-bundle.yml" ]]; then
-            echo "::error::Selected run does not belong to Nightly Windows Bundle."
+            echo "::error::Selected run does not belong to Legacy Windows Bundle Candidate."
             exit 1
           fi
           echo "sha=${sha}" >> "${GITHUB_OUTPUT}"

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Stable and Nightly use separate, self-contained Windows applications. Git,
 Maven, and a separately installed Java runtime are not required.
 
 - **[Latest Stable release](https://github.com/Shederator/wosbot/releases/latest)**
-- **[Nightly releases](https://github.com/Shederator/wosbot/releases)**
+- **[Latest Nightly](https://github.com/Shederator/wosbot/releases/tag/nightly)**
 
 After choosing a build:
 

--- a/build-support/notifications/discord_notify.py
+++ b/build-support/notifications/discord_notify.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
-"""Post a Frostguard build notification to a Discord webhook.
+"""Create or update the maintained Frostguard Nightly Discord message.
 
-The nightly bundle is ~220 MB, far above Discord's per-message upload ceiling,
-and a GitHub Actions artifact link only works for signed-in users with access to
-the repository. The maintained Nightly message therefore links the public
-release asset from a compact user-facing embed and lists the PRs or direct
-commits added since the previous Nightly. CI-only metrics stay in Actions.
+The maintained message links the current immutable native installer and the
+permanent rolling Nightly channel. CI-only metrics stay in Actions.
 
 The webhook URL is read from the environment rather than argv, because anything
 passed on a command line shows up in the process list and in `set -x` traces.
@@ -151,9 +148,17 @@ def build_payload(args: argparse.Namespace) -> dict:
                 f"({args.download_url})**"
             )
             description_parts.append(
-                "Extract the complete archive and use the included Frostguard "
-                "launcher. Java 21 or newer is required."
+                "Run the self-contained per-user MSI installer; a separate Java "
+                "installation is not required. Windows may currently show an "
+                "Unknown publisher warning."
             )
+            links = []
+            if args.release_url:
+                links.append(f"[📋 Release notes]({args.release_url})")
+            if args.channel_url:
+                links.append(f"[🌙 Latest Nightly]({args.channel_url})")
+            if links:
+                description_parts.append(" • ".join(links))
             if args.changes:
                 fields.extend(change_fields(args.changes, args.repository))
         elif args.run_url:
@@ -170,7 +175,7 @@ def build_payload(args: argparse.Namespace) -> dict:
 
     embed = {
         "title": truncate(
-            f"🧪 Frostguard Nightly {version}"
+            f"🌙 Frostguard Nightly {version}"
             if args.status == "success"
             else f"Frostguard {version} — {headline.lower()}",
             EMBED_TITLE_LIMIT,
@@ -306,6 +311,8 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--jar-count", type=lenient_int, default=0)
     parser.add_argument("--test-count", type=lenient_int, default=0)
     parser.add_argument("--download-url", default="")
+    parser.add_argument("--release-url", default="")
+    parser.add_argument("--channel-url", default="")
     parser.add_argument("--run-url", default="")
     parser.add_argument("--run-number", default="")
     parser.add_argument("--repository", default="")

--- a/build-support/notifications/test_discord_notify.py
+++ b/build-support/notifications/test_discord_notify.py
@@ -30,14 +30,16 @@ WEBHOOK = "https://discord.com/api/webhooks/123456789/abcdefTOKEN-value_x"
 
 BASE_ARGS = [
     "--status", "success",
-    "--version", "2.1.0",
-    "--bundle-name", "frostguard-2.1.0-desktop-bundle.zip",
-    "--bundle-bytes", str(231 * 1024 * 1024),
-    "--jar-count", "76",
-    "--test-count", "412",
+    "--version", "3.0.0-nightly.20260812.9",
     "--download-url",
-    "https://github.com/Shederator/wosbot/releases/download/nightly/"
-    "frostguard-2.1.0-desktop-bundle.zip",
+    "https://github.com/Shederator/wosbot/releases/download/"
+    "v3.0.0-nightly.20260812.9/"
+    "Frostguard-Nightly-3.0.0-nightly.20260812.9-windows-x64.msi",
+    "--release-url",
+    "https://github.com/Shederator/wosbot/releases/tag/"
+    "v3.0.0-nightly.20260812.9",
+    "--channel-url",
+    "https://github.com/Shederator/wosbot/releases/tag/nightly",
     "--run-url", "https://github.com/Shederator/wosbot/actions/runs/1",
     "--run-number", "42",
     "--repository", "Shederator/wosbot",
@@ -59,12 +61,14 @@ class PayloadTest(unittest.TestCase):
     def test_success_payload_has_no_bare_url_content(self):
         result = payload()
         self.assertEqual("", result["content"])
-        self.assertIn("releases/download/nightly", result["embeds"][0]["description"])
+        description = result["embeds"][0]["description"]
+        self.assertIn("windows-x64.msi", description)
+        self.assertIn("releases/tag/nightly", description)
 
     def test_success_embed_is_amber_and_names_the_version(self):
         embed = payload()["embeds"][0]
         self.assertEqual(0xF1C40F, embed["color"])
-        self.assertIn("2.1.0", embed["title"])
+        self.assertIn("3.0.0-nightly.20260812.9", embed["title"])
         self.assertIn("Frostguard Nightly", embed["title"])
         self.assertEqual("Nightly #42 • updated automatically", embed["footer"]["text"])
 
@@ -113,6 +117,12 @@ class PayloadTest(unittest.TestCase):
         self.assertNotIn("Trigger", names)
         self.assertNotIn("Branch", names)
         self.assertNotIn("Commit", names)
+
+    def test_native_installer_guidance_does_not_mention_zip_or_external_java(self):
+        description = payload()["embeds"][0]["description"]
+        self.assertIn("self-contained per-user MSI", description)
+        self.assertNotIn("Extract", description)
+        self.assertNotIn("Java 21", description)
 
     def test_respects_every_discord_length_limit(self):
         long = "x" * 6000

--- a/build-support/release/next_nightly_version.py
+++ b/build-support/release/next_nightly_version.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Derive the next date-sequenced Frostguard Nightly version."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from datetime import date, datetime, timezone
+
+STABLE_VERSION = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+NIGHTLY_VERSION = re.compile(
+    r"^((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))"
+    r"-nightly\.(\d{8})\.(0|[1-9]\d*)$"
+)
+
+
+def next_nightly_version(
+        release_date: date,
+        previous_version: str | None = None,
+        base_version: str | None = None) -> str:
+    """Return ``X.Y.Z-nightly.YYYYMMDD.N`` after the supplied predecessor."""
+    stamp = release_date.strftime("%Y%m%d")
+    if previous_version:
+        match = NIGHTLY_VERSION.fullmatch(previous_version)
+        if match is None:
+            raise ValueError("previous Nightly must use X.Y.Z-nightly.YYYYMMDD.N")
+        previous_date = datetime.strptime(match.group(2), "%Y%m%d").date()
+        if release_date < previous_date:
+            raise ValueError("release date cannot precede the previous Nightly")
+        base = match.group(1)
+        sequence = int(match.group(3)) + 1 if release_date == previous_date else 1
+    else:
+        if not base_version or STABLE_VERSION.fullmatch(base_version) is None:
+            raise ValueError("base version must use X.Y.Z when no previous Nightly exists")
+        base = base_version
+        sequence = 1
+    if sequence > 999:
+        raise ValueError("Nightly sequence cannot exceed 999 in one day")
+    return f"{base}-nightly.{stamp}.{sequence}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--previous-version")
+    parser.add_argument("--base-version")
+    parser.add_argument(
+        "--date",
+        default=datetime.now(timezone.utc).strftime("%Y%m%d"),
+        help="UTC release date as YYYYMMDD (defaults to today)",
+    )
+    args = parser.parse_args()
+    try:
+        release_date = datetime.strptime(args.date, "%Y%m%d").date()
+        print(next_nightly_version(
+            release_date,
+            previous_version=args.previous_version,
+            base_version=args.base_version,
+        ))
+    except ValueError as failure:
+        parser.error(str(failure))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build-support/release/test_next_nightly_version.py
+++ b/build-support/release/test_next_nightly_version.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+import unittest
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from next_nightly_version import next_nightly_version  # noqa: E402
+
+
+class NextNightlyVersionTest(unittest.TestCase):
+    def test_increments_the_sequence_on_the_same_utc_date(self):
+        self.assertEqual(
+            "3.0.0-nightly.20260812.9",
+            next_nightly_version(
+                date(2026, 8, 12), "3.0.0-nightly.20260812.8"),
+        )
+
+    def test_resets_the_sequence_on_the_next_utc_date(self):
+        self.assertEqual(
+            "3.0.0-nightly.20260813.1",
+            next_nightly_version(
+                date(2026, 8, 13), "3.0.0-nightly.20260812.8"),
+        )
+
+    def test_starts_from_the_latest_stable_core_without_a_feed(self):
+        self.assertEqual(
+            "3.1.0-nightly.20260813.1",
+            next_nightly_version(date(2026, 8, 13), base_version="3.1.0"),
+        )
+
+    def test_rejects_invalid_or_backdated_inputs(self):
+        invalid = (
+            (date(2026, 8, 11), "3.0.0-nightly.20260812.8", None),
+            (date(2026, 8, 12), "nightly.8", None),
+            (date(2026, 8, 12), None, "3.0"),
+        )
+        for release_date, previous, base in invalid:
+            with self.subTest(previous=previous, base=base):
+                with self.assertRaises(ValueError):
+                    next_nightly_version(release_date, previous, base)
+
+    def test_rejects_more_than_999_builds_per_day(self):
+        with self.assertRaises(ValueError):
+            next_nightly_version(
+                date(2026, 8, 12), "3.0.0-nightly.20260812.999")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/build-support/verification/README.md
+++ b/build-support/verification/README.md
@@ -2,10 +2,12 @@
 
 Pull requests and `main` are built and tested by
 [`ci.yml`](../../.github/workflows/ci.yml) with read-only repository access.
-The separate [`daily-windows-bundle.yml`](../../.github/workflows/daily-windows-bundle.yml)
-builds and publishes the rolling Nightly ZIP. No manual activation is needed;
-the first scheduled Nightly run happens at the next 03:17 UTC after the workflow
-lands on `main`.
+The authenticated
+[`signed-windows-channel-release.yml`](../../.github/workflows/signed-windows-channel-release.yml)
+publishes the native Nightly once per day. The old
+[`daily-windows-bundle.yml`](../../.github/workflows/daily-windows-bundle.yml)
+is manual-only and produces a private Actions artifact solely for an intentional
+legacy 2.x promotion.
 
 ## When it runs
 
@@ -13,10 +15,11 @@ lands on `main`.
 |---|---|
 | CI: `pull_request` | Builds and tests the proposed tree without release permissions |
 | CI: `push` to `main` | Rechecks the integrated tree |
-| Nightly: `schedule` (03:17 UTC daily) | Publishes the rolling Windows ZIP and updates its Discord message |
-| Nightly: `workflow_dispatch` | On-demand Nightly build; publication is limited to `main` |
+| Native channel: `schedule` (daily) | Publishes an authenticated immutable MSI, advances `nightly`, and updates Discord |
+| Native channel: `workflow_dispatch` | Publishes an explicit Stable or additional Nightly from `main` |
+| Legacy bundle: `workflow_dispatch` | Produces a 2.x ZIP candidate as an Actions artifact; never publishes it |
 
-## What the Nightly pipeline does
+## What the legacy ZIP verifier does
 
 1. Checks out the repository **with Git LFS**, then asserts that every LFS asset
    was really materialised. The check fails if `git lfs ls-files` returns nothing
@@ -45,45 +48,29 @@ lands on `main`.
    `Class-Path`, and boots the shaded Telegram watcher for real.
 8. Uploads the bundle (version-tagged, no re-compression) and the Surefire
    reports, and writes a job summary with size, JAR count and test count.
-9. Republishes the rolling **`nightly` prerelease** with the bundle attached, so
-   there is a public download URL that needs no GitHub login.
-10. Posts a **Discord notification** with that download link.
+9. Retains the verified ZIP only as a short-lived Actions artifact. It does not
+   own any public channel or Discord message.
 
 ## Discord notifications
 
-[`discord_notify.py`](discord_notify.py) posts one message per non-PR run to the
-webhook in the `DISCORD_NIGHTLY_WEBHOOK_URL` repository secret.
+[`discord_notify.py`](../notifications/discord_notify.py) updates the single
+maintained Nightly message after the native installer and signed channel feed
+have been published. It uses the webhook in the
+`DISCORD_NIGHTLY_WEBHOOK_URL` repository secret and the message ID in
+`DISCORD_DAILY_MESSAGE_ID`.
 
-### Why a release and not the Actions artifact
+### Permanent channel and immutable download
 
-An artifact download URL only resolves for a signed-in GitHub account with read
-access to the repository, so it is useless as a "downloadable link" in a Discord
-channel. The bundle is also ~220 MB, far above the 8 MiB a webhook may upload.
-The workflow therefore republishes the rolling `nightly` tag on every `main`
-build and links its asset at this permanent URL:
+An Actions artifact URL requires a signed-in GitHub account. The maintained card
+therefore links the current immutable MSI and this permanent channel page:
 
 ```
-https://github.com/Shederator/wosbot/releases/download/nightly/frostguard-windows-desktop-bundle.zip
+https://github.com/Shederator/wosbot/releases/tag/nightly
 ```
 
-Three details keep that link from going stale or 404ing:
-
-- **The asset name carries no version.** A download URL contains the asset
-  filename, so uploading `frostguard-2.1.0-desktop-bundle.zip` would change the
-  link at the next version bump and break every message already in the channel.
-  The versioned ZIP is copied to a fixed name before upload; the version is
-  still reported in the release title, notes and Discord card.
-- **The release is deleted and recreated** (`--cleanup-tag`) rather than edited.
-  `gh release edit --target` does not move an existing tag, so editing in place
-  would leave `nightly` pinned to the first commit it was ever cut from while
-  the notes advertised a newer SHA.
-- **The URL is read back from the API** (`browser_download_url`) and then
-  actually fetched, instead of being predicted from the filename. A predicted
-  URL is precisely how a dead link reaches the channel. If the asset is missing
-  or does not serve a 200/206, the step fails before anything is posted.
-
-The tag is marked *prerelease*, so it never displaces a real tagged release as
-"Latest".
+`nightly` carries only the project-signed manifest and a link to the current
+immutable `vX.Y.Z-nightly.YYYYMMDD.N` release. The MSI remains versioned and is
+never overwritten. GitHub's `releases/latest` remains reserved for Stable.
 
 ### Setting the secret
 
@@ -121,9 +108,12 @@ notification is not worth failing a good artifact over.
 Test the payload without posting anything:
 
 ```sh
-python3 build-support/notifications/test_discord_notify.py     # 21 self-tests, no network
-python3 build-support/notifications/discord_notify.py --status success --version 2.1.0 \
-  --download-url https://example.com/bundle.zip --dry-run
+python3 build-support/notifications/test_discord_notify.py
+python3 build-support/notifications/discord_notify.py --status success \
+  --version 3.0.0-nightly.20260812.9 \
+  --download-url https://example.com/Frostguard-Nightly.msi \
+  --release-url https://example.com/releases/example \
+  --channel-url https://example.com/releases/nightly --dry-run
 ```
 
 ## Why two verification layers
@@ -167,12 +157,11 @@ substitution really took effect in both directions.
 
 ## Stable Windows releases
 
-[`stable-windows-release.yml`](../.github/workflows/stable-windows-release.yml)
-promotes a successful Nightly Windows Bundle run from `main` instead of rebuilding
-a potentially different tree. A maintainer supplies the `X.Y.Z` version and
-daily run ID. The workflow validates the source run and Maven version, pins its
-commit, downloads and re-verifies its bundle, creates an immutable `vX.Y.Z`
-release and checks the public URL before announcing it.
+[`stable-windows-release.yml`](../../.github/workflows/stable-windows-release.yml)
+is retained only for 2.x ZIP maintenance. It promotes a successful manual
+Legacy Windows Bundle Candidate run from `main` instead of rebuilding a
+potentially different tree. Frostguard 3 Stable releases use the authenticated
+Windows Channel Release workflow.
 
 [`stable_release_notify.py`](stable_release_notify.py) updates one maintained
 Stable message without mentioning users. Its payload contains fixed release

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -19,10 +19,12 @@ def properties(element: ET.Element) -> dict[str, str]:
 
 
 class ChannelPackagingTest(unittest.TestCase):
-    def test_pr_ci_and_nightly_publication_are_separate_workflows(self):
+    def test_pr_ci_native_nightly_and_legacy_bundle_are_separate_workflows(self):
         ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-        nightly = (REPO_ROOT / ".github/workflows/daily-windows-bundle.yml").read_text(
+        legacy = (REPO_ROOT / ".github/workflows/daily-windows-bundle.yml").read_text(
             encoding="utf-8")
+        nightly = (REPO_ROOT / ".github/workflows/"
+                   "signed-windows-channel-release.yml").read_text(encoding="utf-8")
         installers = (REPO_ROOT / ".github/workflows/windows-native-package.yml").read_text(
             encoding="utf-8")
 
@@ -32,12 +34,19 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("Build and test Maven reactor", ci)
         self.assertNotIn("contents: write", ci)
 
-        self.assertIn("name: Nightly Windows Bundle", nightly)
+        self.assertIn("name: Legacy Windows Bundle Candidate", legacy)
+        self.assertIn("  workflow_dispatch:", legacy)
+        self.assertNotIn("  schedule:", legacy)
+        self.assertNotIn("contents: write", legacy)
+        self.assertNotIn("gh release create nightly", legacy)
+        self.assertNotIn("Update the Nightly Discord message", legacy)
+
+        self.assertIn("name: Windows Channel Release", nightly)
         self.assertIn("  schedule:", nightly)
         self.assertIn("  workflow_dispatch:", nightly)
         self.assertNotIn("  pull_request:", nightly)
         self.assertNotIn("\n  push:\n", nightly)
-        self.assertIn("  contents: write", nightly)
+        self.assertIn("      contents: write", nightly)
 
         self.assertIn("name: Windows Installers", installers)
         self.assertIn("Build and smoke-test Stable and Nightly installers", installers)
@@ -166,7 +175,13 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertNotIn("releases/tags/$($env:TAG)", workflow)
         self.assertGreaterEqual(
             workflow.count("Where-Object { $_.tag_name -ceq $env:TAG }"), 2)
-        self.assertIn("gh release upload updates-nightly $env:MANIFEST", workflow)
+        self.assertIn("gh release upload nightly $env:MANIFEST", workflow)
+        self.assertIn("releases/download/nightly/frostguard-nightly-manifest.json", workflow)
+        self.assertIn("@('nightly', 'updates-nightly')", workflow)
+        self.assertIn("if ($releaseTags -contains 'updates-nightly')", workflow)
+        self.assertIn('          $tag = "v$($env:VERSION)"', workflow)
+        self.assertIn("next_nightly_version.py", workflow)
+        self.assertIn("Update the maintained Nightly Discord message", workflow)
         self.assertIn("Remove an abandoned draft release", workflow)
         self.assertIn('java-version: "21.0.12+8.0"', workflow)
         for launcher_hash in (

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ required emulator, and building the project from source on Windows.
 | Build | Use it when | Download |
 |:------|:------------|:---------|
 | Stable | You want a tested, versioned build that changes only with a release | [Latest Stable release](https://github.com/Shederator/wosbot/releases/latest) |
-| Nightly | You want the latest authenticated preview without replacing Stable | [Nightly releases](https://github.com/Shederator/wosbot/releases) |
+| Nightly | You want the latest authenticated preview without replacing Stable | [Latest Nightly](https://github.com/Shederator/wosbot/releases/tag/nightly) |
 | PR build | You want to test one or more open pull requests | Run `/build-pr` in Discord `#request-a-build` |
 
 Stable and Nightly use self-contained Windows installers and do not require a

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,23 +1,29 @@
 # Releases
 
 Frostguard publishes project-authenticated installed releases for Stable and
-Nightly plus temporary ZIP builds for pull-request testing. A legacy rolling
-Nightly ZIP remains available while its maintained download channel is retired;
-it is not an automatic-update source.
+Nightly plus temporary ZIP builds for pull-request testing. Public channel links
+are permanent even though the versioned installers behind them change.
 
-| Type | Audience | Lifetime | Discord notification |
+| Type | Permanent entry | Versioned tag | Lifetime |
 |---|---|---|---|
-| Stable `vX.Y.Z` | Regular users | Permanent | Update the maintained Stable message |
-| Nightly `nightly-X.Y.Z-nightly.*` | Testers | Permanent prerelease | Release history; in-app Nightly feed |
-| Legacy daily `nightly` ZIP | Testers | Replaced daily | Maintained legacy download, no mass mention |
-| PR test `pr-test-*` | Requester/testers | Temporary | Reply only to the requester |
+| Stable | [`releases/latest`](https://github.com/Shederator/wosbot/releases/latest) | `vX.Y.Z` | Permanent |
+| Nightly | [`releases/tag/nightly`](https://github.com/Shederator/wosbot/releases/tag/nightly) | `vX.Y.Z-nightly.YYYYMMDD.N` | Current immutable prerelease plus rolling channel |
+| PR test | Discord `/build-pr` | `pr-test-*` | Temporary |
+
+Do not add a separate `stable` rolling release. GitHub's built-in `latest`
+redirect already resolves the newest non-prerelease Stable without duplicating
+it in the release list. The mutable `nightly` release is different: GitHub has
+no built-in latest-prerelease URL, so it provides both the permanent landing
+page and the stable signed-manifest URL required by installed Nightly clients.
 
 ## Authenticated installed releases
 
-Run **Windows Channel Release** manually from `main`. It requires a
-semantic version, the target `stable` or `nightly` identity, and the minimum
-supported updater version. Stable versions use `X.Y.Z`; Nightly versions use an
-immutable prerelease such as `3.1.0-nightly.20260811.1`.
+**Windows Channel Release** runs Nightly automatically once per day
+from `main`. It reads the previous signed feed and derives the next version,
+resetting the sequence to 1 on a new UTC date. A maintainer can also run it
+manually for Stable or an additional Nightly. Stable versions use `X.Y.Z`;
+Nightly versions use an immutable prerelease such as
+`3.1.0-nightly.20260811.1`.
 
 Windows Installer compares only three numeric version fields. Stable maps
 directly to `X.Y.Z`. Nightly derives an independent, monotonically increasing
@@ -42,16 +48,24 @@ Stable and Nightly use different application IDs, upgrade UUIDs, install
 directories, shortcuts, workspaces, and feeds. The workflow builds and smokes
 the selected identity, optionally Authenticode-signs the installer, uploads and
 re-downloads the immutable installer, derives its final size and SHA-256,
-project-signs the manifest, verifies it, and publishes it last. Stable exposes its manifest through
-the latest immutable release; Nightly points `updates-nightly` at an installer
-stored in an immutable `nightly-<version>` release.
+project-signs the manifest, verifies it, and publishes it last. Stable exposes
+its manifest through the latest immutable release. Nightly stores the installer
+in an immutable `v<version>` release and updates the manifest asset on the
+rolling `nightly` release only after that installer is public and verified.
 
 A failure before publication removes the abandoned draft release and tag so the
 same immutable version can be retried. If a Nightly release becomes public but
-promotion of the rolling `updates-nightly` manifest fails afterward, leave the
+promotion of the rolling `nightly` manifest fails afterward, leave the
 immutable release intact and keep the previous rolling manifest active. Recover
 by verifying and promoting the manifest asset from that immutable release; do
 not rebuild or replace its installer.
+
+Nightly builds through `3.0.0-nightly.20260812.8` embed the former
+`updates-nightly` endpoint. During migration the publisher mirrors each new
+manifest there before updating `nightly`, allowing those installations to cross
+the bridge once. New builds embed only `nightly`. Remove the compatibility
+release after the supported old-client window closes; never recreate it after
+that removal.
 
 ### Unpublished Stable release candidates
 
@@ -69,14 +83,16 @@ lower than the final release, so the final `3.0.0` installer can still upgrade
 it. The application displays the prerelease version from its JAR independently
 of the numeric MSI version.
 
-## Transitional ZIP promotion
+## Legacy 2.x ZIP promotion
 
-The legacy Stable ZIP workflow promotes an already successful `Nightly Windows Bundle` run from
-`main`; they do not rebuild a different tree. Run **Stable Windows Release**
-manually with:
+The manual-only **Legacy Windows Bundle Candidate** workflow can still produce
+an Actions artifact for an intentional 2.x maintenance release. It no longer
+publishes a Nightly, has no schedule, and does not update Discord. The legacy
+Stable ZIP workflow promotes one of those successful runs from `main`; it does
+not rebuild a different tree. Run **Stable Windows Release** manually with:
 
 - `version`: the `X.Y.Z` value declared in `pom.xml`;
-- `daily_run_id`: a successful scheduled or manually triggered daily run from
+- `daily_run_id`: a successful manually triggered legacy candidate run from
   `main` after the intended release commit.
 
 This workflow rejects Frostguard 3.x. Installed 3.x releases must use the
@@ -105,8 +121,8 @@ A tested, self-contained Windows build that changes only with a Stable release:
 https://github.com/Shederator/wosbot/releases/latest
 
 Nightly — authenticated previews
-Immutable Windows installer previews with their own app and settings:
-https://github.com/Shederator/wosbot/releases
+The current immutable preview with its own app and settings:
+https://github.com/Shederator/wosbot/releases/tag/nightly
 
 Download the Windows x64 MSI from the selected release. The installer includes
 Java. A Windows Unknown publisher or SmartScreen warning is currently expected.
@@ -118,7 +134,7 @@ filename contains its version. Store the webhook-owned card ID in
 promotion; it resolves and verifies the exact versioned MSI from Latest before
 updating the maintained card.
 
-### Legacy Nightly ZIP message
+### Maintained Nightly message
 
 ```text
 Latest Nightly — Frostguard <version>
@@ -128,20 +144,17 @@ changes.
 
 Download Frostguard <version> for Windows
 
-Changes since the previous Nightly
-- <linked PR title or direct commit subject>
+Run the self-contained per-user MSI installer. A separate Java installation is
+not required.
 
-Extract the complete archive and use the included Frostguard launcher.
-Java 21 or newer is required.
+Release notes · Latest Nightly
 ```
 
-This legacy ZIP URL is deliberately version-independent. Do not post a new
-Discord message for every daily build. Store the webhook-owned message ID in the repository
-variable `DISCORD_DAILY_MESSAGE_ID`; successful builds edit that message. Show
-at most five linked first-parent changes since the previous Nightly and collapse
-older entries into a count.
-Build failures remain visible in Actions and do not replace the last working
-public download.
+Do not post a new Discord message for every daily build. Store the webhook-owned
+message ID in the repository variable `DISCORD_DAILY_MESSAGE_ID`; successful
+native Nightly publications edit that message with the immutable MSI URL and
+permanent channel URL. Build failures link to Actions and do not replace the
+last working public download.
 
 ## Migration
 
@@ -149,7 +162,8 @@ public download.
 2. Publish the first real Stable release before presenting the Stable download.
 3. Store both maintained webhook message IDs as repository variables.
 4. Move `/build-pr` results to `#request-a-build`.
-5. Archive redundant legacy release channels after their links are replaced.
+5. Keep `updates-nightly` only for the old-client migration window, then remove
+   that compatibility release permanently.
 
 ## Native installer update contract
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -3,10 +3,11 @@
 This document summarizes Windows-specific setup for Frostguard.
 
 The [latest Stable release](https://github.com/Shederator/wosbot/releases/latest)
-provides the tested Windows installer. Authenticated Nightly releases appear in
-the [release history](https://github.com/Shederator/wosbot/releases) as a
-separate product identity. Git, Git LFS, Maven, and a JDK are needed only when
-building from source.
+provides the tested Windows installer. The permanent
+[Latest Nightly](https://github.com/Shederator/wosbot/releases/tag/nightly)
+entry points to the current authenticated preview with a separate product
+identity. Git, Git LFS, Maven, and a JDK are needed only when building from
+source.
 
 ## Build Requirements
 

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/update/ChannelSwitchService.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/update/ChannelSwitchService.java
@@ -92,7 +92,7 @@ final class ChannelSwitchService {
         String configured = properties.apply(PAGE_PROPERTY + target.directoryName());
         if (configured == null || configured.isBlank()) {
             configured = target == RuntimeChannel.NIGHTLY
-                    ? "https://github.com/Shederator/wosbot/releases"
+                    ? "https://github.com/Shederator/wosbot/releases/tag/nightly"
                     : "https://github.com/Shederator/wosbot/releases/latest";
         }
         URI uri;

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/update/ChannelSwitchServiceTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/update/ChannelSwitchServiceTest.java
@@ -58,4 +58,18 @@ class ChannelSwitchServiceTest {
 
         assertThrows(IOException.class, () -> service.open(RuntimeChannel.NIGHTLY));
     }
+
+    @Test
+    void opensThePermanentNightlyPageByDefault() throws Exception {
+        AtomicReference<URI> opened = new AtomicReference<>();
+        ChannelSwitchService service = new ChannelSwitchService(property -> null, () -> null,
+                executable -> {
+                    throw new AssertionError("launcher must not run");
+                }, opened::set);
+
+        assertEquals(ChannelSwitchService.Result.OPENED_RELEASE_PAGE,
+                service.open(RuntimeChannel.NIGHTLY));
+        assertEquals(URI.create("https://github.com/Shederator/wosbot/releases/tag/nightly"),
+                opened.get());
+    }
 }

--- a/packaging/desktop/pom.xml
+++ b/packaging/desktop/pom.xml
@@ -29,7 +29,7 @@
         <frostguard.watcher.name>FrostguardWatcher</frostguard.watcher.name>
         <frostguard.product.upgrade-uuid>fa0d66f6-1f7d-4da8-9701-88f7b4570797</frostguard.product.upgrade-uuid>
         <frostguard.channel.page.stable>https://github.com/Shederator/wosbot/releases/latest</frostguard.channel.page.stable>
-        <frostguard.channel.page.nightly>https://github.com/Shederator/wosbot/releases</frostguard.channel.page.nightly>
+        <frostguard.channel.page.nightly>https://github.com/Shederator/wosbot/releases/tag/nightly</frostguard.channel.page.nightly>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

- make GitHub `releases/latest` the sole permanent Stable alias and `releases/tag/nightly` the permanent native Nightly entry
- schedule authenticated native Nightlies with automatic `vX.Y.Z-nightly.YYYYMMDD.N` versions and retain `updates-nightly` only as an old-client bridge
- stop the legacy Java ZIP workflow from scheduling, publishing releases, or updating Discord
- align the installed channel switch, maintained Discord card, documentation, and release-contract tests

## Why

The release list mixed an old rolling ZIP, an internal feed, and several immutable Nightlies without a clear public contract. GitHub already provides a durable Stable alias, while prereleases need an explicit rolling pointer. This establishes those two permanent entry points without making installers mutable or stranding installed `.8` Nightly clients.

Closes #180.

## Validation

- `.\mvnw.cmd package` — passed, 371 JUnit tests with no failures, errors, or skips
- all 12 `build-support/**/test_*.py` files — passed
- `python build-support/verification/check_workflow_python.py` — all inline workflow snippets compile
- every PowerShell block in the channel workflow parsed with the PowerShell AST parser
- `git diff --check` — passed

## Risks

The GitHub schedule and real release mutation require post-merge verification in Actions. The old `updates-nightly` release intentionally remains visible during the compatibility window; it can be deleted after supported `.8` installations have crossed to a build that embeds the new `nightly` feed.