### PR TITLE
docs(actions): clarify workflow purpose and triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI — Java Build and Tests
 
 on:
   pull_request:

--- a/.github/workflows/daily-windows-bundle.yml
+++ b/.github/workflows/daily-windows-bundle.yml
@@ -1,4 +1,4 @@
-name: Legacy Windows Bundle Candidate
+name: Legacy 2.x — Build ZIP Candidate
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-discord-build-pr-worker.yml
+++ b/.github/workflows/deploy-discord-build-pr-worker.yml
@@ -1,4 +1,4 @@
-name: Deploy Discord Build PR Worker
+name: Discord — Deploy /build-pr Worker
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -27,7 +27,7 @@
 # Nothing in this workflow pushes to main or to any PR branch: all merging
 # happens on a detached HEAD inside the runner's disposable checkout.
 
-name: PR Test Build
+name: PR Build — Create Test Release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pr-test-cleanup.yml
+++ b/.github/workflows/pr-test-cleanup.yml
@@ -13,7 +13,7 @@
 # `nightly` release and real releases are untouched: only tags with the
 # pr-test- prefix are ever considered.
 
-name: PR Test Release Cleanup
+name: PR Build — Clean Up Test Releases
 
 on:
   schedule:

--- a/.github/workflows/refresh-nightly-discord.yml
+++ b/.github/workflows/refresh-nightly-discord.yml
@@ -1,4 +1,4 @@
-name: Refresh Nightly Discord Message
+name: Discord — Refresh Nightly Message
 
 on:
   workflow_dispatch:

--- a/.github/workflows/refresh-stable-discord.yml
+++ b/.github/workflows/refresh-stable-discord.yml
@@ -1,4 +1,4 @@
-name: Refresh Stable Discord Message
+name: Discord — Refresh Stable Message
 
 on:
   workflow_dispatch:

--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -1,4 +1,4 @@
-name: Windows Channel Release
+name: Release — Windows Stable or Nightly
 
 on:
   schedule:

--- a/.github/workflows/stable-windows-release.yml
+++ b/.github/workflows/stable-windows-release.yml
@@ -1,4 +1,4 @@
-name: Stable Windows Release
+name: Legacy 2.x — Publish Stable ZIP
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       daily_run_id:
-        description: "Successful Legacy Windows Bundle Candidate run ID from main"
+        description: "Successful Legacy 2.x — Build ZIP Candidate run ID from main"
         required: true
         type: string
 
@@ -55,7 +55,7 @@ jobs:
             exit 1
           fi
           if [[ "${workflow}" != ".github/workflows/daily-windows-bundle.yml" ]]; then
-            echo "::error::Selected run does not belong to Legacy Windows Bundle Candidate."
+            echo "::error::Selected run does not belong to Legacy 2.x — Build ZIP Candidate."
             exit 1
           fi
           echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
@@ -84,7 +84,7 @@ jobs:
             exit 1
           fi
           if (( ${VERSION%%.*} >= 3 )); then
-            echo "::error::Frostguard 3.x must use Windows Channel Release; the legacy ZIP workflow cannot publish an installed Stable identity."
+            echo "::error::Frostguard 3.x must use Release — Windows Stable or Nightly; the legacy ZIP workflow cannot publish an installed Stable identity."
             exit 1
           fi
           project_version="$(./mvnw -B --no-transfer-progress -q help:evaluate -Dexpression=project.version -DforceStdout)"

--- a/.github/workflows/sync-discord-build-pr-command.yml
+++ b/.github/workflows/sync-discord-build-pr-command.yml
@@ -1,4 +1,4 @@
-name: Sync Discord Commands
+name: Discord — Sync /build-pr Command
 
 on:
   workflow_dispatch:

--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -1,4 +1,4 @@
-name: Windows Installers
+name: CI — Windows Installers
 
 on:
   pull_request:

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -28,27 +28,27 @@ class ChannelPackagingTest(unittest.TestCase):
         installers = (REPO_ROOT / ".github/workflows/windows-native-package.yml").read_text(
             encoding="utf-8")
 
-        self.assertIn("name: CI", ci)
+        self.assertIn("name: CI — Java Build and Tests", ci)
         self.assertIn("  pull_request:", ci)
         self.assertIn("  contents: read", ci)
         self.assertIn("Build and test Maven reactor", ci)
         self.assertNotIn("contents: write", ci)
 
-        self.assertIn("name: Legacy Windows Bundle Candidate", legacy)
+        self.assertIn("name: Legacy 2.x — Build ZIP Candidate", legacy)
         self.assertIn("  workflow_dispatch:", legacy)
         self.assertNotIn("  schedule:", legacy)
         self.assertNotIn("contents: write", legacy)
         self.assertNotIn("gh release create nightly", legacy)
         self.assertNotIn("Update the Nightly Discord message", legacy)
 
-        self.assertIn("name: Windows Channel Release", nightly)
+        self.assertIn("name: Release — Windows Stable or Nightly", nightly)
         self.assertIn("  schedule:", nightly)
         self.assertIn("  workflow_dispatch:", nightly)
         self.assertNotIn("  pull_request:", nightly)
         self.assertNotIn("\n  push:\n", nightly)
         self.assertIn("      contents: write", nightly)
 
-        self.assertIn("name: Windows Installers", installers)
+        self.assertIn("name: CI — Windows Installers", installers)
         self.assertIn("Build and smoke-test Stable and Nightly installers", installers)
         self.assertIn('java-version: "21.0.12+8.0"', installers)
 
@@ -204,7 +204,9 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertNotIn("--cleanup-tag --yes", workflow)
         legacy_stable = (REPO_ROOT / ".github/workflows/stable-windows-release.yml").read_text(
             encoding="utf-8")
-        self.assertIn("Frostguard 3.x must use Windows Channel Release", legacy_stable)
+        self.assertIn(
+            "Frostguard 3.x must use Release — Windows Stable or Nightly",
+            legacy_stable)
 
     def test_stable_discord_refresh_resolves_the_versioned_msi(self):
         workflow = (REPO_ROOT / ".github/workflows/refresh-stable-discord.yml").read_text(
@@ -220,7 +222,7 @@ class ChannelPackagingTest(unittest.TestCase):
         workflow = (REPO_ROOT / ".github/workflows/refresh-nightly-discord.yml").read_text(
             encoding="utf-8")
 
-        self.assertIn("name: Refresh Nightly Discord Message", workflow)
+        self.assertIn("name: Discord — Refresh Nightly Message", workflow)
         self.assertIn("  workflow_dispatch:", workflow)
         self.assertIn("  contents: read", workflow)
         self.assertNotIn("contents: write", workflow)

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -26,7 +26,8 @@ merging anything, e.g.:
 This directory contains the Discord half; the build half lives in
 the canonical [`pr-test-build.yml`](../.github/workflows/pr-test-build.yml).
 The Discord command is optional: the same feature works today from the
-GitHub **Actions tab → PR Test Build → Run workflow** with `prs: 47,48,49,65`.
+GitHub **Actions tab → PR Build — Create Test Release → Run workflow** with
+`prs: 47,48,49,65`.
 
 ## How a request flows
 
@@ -120,9 +121,9 @@ Wrangler prints the worker URL, e.g.
 `https://frostguard-build-pr.<your-subdomain>.workers.dev`.
 
 For repeatable deployments, add `CLOUDFLARE_API_TOKEN` and
-`CLOUDFLARE_ACCOUNT_ID` as GitHub repository secrets, then run **Deploy Discord
-Build PR Worker** from the Actions tab. Existing Worker secrets remain stored
-at Cloudflare and are not committed or printed by the workflow.
+`CLOUDFLARE_ACCOUNT_ID` as GitHub repository secrets, then run **Discord —
+Deploy /build-pr Worker** from the Actions tab. Existing Worker secrets remain
+stored at Cloudflare and are not committed or printed by the workflow.
 
 ### 4. Point Discord at the worker
 
@@ -144,7 +145,7 @@ leaves one guild copy of each command instead of duplicate global and guild
 entries.
 
 Alternatively, store the client secret as the GitHub repository secret
-`DISCORD_CLIENT_SECRET` and run **Sync Discord Build PR Command** from the
+`DISCORD_CLIENT_SECRET` and run **Discord — Sync /build-pr Command** from the
 Actions tab. The script requests a short-lived OAuth2 client-credentials token;
 the secret and access token are never printed.
 
@@ -167,7 +168,7 @@ requester and includes an **Open the original request** link instead.
 
 1. In the allowed channel run `/build-pr prs: <an open PR number>`.
 2. Check the plan shows the pinned SHA, press **Build**.
-3. Watch the run under Actions → *PR Test Build*.
+3. Watch the run under Actions → *PR Build — Create Test Release*.
 4. The result arrives in the same channel, mentions only the requester and
    links the original status message.
 
@@ -185,8 +186,8 @@ only needs to:
    read back from GitHub afterward.
 2. Confirm the existing Cloudflare Worker still has `DISCORD_PUBLIC_KEY` and
    its fine-grained `GITHUB_TOKEN` Worker secrets.
-3. Run **Deploy Discord Build PR Worker**.
-4. Run **Sync Discord Build PR Command**.
+3. Run **Discord — Deploy /build-pr Worker**.
+4. Run **Discord — Sync /build-pr Command**.
 5. Test `/build-pr` in `#request-a-build` with a non-admin account.
 
 ## Configuration reference

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -16,9 +16,35 @@ it in the release list. The mutable `nightly` release is different: GitHub has
 no built-in latest-prerelease URL, so it provides both the permanent landing
 page and the stable signed-manifest URL required by installed Nightly clients.
 
+## GitHub Actions quick reference
+
+Workflow names use purpose prefixes so related entries stay together in the
+alphabetical Actions sidebar. GitHub schedules always use UTC; the Central
+European local time shown below shifts when daylight-saving time changes.
+
+| Workflow | Runs | Purpose and side effects |
+|---|---|---|
+| **CI — Java Build and Tests** | Automatically for every pull request and every push to `main` | Builds and tests the complete reactor on Linux. It publishes only short-lived test-report artifacts, never a release. |
+| **CI — Windows Installers** | Automatically for pull requests that touch packaging-related paths | Builds and smoke-tests the Stable and Nightly MSI packages. It uploads short-lived Actions artifacts, never a GitHub Release. |
+| **CI — Windows Installers** | Manually with prerelease application and numeric MSI versions | Produces an unpublished Stable release candidate for upgrade testing. It does not change `releases/latest`. |
+| **PR Build — Create Test Release** | Manually in Actions or dispatched through Discord `/build-pr` | Combines selected open pull requests and publishes a temporary `pr-test-*` prerelease. A Discord-originated request receives the result in Discord. |
+| **PR Build — Clean Up Test Releases** | Daily at 04:43 UTC (06:43 CEST / 05:43 CET), or manually | Deletes expired `pr-test-*` releases and their tags, including builds whose selected pull requests are all closed. It never touches Nightly or permanent releases. |
+| **Release — Windows Stable or Nightly** | Daily at 03:17 UTC (05:17 CEST / 04:17 CET) | Builds and publishes the next authenticated Nightly from `main`, promotes its signed feed, and updates the maintained Nightly Discord message. |
+| **Release — Windows Stable or Nightly** | Manually from `main` with channel, version, and minimum updater version | Publishes a current 3.x Stable or an additional Nightly. This is the only current Windows release workflow. |
+| **Legacy 2.x — Build ZIP Candidate** | Manually | Builds a legacy 2.x ZIP as an Actions artifact. It does not publish a release or update Discord. |
+| **Legacy 2.x — Publish Stable ZIP** | Manually with a version and successful candidate run ID | Verifies and publishes one selected legacy 2.x candidate as Stable, then updates the maintained Stable Discord message. It rejects Frostguard 3.x. |
+| **Discord — Deploy /build-pr Worker** | Manually | Tests and deploys the Cloudflare Worker that receives Discord interactions. |
+| **Discord — Sync /build-pr Command** | Manually | Registers the guild-scoped `/build-pr` command and removes duplicate global commands. |
+| **Discord — Refresh Nightly Message** | Manually | Re-resolves the current signed Nightly release and refreshes its maintained Discord message without building or publishing a release. |
+| **Discord — Refresh Stable Message** | Manually | Re-resolves GitHub's latest Stable release and refreshes its maintained Discord message without building or publishing a release. |
+
+Manual release, legacy publication, cleanup, deployment, synchronization, and
+repair workflows can modify GitHub Releases or external services. Inspect their
+inputs and the relevant section below before selecting **Run workflow**.
+
 ## Authenticated installed releases
 
-**Windows Channel Release** runs Nightly automatically once per day
+**Release — Windows Stable or Nightly** runs Nightly automatically once per day
 from `main`. It reads the previous signed feed and derives the next version,
 resetting the sequence to 1 on a new UTC date. A maintainer can also run it
 manually for Stable or an additional Nightly. Stable versions use `X.Y.Z`;
@@ -66,9 +92,10 @@ recreated.
 
 ### Unpublished Stable release candidates
 
-Before promoting a new Stable major or minor version, manually run **Windows
-Installers** with a prerelease application version such as `3.0.0-rc.1` and a
-numeric Windows Installer version below the final release, such as `2.99.1`.
+Before promoting a new Stable major or minor version, manually run **CI —
+Windows Installers** with a prerelease application version such as
+`3.0.0-rc.1` and a numeric Windows Installer version below the final release,
+such as `2.99.1`.
 The workflow validates that ordering, builds with release updates disabled,
 verifies the pinned Stable launcher hashes, smoke-tests the image, and uploads
 the MSI only as a short-lived Actions artifact. It does not create a GitHub
@@ -82,11 +109,12 @@ of the numeric MSI version.
 
 ## Legacy 2.x ZIP promotion
 
-The manual-only **Legacy Windows Bundle Candidate** workflow can still produce
+The manual-only **Legacy 2.x — Build ZIP Candidate** workflow can still produce
 an Actions artifact for an intentional 2.x maintenance release. It no longer
 publishes a Nightly, has no schedule, and does not update Discord. The legacy
 Stable ZIP workflow promotes one of those successful runs from `main`; it does
-not rebuild a different tree. Run **Stable Windows Release** manually with:
+not rebuild a different tree. Run **Legacy 2.x — Publish Stable ZIP** manually
+with:
 
 - `version`: the `X.Y.Z` value declared in `pom.xml`;
 - `daily_run_id`: a successful manually triggered legacy candidate run from
@@ -127,9 +155,9 @@ Java. A Windows Unknown publisher or SmartScreen warning is currently expected.
 
 The Stable guide links to GitHub's Latest release because the immutable MSI
 filename contains its version. Store the webhook-owned card ID in
-`DISCORD_STABLE_MESSAGE_ID`. Run `Refresh Stable Discord Message` after a Stable
-promotion; it resolves and verifies the exact versioned MSI from Latest before
-updating the maintained card.
+`DISCORD_STABLE_MESSAGE_ID`. Run **Discord — Refresh Stable Message** after a
+Stable promotion; it resolves and verifies the exact versioned MSI from Latest
+before updating the maintained card.
 
 ### Maintained Nightly message
 
@@ -151,7 +179,7 @@ Do not post a new Discord message for every daily build. Store the webhook-owned
 message ID in the repository variable `DISCORD_DAILY_MESSAGE_ID`; successful
 native Nightly publications edit that message with the immutable MSI URL and
 permanent channel URL. Build failures link to Actions and do not replace the
-last working public download. Run **Refresh Nightly Discord Message** to repair
+last working public download. Run **Discord — Refresh Nightly Message** to repair
 the card from the current project-signed feed without building another MSI.
 
 ## Migration


### PR DESCRIPTION
## Summary

- group all 11 GitHub Actions display names by operational purpose
- add a central quick-reference table for automatic, scheduled, manual, and Discord-dispatched runs
- distinguish current 3.x Windows releases from legacy 2.x ZIP publication
- update Discord operator instructions and workflow-name contract tests

## Why

The Actions sidebar mixed CI, release publication, PR-test infrastructure,
Discord maintenance, and legacy workflows without visible grouping. Some names
were actively misleading: `Stable Windows Release` is limited to legacy 2.x,
while current Stable and Nightly installers are published by the former
`Windows Channel Release` workflow.

## Validation

- `python -m unittest build-support.verification.test_channel_packaging` — 6 tests passed
- `python -m unittest discover -s build-support/verification -p "test_*.py"` — 40 tests passed
- `python build-support/verification/check_workflow_python.py` — all 3 inline snippets compile
- custom consistency check — 11 unique workflow names documented; changed local Markdown links resolve
- `git diff --check` — passed

No live release, deployment, or Discord run was performed because workflow
behavior is unchanged.

## Risks

Workflow file paths, triggers, job names, permissions, and publication behavior
are unchanged. The main remaining risk is an external reference to an old
display name; repository-owned references and assertions were updated.

Closes #201
