### PR TITLE
refactor(settings): unify profile and time validation

### DIFF
--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsExtraLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsExtraLayoutController.java
@@ -3,6 +3,7 @@ package dev.frostguard.app.panel.city;
 import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import dev.frostguard.app.panel.profile.ProfileAux;
 import dev.frostguard.app.shared.AbstractProfileController;
+import dev.frostguard.app.shared.SettingValidators;
 import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -13,11 +14,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.ResolverStyle;
 import java.util.List;
-import java.util.Locale;
 
 public class CityEventsExtraLayoutController extends AbstractProfileController {
 
@@ -75,7 +72,6 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
     @FXML
     private void initialize() {
         cityRoutineToggles().forEach(toggle -> checkBoxMappings.put(toggle.control(), toggle.configKey()));
-        arenaTextFields().forEach(field -> textFieldMappings.put(field.control(), field.configKey()));
         comboBoxArenaExtraAttempts.getItems().setAll(EXTRA_ATTEMPT_OPTIONS);
         comboBoxArenaAlliancePolicy.getItems().setAll(ALLIANCE_POLICY_OPTIONS);
         comboBoxArenaServerPolicy.getItems().setAll(SERVER_POLICY_OPTIONS);
@@ -100,12 +96,6 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
             new ToggleBinding(checkBoxArena, ConfigurationKeyEnum.ARENA_TASK_BOOL),
             new ToggleBinding(checkBoxArenaAttackQuickDeploy, ConfigurationKeyEnum.ARENA_TASK_ATTACK_QUICK_DEPLOY_BOOL),
             new ToggleBinding(checkBoxArenaRefreshWithGems, ConfigurationKeyEnum.ARENA_TASK_REFRESH_WITH_GEMS_BOOL)
-        );
-    }
-
-    private List<TextBinding> arenaTextFields() {
-        return List.of(
-            new TextBinding(textFieldArenaActivationHour, ConfigurationKeyEnum.ARENA_TASK_ACTIVATION_TIME_STRING)
         );
     }
 
@@ -154,9 +144,6 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
     private record ToggleBinding(CheckBox control, ConfigurationKeyEnum configKey) {
     }
 
-    private record TextBinding(TextField control, ConfigurationKeyEnum configKey) {
-    }
-
     private final class ArenaSection {
         private void install() {
             List.of(checkBoxArenaAttackQuickDeploy, checkBoxArenaRefreshWithGems,
@@ -178,65 +165,14 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
     }
 
     private final class ArenaTimeField {
-        private final DateTimeFormatter parser = new DateTimeFormatterBuilder()
-            .parseStrict()
-            .appendPattern("HH:mm")
-            .toFormatter(Locale.ROOT)
-            .withResolverStyle(ResolverStyle.STRICT);
-
         private void install() {
             textFieldArenaActivationHour.setPromptText("HH:mm");
             textFieldArenaActivationHour.setTooltip(new Tooltip("Arena runs before 23:56 UTC; example: 19:30"));
-            textFieldArenaActivationHour.setTextFormatter(getTimeTextFormatter());
-            textFieldArenaActivationHour.textProperty().addListener((obs, oldText, newText) -> validate(newText));
-            textFieldArenaActivationHour.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
-                if (!isFocused) {
-                    normalize();
-                }
-            });
-            textFieldArenaActivationHour.setOnAction(event -> normalize());
-        }
-
-        private void normalize() {
-            String digits = textFieldArenaActivationHour.getText() == null
-                ? ""
-                : textFieldArenaActivationHour.getText().replaceAll("\\D", "");
-
-            switch (digits.length()) {
-                case 2 -> textFieldArenaActivationHour.setText(digits + ":00");
-                case 4 -> textFieldArenaActivationHour.setText(digits.substring(0, 2) + ":" + digits.substring(2));
-                default -> {
-                }
-            }
-        }
-
-        private void validate(String timeText) {
-            clearWarning();
-            if (timeText == null || timeText.isBlank()) {
-                return;
-            }
-            if (!timeText.matches("\\d{2}:\\d{2}")) {
-                showWarning("Use HH:mm, for example 19:30.");
-                return;
-            }
-            try {
-                LocalTime time = LocalTime.parse(timeText, parser);
-                if (time.isAfter(LocalTime.of(23, 55))) {
-                    showWarning("Arena time must be 23:55 UTC or earlier.");
-                }
-            } catch (java.time.DateTimeException ex) {
-                showWarning("Hour must be 00-23 and minute must be 00-59.");
-            }
-        }
-
-        private void clearWarning() {
-            labelDateTimeError.setText("");
-            textFieldArenaActivationHour.setStyle("");
-        }
-
-        private void showWarning(String message) {
-            labelDateTimeError.setText(message);
-            textFieldArenaActivationHour.setStyle("-fx-border-color: #ef4444; -fx-border-width: 2px;");
+            registerTimeTextField(
+                textFieldArenaActivationHour,
+                labelDateTimeError,
+                ConfigurationKeyEnum.ARENA_TASK_ACTIVATION_TIME_STRING,
+                SettingValidators.localTimeNoLaterThan("Arena activation time", LocalTime.of(23, 55)));
         }
     }
 }

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/dailies/EventsLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/dailies/EventsLayoutController.java
@@ -2,6 +2,7 @@ package dev.frostguard.app.panel.dailies;
 
 import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import dev.frostguard.app.shared.AbstractProfileController;
+import dev.frostguard.app.shared.SettingValidators;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
@@ -9,19 +10,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.ResolverStyle;
-import java.util.Locale;
-
 public class EventsLayoutController extends AbstractProfileController {
-
-    private static final DateTimeFormatter TIME_FORMATTER = new DateTimeFormatterBuilder()
-        .parseStrict()
-        .appendPattern("HH:mm")
-        .toFormatter(Locale.ROOT)
-        .withResolverStyle(ResolverStyle.STRICT);
 
     @FXML
     private CheckBox checkBoxTundraEvent, checkBoxTundraUseGems, checkBoxTundraSSR, checkBoxHeroMission,
@@ -62,7 +51,6 @@ public class EventsLayoutController extends AbstractProfileController {
 
         comboBoxMappings.put(comboBoxMercenaryFlag, ConfigurationKeyEnum.MERCENARY_FLAG_INT);
         comboBoxMappings.put(comboBoxHeroMissionFlag, ConfigurationKeyEnum.HERO_MISSION_FLAG_INT);
-        textFieldMappings.put(textfieldTundraActivationHour, ConfigurationKeyEnum.TUNDRA_TRUCK_ACTIVATION_TIME_STRING);
     }
 
     private void wireEnablementRules() {
@@ -79,53 +67,10 @@ public class EventsLayoutController extends AbstractProfileController {
     private void prepareActivationTimeField() {
         textfieldTundraActivationHour.setPromptText("HH:mm");
         textfieldTundraActivationHour.setTooltip(new Tooltip("Example: 15:30"));
-        textfieldTundraActivationHour.setTextFormatter(getTimeTextFormatter());
-        textfieldTundraActivationHour.textProperty().addListener((obs, oldText, newText) -> validateTime(newText));
-        textfieldTundraActivationHour.focusedProperty().addListener((obs, wasFocused, isFocused) -> {
-            if (!isFocused) {
-                normalizeTimeField();
-            }
-        });
-        textfieldTundraActivationHour.setOnAction(event -> normalizeTimeField());
-    }
-
-    private void normalizeTimeField() {
-        String digits = textfieldTundraActivationHour.getText() == null
-            ? ""
-            : textfieldTundraActivationHour.getText().replaceAll("\\D", "");
-
-        if (digits.length() == 2) {
-            textfieldTundraActivationHour.setText(digits + ":00");
-        } else if (digits.length() == 4) {
-            textfieldTundraActivationHour.setText(digits.substring(0, 2) + ":" + digits.substring(2, 4));
-        }
-    }
-
-    private void validateTime(String timeText) {
-        clearTimeError();
-        if (timeText == null || timeText.isBlank()) {
-            return;
-        }
-
-        if (!timeText.matches("\\d{2}:\\d{2}")) {
-            showTimeError("Use HH:mm, for example 19:30.");
-            return;
-        }
-
-        try {
-            LocalTime.parse(timeText, TIME_FORMATTER);
-        } catch (java.time.DateTimeException ex) {
-            showTimeError("Hour must be 00-23 and minute must be 00-59.");
-        }
-    }
-
-    private void clearTimeError() {
-        labelDateTimeError.setText("");
-        textfieldTundraActivationHour.setStyle("");
-    }
-
-    private void showTimeError(String message) {
-        labelDateTimeError.setText(message);
-        textfieldTundraActivationHour.setStyle("-fx-border-color: #ef4444; -fx-border-width: 2px;");
+        registerTimeTextField(
+            textfieldTundraActivationHour,
+            labelDateTimeError,
+            ConfigurationKeyEnum.TUNDRA_TRUCK_ACTIVATION_TIME_STRING,
+            SettingValidators.localTime("Tundra activation time"));
     }
 }

--- a/modules/desktop/src/main/java/dev/frostguard/app/shared/AbstractProfileController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/shared/AbstractProfileController.java
@@ -1,8 +1,8 @@
 package dev.frostguard.app.shared;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 
 import org.controlsfx.control.CheckComboBox;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import dev.frostguard.api.configs.PrioritizableItemData;
@@ -22,6 +24,7 @@ import dev.frostguard.app.panel.profile.IProfileObserverInjectable;
 import dev.frostguard.app.panel.profile.ProfileAux;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;
@@ -29,7 +32,9 @@ import javafx.scene.control.ToggleGroup;
 
 public abstract class AbstractProfileController implements IProfileLoadListener, IProfileObserverInjectable {
 
+	private static final Logger logger = LoggerFactory.getLogger(AbstractProfileController.class);
 	private static final DateTimeFormatter PROFILE_DATE_TIME = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
+	private static final DateTimeFormatter PROFILE_TIME = DateTimeFormatter.ofPattern("HH:mm");
 	private static final int MAX_CONFIG_INT = 99_999_999;
 
 	protected final Map<CheckBox, ConfigurationKeyEnum> checkBoxMappings = new HashMap<>();
@@ -41,6 +46,8 @@ public abstract class AbstractProfileController implements IProfileLoadListener,
 	protected final Map<PriorityListView, Class<? extends Enum<?>>> priorityListEnumClasses = new HashMap<>();
 	protected IProfileChangeObserver profileObserver;
 	protected boolean isLoadingProfile = false;
+	private final Map<TextField, FieldValidationPresenter> fieldValidationPresenters = new HashMap<>();
+	private final Map<TextField, ValidatedTextFieldBinding<?>> validatedTextFieldBindings = new HashMap<>();
 
 	@Override
 	public void attachProfileListener(IProfileChangeObserver observer) {
@@ -53,6 +60,24 @@ public abstract class AbstractProfileController implements IProfileLoadListener,
 
 	protected void registerTextField(TextField textField, ConfigurationKeyEnum configKey) {
 		textFieldMappings.put(textField, configKey);
+	}
+
+	protected void registerTimeTextField(
+			TextField textField,
+			Label messageLabel,
+			ConfigurationKeyEnum configKey,
+			SettingValidator<LocalTime> validator) {
+		textField.setPromptText("HH:mm");
+		textField.setTextFormatter(getTimeTextFormatter());
+		ValidatedTextFieldBinding<LocalTime> binding = new ValidatedTextFieldBinding<>(
+				textField,
+				messageLabel,
+				validator,
+				PROFILE_TIME::format,
+				value -> publishWhenReady(configKey, PROFILE_TIME.format(value)),
+				AbstractProfileController::normalizeTimeDraft);
+		textFieldMappings.put(textField, configKey);
+		validatedTextFieldBindings.put(textField, binding);
 	}
 
 	protected void registerRadioButton(RadioButton radioButton, ConfigurationKeyEnum configKey) {
@@ -80,7 +105,7 @@ public abstract class AbstractProfileController implements IProfileLoadListener,
 				.filter(entry -> entry.getKey() != null)
 				.forEach(entry -> setupCheckBoxListener(entry.getKey(), entry.getValue()));
 		textFieldMappings.entrySet().stream()
-				.filter(entry -> entry.getKey() != null)
+				.filter(entry -> entry.getKey() != null && !validatedTextFieldBindings.containsKey(entry.getKey()))
 				.forEach(entry -> setupTextFieldUpdateOnFocusOrEnter(entry.getKey(), entry.getValue()));
 		radioButtonMappings.entrySet().stream()
 				.filter(entry -> entry.getKey() != null)
@@ -214,11 +239,14 @@ public abstract class AbstractProfileController implements IProfileLoadListener,
 	}
 
 	private void commitIntegerField(TextField textField, ConfigurationKeyEnum configKey, String candidate) {
-		if (isValidPositiveInteger(candidate)) {
-			publishWhenReady(configKey, Integer.valueOf(candidate));
+		ValidationResult<Integer> result = SettingValidators.rangedInteger(
+				readable(textField.getPromptText(), configKey), 0, MAX_CONFIG_INT).validate(candidate);
+		if (result.isValid()) {
+			presenter(textField).clear();
+			publishWhenReady(configKey, result.value());
 			return;
 		}
-		textField.setText(configKey.getDefaultValue());
+		presenter(textField).showError(result.message());
 	}
 
 	private void commitDateTimeField(TextField textField, ConfigurationKeyEnum configKey, String candidate) {
@@ -227,24 +255,18 @@ public abstract class AbstractProfileController implements IProfileLoadListener,
 			return;
 		}
 
-		try {
-			LocalDateTime.parse(candidate, PROFILE_DATE_TIME);
+		ValidationResult<LocalDateTime> result = SettingValidators.localDateTime(
+				readable(textField.getPromptText(), configKey), PROFILE_DATE_TIME).validate(candidate);
+		if (result.isValid()) {
+			presenter(textField).clear();
 			publishWhenReady(configKey, candidate);
-		} catch (DateTimeParseException e) {
-			textField.setText(configKey.getDefaultValue());
+		} else {
+			presenter(textField).showError(result.message());
 		}
 	}
 
-	private boolean isValidPositiveInteger(String value) {
-		if (value == null || value.isBlank()) {
-			return false;
-		}
-		try {
-			int number = Integer.parseInt(value);
-			return number >= 0 && number <= MAX_CONFIG_INT;
-		} catch (NumberFormatException e) {
-			return false;
-		}
+	private FieldValidationPresenter presenter(TextField textField) {
+		return fieldValidationPresenters.computeIfAbsent(textField, FieldValidationPresenter::new);
 	}
 
 	@Override
@@ -276,6 +298,15 @@ public abstract class AbstractProfileController implements IProfileLoadListener,
 
 	private void loadTextField(ProfileAux profile, TextField textField, ConfigurationKeyEnum key) {
 		Object value = profile.getConfiguration(key);
+		ValidatedTextFieldBinding<?> binding = validatedTextFieldBindings.get(textField);
+		if (binding != null) {
+			String persisted = value == null ? null : value.toString();
+			binding.loadPersisted(persisted, key.getDefaultValue(), reason -> logger.warn(
+					"Invalid persisted profile setting; key={}, value={}, fallback={}, reason={}",
+					key, persisted, key.getDefaultValue(), reason));
+			return;
+		}
+		presenter(textField).clear();
 		if (value instanceof LocalDateTime dateTime) {
 			textField.setText(dateTime.format(PROFILE_DATE_TIME));
 		} else if (value != null) {
@@ -473,5 +504,14 @@ public abstract class AbstractProfileController implements IProfileLoadListener,
 			return digits;
 		}
 		return digits.substring(0, 2) + ":" + digits.substring(2);
+	}
+
+	private static String normalizeTimeDraft(String text) {
+		String digits = text == null ? "" : text.replaceAll("\\D", "");
+		return switch (digits.length()) {
+			case 2 -> digits + ":00";
+			case 4 -> digits.substring(0, 2) + ":" + digits.substring(2);
+			default -> text == null ? "" : text;
+		};
 	}
 }

--- a/modules/desktop/src/main/java/dev/frostguard/app/shared/FieldValidationPresenter.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/shared/FieldValidationPresenter.java
@@ -18,27 +18,41 @@ public final class FieldValidationPresenter {
         this.messageLabel = messageLabel;
         originalTooltip = field.getTooltip();
         originalAccessibleHelp = field.getAccessibleHelp();
-        messageLabel.getStyleClass().add("setting-validation-message");
+        if (messageLabel != null) {
+            messageLabel.getStyleClass().add("setting-validation-message");
+        }
         clear();
+    }
+
+    public FieldValidationPresenter(TextField field) {
+        this(field, null);
     }
 
     public void showError(String message) {
         if (!field.getStyleClass().contains(ERROR_CLASS)) {
             field.getStyleClass().add(ERROR_CLASS);
         }
-        field.setTooltip(new Tooltip(message));
+        if (!field.tooltipProperty().isBound()) {
+            field.setTooltip(new Tooltip(message));
+        }
         field.setAccessibleHelp(message);
-        messageLabel.setText(message);
-        messageLabel.setManaged(true);
-        messageLabel.setVisible(true);
+        if (messageLabel != null) {
+            messageLabel.setText(message);
+            messageLabel.setManaged(true);
+            messageLabel.setVisible(true);
+        }
     }
 
     public void clear() {
         field.getStyleClass().remove(ERROR_CLASS);
-        field.setTooltip(originalTooltip);
+        if (!field.tooltipProperty().isBound()) {
+            field.setTooltip(originalTooltip);
+        }
         field.setAccessibleHelp(originalAccessibleHelp);
-        messageLabel.setText("");
-        messageLabel.setManaged(false);
-        messageLabel.setVisible(false);
+        if (messageLabel != null) {
+            messageLabel.setText("");
+            messageLabel.setManaged(false);
+            messageLabel.setVisible(false);
+        }
     }
 }

--- a/modules/desktop/src/main/java/dev/frostguard/app/shared/SettingValidators.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/shared/SettingValidators.java
@@ -1,5 +1,6 @@
 package dev.frostguard.app.shared;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -57,6 +58,29 @@ public final class SettingValidators {
                 return ValidationResult.valid(LocalTime.parse(candidate, TIME_FORMATTER));
             } catch (DateTimeParseException exception) {
                 return ValidationResult.invalid(label + " must be between 00:00 and 23:59.");
+            }
+        };
+    }
+
+    public static SettingValidator<LocalTime> localTimeNoLaterThan(String label, LocalTime latest) {
+        SettingValidator<LocalTime> base = localTime(label);
+        return input -> {
+            ValidationResult<LocalTime> result = base.validate(input);
+            if (result.isValid() && result.value().isAfter(latest)) {
+                return ValidationResult.invalid(label + " must be no later than "
+                        + latest.format(TIME_FORMATTER) + ".");
+            }
+            return result;
+        };
+    }
+
+    public static SettingValidator<LocalDateTime> localDateTime(String label, DateTimeFormatter formatter) {
+        return input -> {
+            String candidate = trimmed(input);
+            try {
+                return ValidationResult.valid(LocalDateTime.parse(candidate, formatter));
+            } catch (DateTimeParseException exception) {
+                return ValidationResult.invalid(label + " has an invalid date or time.");
             }
         };
     }

--- a/modules/desktop/src/main/java/dev/frostguard/app/shared/UtcDateTimeEditor.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/shared/UtcDateTimeEditor.java
@@ -34,6 +34,9 @@ public final class UtcDateTimeEditor extends VBox {
     private final Label nextActivationPreview = new Label("Next activation: —");
     private final Label localPreview = new Label("Local time: —");
     private final Label validationMessage = new Label();
+    private final FieldValidationPresenter datePresenter = new FieldValidationPresenter(datePicker.getEditor());
+    private final FieldValidationPresenter hourPresenter = new FieldValidationPresenter(hourSpinner.getEditor());
+    private final FieldValidationPresenter minutePresenter = new FieldValidationPresenter(minuteSpinner.getEditor());
     private final BooleanProperty timerEnabled = new SimpleBooleanProperty(false);
     private final ZoneId localZone;
     private final Clock clock;
@@ -91,7 +94,7 @@ public final class UtcDateTimeEditor extends VBox {
         nextActivationPreview.setWrapText(true);
         localPreview.getStyleClass().add("task-card-description");
         localPreview.setWrapText(true);
-        validationMessage.setStyle("-fx-font-size: 11px; -fx-text-fill: #ff4444;");
+        validationMessage.getStyleClass().add("setting-validation-message");
         validationMessage.setWrapText(true);
         validationMessage.setManaged(false);
         validationMessage.setVisible(false);
@@ -240,6 +243,7 @@ public final class UtcDateTimeEditor extends VBox {
         validationMessage.setText(error);
         validationMessage.setVisible(!error.isEmpty());
         validationMessage.setManaged(!error.isEmpty());
+        updateInputErrorState(error);
         applyButton.setDisable(!selection.isValid() || selection.value().equals(committedValue));
         clearButton.setDisable(committedValue == null);
     }
@@ -257,6 +261,18 @@ public final class UtcDateTimeEditor extends VBox {
             case INCOMPLETE -> INCOMPLETE_MESSAGE;
             case INVALID -> INVALID_MESSAGE;
         };
+    }
+
+    private void updateInputErrorState(String error) {
+        if (error.isEmpty()) {
+            datePresenter.clear();
+            hourPresenter.clear();
+            minutePresenter.clear();
+        } else {
+            datePresenter.showError(error);
+            hourPresenter.showError(error);
+            minutePresenter.showError(error);
+        }
     }
 
     private static void setSpinnerValue(Spinner<Integer> spinner, int value) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/shared/ValidatedTextFieldBinding.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/shared/ValidatedTextFieldBinding.java
@@ -3,6 +3,7 @@ package dev.frostguard.app.shared;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
@@ -14,6 +15,7 @@ public final class ValidatedTextFieldBinding<T> {
     private final Function<T, String> formatter;
     private final Consumer<T> commitHandler;
     private final FieldValidationPresenter presenter;
+    private final UnaryOperator<String> draftNormalizer;
     private boolean errorVisible;
 
     public ValidatedTextFieldBinding(
@@ -22,11 +24,22 @@ public final class ValidatedTextFieldBinding<T> {
             SettingValidator<T> validator,
             Function<T, String> formatter,
             Consumer<T> commitHandler) {
+        this(field, messageLabel, validator, formatter, commitHandler, UnaryOperator.identity());
+    }
+
+    public ValidatedTextFieldBinding(
+            TextField field,
+            Label messageLabel,
+            SettingValidator<T> validator,
+            Function<T, String> formatter,
+            Consumer<T> commitHandler,
+            UnaryOperator<String> draftNormalizer) {
         this.field = Objects.requireNonNull(field);
         this.validator = Objects.requireNonNull(validator);
         this.formatter = Objects.requireNonNull(formatter);
         this.commitHandler = Objects.requireNonNull(commitHandler);
-        presenter = new FieldValidationPresenter(field, Objects.requireNonNull(messageLabel));
+        this.draftNormalizer = Objects.requireNonNull(draftNormalizer);
+        presenter = new FieldValidationPresenter(field, messageLabel);
         field.focusedProperty().addListener((obs, wasFocused, focused) -> {
             if (!focused && !field.isDisabled()) {
                 commit();
@@ -41,7 +54,9 @@ public final class ValidatedTextFieldBinding<T> {
     }
 
     public boolean commit() {
-        ValidationResult<T> result = validator.validate(field.getText());
+        String normalized = draftNormalizer.apply(field.getText());
+        field.setText(normalized);
+        ValidationResult<T> result = validator.validate(normalized);
         present(result);
         if (!result.isValid()) {
             return false;

--- a/modules/desktop/src/test/java/dev/frostguard/app/shared/BearTrapTimerDateTimeUxTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/shared/BearTrapTimerDateTimeUxTest.java
@@ -9,6 +9,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,10 +31,12 @@ import dev.frostguard.app.panel.combat.BearTrapLayoutController;
 import dev.frostguard.app.panel.profile.ConfigAux;
 import dev.frostguard.app.panel.profile.ProfileAux;
 import javafx.application.Platform;
+import javafx.event.ActionEvent;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
 
 class BearTrapTimerDateTimeUxTest {
 
@@ -130,6 +133,8 @@ class BearTrapTimerDateTimeUxTest {
 
             editor.setDraft(LocalDate.of(2026, 7, 28), "99", "30");
             assertFalse(editor.getValidationMessage().isEmpty());
+            assertTrue(editor.datePicker().getEditor().getStyleClass().contains("setting-field-error"));
+            assertFalse(editor.datePicker().getEditor().getAccessibleHelp().isBlank());
             editor.commitSelection();
             assertEquals(1, commits.size(), "invalid input must not be persisted");
 
@@ -142,6 +147,65 @@ class BearTrapTimerDateTimeUxTest {
             assertTrue(cleared.get());
             assertFalse(editor.hasCommittedDateTime());
             assertNull(editor.getDateTime());
+            return null;
+        });
+    }
+
+    @Test
+    void sharedTimeBindingPreservesInvalidDraftAndSuppressesPersistence() throws Exception {
+        runOnFxThread(() -> {
+            TextField field = new TextField();
+            Label error = new Label();
+            List<LocalTime> commits = new ArrayList<>();
+            new ValidatedTextFieldBinding<>(
+                    field,
+                    error,
+                    SettingValidators.localTime("Activation time"),
+                    value -> String.format("%02d:%02d", value.getHour(), value.getMinute()),
+                    commits::add,
+                    text -> text != null && text.matches("\\d{4}")
+                            ? text.substring(0, 2) + ":" + text.substring(2)
+                            : text);
+
+            field.setText("99:00");
+            field.fireEvent(new ActionEvent());
+
+            assertEquals("99:00", field.getText());
+            assertTrue(error.isVisible());
+            assertTrue(commits.isEmpty());
+
+            field.setText("0930");
+            field.fireEvent(new ActionEvent());
+
+            assertEquals("09:30", field.getText());
+            assertEquals(List.of(LocalTime.of(9, 30)), commits);
+            assertFalse(error.isVisible());
+            return null;
+        });
+    }
+
+    @Test
+    void profileIntegerFieldKeepsInvalidUserInput() throws Exception {
+        runOnFxThread(() -> {
+            TestProfileController controller = new TestProfileController();
+            TextField field = new TextField();
+            List<Change> changes = new ArrayList<>();
+            controller.register(field, ConfigurationKeyEnum.BEAR_TRAP_NUMBER_INT);
+            controller.attachProfileListener((key, value) -> changes.add(new Change(key, value)));
+            controller.startListening();
+
+            field.setText("invalid");
+            field.fireEvent(new ActionEvent());
+
+            assertEquals("invalid", field.getText());
+            assertTrue(field.getStyleClass().contains("setting-field-error"));
+            assertTrue(changes.isEmpty());
+
+            field.setText("2");
+            field.fireEvent(new ActionEvent());
+
+            assertFalse(field.getStyleClass().contains("setting-field-error"));
+            assertEquals(List.of(new Change(ConfigurationKeyEnum.BEAR_TRAP_NUMBER_INT, 2)), changes);
             return null;
         });
     }
@@ -478,6 +542,16 @@ class BearTrapTimerDateTimeUxTest {
     }
 
     private record Change(ConfigurationKeyEnum key, Object value) {
+    }
+
+    private static final class TestProfileController extends AbstractProfileController {
+        private void register(TextField field, ConfigurationKeyEnum key) {
+            registerTextField(field, key);
+        }
+
+        private void startListening() {
+            initializeChangeEvents();
+        }
     }
 
     private record LoadedBearView(


### PR DESCRIPTION
## Summary

- keep invalid profile integer and date/time drafts visible instead of restoring defaults
- consolidate Events and Arena `HH:mm` parsing, normalization, error presentation, and commits
- apply shared error styling, tooltips, and accessible help to Bear Trap UTC editors
- cover Enter/Apply behavior and persistence suppression for invalid drafts

## Why

Profile panels currently inherit silent fallback behavior while equivalent time fields duplicate validation code. This is stack 2/3 for #141 and builds on the shared primitives introduced by #190.

## Stack

1. #190 -> `main`
2. **This PR** -> `agent/settings-validation-foundation`
3. `agent/settings-validation-dialogs` -> this branch

Review and merge after #190. Once #190 merges, retarget this PR to `main`; then retarget PR 3 to this branch until this PR merges.

## Validation

- `mvnw.cmd -pl modules/desktop -am test`
- 375 tests passed with 0 failures, errors, or skips
- the first run exposed a bound JavaFX Spinner tooltip; the presenter was corrected and the full command passed on rerun
- automated tests only; no live UI verification performed

## Risks

Generic legacy profile fields without dedicated FXML message labels use the shared border, tooltip, and accessible help state. Migrated time surfaces include their visible inline labels.

Part of #141
