### PR TITLE
fix(release): restore complete Nightly changelog

### DIFF
--- a/.github/workflows/refresh-nightly-discord.yml
+++ b/.github/workflows/refresh-nightly-discord.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -30,11 +32,10 @@ jobs:
           ./mvnw -B --no-transfer-progress -Dstyle.color=never
           -pl modules/update -am -DskipTests package dependency:copy-dependencies
 
-      - name: Resolve, verify, and publish the current Nightly
+      - name: Resolve and verify the current Nightly
+        id: nightly
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
-          DISCORD_DAILY_MESSAGE_ID: ${{ vars.DISCORD_DAILY_MESSAGE_ID }}
         shell: bash
         run: |
           set -euo pipefail
@@ -83,11 +84,58 @@ jobs:
             exit 1
           fi
 
-          python3 build-support/notifications/discord_notify.py \
-            --status success \
-            --version "${version}" \
-            --download-url "${installer_url}" \
-            --release-url "${release_url}" \
-            --channel-url "${channel_url}" \
+          {
+            echo "version=${version}"
+            echo "release_url=${release_url}"
+            echo "installer_url=${installer_url}"
+            echo "channel_url=${channel_url}"
+            echo "immutable_tag=${immutable_tag}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Collect changes between Nightly builds
+        id: nightly-changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMMUTABLE_TAG: ${{ steps.nightly.outputs.immutable_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          history="$(mktemp)"
+          gh api --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > "${history}"
+          python3 build-support/release/nightly_changes.py \
             --repository "${GITHUB_REPOSITORY}" \
+            --release-history "${history}" \
+            --current-tag "${IMMUTABLE_TAG}" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Update the maintained Nightly Discord message
+        env:
+          DISCORD_NIGHTLY_WEBHOOK_URL: ${{ secrets.DISCORD_NIGHTLY_WEBHOOK_URL }}
+          DISCORD_DAILY_MESSAGE_ID: ${{ vars.DISCORD_DAILY_MESSAGE_ID }}
+          VERSION: ${{ steps.nightly.outputs.version }}
+          RELEASE_URL: ${{ steps.nightly.outputs.release_url }}
+          INSTALLER_URL: ${{ steps.nightly.outputs.installer_url }}
+          CHANNEL_URL: ${{ steps.nightly.outputs.channel_url }}
+          NIGHTLY_CHANGES: ${{ steps.nightly-changes.outputs.changes }}
+          CHANGES_UNCHANGED: ${{ steps.nightly-changes.outputs.unchanged }}
+          CHANGES_UPDATED_AT: ${{ steps.nightly-changes.outputs.updated_at }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          notification_args=(
+            --status success
+            --version "${VERSION}"
+            --download-url "${INSTALLER_URL}"
+            --release-url "${RELEASE_URL}"
+            --channel-url "${CHANNEL_URL}"
+            --repository "${GITHUB_REPOSITORY}"
+            --changes "${NIGHTLY_CHANGES}"
+            --changes-updated-at "${CHANGES_UPDATED_AT}"
             --message-id "${DISCORD_DAILY_MESSAGE_ID}"
+          )
+          if [[ "${CHANGES_UNCHANGED}" == "true" ]]; then
+            notification_args+=(--changes-unchanged)
+          fi
+          python3 build-support/notifications/discord_notify.py \
+            "${notification_args[@]}"

--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Check out main with release assets
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           lfs: true
 
       - name: Verify Git LFS assets are real binaries
@@ -523,6 +524,29 @@ jobs:
                   -Encoding utf8 -Append
           }
 
+      - name: Collect changes between Nightly builds
+        id: nightly-changes
+        if: success() && env.CHANNEL == 'nightly'
+        shell: pwsh
+        env:
+          TAG: ${{ steps.identity.outputs.tag }}
+        run: |
+          $history = Join-Path $env:RUNNER_TEMP "nightly-release-history.json"
+          gh api --paginate --slurp `
+              "repos/$($env:GITHUB_REPOSITORY)/releases?per_page=100" |
+              Out-File -LiteralPath $history -Encoding utf8
+          if ($LASTEXITCODE -ne 0) {
+              throw "Could not list immutable Nightly releases"
+          }
+          python build-support/release/nightly_changes.py `
+              --repository $env:GITHUB_REPOSITORY `
+              --release-history $history `
+              --current-tag $env:TAG `
+              --github-output $env:GITHUB_OUTPUT
+          if ($LASTEXITCODE -ne 0) {
+              throw "Could not collect changes between Nightly builds"
+          }
+
       - name: Update the maintained Nightly Discord message
         if: always() && env.CHANNEL == 'nightly'
         continue-on-error: true
@@ -534,6 +558,9 @@ jobs:
           RELEASE_URL: ${{ steps.publish.outputs.release_url }}
           CHANNEL_URL: ${{ steps.publish.outputs.channel_url }}
           TAG: ${{ steps.identity.outputs.tag }}
+          NIGHTLY_CHANGES: ${{ steps.nightly-changes.outputs.changes }}
+          CHANGES_UNCHANGED: ${{ steps.nightly-changes.outputs.unchanged }}
+          CHANGES_UPDATED_AT: ${{ steps.nightly-changes.outputs.updated_at }}
         shell: pwsh
         run: |
           $notificationArgs = @(
@@ -544,8 +571,13 @@ jobs:
               '--channel-url', $env:CHANNEL_URL,
               '--run-url', "$($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)",
               '--repository', $env:GITHUB_REPOSITORY,
+              '--changes', $env:NIGHTLY_CHANGES,
+              '--changes-updated-at', $env:CHANGES_UPDATED_AT,
               '--message-id', $env:DISCORD_DAILY_MESSAGE_ID
           )
+          if ($env:CHANGES_UNCHANGED -eq 'true') {
+              $notificationArgs += '--changes-unchanged'
+          }
           python build-support/notifications/discord_notify.py @notificationArgs
 
       - name: Remove an abandoned draft release

--- a/build-support/notifications/discord_notify.py
+++ b/build-support/notifications/discord_notify.py
@@ -40,7 +40,11 @@ EMBED_FOOTER_LIMIT = 2048
 # and falls back to a link when the file is larger, because a failed upload
 # would otherwise swallow the notification entirely.
 ATTACHMENT_LIMIT_BYTES = 8 * 1024 * 1024
-MAX_CHANGE_FIELDS = 4
+EMBED_TOTAL_LIMIT = 6000
+MAX_EMBED_FIELDS = 10
+# Leaves room for the Nightly title, download guidance, field names and footer.
+CHANGE_VALUES_TOTAL_LIMIT = 4400
+MIN_CHANGE_LINE_LIMIT = 80
 
 STATUS_STYLE = {
     # Amber distinguishes an intentionally unstable Nightly from the green
@@ -89,8 +93,19 @@ def first_line(text: str) -> str:
 
 def change_fields(changes: str, repository: str) -> list[dict]:
     """Split Nightly changes across readable fields within Discord's limits."""
-    lines = [truncate(line, EMBED_FIELD_VALUE_LIMIT) for line in changes.splitlines()
-             if line.strip()]
+    lines = [line.strip() for line in changes.splitlines() if line.strip()]
+    if not lines:
+        return []
+    separators = max(0, len(lines) - 1)
+    per_line_limit = min(
+        EMBED_FIELD_VALUE_LIMIT,
+        (CHANGE_VALUES_TOTAL_LIMIT - separators) // len(lines),
+    )
+    if per_line_limit < MIN_CHANGE_LINE_LIMIT:
+        raise ValueError(
+            "Nightly changelog has too many entries for one Discord message"
+        )
+    lines = [truncate(line, per_line_limit) for line in lines]
     chunks: list[list[str]] = []
     for line in lines:
         if not chunks or len("\n".join([*chunks[-1], line])) > EMBED_FIELD_VALUE_LIMIT:
@@ -98,13 +113,10 @@ def change_fields(changes: str, repository: str) -> list[dict]:
         else:
             chunks[-1].append(line)
 
-    if len(chunks) > MAX_CHANGE_FIELDS:
-        chunks = chunks[-MAX_CHANGE_FIELDS:]
-        release_url = f"https://github.com/{repository}/releases/tag/nightly"
-        link = f"• Earlier changes: [view the complete Nightly changelog]({release_url})"
-        while chunks[0] and len("\n".join([link, *chunks[0]])) > EMBED_FIELD_VALUE_LIMIT:
-            chunks[0].pop(0)
-        chunks[0].insert(0, link)
+    if len(chunks) > MAX_EMBED_FIELDS:
+        raise ValueError(
+            "Nightly changelog needs more than Discord's ten embed fields"
+        )
 
     return [{
         "name": "Changes since the previous Nightly"
@@ -159,6 +171,12 @@ def build_payload(args: argparse.Namespace) -> dict:
                 links.append(f"[🌙 Latest Nightly]({args.channel_url})")
             if links:
                 description_parts.append(" • ".join(links))
+            if args.changes_unchanged:
+                updated = discord_timestamp(args.changes_updated_at)
+                description_parts.append(
+                    "No code changes were added in this build. The changelog "
+                    f"below was retained from its last update {updated}."
+                )
             if args.changes:
                 fields.extend(change_fields(args.changes, args.repository))
         elif args.run_url:
@@ -191,6 +209,18 @@ def build_payload(args: argparse.Namespace) -> dict:
     elif args.run_url:
         embed["url"] = args.run_url
 
+    embed_characters = (
+        len(embed["title"]) + len(embed["description"])
+        + len(embed.get("footer", {}).get("text", ""))
+        + sum(len(field["name"]) + len(field["value"])
+              for field in embed["fields"])
+    )
+    if embed_characters > EMBED_TOTAL_LIMIT:
+        raise ValueError(
+            f"Nightly Discord embed uses {embed_characters} characters; "
+            f"the limit is {EMBED_TOTAL_LIMIT}"
+        )
+
     payload = {
         # PATCH preserves omitted fields. Explicitly clear content so the raw
         # URL from the original version of the maintained message disappears.
@@ -201,6 +231,16 @@ def build_payload(args: argparse.Namespace) -> dict:
         "allowed_mentions": {"parse": []},
     }
     return payload
+
+
+def discord_timestamp(value: str) -> str:
+    """Render an ISO-8601 release time in Discord's absolute and relative forms."""
+    try:
+        parsed = datetime.fromisoformat((value or "").replace("Z", "+00:00"))
+        epoch = int(parsed.timestamp())
+    except (TypeError, ValueError):
+        return "at an unknown time"
+    return f"on <t:{epoch}:f> (<t:{epoch}:R>)"
 
 
 def encode_multipart(payload: dict, file_path: str) -> tuple[bytes, str]:
@@ -324,6 +364,8 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--commit-message", default="")
     parser.add_argument("--actor", default="")
     parser.add_argument("--changes", default="")
+    parser.add_argument("--changes-unchanged", action="store_true")
+    parser.add_argument("--changes-updated-at", default="")
     parser.add_argument("--username", default="Frostguard Builds")
     parser.add_argument(
         "--attach",

--- a/build-support/notifications/test_discord_notify.py
+++ b/build-support/notifications/test_discord_notify.py
@@ -93,21 +93,34 @@ class PayloadTest(unittest.TestCase):
         )
         self.assertIn("#79", changes["value"])
 
-    def test_splits_many_changes_instead_of_truncating_at_five(self):
-        changes = "\n".join(f"• change {index} " + "x" * 180 for index in range(12))
+    def test_splits_many_changes_without_omitting_any(self):
+        changes = "\n".join(f"• change {index} " + "x" * 180 for index in range(20))
         fields = payload(["--changes", changes])["embeds"][0]["fields"]
         text = "\n".join(field["value"] for field in fields)
         self.assertGreater(len(fields), 1)
-        self.assertIn("change 0", text)
-        self.assertIn("change 11", text)
+        for index in range(20):
+            self.assertIn(f"change {index} ", text)
 
-    def test_overflow_links_the_complete_release_changelog(self):
+    def test_long_entries_are_shortened_but_every_change_remains(self):
         changes = "\n".join(f"• change {index} " + "x" * 900 for index in range(8))
         fields = payload(["--changes", changes])["embeds"][0]["fields"]
         text = "\n".join(field["value"] for field in fields)
-        self.assertEqual(len(fields), discord_notify.MAX_CHANGE_FIELDS)
-        self.assertIn("releases/tag/nightly", text)
-        self.assertIn("change 7", text)
+        for index in range(8):
+            self.assertIn(f"change {index} ", text)
+
+    def test_impossible_change_count_fails_instead_of_hiding_entries(self):
+        changes = "\n".join(f"• change {index}" for index in range(100))
+        with self.assertRaisesRegex(ValueError, "too many entries"):
+            payload(["--changes", changes])
+
+    def test_unchanged_build_retains_changes_and_dates_their_last_update(self):
+        embed = payload([
+            "--changes-unchanged",
+            "--changes-updated-at", "2026-08-13T04:00:00Z",
+        ])["embeds"][0]
+        self.assertIn("No code changes were added", embed["description"])
+        self.assertIn("<t:1786593600:f>", embed["description"])
+        self.assertIn("#79", embed["fields"][0]["value"])
 
     def test_omits_internal_ci_metrics(self):
         result = payload()
@@ -145,6 +158,13 @@ class PayloadTest(unittest.TestCase):
             self.assertLessEqual(
                 len(field["value"]), discord_notify.EMBED_FIELD_VALUE_LIMIT
             )
+        total = (
+            len(embed["title"]) + len(embed["description"])
+            + len(embed["footer"]["text"])
+            + sum(len(field["name"]) + len(field["value"])
+                  for field in embed["fields"])
+        )
+        self.assertLessEqual(total, discord_notify.EMBED_TOTAL_LIMIT)
 
     def test_embed_stays_within_the_ten_field_ceiling_of_a_readable_card(self):
         self.assertLessEqual(len(payload()["embeds"][0]["fields"]), 10)

--- a/build-support/release/nightly_changes.py
+++ b/build-support/release/nightly_changes.py
@@ -4,11 +4,23 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import subprocess
+from dataclasses import dataclass
+from pathlib import Path
 
 MERGE_PR = re.compile(r"^Merge pull request #(\d+)\b")
 SQUASH_PR = re.compile(r"^(.*?)\s*\(#(\d+)\)$")
+NIGHTLY_TAG = re.compile(r"^v\d+\.\d+\.\d+-nightly\.\d{8}\.\d+$")
+
+
+@dataclass(frozen=True)
+class ChangeRange:
+    previous: str
+    current: str
+    unchanged: bool
+    updated_at: str
 
 
 def git(*args: str) -> str:
@@ -40,7 +52,7 @@ def describe(repository: str, commit: str) -> str:
 
     short = commit[:7]
     return (
-        f"• [`{short}`](https://github.com/{repository}/commit/{commit}) "
+        f"• [`{short}`](https://github.com/{repository}/commit/{short}) "
         f"{escape_link_text(subject)}"
     )
 
@@ -61,12 +73,94 @@ def summary(repository: str, previous: str, current: str) -> str:
     return "\n".join(describe(repository, commit) for commit in commits)
 
 
+def resolve_range(releases: list[dict], current_tag: str) -> ChangeRange:
+    """Resolve the last code-changing Nightly interval from release history."""
+    if releases and isinstance(releases[0], list):
+        releases = [release for page in releases for release in page]
+
+    def value(release: dict, camel: str, snake: str):
+        return release.get(camel, release.get(snake))
+
+    normalized = [{
+        "tagName": value(release, "tagName", "tag_name"),
+        "targetCommitish": value(release, "targetCommitish", "target_commitish"),
+        "publishedAt": value(release, "publishedAt", "published_at"),
+        "isDraft": value(release, "isDraft", "draft"),
+    } for release in releases]
+    nightlies = sorted(
+        (
+            release for release in normalized
+            if NIGHTLY_TAG.match(str(release.get("tagName", "")))
+            and not release.get("isDraft", False)
+            and release.get("targetCommitish")
+            and release.get("publishedAt")
+        ),
+        key=lambda release: release["publishedAt"],
+        reverse=True,
+    )
+    current_index = next(
+        (index for index, release in enumerate(nightlies)
+         if release["tagName"] == current_tag),
+        None,
+    )
+    if current_index is None:
+        raise ValueError(f"Current Nightly release {current_tag!r} is missing")
+
+    current = nightlies[current_index]
+    older = nightlies[current_index + 1:]
+    if not older:
+        return ChangeRange("", current["targetCommitish"], False,
+                           current["publishedAt"])
+
+    current_sha = current["targetCommitish"]
+    previous = older[0]
+    if previous["targetCommitish"] != current_sha:
+        return ChangeRange(previous["targetCommitish"], current_sha, False,
+                           current["publishedAt"])
+
+    # Several Nightlies may intentionally point at the same commit. Keep the
+    # changelog from the first one in that run, and compare it to the preceding
+    # distinct build instead of replacing useful entries with "no changes".
+    oldest_same = current
+    for release in older:
+        if release["targetCommitish"] != current_sha:
+            return ChangeRange(release["targetCommitish"], current_sha, True,
+                               oldest_same["publishedAt"])
+        oldest_same = release
+
+    return ChangeRange("", current_sha, True, oldest_same["publishedAt"])
+
+
+def write_github_output(path: str, changes: str, change_range: ChangeRange) -> None:
+    with open(path, "a", encoding="utf-8") as output:
+        output.write("changes<<FROSTGUARD_CHANGES\n")
+        output.write(changes + "\n")
+        output.write("FROSTGUARD_CHANGES\n")
+        output.write(f"unchanged={str(change_range.unchanged).lower()}\n")
+        output.write(f"updated_at={change_range.updated_at}\n")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repository", required=True)
     parser.add_argument("--previous", default="")
-    parser.add_argument("--current", required=True)
+    parser.add_argument("--current", default="")
+    parser.add_argument("--release-history", default="")
+    parser.add_argument("--current-tag", default="")
+    parser.add_argument("--github-output", default="")
     args = parser.parse_args()
+    if args.release_history:
+        releases = json.loads(
+            Path(args.release_history).read_text(encoding="utf-8-sig")
+        )
+        change_range = resolve_range(releases, args.current_tag)
+        result = summary(args.repository, change_range.previous, change_range.current)
+        if args.github_output:
+            write_github_output(args.github_output, result, change_range)
+        print(result)
+        return 0
+    if not args.current:
+        parser.error("--current is required without --release-history")
     print(summary(args.repository, args.previous, args.current))
     return 0
 

--- a/build-support/release/test_nightly_changes.py
+++ b/build-support/release/test_nightly_changes.py
@@ -31,7 +31,7 @@ class NightlyChangesTest(unittest.TestCase):
         with mock.patch.object(changes, "git", return_value="docs: explain Nightly"):
             line = changes.describe("Shederator/wosbot", "123456789")
         self.assertIn("[`1234567`]", line)
-        self.assertIn("/commit/123456789", line)
+        self.assertIn("/commit/1234567", line)
 
     def test_summary_keeps_every_change(self):
         commits = "\n".join(f"commit{i}" for i in range(7))
@@ -49,6 +49,60 @@ class NightlyChangesTest(unittest.TestCase):
 
     def test_markdown_in_titles_is_escaped(self):
         self.assertEqual(r"fix \[text\]", changes.escape_link_text(r"fix [text]"))
+
+    def test_release_range_compares_adjacent_distinct_builds(self):
+        result = changes.resolve_range([
+            release("v3.0.0-nightly.20260813.2", "new", "2026-08-13T04:00:00Z"),
+            release("v3.0.0-nightly.20260813.1", "old", "2026-08-13T03:00:00Z"),
+        ], "v3.0.0-nightly.20260813.2")
+        self.assertEqual(("old", "new"), (result.previous, result.current))
+        self.assertFalse(result.unchanged)
+        self.assertEqual("2026-08-13T04:00:00Z", result.updated_at)
+
+    def test_unchanged_build_retains_last_non_empty_range_and_update_time(self):
+        result = changes.resolve_range([
+            release("v3.0.0-nightly.20260813.3", "same", "2026-08-13T05:00:00Z"),
+            release("v3.0.0-nightly.20260813.2", "same", "2026-08-13T04:00:00Z"),
+            release("v3.0.0-nightly.20260813.1", "old", "2026-08-13T03:00:00Z"),
+        ], "v3.0.0-nightly.20260813.3")
+        self.assertEqual(("old", "same"), (result.previous, result.current))
+        self.assertTrue(result.unchanged)
+        self.assertEqual("2026-08-13T04:00:00Z", result.updated_at)
+
+    def test_ignores_rolling_and_draft_releases(self):
+        result = changes.resolve_range([
+            release("nightly", "rolling", "2026-08-13T06:00:00Z"),
+            release("v3.0.0-nightly.20260813.2", "new", "2026-08-13T05:00:00Z"),
+            release("v3.0.0-nightly.20260813.1", "draft", "2026-08-13T04:00:00Z", True),
+            release("v3.0.0-nightly.20260812.9", "old", "2026-08-12T03:00:00Z"),
+        ], "v3.0.0-nightly.20260813.2")
+        self.assertEqual("old", result.previous)
+
+    def test_accepts_paginated_github_rest_release_data(self):
+        result = changes.resolve_range([[
+            {
+                "tag_name": "v3.0.0-nightly.20260813.2",
+                "target_commitish": "new",
+                "published_at": "2026-08-13T05:00:00Z",
+                "draft": False,
+            },
+            {
+                "tag_name": "v3.0.0-nightly.20260813.1",
+                "target_commitish": "old",
+                "published_at": "2026-08-13T04:00:00Z",
+                "draft": False,
+            },
+        ]], "v3.0.0-nightly.20260813.2")
+        self.assertEqual(("old", "new"), (result.previous, result.current))
+
+
+def release(tag: str, sha: str, published_at: str, draft: bool = False) -> dict:
+    return {
+        "tagName": tag,
+        "targetCommitish": sha,
+        "publishedAt": published_at,
+        "isDraft": draft,
+    }
 
 
 if __name__ == "__main__":

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -180,6 +180,10 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn('          $tag = "v$($env:VERSION)"', workflow)
         self.assertIn("next_nightly_version.py", workflow)
         self.assertIn("Update the maintained Nightly Discord message", workflow)
+        self.assertIn("Collect changes between Nightly builds", workflow)
+        self.assertIn("build-support/release/nightly_changes.py", workflow)
+        self.assertIn("--changes-unchanged", workflow)
+        self.assertIn("fetch-depth: 0", workflow)
         self.assertIn("Remove an abandoned draft release", workflow)
         self.assertIn('java-version: "21.0.12+8.0"', workflow)
         for launcher_hash in (
@@ -234,6 +238,9 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("does not match exactly one public installer asset", workflow)
         self.assertIn("Nightly installer URL returned HTTP", workflow)
         self.assertIn("build-support/notifications/discord_notify.py", workflow)
+        self.assertIn("build-support/release/nightly_changes.py", workflow)
+        self.assertIn("--changes-unchanged", workflow)
+        self.assertIn("fetch-depth: 0", workflow)
         self.assertNotIn("gh release create", workflow)
 
 


### PR DESCRIPTION
## Summary

- restore the first-parent changelog between immutable Nightly builds in automatic publication and manual Discord refreshes
- retain the last non-empty changelog when consecutive Nightlies use the same commit, including its last-updated time
- keep every PR or commit represented within Discord's embed budget instead of silently replacing earlier entries with a generic link

## Why

The Frostguard 3 release-workflow restructure preserved `nightly_changes.py` but stopped invoking it. It also switched the release checkout to shallow history, which prevented reliable comparison with an earlier Nightly. Separately, the notifier capped change output at four fields and silently discarded the oldest entries on overflow.

Closes #206.

## Validation

- all 12 Python test files under `build-support/notifications`, `build-support/release`, and `build-support/verification` passed
- focused coverage: 30 Discord notifier tests, 10 Nightly changelog tests, and 6 channel-packaging workflow tests passed
- `python build-support/verification/check_workflow_python.py` passed; all 3 inline workflow Python snippets compile
- `git diff --check` passed
- public release-history reconstruction produced all 11 changes from `6958e4b` to `897502f` in two Discord fields using 1,767 of 6,000 embed characters
- same-commit simulation retained all 11 changes and reported their original update time (`2026-08-12T23:29:02Z`)
- no Discord webhook request or GitHub Actions workflow was dispatched

## Risks

- Live Discord rendering remains unverified by design; the maintainer will manually run `Discord — Refresh Nightly Message` after merge.
- Discord has a hard per-message limit. If an unusually large build interval cannot represent every commit even after compacting titles, the notifier now fails without overwriting the maintained message instead of silently omitting changes.