### PR TITLE
refactor(settings): validate task and profile forms inline

### DIFF
--- a/docs/settings-ux.md
+++ b/docs/settings-ux.md
@@ -20,3 +20,15 @@ Frostguard settings use the following interaction rules:
 Parsers, ranges, units, defaults, empty-value semantics, and commit policies
 belong in shared setting definitions or validators rather than controller-local
 listeners.
+
+## Migration inventory
+
+The shared approach currently covers Instance Settings, generic profile integer
+and date/time fields, Bear Trap UTC editors, Arena and Tundra `HH:mm` fields,
+Custom Tasks, and profile creation/editing.
+
+Follow-up migrations should inventory and convert the remaining controller-local
+parsing and styling in scheduler dialogs, Telegram settings, statistics filters,
+and Task Builder editors. Those surfaces are intentionally outside issue #141's
+representative migration set and must not silently acquire new validation
+patterns in the meantime.

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/combat/BearTrapLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/combat/BearTrapLayoutController.java
@@ -48,6 +48,9 @@ public class BearTrapLayoutController extends AbstractProfileController {
     private TextField textFieldPreparationTime;
 
     @FXML
+    private Label labelPreparationTimeError;
+
+    @FXML
     private CheckBox checkBoxActivePets;
 
     @FXML
@@ -127,7 +130,8 @@ public class BearTrapLayoutController extends AbstractProfileController {
         checkBoxMappings.put(checkBoxCallRally, ConfigurationKeyEnum.BEAR_TRAP_CALL_RALLY_BOOL);
         checkBoxMappings.put(checkBoxEnableJoin, ConfigurationKeyEnum.BEAR_TRAP_JOIN_RALLY_BOOL);
 
-        textFieldMappings.put(textFieldPreparationTime, ConfigurationKeyEnum.BEAR_TRAP_PREPARATION_TIME_INT);
+        registerTextField(textFieldPreparationTime, labelPreparationTimeError,
+                ConfigurationKeyEnum.BEAR_TRAP_PREPARATION_TIME_INT);
 
         comboBoxMappings.put(comboBoxTrapNumber, ConfigurationKeyEnum.BEAR_TRAP_NUMBER_INT);
         comboBoxMappings.put(comboBoxRallyFlag, ConfigurationKeyEnum.BEAR_TRAP_RALLY_FLAG_INT);
@@ -352,7 +356,7 @@ public class BearTrapLayoutController extends AbstractProfileController {
             timerBindings.forEach(binding -> binding.editor().setDateTime(
                     loadSavedDateTime(profile, binding.scheduleKey())));
             timerBindings.forEach(binding -> binding.protectionMode().setValue(
-                    loadProtectionMode(profile, binding)));
+                    binding.editor().hasCommittedDateTime() ? loadProtectionMode(profile, binding) : ProtectionMode.OFF));
             refreshAvailableParticipationTimers();
         } finally {
             loadingProtectionModes = false;

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/custom/CustomTasksLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/custom/CustomTasksLayoutController.java
@@ -9,6 +9,8 @@ import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.TaskQueue;
 import dev.frostguard.api.domain.TaskStateData;
 import dev.frostguard.api.configs.TpDailyTaskEnum;
+import dev.frostguard.app.shared.SettingValidators;
+import dev.frostguard.app.shared.ValidatedTextFieldBinding;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.geometry.Insets;
@@ -218,19 +220,16 @@ public class CustomTasksLayoutController {
             firstExecutionField.setPromptText("yyyy-MM-dd HH:mm");
 
             TextField followUpDelayField = new TextField(String.valueOf(initialFollowUpDelayHours));
-            Runnable commitTimingChange = () -> {
-                if (!commitTimingSettings(className, firstExecutionField.getText(), followUpDelayField.getText())) {
-                    firstExecutionField.setText(taskFirstExecutionUtc.getOrDefault(
-                            className, getDefaultFirstExecutionUtc(className)));
-                }
-            };
-            firstExecutionField.setOnAction(e -> commitTimingChange.run());
-            firstExecutionField.focusedProperty().addListener((obs, oldVal, newVal) -> {
-                if (!newVal) {
-                    commitTimingChange.run();
-                }
-            });
-            firstExecutionBox.getChildren().addAll(firstExecutionLabel, firstExecutionField);
+			followUpDelayField.setTextFormatter(nonNegativeIntegerFormatter());
+            Label firstExecutionError = validationLabel();
+            new ValidatedTextFieldBinding<>(
+                    firstExecutionField,
+                    firstExecutionError,
+                    SettingValidators.localDateTime("First execution", UTC_INPUT_FORMATTER),
+                    UTC_INPUT_FORMATTER::format,
+                    value -> commitTimingSettings(
+                            className, UTC_INPUT_FORMATTER.format(value), followUpDelayField.getText()));
+            firstExecutionBox.getChildren().addAll(firstExecutionLabel, firstExecutionField, firstExecutionError);
 
             VBox followUpDelayBox = new VBox(4);
             Label followUpDelayLabel = new Label("Follow-up delay (hours)");
@@ -239,19 +238,15 @@ public class CustomTasksLayoutController {
             followUpDelayField.setPrefWidth(120);
             followUpDelayField.setMaxWidth(120);
             followUpDelayField.setPromptText(String.valueOf(DEFAULT_FOLLOW_UP_DELAY_HOURS));
-            Runnable commitDelayChange = () -> {
-                if (!commitTimingSettings(className, firstExecutionField.getText(), followUpDelayField.getText())) {
-                    followUpDelayField.setText(String.valueOf(taskFollowUpDelayHours.getOrDefault(
-                            className, DEFAULT_FOLLOW_UP_DELAY_HOURS)));
-                }
-            };
-            followUpDelayField.setOnAction(e -> commitDelayChange.run());
-            followUpDelayField.focusedProperty().addListener((obs, oldVal, newVal) -> {
-                if (!newVal) {
-                    commitDelayChange.run();
-                }
-            });
-            followUpDelayBox.getChildren().addAll(followUpDelayLabel, followUpDelayField);
+            Label followUpDelayError = validationLabel();
+            new ValidatedTextFieldBinding<>(
+                    followUpDelayField,
+                    followUpDelayError,
+                    SettingValidators.positiveInteger("Follow-up delay"),
+                    String::valueOf,
+                    value -> commitTimingSettings(
+                            className, firstExecutionField.getText(), String.valueOf(value)));
+            followUpDelayBox.getChildren().addAll(followUpDelayLabel, followUpDelayField, followUpDelayError);
 
             enableBox.getChildren().addAll(firstExecutionBox, followUpDelayBox);
         }
@@ -261,23 +256,21 @@ public class CustomTasksLayoutController {
         Label offsetLabel = new Label("Offset (minutes)");
         offsetLabel.getStyleClass().add("custom-task-field-label");
         TextField offsetField = new TextField(String.valueOf(initialOffset));
+		offsetField.setTextFormatter(nonNegativeIntegerFormatter());
         offsetField.getStyleClass().add("custom-task-field");
         offsetField.setPrefWidth(100);
         offsetField.setMaxWidth(100);
-        offsetField.textProperty().addListener((obs, oldVal, newVal) -> {
-            try {
-                int offset = Integer.parseInt(newVal.trim());
-                if (offset >= 0) {
-                    taskOffsets.put(className, offset);
-                }
-            } catch (NumberFormatException ignored) {}
-        });
-        offsetField.focusedProperty().addListener((obs, oldVal, newVal) -> {
-            if (!newVal) {
-                persistCurrentSettings(className);
-            }
-        });
-        offsetBox.getChildren().addAll(offsetLabel, offsetField);
+        Label offsetError = validationLabel();
+        new ValidatedTextFieldBinding<>(
+                offsetField,
+                offsetError,
+                SettingValidators.nonNegativeInteger("Offset"),
+                String::valueOf,
+                value -> {
+                    taskOffsets.put(className, value);
+                    persistCurrentSettings(className);
+                });
+        offsetBox.getChildren().addAll(offsetLabel, offsetField, offsetError);
 
         // Priority field
         VBox priorityBox = new VBox(4);
@@ -288,18 +281,17 @@ public class CustomTasksLayoutController {
         priorityField.setPrefWidth(80);
         priorityField.setMaxWidth(80);
         priorityField.setPromptText("0");
-        priorityField.textProperty().addListener((obs, oldVal, newVal) -> {
-            try {
-                int priority = Integer.parseInt(newVal.trim());
-                taskPriorities.put(className, priority);
-            } catch (NumberFormatException ignored) {}
-        });
-        priorityField.focusedProperty().addListener((obs, oldVal, newVal) -> {
-            if (!newVal) {
-                persistCurrentSettings(className);
-            }
-        });
-        priorityBox.getChildren().addAll(priorityLabel, priorityField);
+        Label priorityError = validationLabel();
+        new ValidatedTextFieldBinding<>(
+                priorityField,
+                priorityError,
+                SettingValidators.integer("Priority"),
+                String::valueOf,
+                value -> {
+                    taskPriorities.put(className, value);
+                    persistCurrentSettings(className);
+                });
+        priorityBox.getChildren().addAll(priorityLabel, priorityField, priorityError);
 
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
@@ -455,6 +447,17 @@ public class CustomTasksLayoutController {
             return scheduleTask(className);
         }
         return true;
+    }
+
+    private Label validationLabel() {
+        Label label = new Label();
+        label.setWrapText(true);
+        return label;
+    }
+
+    private javafx.scene.control.TextFormatter<String> nonNegativeIntegerFormatter() {
+        return new javafx.scene.control.TextFormatter<>(change ->
+                change.getControlNewText().matches("\\d*") ? change : null);
     }
 
     private void persistCurrentSettings(String className) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/emulator/EmuConfigLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/emulator/EmuConfigLayoutController.java
@@ -268,6 +268,10 @@ public class EmuConfigLayoutController {
 			String label,
 			Map<String, String> cfg,
 			boolean rescheduleAutoStart) {
+		if (field.getTextFormatter() == null) {
+			field.setTextFormatter(new javafx.scene.control.TextFormatter<>(change ->
+					change.getControlNewText().matches("\\d*") ? change : null));
+		}
 		ValidatedTextFieldBinding<Integer> binding = new ValidatedTextFieldBinding<>(
 				field,
 				errorLabel,

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/profile/EditProfileController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/profile/EditProfileController.java
@@ -1,8 +1,10 @@
 package dev.frostguard.app.panel.profile;
 
 import dev.frostguard.api.configs.TpMessageSeverityEnum;
-import dev.frostguard.app.panel.profile.ProfileManagerActionController;
-import dev.frostguard.app.panel.profile.ProfileAux;
+import dev.frostguard.app.shared.FieldValidationPresenter;
+import dev.frostguard.app.shared.SettingValidator;
+import dev.frostguard.app.shared.SettingValidators;
+import dev.frostguard.app.shared.ValidationResult;
 import dev.frostguard.engine.service.LoggingService;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
@@ -25,6 +27,7 @@ import java.util.TreeSet;
 import java.util.function.UnaryOperator;
 
 public class EditProfileController implements Initializable {
+	private static final long MAX_RECONNECTION_MINUTES = 10_080;
 
     private static final UnaryOperator<TextFormatter.Change> DIGITS_ONLY = change ->
         change.getControlNewText().matches("\\d*") ? change : null;
@@ -60,6 +63,15 @@ public class EditProfileController implements Initializable {
     private TextField txtReconnectionTime;
 
     @FXML
+    private Label lblProfileNameError;
+
+    @FXML
+    private Label lblEmulatorNumberError;
+
+    @FXML
+    private Label lblReconnectionTimeError;
+
+    @FXML
     private TextField txtCharacterName;
 
     @FXML
@@ -83,10 +95,17 @@ public class EditProfileController implements Initializable {
     private ProfileManagerActionController actionController;
     private Stage dialogStage;
     private boolean saveClicked = false;
+    private FieldValidationPresenter profileNamePresenter;
+    private FieldValidationPresenter emulatorNumberPresenter;
+    private FieldValidationPresenter reconnectionTimePresenter;
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         installInputGuards();
+        profileNamePresenter = new FieldValidationPresenter(txtProfileName, lblProfileNameError);
+        emulatorNumberPresenter = new FieldValidationPresenter(txtEmulatorNumber, lblEmulatorNumberError);
+        reconnectionTimePresenter = new FieldValidationPresenter(txtReconnectionTime, lblReconnectionTimeError);
+        installValidationListeners();
         bindPriorityLabel();
     }
 
@@ -158,7 +177,7 @@ public class EditProfileController implements Initializable {
 
     @FXML
     private void handleSave() {
-        if (!validateInput()) {
+        if (!validateInput(true)) {
             return;
         }
 
@@ -181,18 +200,39 @@ public class EditProfileController implements Initializable {
         dialogStage.close();
     }
 
-    private boolean validateInput() {
-        StringBuilder errorMessage = new StringBuilder();
-        requireText(txtProfileName, "Profile name", errorMessage);
-        requireNonNegativeInt(txtEmulatorNumber, "Emulator number", "integer", errorMessage);
-        requireNonNegativeLong(txtReconnectionTime, "Reconnection time", "number", errorMessage);
+    private boolean validateInput(boolean presentErrors) {
+        boolean nameValid = validateField(
+            txtProfileName, SettingValidators.requiredText("Profile name"), profileNamePresenter, presentErrors);
+        boolean emulatorValid = validateField(
+            txtEmulatorNumber, SettingValidators.nonNegativeInteger("Emulator number"),
+            emulatorNumberPresenter, presentErrors);
+        boolean reconnectValid = validateField(
+            txtReconnectionTime, SettingValidators.rangedLong("Reconnection time", 0, MAX_RECONNECTION_MINUTES),
+            reconnectionTimePresenter, presentErrors);
+        return nameValid && emulatorValid && reconnectValid;
+    }
 
-        if (!errorMessage.isEmpty()) {
-            showAlert(Alert.AlertType.ERROR, "Invalid Input", "Please correct the following errors:", errorMessage.toString());
-            return false;
+    private <T> boolean validateField(
+            TextField field,
+            SettingValidator<T> validator,
+            FieldValidationPresenter presenter,
+            boolean presentErrors) {
+        ValidationResult<T> result = validator.validate(field.getText());
+        if (presentErrors) {
+            if (result.isValid()) {
+                presenter.clear();
+            } else {
+                presenter.showError(result.message());
+            }
         }
+        return result.isValid();
+    }
 
-        return true;
+    private void installValidationListeners() {
+        List.of(txtProfileName, txtEmulatorNumber, txtReconnectionTime).forEach(field ->
+            field.textProperty().addListener((obs, oldValue, newValue) ->
+                btnSave.setDisable(!validateInput(true))));
+        btnSave.setDisable(!validateInput(false));
     }
 
     private void installInputGuards() {
@@ -220,46 +260,6 @@ public class EditProfileController implements Initializable {
         profileToEdit.setCharacterAllianceCode(blankToNullUppercase(txtCharacterAllianceCode));
         profileToEdit.setCharacterServer(blankToNull(txtCharacterServer));
         profileToEdit.setTags(tagChoices.stream().filter(CheckBox::isSelected).map(CheckBox::getText).toList());
-    }
-
-    private void requireText(TextField field, String label, StringBuilder errors) {
-        if (field.getText() == null || field.getText().trim().isEmpty()) {
-            errors.append(label).append(" cannot be empty.\n");
-        }
-    }
-
-    private void requireNonNegativeInt(TextField field, String label, String typeName, StringBuilder errors) {
-        String value = field.getText() == null ? "" : field.getText().trim();
-        if (value.isEmpty()) {
-            errors.append(label).append(" cannot be empty.\n");
-            return;
-        }
-
-        try {
-            int parsed = Integer.parseInt(value);
-            if (parsed < 0) {
-                errors.append(label).append(" must be a non-negative ").append(typeName).append(" (0 or greater).\n");
-            }
-        } catch (NumberFormatException e) {
-            errors.append(label).append(" must be a valid ").append(typeName).append(".\n");
-        }
-    }
-
-    private void requireNonNegativeLong(TextField field, String label, String typeName, StringBuilder errors) {
-        String value = field.getText() == null ? "" : field.getText().trim();
-        if (value.isEmpty()) {
-            errors.append(label).append(" cannot be empty.\n");
-            return;
-        }
-
-        try {
-            long parsed = Long.parseLong(value);
-            if (parsed < 0) {
-                errors.append(label).append(" must be a non-negative ").append(typeName).append(" (0 or greater).\n");
-            }
-        } catch (NumberFormatException e) {
-            errors.append(label).append(" must be a valid ").append(typeName).append(".\n");
-        }
     }
 
     private long parseLongOrZero(TextField textField) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/profile/NewProfileLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/profile/NewProfileLayoutController.java
@@ -4,6 +4,10 @@ import java.util.List;
 import java.util.function.UnaryOperator;
 
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.app.shared.FieldValidationPresenter;
+import dev.frostguard.app.shared.SettingValidator;
+import dev.frostguard.app.shared.SettingValidators;
+import dev.frostguard.app.shared.ValidationResult;
 import javafx.beans.value.ChangeListener;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
@@ -13,7 +17,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;
-import javafx.util.converter.IntegerStringConverter;
 
 /**
  * Handles the "New Profile" form – validates user input, enforces
@@ -21,6 +24,7 @@ import javafx.util.converter.IntegerStringConverter;
  * {@link ProfileManagerActionController}.
  */
 public class NewProfileLayoutController {
+	private static final long MAX_RECONNECTION_MINUTES = 10_080;
 
 	/** Rejects any character that is not a digit. */
 	private static final UnaryOperator<TextFormatter.Change> NUMERIC_FILTER = change ->
@@ -67,6 +71,19 @@ public class NewProfileLayoutController {
 	@FXML
 	private TextField textfieldCharacterServer;
 
+	@FXML
+	private Label labelProfileNameError;
+
+	@FXML
+	private Label labelEmulatorNumberError;
+
+	@FXML
+	private Label labelReconnectionTimeError;
+
+	private FieldValidationPresenter profileNamePresenter;
+	private FieldValidationPresenter emulatorNumberPresenter;
+	private FieldValidationPresenter reconnectionTimePresenter;
+
 	/* ── Constructor ── */
 
 	public NewProfileLayoutController(ProfileManagerActionController profileManagerActionController) {
@@ -80,6 +97,9 @@ public class NewProfileLayoutController {
 	@FXML
 	private void initialize() {
 		applyInputFormatters();
+		profileNamePresenter = new FieldValidationPresenter(textfieldProfileName, labelProfileNameError);
+		emulatorNumberPresenter = new FieldValidationPresenter(textfieldEmulatorNumber, labelEmulatorNumberError);
+		reconnectionTimePresenter = new FieldValidationPresenter(textfieldReconnectionTime, labelReconnectionTimeError);
 		linkPriorityLabelToSlider();
 		registerFieldValidationWatchers();
 		buttonSaveProfile.setDisable(!isFormValid());
@@ -90,16 +110,15 @@ public class NewProfileLayoutController {
 	 * ──────────────────────────────────────────────── */
 
 	private void applyInputFormatters() {
-		attachIntegerFormatter(textfieldEmulatorNumber, 0);
-		attachIntegerFormatter(textfieldReconnectionTime, 0);
-		attachIntegerFormatter(textfieldCharacterId, null);
+		attachIntegerFormatter(textfieldEmulatorNumber);
+		attachIntegerFormatter(textfieldReconnectionTime);
+		attachIntegerFormatter(textfieldCharacterId);
 		textfieldCharacterAllianceCode.setTextFormatter(new TextFormatter<>(TAG_FILTER));
 		textfieldCharacterServer.setTextFormatter(new TextFormatter<>(NUMERIC_FILTER));
 	}
 
-	private void attachIntegerFormatter(TextField target, Integer fallback) {
-		target.setTextFormatter(
-				new TextFormatter<>(new IntegerStringConverter(), fallback, NUMERIC_FILTER));
+	private void attachIntegerFormatter(TextField target) {
+		target.setTextFormatter(new TextFormatter<>(NUMERIC_FILTER));
 	}
 
 	/* ────────────────────────────────────────────────
@@ -118,7 +137,7 @@ public class NewProfileLayoutController {
 
 	private void registerFieldValidationWatchers() {
 		ChangeListener<String> refresher = (obs, oldVal, newVal) ->
-			buttonSaveProfile.setDisable(!isFormValid());
+			buttonSaveProfile.setDisable(!validateForm(true));
 		mandatoryFields().forEach(tf -> tf.textProperty().addListener(refresher));
 	}
 
@@ -127,31 +146,37 @@ public class NewProfileLayoutController {
 	}
 
 	private boolean isFormValid() {
-		String emuText = textfieldEmulatorNumber.getText();
-		String nameText = textfieldProfileName.getText();
-		String reconnectText = textfieldReconnectionTime.getText();
+		return validateForm(false);
+	}
 
-		if (emuText.isEmpty() || nameText.isEmpty()) {
-			return false;
-		}
+	private boolean validateForm(boolean presentErrors) {
+		boolean nameValid = validateField(
+				textfieldProfileName, SettingValidators.requiredText("Profile name"), profileNamePresenter, presentErrors);
+		boolean emulatorValid = validateField(
+				textfieldEmulatorNumber, SettingValidators.nonNegativeInteger("Emulator number"),
+				emulatorNumberPresenter, presentErrors);
+		SettingValidator<Long> reconnectValidator = input -> input == null || input.isBlank()
+				? ValidationResult.valid(0L)
+				: SettingValidators.rangedLong("Reconnection time", 0, MAX_RECONNECTION_MINUTES).validate(input);
+		boolean reconnectValid = validateField(
+				textfieldReconnectionTime, reconnectValidator, reconnectionTimePresenter, presentErrors);
+		return nameValid && emulatorValid && reconnectValid;
+	}
 
-		try {
-			int emuIndex = Integer.parseInt(emuText);
-			if (emuIndex < 0) {
-				return false;
+	private <T> boolean validateField(
+			TextField field,
+			SettingValidator<T> validator,
+			FieldValidationPresenter presenter,
+			boolean presentErrors) {
+		ValidationResult<T> result = validator.validate(field.getText());
+		if (presentErrors) {
+			if (result.isValid()) {
+				presenter.clear();
+			} else {
+				presenter.showError(result.message());
 			}
-
-			if (!reconnectText.isEmpty()) {
-				int reconnectDelay = Integer.parseInt(reconnectText);
-				if (reconnectDelay < 0) {
-					return false;
-				}
-			}
-
-			return true;
-		} catch (NumberFormatException ex) {
-			return false;
 		}
+		return result.isValid();
 	}
 
 	/* ────────────────────────────────────────────────
@@ -160,6 +185,9 @@ public class NewProfileLayoutController {
 
 	@FXML
 	private void handleSaveProfileButton(ActionEvent event) {
+		if (!validateForm(true)) {
+			return;
+		}
 		profileManagerActionController.addProfile(assembleDescriptor());
 		profileManagerActionController.closeNewProfileDialog();
 	}

--- a/modules/desktop/src/main/java/dev/frostguard/app/shared/AbstractProfileController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/shared/AbstractProfileController.java
@@ -62,6 +62,11 @@ public abstract class AbstractProfileController implements IProfileLoadListener,
 		textFieldMappings.put(textField, configKey);
 	}
 
+	protected void registerTextField(TextField textField, Label messageLabel, ConfigurationKeyEnum configKey) {
+		textFieldMappings.put(textField, configKey);
+		fieldValidationPresenters.put(textField, new FieldValidationPresenter(textField, messageLabel));
+	}
+
 	protected void registerTimeTextField(
 			TextField textField,
 			Label messageLabel,
@@ -185,6 +190,9 @@ public abstract class AbstractProfileController implements IProfileLoadListener,
 	}
 
 	protected void setupTextFieldUpdateOnFocusOrEnter(TextField textField, ConfigurationKeyEnum configKey) {
+		if (Integer.class.equals(configKey.getType()) && textField.getTextFormatter() == null) {
+			textField.setTextFormatter(nonNegativeIntegerTextFormatter());
+		}
 		textField.focusedProperty().addListener((obs, wasFocused, focused) -> {
 			if (!focused) {
 				updateProfile(textField, configKey);
@@ -492,6 +500,10 @@ public abstract class AbstractProfileController implements IProfileLoadListener,
 			}
 			return change;
 		});
+	}
+
+	protected static @NotNull TextFormatter<String> nonNegativeIntegerTextFormatter() {
+		return new TextFormatter<>(change -> change.getControlNewText().matches("\\d*") ? change : null);
 	}
 
 	private static String timeMask(String text) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/shared/SettingValidators.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/shared/SettingValidators.java
@@ -27,6 +27,54 @@ public final class SettingValidators {
         return rangedInteger(label, 0, Integer.MAX_VALUE);
     }
 
+    public static SettingValidator<Integer> integer(String label) {
+        return input -> {
+            String candidate = trimmed(input);
+            if (!candidate.matches("-?\\d+")) {
+                return ValidationResult.invalid(label + " must be a whole number.");
+            }
+            try {
+                return ValidationResult.valid(Integer.parseInt(candidate));
+            } catch (NumberFormatException exception) {
+                return ValidationResult.invalid(label + " is outside the supported range.");
+            }
+        };
+    }
+
+    public static SettingValidator<Long> nonNegativeLong(String label) {
+        return rangedLong(label, 0, Long.MAX_VALUE);
+    }
+
+    public static SettingValidator<Long> rangedLong(String label, long minimum, long maximum) {
+        if (minimum > maximum) {
+            throw new IllegalArgumentException("Minimum must not exceed maximum");
+        }
+        return input -> {
+            String candidate = trimmed(input);
+            if (!candidate.matches("\\d+")) {
+                return ValidationResult.invalid(label + " must be a whole number.");
+            }
+            try {
+                long value = Long.parseLong(candidate);
+                if (value < minimum || value > maximum) {
+                    return ValidationResult.invalid(rangeMessage(label, minimum, maximum));
+                }
+                return ValidationResult.valid(value);
+            } catch (NumberFormatException exception) {
+                return ValidationResult.invalid(rangeMessage(label, minimum, maximum));
+            }
+        };
+    }
+
+    public static SettingValidator<String> requiredText(String label) {
+        return input -> {
+            String candidate = trimmed(input);
+            return candidate.isEmpty()
+                    ? ValidationResult.invalid(label + " cannot be empty.")
+                    : ValidationResult.valid(candidate);
+        };
+    }
+
     public static SettingValidator<Integer> rangedInteger(String label, int minimum, int maximum) {
         if (minimum > maximum) {
             throw new IllegalArgumentException("Minimum must not exceed maximum");
@@ -91,6 +139,13 @@ public final class SettingValidators {
 
     private static String rangeMessage(String label, int minimum, int maximum) {
         if (maximum == Integer.MAX_VALUE) {
+            return label + " must be at least " + minimum + ".";
+        }
+        return label + " must be between " + minimum + " and " + maximum + ".";
+    }
+
+    private static String rangeMessage(String label, long minimum, long maximum) {
+        if (maximum == Long.MAX_VALUE) {
             return label + " must be at least " + minimum + ".";
         }
         return label + " must be between " + minimum + " and " + maximum + ".";

--- a/modules/desktop/src/main/resources/layout/BearTrapLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/BearTrapLayout.fxml
@@ -28,6 +28,7 @@
                             <VBox spacing="4">
                                 <Label styleClass="task-field-label" text="Preparation &amp; protection lead time" />
                                 <TextField fx:id="textFieldPreparationTime" prefWidth="100.0" promptText="10" />
+                                <Label fx:id="labelPreparationTimeError" maxWidth="190.0" wrapText="true" />
                             </VBox>
                             <Label maxWidth="420" styleClass="task-card-description"
                                    text="Minutes before each event when Bear preparation and the selected protection mode begin."

--- a/modules/desktop/src/main/resources/layout/CityEventsExtraLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/CityEventsExtraLayout.fxml
@@ -41,20 +41,22 @@
                                 <Label styleClass="task-field-label" text="Activation time (UTC)" GridPane.columnIndex="0" GridPane.rowIndex="1" />
                                 <TextField fx:id="textFieldArenaActivationHour" maxWidth="100.0" prefWidth="90.0"
                                            promptText="HH:mm" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                                <Label fx:id="labelDateTimeError" maxWidth="Infinity" wrapText="true"
+                                       GridPane.columnIndex="0" GridPane.columnSpan="2" GridPane.rowIndex="2" />
 
-                                <Label styleClass="task-field-label" text="Extra attempts" GridPane.columnIndex="0" GridPane.rowIndex="2" />
+                                <Label styleClass="task-field-label" text="Extra attempts" GridPane.columnIndex="0" GridPane.rowIndex="3" />
                                 <ComboBox fx:id="comboBoxArenaExtraAttempts" maxWidth="100.0" prefWidth="90.0"
-                                          promptText="0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                                          promptText="0" GridPane.columnIndex="1" GridPane.rowIndex="3" />
 
-                                <Label styleClass="task-field-label" text="List refresh" GridPane.columnIndex="0" GridPane.rowIndex="3" />
+                                <Label styleClass="task-field-label" text="List refresh" GridPane.columnIndex="0" GridPane.rowIndex="4" />
                                 <CheckBox fx:id="checkBoxArenaRefreshWithGems" mnemonicParsing="false"
                                           text="Allow paid list refreshes"
-                                          GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                                          GridPane.columnIndex="1" GridPane.rowIndex="4" />
 
-                                <Label styleClass="task-field-label" text="Attack formation" GridPane.columnIndex="0" GridPane.rowIndex="4" />
+                                <Label styleClass="task-field-label" text="Attack formation" GridPane.columnIndex="0" GridPane.rowIndex="5" />
                                 <CheckBox fx:id="checkBoxArenaAttackQuickDeploy" mnemonicParsing="false"
                                           text="Use Quick Deploy for attacks"
-                                          GridPane.columnIndex="1" GridPane.rowIndex="4" />
+                                          GridPane.columnIndex="1" GridPane.rowIndex="5" />
                             </GridPane>
 
                             <Separator style="-fx-opacity: 0.15;" />
@@ -88,9 +90,6 @@
                                 </GridPane>
                             </VBox>
 
-                            <Label fx:id="labelDateTimeError"
-                                   style="-fx-font-size: 11px; -fx-text-fill: #ff4444;"
-                                   text="" wrapText="true" />
                         </VBox>
                     </Tab>
 

--- a/modules/desktop/src/main/resources/layout/EditProfile.fxml
+++ b/modules/desktop/src/main/resources/layout/EditProfile.fxml
@@ -33,15 +33,24 @@
                 <VBox spacing="10">
                     <HBox alignment="CENTER_LEFT" spacing="14">
                         <Label text="Name" minWidth="140" />
-                        <TextField fx:id="txtProfileName" HBox.hgrow="ALWAYS" />
+                        <VBox HBox.hgrow="ALWAYS">
+                            <TextField fx:id="txtProfileName" />
+                            <Label fx:id="lblProfileNameError" wrapText="true" />
+                        </VBox>
                     </HBox>
                     <HBox alignment="CENTER_LEFT" spacing="14">
                         <Label text="Emulator" minWidth="140" />
-                        <TextField fx:id="txtEmulatorNumber" HBox.hgrow="ALWAYS" />
+                        <VBox HBox.hgrow="ALWAYS">
+                            <TextField fx:id="txtEmulatorNumber" />
+                            <Label fx:id="lblEmulatorNumberError" wrapText="true" />
+                        </VBox>
                     </HBox>
                     <HBox alignment="CENTER_LEFT" spacing="14">
                         <Label text="Reconnect (min)" minWidth="140" />
-                        <TextField fx:id="txtReconnectionTime" HBox.hgrow="ALWAYS" />
+                        <VBox HBox.hgrow="ALWAYS">
+                            <TextField fx:id="txtReconnectionTime" />
+                            <Label fx:id="lblReconnectionTimeError" wrapText="true" />
+                        </VBox>
                     </HBox>
                 </VBox>
 

--- a/modules/desktop/src/main/resources/layout/EmuConfigLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/EmuConfigLayout.fxml
@@ -51,7 +51,7 @@
                           <HBox alignment="CENTER_LEFT" spacing="10" GridPane.columnIndex="1" GridPane.rowIndex="0">
                               <Label text="Max Concurrent Instances" />
                               <Region HBox.hgrow="ALWAYS" />
-                              <VBox alignment="CENTER_RIGHT">
+                              <VBox alignment="CENTER_RIGHT" minWidth="190.0" prefWidth="190.0" maxWidth="190.0">
                                   <TextField fx:id="textfieldMaxConcurrentInstances" maxWidth="100.0" minWidth="70.0" prefWidth="80.0" />
                                   <Label fx:id="labelMaxConcurrentInstancesError" maxWidth="220.0" wrapText="true" />
                               </VBox>
@@ -61,20 +61,25 @@
                           <HBox alignment="CENTER_LEFT" spacing="10" GridPane.columnIndex="0" GridPane.rowIndex="1">
                               <Label text="Max Idle Time (minutes)" />
                               <Region HBox.hgrow="ALWAYS" />
-                              <VBox alignment="CENTER_RIGHT">
+                              <VBox alignment="CENTER_RIGHT" minWidth="190.0" prefWidth="190.0" maxWidth="190.0">
                                   <TextField fx:id="textfieldMaxIdleTime" maxWidth="100.0" minWidth="70.0" prefWidth="80.0" />
                                   <Label fx:id="labelMaxIdleTimeError" maxWidth="220.0" wrapText="true" />
                               </VBox>
                           </HBox>
-                          <HBox alignment="CENTER_LEFT" spacing="10" GridPane.columnIndex="1" GridPane.rowIndex="1">
-                              <CheckBox fx:id="checkboxProfileMaxActiveTimeEnabled" text="Limit Profile Active Time" />
-                              <Region HBox.hgrow="ALWAYS" />
-                              <Label text="min" />
-                              <VBox alignment="CENTER_RIGHT">
-                                  <TextField fx:id="textfieldProfileMaxActiveTimeMinutes" maxWidth="100.0" minWidth="70.0" prefWidth="80.0" />
-                                  <Label fx:id="labelProfileMaxActiveTimeError" maxWidth="220.0" wrapText="true" />
-                              </VBox>
-                          </HBox>
+                          <GridPane hgap="8" vgap="4" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                              <columnConstraints>
+                                  <ColumnConstraints hgrow="ALWAYS" />
+                                  <ColumnConstraints minWidth="70.0" prefWidth="100.0" />
+                                  <ColumnConstraints minWidth="28.0" />
+                              </columnConstraints>
+                              <CheckBox fx:id="checkboxProfileMaxActiveTimeEnabled" text="Limit Profile Active Time"
+                                        GridPane.columnIndex="0" GridPane.rowIndex="0" />
+                              <TextField fx:id="textfieldProfileMaxActiveTimeMinutes" maxWidth="100.0"
+                                         minWidth="70.0" prefWidth="80.0" GridPane.columnIndex="1" GridPane.rowIndex="0" />
+                              <Label text="min" GridPane.columnIndex="2" GridPane.rowIndex="0" />
+                              <Label fx:id="labelProfileMaxActiveTimeError" maxWidth="Infinity" wrapText="true"
+                                     GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="1" />
+                          </GridPane>
 
                           <!-- Row 3 -->
                           <HBox alignment="CENTER_LEFT" spacing="10" GridPane.columnIndex="0" GridPane.rowIndex="2">
@@ -92,15 +97,17 @@
                               <Region HBox.hgrow="ALWAYS" />
                               <ComboBox fx:id="comboboxStopBehaviorTelegram" maxWidth="Infinity" prefWidth="180.0" />
                           </HBox>
-                          <HBox alignment="CENTER_LEFT" spacing="8" GridPane.columnIndex="1" GridPane.rowIndex="3">
-                              <Label text="Delay:" />
-                              <VBox alignment="CENTER_RIGHT">
-                                  <TextField fx:id="textfieldAutoStartMinutes" maxWidth="70.0" minWidth="50.0" prefWidth="60.0" />
-                                  <Label fx:id="labelAutoStartMinutesError" maxWidth="220.0" wrapText="true" />
-                              </VBox>
-                              <Label text="min. Mode:" />
-                              <ComboBox fx:id="comboboxAutoStartMode" maxWidth="Infinity" prefWidth="150.0" />
-                          </HBox>
+                          <GridPane hgap="8" vgap="4" GridPane.columnIndex="1" GridPane.rowIndex="3">
+                              <Label text="Delay:" GridPane.columnIndex="0" GridPane.rowIndex="0" />
+                              <TextField fx:id="textfieldAutoStartMinutes" maxWidth="70.0" minWidth="50.0"
+                                         prefWidth="60.0" GridPane.columnIndex="1" GridPane.rowIndex="0" />
+                              <Label text="min" GridPane.columnIndex="2" GridPane.rowIndex="0" />
+                              <Label text="Mode:" GridPane.columnIndex="3" GridPane.rowIndex="0" />
+                              <ComboBox fx:id="comboboxAutoStartMode" maxWidth="Infinity" prefWidth="150.0"
+                                        GridPane.columnIndex="4" GridPane.rowIndex="0" />
+                              <Label fx:id="labelAutoStartMinutesError" maxWidth="Infinity" wrapText="true"
+                                     GridPane.columnIndex="1" GridPane.columnSpan="4" GridPane.rowIndex="1" />
+                          </GridPane>
                       </children>
                   </GridPane>
               </VBox>

--- a/modules/desktop/src/main/resources/layout/NewProfileLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/NewProfileLayout.fxml
@@ -31,17 +31,26 @@
 
             <HBox alignment="CENTER_LEFT" spacing="12">
                 <Label text="Name" minWidth="150" prefWidth="170" />
-                <TextField fx:id="textfieldProfileName" HBox.hgrow="ALWAYS" />
+                <VBox HBox.hgrow="ALWAYS">
+                    <TextField fx:id="textfieldProfileName" />
+                    <Label fx:id="labelProfileNameError" wrapText="true" />
+                </VBox>
             </HBox>
 
             <HBox alignment="CENTER_LEFT" spacing="12">
                 <Label text="Emulator" minWidth="150" prefWidth="170" />
-                <TextField fx:id="textfieldEmulatorNumber" HBox.hgrow="ALWAYS" />
+                <VBox HBox.hgrow="ALWAYS">
+                    <TextField fx:id="textfieldEmulatorNumber" />
+                    <Label fx:id="labelEmulatorNumberError" wrapText="true" />
+                </VBox>
             </HBox>
 
             <HBox alignment="CENTER_LEFT" spacing="12">
                 <Label text="Reconnect (min)" minWidth="150" prefWidth="170" />
-                <TextField fx:id="textfieldReconnectionTime" text="30" HBox.hgrow="ALWAYS" />
+                <VBox HBox.hgrow="ALWAYS">
+                    <TextField fx:id="textfieldReconnectionTime" text="30" />
+                    <Label fx:id="labelReconnectionTimeError" wrapText="true" />
+                </VBox>
             </HBox>
 
             <HBox alignment="CENTER_LEFT" spacing="12">

--- a/modules/desktop/src/test/java/dev/frostguard/app/shared/BearTrapTimerDateTimeUxTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/shared/BearTrapTimerDateTimeUxTest.java
@@ -185,7 +185,7 @@ class BearTrapTimerDateTimeUxTest {
     }
 
     @Test
-    void profileIntegerFieldKeepsInvalidUserInput() throws Exception {
+    void profileIntegerFieldRejectsCharactersBeforeValidation() throws Exception {
         runOnFxThread(() -> {
             TestProfileController controller = new TestProfileController();
             TextField field = new TextField();
@@ -197,7 +197,7 @@ class BearTrapTimerDateTimeUxTest {
             field.setText("invalid");
             field.fireEvent(new ActionEvent());
 
-            assertEquals("invalid", field.getText());
+            assertEquals("", field.getText());
             assertTrue(field.getStyleClass().contains("setting-field-error"));
             assertTrue(changes.isEmpty());
 
@@ -317,7 +317,7 @@ class BearTrapTimerDateTimeUxTest {
     }
 
     @Test
-    void enabledTimerWithMissingValueShowsValidationWithoutPersistingFallback() throws Exception {
+    void enabledTimerWithMissingValueFallsBackToOffWithoutPersisting() throws Exception {
         runOnFxThread(() -> {
             LoadedBearView view = loadBearView();
             List<Change> changes = new ArrayList<>();
@@ -330,7 +330,7 @@ class BearTrapTimerDateTimeUxTest {
             view.controller().onProfileLoad(profile);
 
             assertNull(view.timer1().getDateTime());
-            assertFalse(view.timer1().getValidationMessage().isEmpty());
+            assertTrue(view.timer1().getValidationMessage().isEmpty());
             assertTrue(view.timer2().getValidationMessage().isEmpty());
             assertTrue(view.trapNumber().getItems().isEmpty());
             assertTrue(view.trapNumber().isDisabled());

--- a/modules/desktop/src/test/java/dev/frostguard/app/shared/SettingValidatorsTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/shared/SettingValidatorsTest.java
@@ -39,4 +39,30 @@ class SettingValidatorsTest {
         assertFalse(validator.validate("24:00").isValid());
         assertFalse(validator.validate("9:30").isValid());
     }
+
+    @Test
+    void acceptsSignedPriorityButRejectsIntegerOverflow() {
+        SettingValidator<Integer> validator = SettingValidators.integer("Priority");
+
+        assertEquals(-10, validator.validate("-10").value());
+        assertFalse(validator.validate("999999999999999999999").isValid());
+    }
+
+    @Test
+    void validatesRequiredTextAndLongDurations() {
+        assertFalse(SettingValidators.requiredText("Name").validate("  ").isValid());
+        assertEquals("Frost", SettingValidators.requiredText("Name").validate(" Frost ").value());
+        assertEquals(0L, SettingValidators.nonNegativeLong("Delay").validate("0").value());
+        assertFalse(SettingValidators.nonNegativeLong("Delay").validate("9223372036854775808").isValid());
+    }
+
+    @Test
+    void rejectsReconnectDurationsBeyondOneWeek() {
+        SettingValidator<Long> validator = SettingValidators.rangedLong("Reconnection time", 0, 10_080);
+
+        assertEquals(10_080L, validator.validate("10080").value());
+        assertFalse(validator.validate("10081").isValid());
+        assertEquals("Reconnection time must be between 0 and 10080.",
+                validator.validate("10081").message());
+    }
 }


### PR DESCRIPTION
## Summary

- migrate Custom Task date/time, delay, offset, and priority fields to shared validation bindings
- keep invalid task drafts visible and prevent them from updating saved settings
- migrate profile creation and editing to consistent inline field feedback
- reject non-numeric input consistently and bound reconnect delays to 10,080 minutes
- keep unit labels stable, show complete Arena and Bear Trap messages, and reset Bear protection to Off when its timer is cleared

## Why

Custom Tasks and profile dialogs complete the representative migration set in #141. They previously ignored parse errors, restored older values, deferred feedback to a modal summary, or showed a red border without an actionable message. This is stack 3/3 and depends on #191.

## Stack

1. #190 -> `main`
2. #191 -> foundation branch
3. **This PR** -> `agent/settings-validation-profile-fields`

Merge through native GitHub stack #193.

## Validation

- `.\mvnw.cmd -pl modules/desktop -am test`
- 378 tests passed with 0 failures, errors, or skips
- FXML/controller binding tests cover the added inline labels
- live source-run UI verification confirmed consistent field filtering, stable unit placement, visible error messages, and the Bear protection fallback

## Risks

The inline errors can increase form height. The tested Emulator, Arena, Bear Trap, Custom Task, and profile surfaces behaved correctly in the source-run UI.

The mixed-DPI Windows snapping/taskbar behavior is unrelated and tracked separately in #196.

Closes #141