### PR TITLE
fix(release): create immutable tag before publishing

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -445,6 +445,21 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
               throw "Signed manifest could not be uploaded to the immutable release"
           }
+          $tagRef = "refs/tags/$($env:TAG)"
+          $createdRefJson = gh api --method POST `
+              "repos/$($env:GITHUB_REPOSITORY)/git/refs" `
+              -f ref=$tagRef -f sha=$env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) {
+              throw "Immutable release tag could not be created"
+          }
+          "tag_created=true" | Out-File -FilePath $env:GITHUB_OUTPUT `
+              -Encoding utf8 -Append
+          $createdRef = $createdRefJson | ConvertFrom-Json
+          if ($createdRef.ref -cne $tagRef -or
+              $createdRef.object.type -cne 'commit' -or
+              $createdRef.object.sha -cne $env:GITHUB_SHA) {
+              throw "Immutable release tag does not target the current build"
+          }
           if ($env:CHANNEL -eq 'stable') {
               gh release edit $env:TAG --repo $env:GITHUB_REPOSITORY --draft=false --latest
               if ($LASTEXITCODE -ne 0) {
@@ -585,6 +600,7 @@ jobs:
         shell: pwsh
         env:
           TAG: ${{ steps.identity.outputs.tag }}
+          TAG_CREATED: ${{ steps.publish.outputs.tag_created }}
         run: |
           $releasesJson = gh api "repos/$($env:GITHUB_REPOSITORY)/releases?per_page=100"
           if ($LASTEXITCODE -ne 0) {
@@ -593,11 +609,29 @@ jobs:
           $releases = $releasesJson | ConvertFrom-Json
           $release = $releases | Where-Object { $_.tag_name -ceq $env:TAG } |
               Select-Object -First 1
+          $publishedReleaseExists = $null -ne $release -and -not $release.draft
           if ($null -ne $release -and $release.draft) {
               gh api --method DELETE `
                   "repos/$($env:GITHUB_REPOSITORY)/releases/$($release.id)"
               if ($LASTEXITCODE -ne 0) {
                   throw "Abandoned draft release could not be removed"
+              }
+          }
+          if ($env:TAG_CREATED -eq 'true' -and -not $publishedReleaseExists) {
+              $tagRef = gh api `
+                  "repos/$($env:GITHUB_REPOSITORY)/git/refs/tags/$($env:TAG)" |
+                  ConvertFrom-Json
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Run-created immutable tag could not be resolved during cleanup"
+              }
+              if ($tagRef.object.type -cne 'commit' -or
+                  $tagRef.object.sha -cne $env:GITHUB_SHA) {
+                  throw "Run-created immutable tag no longer targets the current build"
+              }
+              gh api --method DELETE `
+                  "repos/$($env:GITHUB_REPOSITORY)/git/refs/tags/$($env:TAG)"
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Run-created immutable tag could not be removed"
               }
           }
 

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -205,6 +205,22 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("-pl packaging/desktop clean", installers)
         self.assertIn('gh api --method DELETE `', workflow)
         self.assertIn('releases/$($release.id)', workflow)
+        manifest_upload = workflow.index("gh release upload $env:TAG $env:MANIFEST")
+        immutable_tag_create = workflow.index(
+            '"repos/$($env:GITHUB_REPOSITORY)/git/refs"')
+        immutable_release_publish = workflow.index("gh release edit $env:TAG")
+        self.assertLess(manifest_upload, immutable_tag_create)
+        self.assertLess(immutable_tag_create, immutable_release_publish)
+        self.assertIn('"tag_created=true"', workflow)
+        self.assertIn("TAG_CREATED: ${{ steps.publish.outputs.tag_created }}", workflow)
+        self.assertIn(
+            "if ($env:TAG_CREATED -eq 'true' -and -not $publishedReleaseExists)",
+            workflow)
+        self.assertGreaterEqual(
+            workflow.count(
+                '"repos/$($env:GITHUB_REPOSITORY)/git/refs/tags/$($env:TAG)"'),
+            2)
+        self.assertIn("$tagRef.object.sha -cne $env:GITHUB_SHA", workflow)
         self.assertNotIn("--cleanup-tag --yes", workflow)
         legacy_stable = (REPO_ROOT / ".github/workflows/stable-windows-release.yml").read_text(
             encoding="utf-8")


### PR DESCRIPTION
Closes #214

## Summary

- Create the immutable release tag explicitly after the installer and signed manifest are ready.
- Verify that the new lightweight tag points to the exact workflow commit before publishing the draft release.
- Clean up only a tag proven to have been created by the failed run, only when no published release exists, and only while it still targets that run's commit.
- Add release-contract coverage for tag creation ordering and cleanup safeguards.

## Why

Nightly run 31771671911 failed twice at the final publish boundary with `Published releases must have a valid tag`. Both attempts successfully built and smoke-tested the MSI, uploaded and hash-verified it, and generated and verified the Ed25519-signed manifest. GitHub created the draft release but did not materialize a valid Git tag when `gh release edit --draft=false` attempted to publish it.

Creating and verifying the immutable ref immediately before publication preserves the existing publish-last contract while removing reliance on GitHub's implicit draft-tag creation.

## Validation

- `python -m unittest discover -s build-support/verification -p 'test_*.py'` — 40 passed.
- `python -m unittest discover -s build-support/release -p 'test_*.py'` — 56 passed.
- `python -m unittest discover -s build-support/notifications -p 'test_*.py'` — 64 passed.
- `git diff --check` — passed.
- Real Nightly run 31771671911 attempt 2 reproduced the original tag failure before this change.

## Risks

The actual GitHub release mutation cannot be reproduced locally. Merge validation therefore requires a real Nightly workflow run. Cleanup is deliberately conservative: it will leave a tag in place and fail visibly if ownership or target-SHA checks do not match.
