### PR TITLE
docs(guidance): correct runtime evidence paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,12 @@ changes.
 
 Logs should make decisions explainable: include relevant profile context,
 evidence, the chosen outcome, and retry or fallback reasons without flooding hot
-loops. Runtime evidence is normally under `modules/desktop/target`: account logs in
-`logs/`, the global log in `log/frostguard.log`, archives in `log/archive/`, and
-debug screenshots in `temp/`.
+loops. Runtime evidence belongs to the selected workspace, not generated
+`target/` output. Source and IDE launches normally use `<worktree>/.frostguard-dev`;
+installed Stable and Nightly releases default to
+`~/.frostguard/workspaces/<channel>/<name>`. Each workspace keeps the global log
+at `logs/frostguard.log`, account logs as `logs/account_<name>_<id>.log`, and
+rotated archives under `logs/archive/`.
 
 State the evidence level whenever reporting a behavioral fix:
 


### PR DESCRIPTION
## Summary

- point runtime-log investigation at the selected Frostguard workspace instead of Maven `target/` output
- document the Development and installed Stable/Nightly workspace defaults
- correct the global, account, and archive log locations
- remove obsolete guidance claiming debug screenshots live in `temp/`

## Why

The contributor guidance still described the pre-workspace runtime layout. This sent Nightly log investigation to `modules/desktop/target`, while current installed releases store mutable state under `~/.frostguard/workspaces/<channel>/<name>` and source runs use `<worktree>/.frostguard-dev`.

A repository-wide audit found no other stale runtime-log-path statement. The related developer and architecture guides already describe workspace ownership correctly.

## Validation

- `mvnw.cmd -pl modules/api -am test` — 35 tests passed, including 9 `WorkspaceSessionTest` cases
- `git diff --check`
- repository-wide search for the old `target/logs`, `log/frostguard.log`, `log/archive`, and `temp/` runtime-evidence guidance
- compared the guidance with `WorkspacePaths`, `WorkspaceSession`, `ProfileContextLogger`, and `logback.xml`
- observed the active Nightly logs at `C:\Users\david\.frostguard\workspaces\nightly\default\logs`

## Risks

Documentation-only. No runtime behavior changed.
