### PR TITLE
fix(release): keep nightly metadata current

### DIFF
--- a/.github/workflows/refresh-nightly-discord.yml
+++ b/.github/workflows/refresh-nightly-discord.yml
@@ -1,0 +1,93 @@
+name: Refresh Nightly Discord Message
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    name: Update the maintained Nightly download
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21.0.12+8.0"
+          cache: maven
+
+      - name: Test the Nightly notifier
+        run: python3 build-support/notifications/test_discord_notify.py
+
+      - name: Compile the project manifest verifier
+        run: >-
+          ./mvnw -B --no-transfer-progress -Dstyle.color=never
+          -pl modules/update -am -DskipTests package dependency:copy-dependencies
+
+      - name: Resolve, verify, and publish the current Nightly
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          DISCORD_DAILY_MESSAGE_ID: ${{ vars.DISCORD_DAILY_MESSAGE_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel_tag="nightly"
+          manifest_name="frostguard-nightly-manifest.json"
+          channel_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${channel_tag}"
+          channel_release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${channel_tag}")"
+          manifest_id="$(jq -r --arg name "${manifest_name}" \
+            '[.assets[] | select(.name == $name)] | if length == 1 then .[0].id else empty end' \
+            <<< "${channel_release}")"
+          if [[ -z "${manifest_id}" ]]; then
+            echo "::error::Permanent Nightly channel does not contain exactly one ${manifest_name}."
+            exit 1
+          fi
+
+          manifest="$(mktemp)"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/assets/${manifest_id}" \
+            -H "Accept: application/octet-stream" > "${manifest}"
+          java -cp 'modules/update/target/classes:modules/api/target/classes:modules/update/target/dependency/*' \
+            dev.frostguard.update.ProjectManifestSigner verify "${manifest}"
+
+          payload="$(jq -r '.payload' "${manifest}" | base64 --decode)"
+          if [[ "$(jq -r '.channel' <<< "${payload}")" != "nightly" ]]; then
+            echo "::error::The permanent Nightly manifest carries the wrong channel."
+            exit 1
+          fi
+          version="$(jq -r '.version' <<< "${payload}")"
+          release_url="$(jq -r '.releaseNotesUrl' <<< "${payload}")"
+          installer_name="$(jq -r '.artifacts["windows-x64"].fileName' <<< "${payload}")"
+          installer_url="$(jq -r '.artifacts["windows-x64"].url' <<< "${payload}")"
+          immutable_tag="${release_url##*/}"
+          immutable_release="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${immutable_tag}")"
+          published_url="$(jq -r --arg name "${installer_name}" \
+            '[.assets[] | select(.name == $name)] | if length == 1 then .[0].browser_download_url else empty end' \
+            <<< "${immutable_release}")"
+          if [[ -z "${published_url}" || "${published_url}" != "${installer_url}" ]]; then
+            echo "::error::Signed Nightly manifest does not match exactly one public installer asset."
+            exit 1
+          fi
+          code="$(curl -sSL -o /dev/null -w '%{http_code}' --max-time 120 \
+            --fail --retry 12 --retry-delay 5 --retry-all-errors \
+            -r 0-1023 "${installer_url}" || true)"
+          if [[ "${code}" != "200" && "${code}" != "206" ]]; then
+            echo "::error::Nightly installer URL returned HTTP ${code}."
+            exit 1
+          fi
+
+          python3 build-support/notifications/discord_notify.py \
+            --status success \
+            --version "${version}" \
+            --download-url "${installer_url}" \
+            --release-url "${release_url}" \
+            --channel-url "${channel_url}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --message-id "${DISCORD_DAILY_MESSAGE_ID}"

--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -525,7 +525,7 @@ jobs:
               }
               gh release edit nightly --repo $env:GITHUB_REPOSITORY `
                   --title "Frostguard Nightly - Latest" --notes $channelNotes `
-                  --prerelease
+                  --target $env:GITHUB_SHA --prerelease
               if ($LASTEXITCODE -ne 0) {
                   throw "Permanent Nightly channel metadata could not be updated"
               }
@@ -561,7 +561,6 @@ jobs:
               '--release-url', $env:RELEASE_URL,
               '--channel-url', $env:CHANNEL_URL,
               '--run-url', "$($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)",
-              '--run-number', $env:GITHUB_RUN_NUMBER,
               '--repository', $env:GITHUB_REPOSITORY,
               '--message-id', $env:DISCORD_DAILY_MESSAGE_ID
           )

--- a/build-support/notifications/discord_notify.py
+++ b/build-support/notifications/discord_notify.py
@@ -187,8 +187,7 @@ def build_payload(args: argparse.Namespace) -> dict:
     }
     if args.status == "success" and args.download_url:
         embed["url"] = args.download_url
-        build_identity = f"Nightly #{args.run_number}" if args.run_number else "Nightly"
-        embed["footer"] = {"text": f"{build_identity} • updated automatically"}
+        embed["footer"] = {"text": "Nightly channel • updated automatically"}
     elif args.run_url:
         embed["url"] = args.run_url
 
@@ -314,7 +313,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--release-url", default="")
     parser.add_argument("--channel-url", default="")
     parser.add_argument("--run-url", default="")
-    parser.add_argument("--run-number", default="")
     parser.add_argument("--repository", default="")
     parser.add_argument("--branch", default="")
     parser.add_argument(

--- a/build-support/notifications/test_discord_notify.py
+++ b/build-support/notifications/test_discord_notify.py
@@ -41,7 +41,6 @@ BASE_ARGS = [
     "--channel-url",
     "https://github.com/Shederator/wosbot/releases/tag/nightly",
     "--run-url", "https://github.com/Shederator/wosbot/actions/runs/1",
-    "--run-number", "42",
     "--repository", "Shederator/wosbot",
     "--branch", "main",
     "--commit", "b962083c0ffee1234567890abcdefabcdefabcde",
@@ -70,7 +69,8 @@ class PayloadTest(unittest.TestCase):
         self.assertEqual(0xF1C40F, embed["color"])
         self.assertIn("3.0.0-nightly.20260812.9", embed["title"])
         self.assertIn("Frostguard Nightly", embed["title"])
-        self.assertEqual("Nightly #42 • updated automatically", embed["footer"]["text"])
+        self.assertEqual("Nightly channel • updated automatically",
+                         embed["footer"]["text"])
 
     def test_failure_payload_is_red_and_links_the_log_not_a_download(self):
         result = payload(["--status", "failure"])

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -218,6 +218,23 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("Stable installer URL returned HTTP", workflow)
         self.assertNotIn("frostguard-windows-desktop-bundle.zip", workflow)
 
+    def test_nightly_discord_refresh_uses_the_verified_permanent_feed(self):
+        workflow = (REPO_ROOT / ".github/workflows/refresh-nightly-discord.yml").read_text(
+            encoding="utf-8")
+
+        self.assertIn("name: Refresh Nightly Discord Message", workflow)
+        self.assertIn("  workflow_dispatch:", workflow)
+        self.assertIn("  contents: read", workflow)
+        self.assertNotIn("contents: write", workflow)
+        self.assertIn('channel_tag="nightly"', workflow)
+        self.assertIn("ProjectManifestSigner verify", workflow)
+        self.assertIn('if [[ "$(jq -r \'.channel\' <<< "${payload}")" != "nightly" ]]',
+                      workflow)
+        self.assertIn("does not match exactly one public installer asset", workflow)
+        self.assertIn("Nightly installer URL returned HTTP", workflow)
+        self.assertIn("build-support/notifications/discord_notify.py", workflow)
+        self.assertNotIn("gh release create", workflow)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -154,7 +154,8 @@ Do not post a new Discord message for every daily build. Store the webhook-owned
 message ID in the repository variable `DISCORD_DAILY_MESSAGE_ID`; successful
 native Nightly publications edit that message with the immutable MSI URL and
 permanent channel URL. Build failures link to Actions and do not replace the
-last working public download.
+last working public download. Run **Refresh Nightly Discord Message** to repair
+the card from the current project-signed feed without building another MSI.
 
 ## Migration
 


### PR DESCRIPTION
## What changed
- keep the rolling Nightly release target metadata aligned with the promoted commit
- replace the confusing workflow run number in the maintained Discord card with a durable Nightly channel label
- add a read-only manual Discord refresh that verifies the project-signed permanent feed and exact immutable MSI asset before updating the card

## Why
The first real permanent-channel publication exposed stale GitHub release metadata and a misleading Discord footer. The refresh workflow lets us repair the maintained card without rebuilding or republishing the 273 MiB installer.

## Validation
- all build-support Python test suites
- inline workflow Python compilation check
- focused manifest-verifier Maven package and dependency staging
- current public Nightly .9 manifest verified locally with ProjectManifestSigner
- git diff --check

Closes #180