### PR TITLE
fix(release): create tag before drafting release

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -349,6 +349,21 @@ jobs:
           TAG: ${{ steps.identity.outputs.tag }}
           INSTALLER: ${{ steps.installer.outputs.path }}
         run: |
+          $tagRef = "refs/tags/$($env:TAG)"
+          $createdRefJson = gh api --method POST `
+              "repos/$($env:GITHUB_REPOSITORY)/git/refs" `
+              -f ref=$tagRef -f sha=$env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) {
+              throw "Immutable release tag could not be created"
+          }
+          "tag_created=true" | Out-File -FilePath $env:GITHUB_OUTPUT `
+              -Encoding utf8 -Append
+          $createdRef = $createdRefJson | ConvertFrom-Json
+          if ($createdRef.ref -cne $tagRef -or
+              $createdRef.object.type -cne 'commit' -or
+              $createdRef.object.sha -cne $env:GITHUB_SHA) {
+              throw "Immutable release tag does not target the current build"
+          }
           $title = if ($env:CHANNEL -eq 'nightly') {
               if ($env:VERSION -notmatch '^\d+\.\d+\.\d+-nightly\.(\d{4})(\d{2})(\d{2})\.(\d+)$') {
                   throw "Nightly title requires X.Y.Z-nightly.YYYYMMDD.N"
@@ -444,21 +459,6 @@ jobs:
           gh release upload $env:TAG $env:MANIFEST --repo $env:GITHUB_REPOSITORY
           if ($LASTEXITCODE -ne 0) {
               throw "Signed manifest could not be uploaded to the immutable release"
-          }
-          $tagRef = "refs/tags/$($env:TAG)"
-          $createdRefJson = gh api --method POST `
-              "repos/$($env:GITHUB_REPOSITORY)/git/refs" `
-              -f ref=$tagRef -f sha=$env:GITHUB_SHA
-          if ($LASTEXITCODE -ne 0) {
-              throw "Immutable release tag could not be created"
-          }
-          "tag_created=true" | Out-File -FilePath $env:GITHUB_OUTPUT `
-              -Encoding utf8 -Append
-          $createdRef = $createdRefJson | ConvertFrom-Json
-          if ($createdRef.ref -cne $tagRef -or
-              $createdRef.object.type -cne 'commit' -or
-              $createdRef.object.sha -cne $env:GITHUB_SHA) {
-              throw "Immutable release tag does not target the current build"
           }
           if ($env:CHANNEL -eq 'stable') {
               gh release edit $env:TAG --repo $env:GITHUB_REPOSITORY --draft=false --latest
@@ -600,7 +600,7 @@ jobs:
         shell: pwsh
         env:
           TAG: ${{ steps.identity.outputs.tag }}
-          TAG_CREATED: ${{ steps.publish.outputs.tag_created }}
+          TAG_CREATED: ${{ steps.draft.outputs.tag_created }}
         run: |
           $releasesJson = gh api "repos/$($env:GITHUB_REPOSITORY)/releases?per_page=100"
           if ($LASTEXITCODE -ne 0) {

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -205,14 +205,16 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("-pl packaging/desktop clean", installers)
         self.assertIn('gh api --method DELETE `', workflow)
         self.assertIn('releases/$($release.id)', workflow)
-        manifest_upload = workflow.index("gh release upload $env:TAG $env:MANIFEST")
         immutable_tag_create = workflow.index(
             '"repos/$($env:GITHUB_REPOSITORY)/git/refs"')
+        draft_release_create = workflow.index("gh release create $env:TAG")
+        manifest_upload = workflow.index("gh release upload $env:TAG $env:MANIFEST")
         immutable_release_publish = workflow.index("gh release edit $env:TAG")
-        self.assertLess(manifest_upload, immutable_tag_create)
-        self.assertLess(immutable_tag_create, immutable_release_publish)
+        self.assertLess(immutable_tag_create, draft_release_create)
+        self.assertLess(draft_release_create, manifest_upload)
+        self.assertLess(manifest_upload, immutable_release_publish)
         self.assertIn('"tag_created=true"', workflow)
-        self.assertIn("TAG_CREATED: ${{ steps.publish.outputs.tag_created }}", workflow)
+        self.assertIn("TAG_CREATED: ${{ steps.draft.outputs.tag_created }}", workflow)
         self.assertIn(
             "if ($env:TAG_CREATED -eq 'true' -and -not $publishedReleaseExists)",
             workflow)


### PR DESCRIPTION
Closes #214

## Summary

- Create and verify the immutable Git tag immediately before creating the draft release.
- Carry run ownership from the draft step into conservative tag cleanup.
- Preserve installer verification, signed-manifest upload, and publish-last ordering.
- Update release-contract coverage to enforce the corrected sequence.

## Why

Follow-up to #215. The real Nightly validation run 31847368815 showed that GitHub already reserves the release tag identity once a draft exists. Attempting to create the explicit ref during the later publish step therefore failed with `Reference update failed (HTTP 422)`.

Creating the ref immediately before `gh release create --draft` gives the draft an existing, verified tag. If draft creation or any later step fails, cleanup still removes only a tag proven to have been created by that run and only while it targets the exact run commit.

## Validation

- `python -m unittest discover -s build-support/verification -p 'test_*.py'` — 40 passed.
- `python -m unittest discover -s build-support/release -p 'test_*.py'` — 56 passed.
- `python -m unittest discover -s build-support/notifications -p 'test_*.py'` — 64 passed.
- `git diff --check` — passed.
- Real Nightly run 31847368815 reproduced the post-draft ref conflict and confirmed abandoned-draft cleanup succeeded.

## Risks

The corrected GitHub release mutation requires another real Nightly run after merge. Cleanup remains intentionally conservative and fails visibly rather than deleting a tag when run ownership, publication state, or target SHA is uncertain.
