### PR TITLE
fix(arena): skip refresh after final defeat

### DIFF
--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/ArenaRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/ArenaRoutine.java
@@ -448,6 +448,12 @@ public class ArenaRoutine extends DelayedTask {
                         break;
                     }
                     if (outcome == ChallengeOutcome.DEFEAT) {
+                        if (!shouldRefreshAfterDefeat(attempts)) {
+                            logInfo(String.format(
+                                    "Our attack lost to opponent %d. No attempts remain; skipping list refresh.",
+                                    opponent.number()));
+                            continue;
+                        }
                         logInfo(String.format(
                                 "Our attack lost to opponent %d. Refreshing list before using another attempt.",
                                 opponent.number()));
@@ -499,6 +505,10 @@ public class ArenaRoutine extends DelayedTask {
         } else {
             logInfo("Arena run finished after using available eligible attempts.");
         }
+    }
+
+    static boolean shouldRefreshAfterDefeat(int remainingAttempts) {
+        return remainingAttempts > 0;
     }
 
     private OpponentCandidate findEligibleOpponent() {

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/combat/ArenaRoutineAttemptFlowTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/combat/ArenaRoutineAttemptFlowTest.java
@@ -1,0 +1,19 @@
+package dev.frostguard.tasks.combat;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArenaRoutineAttemptFlowTest {
+
+    @Test
+    void skipsRefreshAfterDefeatWhenLastAttemptWasConsumed() {
+        assertFalse(ArenaRoutine.shouldRefreshAfterDefeat(0));
+    }
+
+    @Test
+    void keepsRefreshAfterDefeatWhenAnotherAttemptRemains() {
+        assertTrue(ArenaRoutine.shouldRefreshAfterDefeat(1));
+    }
+}


### PR DESCRIPTION
## Summary

- skip the post-defeat opponent-list refresh when the battle consumed the final attempt
- preserve the existing refresh-and-rescan behavior when at least one attempt remains
- cover both attempt-budget boundaries with focused tests

## Why

The live Nightly run that confirmed the Arena power-ranking fix exposed a follow-up at the end of the run. After the final purchased attempt ended in defeat, `challengeOpponent` reduced the remaining-attempt count to zero, but the defeat path still consumed a free list refresh and logged that it would rescan. The outer loop then exited immediately because no attempt remained.

This is a localized follow-up to #204.

## Validation

- `mvnw.cmd -pl modules/tasks -am -Dtest=ArenaRoutineAttemptFlowTest -Dsurefire.failIfNoSpecifiedTests=false test` — passed
- `mvnw.cmd -pl modules/tasks -am test` — passed
- `git diff --check`
- live pre-fix evidence: after the final defeat at zero remaining attempts, Nightly used free refresh 1/3, logged a rescan, and immediately finished the Arena run

## Risks

- the corrected zero-attempt path has automated coverage but has not yet been observed in a post-fix live Arena run
- OCR, opponent eligibility, power ranking, refresh limits, and the path with remaining attempts are unchanged
