### PR TITLE
fix(scheduler): await active task shutdown

### DIFF
--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/TemplateSearchHelper.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/TemplateSearchHelper.java
@@ -82,6 +82,7 @@ public class TemplateSearchHelper {
                                               boolean mono, boolean multiScale) {
         ImageSearchResultData last = null;
         for (int a = 1; a <= cfg.getMaxAttempts(); a++) {
+            preemptionHook.run();
             last = multiScale ? doSearchMultiScale(tpl, cfg) : mono ? doSearchGrey(tpl, cfg) : doSearch(tpl, cfg);
             if (last != null && last.isFound()) {
                 dbg(tpl.name() + (multiScale ? " (multi-scale)" : "") + " found @ attempt " + a);
@@ -97,6 +98,7 @@ public class TemplateSearchHelper {
                                                          boolean mono) {
         List<ImageSearchResultData> last = null;
         for (int a = 1; a <= cfg.getMaxAttempts(); a++) {
+            preemptionHook.run();
             last = mono ? doMultiGrey(tpl, cfg) : doMulti(tpl, cfg);
             if (last != null && !last.isEmpty()) {
                 dbg(tpl.name() + ": " + last.size() + " matches");
@@ -148,6 +150,8 @@ public class TemplateSearchHelper {
         catch (InterruptedException e) {
             warn("Sleep interrupted");
             Thread.currentThread().interrupt();
+            preemptionHook.run();
+            throw new java.util.concurrent.CancellationException("Template search interrupted");
         }
     }
 

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/DelayedTask.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/DelayedTask.java
@@ -147,8 +147,10 @@ public abstract class DelayedTask implements Runnable, Delayed, StaminaWaitSched
 
     @Override
     public void run() {
+        checkPreemption();
         staminaDeferral = null;
         refreshProfileFromDb();
+        checkPreemption();
         boolean switchedProfileOnEmulator = markAndDetectProfileSwitchFlow();
         if (switchedProfileOnEmulator) {
             // Changed by pernerch | Date: 2026-07-02 | Why: publish active-profile changes

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/ExecutionContext.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/ExecutionContext.java
@@ -21,6 +21,11 @@ public class ExecutionContext {
         cancellationToken.trigger(rule);
     }
 
+    /** Permanently cancels the bound task because its queue is shutting down. */
+    public void cancel() {
+        cancellationToken.cancel();
+    }
+
     // Returns the task bound to this context.
     public DelayedTask getTask() {
         return boundTask;

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskDispatcher.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskDispatcher.java
@@ -1,5 +1,6 @@
 package dev.frostguard.engine.schedule;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -18,6 +19,7 @@ import org.slf4j.LoggerFactory;
 public class TaskDispatcher implements PreemptionListener, StaminaChangeListener {
 
     private static final Logger log = LoggerFactory.getLogger(TaskDispatcher.class);
+    private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
 
     private final Map<Long, TaskQueue> managedQueues = new ConcurrentHashMap<>();
     private final Map<Long, Boolean> pauseFlags = new ConcurrentHashMap<>();
@@ -86,6 +88,14 @@ public class TaskDispatcher implements PreemptionListener, StaminaChangeListener
     // ── start all queues ────────────────────────────────────────────
 
     public void startAll() {
+        List<String> liveProfiles = managedQueues.values().stream()
+                .filter(TaskQueue::hasLiveExecutor)
+                .map(queue -> queue.getProfile().getName())
+                .toList();
+        if (!liveProfiles.isEmpty()) {
+            throw new IllegalStateException("Cannot start queues while previous workers are alive: "
+                    + String.join(", ", liveProfiles));
+        }
         GlobalMonitorService monitor = GlobalMonitorService.getInstance();
         monitor.registerListener(this);
         StaminaService.getServices().addStaminaChangeListener(this);
@@ -129,9 +139,11 @@ public class TaskDispatcher implements PreemptionListener, StaminaChangeListener
 
     // ── stop all queues ─────────────────────────────────────────────
 
-    public void stopAll() {
+    public StopAllResult stopAll() {
         LoggingService.obtain().emit(TpMessageSeverityEnum.INFO, "TaskDispatcher", "-", "Stopping all queues");
         log.info("Stopping all queues");
+
+        List<Map.Entry<Long, TaskQueue>> queues = new ArrayList<>(managedQueues.entrySet());
 
         // mark all tasks as not scheduled
         for (Map.Entry<Long, TaskQueue> entry : managedQueues.entrySet()) {
@@ -147,12 +159,50 @@ public class TaskDispatcher implements PreemptionListener, StaminaChangeListener
         StaminaService.getServices().removeStaminaChangeListener(this);
         GlobalMonitorService.getInstance().shutdown();
 
-        managedQueues.values().forEach(TaskQueue::stop);
+        queues.forEach(entry -> entry.getValue().requestStop());
 
-        try { Thread.sleep(500); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); }
+        long deadline = System.nanoTime() + SHUTDOWN_TIMEOUT.toNanos();
+        List<TaskQueue.StopResult> results = new ArrayList<>();
+        for (Map.Entry<Long, TaskQueue> entry : queues) {
+            long remainingNanos = Math.max(0L, deadline - System.nanoTime());
+            TaskQueue.StopResult result = entry.getValue().awaitStop(Duration.ofNanos(remainingNanos));
+            results.add(result);
+            if (result.terminated()) {
+                managedQueues.remove(entry.getKey(), entry.getValue());
+                pauseFlags.remove(entry.getKey());
+            }
+        }
 
-        managedQueues.clear();
-        pauseFlags.clear();
+        StopAllResult outcome = new StopAllResult(List.copyOf(results));
+        if (outcome.complete()) {
+            log.info("All {} queue worker(s) terminated", results.size());
+        } else {
+            log.error("Queue shutdown incomplete; retaining {} live queue(s): {}",
+                    outcome.failures().size(), outcome.failureSummary());
+        }
+        return outcome;
+    }
+
+    public boolean hasManagedQueues() {
+        return !managedQueues.isEmpty();
+    }
+
+    public record StopAllResult(List<TaskQueue.StopResult> queues) {
+        public boolean complete() {
+            return queues.stream().allMatch(TaskQueue.StopResult::terminated);
+        }
+
+        public List<TaskQueue.StopResult> failures() {
+            return queues.stream().filter(result -> !result.terminated()).toList();
+        }
+
+        public String failureSummary() {
+            return failures().stream()
+                    .map(result -> result.profileName() + "/" + result.activeTask()
+                            + "=" + result.status() + " after " + result.elapsedMillis() + "ms")
+                    .reduce((left, right) -> left + ", " + right)
+                    .orElse("none");
+        }
     }
 
     // ── bulk pause / resume ─────────────────────────────────────────

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -69,13 +69,27 @@ public class TaskQueue {
     protected final EmulatorController deviceBridge = EmulatorController.getInstance();
 
     final TaskQueueStatusData statusModel = new TaskQueueStatusData();
-    private Thread              executor;
+    private final TaskQueueExecutor executor = new TaskQueueExecutor();
     private AccountDescriptor   profile;
     private volatile ExecutionContext   runningContext;
     private volatile LocalDateTime      sessionOrigin;
     // Changed by pernerch | Date: 2026-07-04 | Why: ensure first startup cycle runs Initialize regardless of idle heuristics.
     private volatile boolean    forceInitialInitialize = true;
     private volatile boolean    shuttingDown = false;
+    private volatile boolean    stoppedCleanly = false;
+
+    public enum StopStatus {
+        TERMINATED,
+        TIMED_OUT,
+        CALLER_INTERRUPTED
+    }
+
+    public record StopResult(Long profileId, String profileName, String activeTask,
+            StopStatus status, long elapsedMillis) {
+        public boolean terminated() {
+            return status == StopStatus.TERMINATED;
+        }
+    }
 
     public TaskQueue(AccountDescriptor profile) { this.profile = profile; }
 
@@ -285,31 +299,70 @@ public class TaskQueue {
 
     public void start() {
         if (statusModel.isRunning()) return;
+        if (executor.isAlive()) {
+            throw new IllegalStateException("Cannot start queue while its previous worker is still alive: "
+                    + profile.getName());
+        }
         // Changed by pernerch | Date: 2026-07-04 | Why: reset startup Initialize gate on each queue start.
         forceInitialInitialize = true;
+        shuttingDown = false;
+        stoppedCleanly = false;
         statusModel.setRunning(true);
-        executor = Thread.ofVirtual().unstarted(this::mainLoop);
-        executor.setName("TaskQueue-" + profile.getName());
-        executor.start();
+        executor.start(this::mainLoop, "TaskQueue-" + profile.getName());
     }
 
-    public void stop() {
+    public void requestStop() {
         shuttingDown = true;
         statusModel.setRunning(false);
         sessionOrigin = null;
-        if (executor != null) {
-            executor.interrupt();
-            try { 
-                // Give the task 2 seconds to finish gracefully
-                executor.join(2000); 
-            } catch (InterruptedException ie) { 
-                Thread.currentThread().interrupt(); 
-            }
+        ExecutionContext context = runningContext;
+        if (context != null) {
+            context.cancel();
         }
+        executor.interrupt();
+    }
+
+    public StopResult awaitStop(Duration timeout) {
+        String activeTask = activeTaskName();
+        TaskQueueExecutor.AwaitResult result = executor.awaitTermination(timeout);
+        StopResult stopResult = new StopResult(profile.getId(), profile.getName(), activeTask,
+                StopStatus.valueOf(result.termination().name()), result.elapsedMillis());
+        if (stopResult.terminated()) {
+            completeStop();
+        } else {
+            String reason = result.termination() == TaskQueueExecutor.Termination.TIMED_OUT
+                    ? "shutdown deadline exceeded"
+                    : "shutdown waiter interrupted";
+            broadcastStatus("STOPPING - " + reason);
+            emitError("Queue still active after stop request: task=" + activeTask
+                    + ", reason=" + reason + ", waitedMs=" + result.elapsedMillis());
+        }
+        return stopResult;
+    }
+
+    public StopResult stop() {
+        requestStop();
+        return awaitStop(Duration.ofSeconds(10));
+    }
+
+    public boolean hasLiveExecutor() {
+        return executor.isAlive();
+    }
+
+    private synchronized void completeStop() {
+        if (stoppedCleanly) {
+            return;
+        }
+        stoppedCleanly = true;
         statusModel.reset();
         taskBacklog.clear();
         broadcastStatus("NOT RUNNING");
-        emitInfo("TaskQueue stopped");
+        emitInfo("TaskQueue stopped after worker termination");
+    }
+
+    private String activeTaskName() {
+        ExecutionContext context = runningContext;
+        return context == null ? "none" : context.getTask().getTaskName();
     }
 
     public void pause()  { statusModel.userPause(); broadcastStatus("PAUSE REQUESTED"); emitInfo("Queue paused"); }
@@ -442,7 +495,12 @@ public class TaskQueue {
         long t0 = System.currentTimeMillis();
         boolean ok;
         ExecutionContext ctx = new ExecutionContext(task);
-        synchronized (this) { runningContext = ctx; }
+        synchronized (this) {
+            runningContext = ctx;
+            if (shuttingDown) {
+                ctx.cancel();
+            }
+        }
         try {
             emitInfoTask(task, "Executing: " + task.getTaskName());
             broadcastStatus("Executing " + task.getTaskName());

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueueExecutor.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueueExecutor.java
@@ -1,0 +1,89 @@
+package dev.frostguard.engine.schedule;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Owns the lifecycle of one queue worker without losing a timed-out thread.
+ */
+final class TaskQueueExecutor {
+
+    enum Termination {
+        TERMINATED,
+        TIMED_OUT,
+        CALLER_INTERRUPTED
+    }
+
+    record AwaitResult(Termination termination, long elapsedMillis) {
+        boolean terminated() {
+            return termination == Termination.TERMINATED;
+        }
+    }
+
+    private volatile Thread worker;
+
+    synchronized void start(Runnable runnable, String name) {
+        Objects.requireNonNull(runnable, "runnable");
+        Thread previous = worker;
+        if (previous != null && previous.isAlive()) {
+            throw new IllegalStateException("Previous queue worker is still running: " + previous.getName());
+        }
+
+        Thread next = Thread.ofVirtual().unstarted(runnable);
+        next.setName(name);
+        worker = next;
+        next.start();
+    }
+
+    void interrupt() {
+        Thread snapshot = worker;
+        if (snapshot != null) {
+            snapshot.interrupt();
+        }
+    }
+
+    AwaitResult awaitTermination(Duration timeout) {
+        Objects.requireNonNull(timeout, "timeout");
+        if (timeout.isNegative()) {
+            throw new IllegalArgumentException("timeout must not be negative");
+        }
+
+        Thread snapshot = worker;
+        if (snapshot == null || !snapshot.isAlive()) {
+            clearTerminated(snapshot);
+            return new AwaitResult(Termination.TERMINATED, 0L);
+        }
+        if (timeout.isZero()) {
+            return new AwaitResult(Termination.TIMED_OUT, 0L);
+        }
+
+        long startedAt = System.nanoTime();
+        try {
+            snapshot.join(Math.max(1L, timeout.toMillis()));
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return new AwaitResult(Termination.CALLER_INTERRUPTED, elapsedMillis(startedAt));
+        }
+
+        if (snapshot.isAlive()) {
+            return new AwaitResult(Termination.TIMED_OUT, elapsedMillis(startedAt));
+        }
+        clearTerminated(snapshot);
+        return new AwaitResult(Termination.TERMINATED, elapsedMillis(startedAt));
+    }
+
+    boolean isAlive() {
+        Thread snapshot = worker;
+        return snapshot != null && snapshot.isAlive();
+    }
+
+    private void clearTerminated(Thread expected) {
+        if (worker == expected && (expected == null || !expected.isAlive())) {
+            worker = null;
+        }
+    }
+
+    private static long elapsedMillis(long startedAt) {
+        return Duration.ofNanos(System.nanoTime() - startedAt).toMillis();
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/preempt/PreemptionToken.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/preempt/PreemptionToken.java
@@ -1,6 +1,7 @@
 package dev.frostguard.engine.schedule.preempt;
 
 import dev.frostguard.engine.error.TaskPreemptedException;
+import dev.frostguard.engine.error.StopExecutionException;
 
 /**
  * Thread-safe flag that allows the scheduler to signal a running task
@@ -10,6 +11,7 @@ import dev.frostguard.engine.error.TaskPreemptedException;
 public class PreemptionToken {
 
     private volatile PreemptionRule activeRule;
+    private volatile boolean cancellationRequested;
 
     /**
      * Arms the token with the triggering rule.  Only the first
@@ -26,13 +28,20 @@ public class PreemptionToken {
      * @throws TaskPreemptedException when the token is armed
      */
     public void check() {
+        if (cancellationRequested) throw StopExecutionException.userCancelled();
         PreemptionRule snapshot = activeRule;
         if (snapshot != null) throw new TaskPreemptedException(snapshot.getRuleName());
     }
+
+    /** Signals permanent queue shutdown independently of the worker interrupt flag. */
+    public void cancel() { cancellationRequested = true; }
 
     /** Non-throwing probe — returns {@code true} when the token is armed. */
     public boolean isTriggered() { return activeRule != null; }
 
     /** Disarms the token so it can be safely discarded. */
-    public synchronized void clear() { activeRule = null; }
+    public synchronized void clear() {
+        activeRule = null;
+        cancellationRequested = false;
+    }
 }

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/ScheduleService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/ScheduleService.java
@@ -77,7 +77,14 @@ public class ScheduleService {
 		}
 	}
 
-	public void launchEngine() {
+	public synchronized void launchEngine() {
+		if (dispatcher.hasManagedQueues()) {
+			log(TpMessageSeverityEnum.ERROR, "ScheduleService", "-",
+					"Engine launch blocked because a previous queue shutdown is incomplete");
+			notifyBotState(true, false);
+			notifyQueueState(null, false);
+			return;
+		}
 		if (!initializeBridge()) {
 			notifyBotState(false, false);
 			return;
@@ -129,8 +136,16 @@ public class ScheduleService {
 		haltEngine(resolveStopBehavior(ConfigurationKeyEnum.STOP_BEHAVIOR_TELEGRAM_STRING));
 	}
 
-	public void haltEngine(StopBehaviorEnum stopBehavior) {
-		dispatcher.stopAll();
+	public synchronized void haltEngine(StopBehaviorEnum stopBehavior) {
+		TaskDispatcher.StopAllResult result = dispatcher.stopAll();
+		if (!result.complete()) {
+			String detail = result.failureSummary();
+			log(TpMessageSeverityEnum.ERROR, "ScheduleService", "-",
+					"Bot stop incomplete; still-running queues remain tracked: " + detail);
+			notifyBotState(true, false);
+			notifyQueueState(null, false);
+			throw new IncompleteTaskShutdownException(detail);
+		}
 		if (stopBehavior == StopBehaviorEnum.CLOSE_EMULATOR) {
 			closeEnabledEmulators();
 		}
@@ -140,6 +155,12 @@ public class ScheduleService {
 		}
 		notifyBotState(false, false);
 		notifyQueueState(null, false);
+	}
+
+	public static final class IncompleteTaskShutdownException extends IllegalStateException {
+		public IncompleteTaskShutdownException(String detail) {
+			super("Task queues did not terminate: " + detail);
+		}
 	}
 
 	private StopBehaviorEnum resolveStopBehavior(ConfigurationKeyEnum key) {

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramBotService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TelegramBotService.java
@@ -182,8 +182,12 @@ public class TelegramBotService implements BotStateListener {
             } else {
                 Thread.ofVirtual().start(() -> {
                     // Changed by pernerch | Date: 2026-07-04 | Why: use Telegram-specific stop policy instead of generic stop path.
-                    ScheduleService.obtain().haltEngineFromTelegram();
-                    sendMessage(chatId, "⏹️ Bot stopped.");
+                    try {
+                        ScheduleService.obtain().haltEngineFromTelegram();
+                        sendMessage(chatId, "⏹️ Bot stopped.");
+                    } catch (ScheduleService.IncompleteTaskShutdownException exception) {
+                        sendMessage(chatId, "⚠️ Bot stop is incomplete. A task is still stopping; no replacement queue will start.");
+                    }
                 });
             }
         } else if (text.startsWith("/status") || text.contains("status")) {
@@ -1160,8 +1164,10 @@ public class TelegramBotService implements BotStateListener {
 
             try {
                 ScheduleService.obtain().haltEngine();
-            } catch (Exception ex) {
-                logger.warn("Reboot: stopBot soft handled: {}", ex.getMessage());
+            } catch (ScheduleService.IncompleteTaskShutdownException exception) {
+                logger.error("Reboot cancelled because task shutdown is incomplete: {}", exception.getMessage());
+                sendMessage(chatId, "⚠️ Restart cancelled because a task is still stopping.");
+                return;
             }
             Thread.sleep(1500);
 

--- a/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueExecutorTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueExecutorTest.java
@@ -1,0 +1,70 @@
+package dev.frostguard.engine.schedule;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+
+import org.junit.jupiter.api.Test;
+
+class TaskQueueExecutorTest {
+
+    @Test
+    void interruptibleWorkerTerminatesBeforeStopCompletes() throws Exception {
+        TaskQueueExecutor executor = new TaskQueueExecutor();
+        CountDownLatch started = new CountDownLatch(1);
+
+        executor.start(() -> {
+            started.countDown();
+            try {
+                Thread.sleep(Duration.ofMinutes(1));
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+            }
+        }, "cooperative-worker");
+        assertTrue(started.await(1, TimeUnit.SECONDS));
+
+        executor.interrupt();
+        TaskQueueExecutor.AwaitResult result = executor.awaitTermination(Duration.ofSeconds(1));
+
+        assertTrue(result.terminated());
+        assertFalse(executor.isAlive());
+    }
+
+    @Test
+    void timedOutWorkerRemainsTrackedAndBlocksReplacement() throws Exception {
+        TaskQueueExecutor executor = new TaskQueueExecutor();
+        CountDownLatch started = new CountDownLatch(1);
+        AtomicBoolean release = new AtomicBoolean();
+
+        executor.start(() -> {
+            started.countDown();
+            while (!release.get()) {
+                Thread.interrupted();
+                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+            }
+        }, "non-cooperative-worker");
+        assertTrue(started.await(1, TimeUnit.SECONDS));
+
+        try {
+            executor.interrupt();
+            assertFalse(executor.awaitTermination(Duration.ZERO).terminated());
+            TaskQueueExecutor.AwaitResult timedOut = executor.awaitTermination(Duration.ofMillis(25));
+
+            assertFalse(timedOut.terminated());
+            assertTrue(executor.isAlive());
+            assertThrows(IllegalStateException.class,
+                    () -> executor.start(() -> { }, "replacement-worker"));
+        } finally {
+            release.set(true);
+        }
+
+        assertTrue(executor.awaitTermination(Duration.ofSeconds(1)).terminated());
+        assertFalse(executor.isAlive());
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/schedule/preempt/PreemptionTokenTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/schedule/preempt/PreemptionTokenTest.java
@@ -1,0 +1,26 @@
+package dev.frostguard.engine.schedule.preempt;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import dev.frostguard.engine.error.StopExecutionException;
+
+class PreemptionTokenTest {
+
+    @Test
+    void queueCancellationRemainsArmedUntilExecutionCompletes() {
+        PreemptionToken token = new PreemptionToken();
+
+        token.cancel();
+
+        StopExecutionException first = assertThrows(StopExecutionException.class, token::check);
+        assertTrue(first.isCancellation());
+        assertThrows(StopExecutionException.class, token::check);
+
+        token.clear();
+        assertDoesNotThrow(token::check);
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/vision/ocr/ResilientOcrExecutorTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/vision/ocr/ResilientOcrExecutorTest.java
@@ -1,0 +1,30 @@
+package dev.frostguard.vision.ocr;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.CancellationException;
+
+import org.junit.jupiter.api.Test;
+
+import dev.frostguard.api.domain.PointData;
+
+class ResilientOcrExecutorTest {
+
+    @Test
+    void rejectsRecognitionWhenCallingThreadIsAlreadyInterrupted() {
+        ResilientOcrExecutor<String> executor = new ResilientOcrExecutor<>((config, topLeft, bottomRight) -> "42");
+        Thread.currentThread().interrupt();
+        try {
+            assertThrows(CancellationException.class, () -> executor.attemptRecognition(
+                    new PointData(0, 0),
+                    new PointData(10, 10),
+                    1,
+                    0,
+                    null,
+                    text -> true,
+                    text -> text));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
@@ -1116,11 +1116,24 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
                     buttonPauseResume.setDisable(true);
                 });
                 isStartup = false;
-                actionController.stopBot();
+                try {
+                    actionController.stopBot();
+                } catch (ScheduleService.IncompleteTaskShutdownException exception) {
+                    Platform.runLater(() -> showIncompleteStopWarning(exception.getMessage()));
+                }
             }
         });
         startStopThread.setName("Start-Stop-Thread");
         startStopThread.start();
+    }
+
+    private void showIncompleteStopWarning(String detail) {
+        Alert alert = new Alert(Alert.AlertType.ERROR);
+        alert.setTitle("Bot stop incomplete");
+        alert.setHeaderText("One or more tasks are still stopping");
+        alert.setContentText(detail + "\n\nThe queues remain tracked and Frostguard will not start replacements. "
+                + "Try Stop again after the blocking operation returns.");
+        alert.showAndWait();
     }
 
     public void forceStartBot() { /* bind */

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/ResilientOcrExecutor.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/ResilientOcrExecutor.java
@@ -6,6 +6,7 @@ import dev.frostguard.api.domain.TesseractSettingsData;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.CancellationException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import net.sourceforge.tess4j.TesseractException;
@@ -78,9 +79,11 @@ public class ResilientOcrExecutor<R> {
                                 Function<String, R> transformer) {
 
         for (int trial = 0; trial < maxAttempts; trial++) {
+            checkCancellation();
             log.debug("OCR trial {} / {}", trial + 1, maxAttempts);
             try {
                 String raw = textExtractor.extractText(config, upperLeft, lowerRight);
+                checkCancellation();
                 if (raw != null) {
                     if (acceptor.test(raw)) {
                         log.info("=== OCR Completed === Text: '{}', Match: true, Position: ({},{}) to ({},{})",
@@ -95,6 +98,8 @@ public class ResilientOcrExecutor<R> {
                                 lowerRight.getX(), lowerRight.getY());
                     }
                 }
+            } catch (CancellationException exception) {
+                throw exception;
             } catch (IOException | TesseractException | RuntimeException ex) {
                 log.warn("OCR trial {} failed: {}", trial + 1, ex.getMessage());
             }
@@ -104,11 +109,17 @@ public class ResilientOcrExecutor<R> {
                     Thread.sleep(pauseMillis);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
-                    return null;
+                    throw new CancellationException("OCR retry interrupted");
                 }
             }
         }
         return null;
+    }
+
+    private static void checkCancellation() {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new CancellationException("OCR cancelled");
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- stop all queue workers concurrently and wait for their actual termination before reporting the bot stopped
- retain timed-out workers so a replacement queue cannot start alongside an orphaned task
- propagate persistent cancellation through task delays, template searches, and resilient OCR retries
- surface incomplete shutdown through desktop, Telegram, reboot, and application lifecycle paths

## Why

Stopping previously cleared scheduler state after interrupting queue threads without proving that the workers had exited. A task that swallowed or delayed interruption could therefore continue emulator actions after the UI reported the bot stopped, and a subsequent start could launch a second worker for the same profile.

Closes #189.

## Validation

- Automated tests: `mvnw.cmd package` — 384 tests passed and the desktop bundle built successfully.
- Live account log: MuMu profile `Default` was stopped twice during active `Gather Resources` execution. Both runs logged `Task interrupted during shutdown`, then `TaskQueue stopped after worker termination`, then `All 1 queue worker(s) terminated` within milliseconds.
- Live restart: the bot restarted cleanly after the first stop.
- Post-stop evidence: no emulator taps, swipes, OCR calls, or task entries appeared after the final worker-termination message.

## Risks

Live verification covered one MuMu profile. Concurrent multi-queue shutdown and timeout retention are covered by automated tests but were not exercised with multiple live emulators.