### PR TITLE
docs(guidance): make project tracking proactive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,17 +85,50 @@ Vision, OCR, and pattern changes should normally have saved-frame coverage and
 live-log confirmation before merge readiness. Missing evidence must remain
 explicit in the handoff or pull request.
 
-## Git And Pull Requests
+## Project Workboard
 
-Use the GitHub Project workboard as the source of truth for planned work and
-work status. Before starting implementation, check for an existing work item
-and keep its status aligned with actual progress. Link related issues and pull
-requests instead of duplicating their details in the board.
+Use the public GitHub Project as the source of truth for planned work,
+ownership, priority, and status, and keep it current throughout the work.
+
+Substantial work needs an existing or new issue and project item. This includes
+work spanning files, modules, sessions, or contributors; user-visible or
+architectural changes; persistence, scheduling, automation-safety, CI,
+packaging, or release work; and anything needing explicit scope, dependencies,
+prioritization, or live validation. Search first and do not duplicate items.
+Typos, tiny mechanical or localized low-risk fixes, and corrections already
+tracked by a PR or parent issue do not need standalone issues.
+
+Issues must capture the outcome, scope, acceptance criteria, evidence,
+dependencies, and important risks. Use existing category labels and the
+board's documented priority and status workflow (`Backlog`, `Ready`, `In
+progress`, `In review`, `Blocked`, `Done`); set relative `Size` (`XS`-`XL`) from
+breadth, risk, and validation effort, and assign only the actual owner. Update
+ownership, metadata, links, status, evidence, and blockers at each real
+transition. Use `Blocked` only for a stated blocker and `Done` only for a
+completed outcome. Keep durable detail in the issue or PR discussion. If
+permissions prevent an update, report exactly what remains stale.
+
+## Git And Pull Requests
 
 Start feature and fix branches from `main` unless a stacked dependency is
 intentional and documented. Keep commits reviewable and do not commit
 credentials, profile databases, emulator-specific paths, private logs, runtime
 artifacts, or generated output.
+
+Prefer a short native GitHub PR stack when substantial work has ordered,
+dependent units that are independently reviewable and testable; do not stack
+unrelated work or split mechanically. Use the official `gh stack` extension:
+initialize and submit new stacks through it, or register existing PRs bottom to
+top with `gh stack link`. Chained base branches alone are not a native stack.
+Before reporting completion, verify that every PR has the same non-null stack
+ID and the expected position and size; a "can be stacked" banner means this is
+not yet complete.
+
+Each PR must name its stack position and size, parent/child links, shared issue,
+dependency, and merge order. Use one issue unless units need separate planning
+or ownership, and never base stacks on local integration or deployment
+branches. Merge bottom-up; after a parent merges, sync the stack, rerun affected
+checks, and verify that the next PR's diff contains only its review unit.
 
 Shape commits around coherent changes, not an arbitrary commit count. Keep
 independently reviewable changes separate; fold fixups, naming cleanup, and


### PR DESCRIPTION
## Summary

- define when substantial work needs a GitHub issue and Project item
- require category, priority, size, ownership, links, and status to stay aligned with actual work
- keep tiny fixes and already-tracked review corrections exempt from standalone issues
- prefer short native GitHub PR stacks for dependent review units and require registration through the official `gh stack` extension
- require stack metadata verification so chained base branches are never mistaken for a native stack
- document safe bottom-up handling and post-merge stack synchronization

## Why

The previous guidance named the Project as the source of truth but did not tell agents when to create work items, which metadata to maintain, or when to move items through the workflow. It also mentioned stacked dependencies without defining when or how to create and verify a native GitHub stack.

The updated contract makes project tracking an active part of substantial work while avoiding issue noise for small fixes. It also prevents agents from reporting a branch chain as a completed stack before GitHub has registered native stack metadata.

## Validation

- `git diff --check origin/main...HEAD` — passed
- confirmed the branch is exactly one commit ahead of current `origin/main`
- verified the installed official `github/gh-stack` extension exposes `gh stack submit`, `link`, `sync`, and stack navigation commands
- verified native stack #193: PRs #190–#192 share stack ID `PRS_kwDORbGKtM4ABPPx`, positions 1–3, and size 3
- documentation-only change; no application tests were run

## Risks

- Contributors need the official `github/gh-stack` extension to create or link native stacks from the CLI.
- Process guidance only; no runtime behavior changes.