### PR TITLE
fix(release): use portable Java selector

### DIFF
--- a/.github/workflows/refresh-nightly-discord.yml
+++ b/.github/workflows/refresh-nightly-discord.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21.0.12+8.0"
+          java-version: "21"
           cache: maven
 
       - name: Test the Nightly notifier

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -226,6 +226,7 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("  workflow_dispatch:", workflow)
         self.assertIn("  contents: read", workflow)
         self.assertNotIn("contents: write", workflow)
+        self.assertIn('java-version: "21"', workflow)
         self.assertIn('channel_tag="nightly"', workflow)
         self.assertIn("ProjectManifestSigner verify", workflow)
         self.assertIn('if [[ "$(jq -r \'.channel\' <<< "${payload}")" != "nightly" ]]',


### PR DESCRIPTION
## What changed
- select the Java 21 feature release in the Nightly Discord refresh workflow
- cover the portable selector in the workflow contract test

## Why
The first live refresh run showed that setup-java on Ubuntu exposes the current Temurin build as an LTS-qualified version and does not resolve the Windows-compatible exact selector.

## Validation
- channel packaging contract tests
- git diff --check
- live failure reproduced in Actions run 31618583555

Closes #180