### PR TITLE
chore(release): retain two immutable nightlies

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -562,6 +562,32 @@ jobs:
               throw "Could not collect changes between Nightly builds"
           }
 
+      - name: Retain the two newest immutable Nightly releases
+        if: success() && env.CHANNEL == 'nightly'
+        shell: pwsh
+        env:
+          TAG: ${{ steps.identity.outputs.tag }}
+        run: |
+          $history = Join-Path $env:RUNNER_TEMP "nightly-retention-history.json"
+          gh api --paginate --slurp `
+              "repos/$($env:GITHUB_REPOSITORY)/releases?per_page=100" |
+              Out-File -LiteralPath $history -Encoding utf8
+          if ($LASTEXITCODE -ne 0) {
+              throw "Could not list immutable Nightly releases for retention"
+          }
+          $obsoleteTags = @(python build-support/release/nightly_retention.py `
+              --release-history $history --current-tag $env:TAG --keep 2)
+          if ($LASTEXITCODE -ne 0) {
+              throw "Could not select obsolete immutable Nightly releases"
+          }
+          foreach ($tag in $obsoleteTags) {
+              gh release delete $tag --repo $env:GITHUB_REPOSITORY `
+                  --cleanup-tag --yes
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Could not delete obsolete Nightly release $tag"
+              }
+          }
+
       - name: Update the maintained Nightly Discord message
         if: always() && env.CHANNEL == 'nightly'
         continue-on-error: true

--- a/build-support/release/nightly_retention.py
+++ b/build-support/release/nightly_retention.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Select obsolete immutable Frostguard Nightly releases for deletion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+
+NIGHTLY_TAG = re.compile(r"^v\d+\.\d+\.\d+-nightly\.\d{8}\.\d+$")
+
+
+def _value(release: dict, camel: str, snake: str):
+    return release.get(camel, release.get(snake))
+
+
+def _published_at(release: dict) -> datetime:
+    value = release["publishedAt"]
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Nightly release {release['tagName']!r} has no publication time")
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(
+            f"Nightly release {release['tagName']!r} has an invalid publication time"
+        ) from error
+
+
+def obsolete_nightlies(
+        releases: list[dict], current_tag: str, keep: int = 2) -> list[str]:
+    """Return public immutable Nightly tags older than the retained releases."""
+    if keep < 1:
+        raise ValueError("At least one immutable Nightly must be retained")
+    if not NIGHTLY_TAG.fullmatch(current_tag):
+        raise ValueError(f"Current Nightly tag {current_tag!r} is invalid")
+    if releases and isinstance(releases[0], list):
+        releases = [release for page in releases for release in page]
+
+    nightlies = []
+    seen_tags = set()
+    for release in releases:
+        tag = _value(release, "tagName", "tag_name")
+        if not isinstance(tag, str) or not NIGHTLY_TAG.fullmatch(tag):
+            continue
+        if _value(release, "isDraft", "draft"):
+            continue
+        if tag in seen_tags:
+            raise ValueError(f"Nightly release {tag!r} occurs more than once")
+        seen_tags.add(tag)
+        normalized = {
+            "tagName": tag,
+            "publishedAt": _value(release, "publishedAt", "published_at"),
+        }
+        nightlies.append((_published_at(normalized), tag))
+
+    nightlies.sort(reverse=True)
+    tags = [tag for _, tag in nightlies]
+    if current_tag not in tags:
+        raise ValueError(f"Current Nightly release {current_tag!r} is missing")
+    retained = tags[:keep]
+    if current_tag not in retained:
+        raise ValueError(
+            f"Current Nightly release {current_tag!r} is not among the newest {keep}")
+    return tags[keep:]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release-history", required=True)
+    parser.add_argument("--current-tag", required=True)
+    parser.add_argument("--keep", type=int, default=2)
+    args = parser.parse_args()
+    releases = json.loads(
+        Path(args.release_history).read_text(encoding="utf-8-sig"))
+    for tag in obsolete_nightlies(releases, args.current_tag, args.keep):
+        print(tag)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build-support/release/test_nightly_retention.py
+++ b/build-support/release/test_nightly_retention.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from nightly_retention import obsolete_nightlies  # noqa: E402
+
+
+def release(tag: str, published_at: str, *, draft: bool = False) -> dict:
+    return {
+        "tag_name": tag,
+        "published_at": published_at,
+        "draft": draft,
+    }
+
+
+class NightlyRetentionTest(unittest.TestCase):
+    CURRENT = "v3.0.0-nightly.20260817.1"
+
+    def test_keeps_the_two_newest_immutable_nightlies(self):
+        releases = [
+            release(self.CURRENT, "2026-08-17T03:20:00Z"),
+            release("v3.0.0-nightly.20260816.1", "2026-08-16T03:20:00Z"),
+            release("v3.0.0-nightly.20260815.1", "2026-08-15T03:20:00Z"),
+            release("v3.0.0-nightly.20260813.3", "2026-08-13T05:00:00Z"),
+        ]
+
+        self.assertEqual(
+            ["v3.0.0-nightly.20260815.1",
+             "v3.0.0-nightly.20260813.3"],
+            obsolete_nightlies(releases, self.CURRENT),
+        )
+
+    def test_accepts_paginated_camel_case_release_history(self):
+        releases = [[{
+            "tagName": self.CURRENT,
+            "publishedAt": "2026-08-17T03:20:00Z",
+            "isDraft": False,
+        }], [{
+            "tagName": "v3.0.0-nightly.20260816.1",
+            "publishedAt": "2026-08-16T03:20:00Z",
+            "isDraft": False,
+        }, {
+            "tagName": "v3.0.0-nightly.20260815.1",
+            "publishedAt": "2026-08-15T03:20:00Z",
+            "isDraft": False,
+        }]]
+
+        self.assertEqual(
+            ["v3.0.0-nightly.20260815.1"],
+            obsolete_nightlies(releases, self.CURRENT),
+        )
+
+    def test_ignores_rolling_stable_pr_test_and_draft_releases(self):
+        releases = [
+            release(self.CURRENT, "2026-08-17T03:20:00Z"),
+            release("v3.0.0-nightly.20260816.1", "2026-08-16T03:20:00Z"),
+            release("v3.0.0", "2026-08-12T15:00:00Z"),
+            release("nightly", "2026-08-17T03:21:00Z"),
+            release("pr-test-example", "2026-08-17T03:22:00Z"),
+            release(
+                "v3.0.0-nightly.20260818.1",
+                "2026-08-18T03:20:00Z",
+                draft=True,
+            ),
+        ]
+
+        self.assertEqual([], obsolete_nightlies(releases, self.CURRENT))
+
+    def test_refuses_cleanup_when_current_release_is_missing_or_not_newest(self):
+        with self.assertRaisesRegex(ValueError, "is missing"):
+            obsolete_nightlies([], self.CURRENT)
+
+        releases = [
+            release("v3.0.0-nightly.20260818.2", "2026-08-18T04:20:00Z"),
+            release("v3.0.0-nightly.20260818.1", "2026-08-18T03:20:00Z"),
+            release(self.CURRENT, "2026-08-17T03:20:00Z"),
+        ]
+        with self.assertRaisesRegex(ValueError, "is not among the newest 2"):
+            obsolete_nightlies(releases, self.CURRENT)
+
+    def test_rejects_unsafe_inputs(self):
+        with self.assertRaisesRegex(ValueError, "At least one"):
+            obsolete_nightlies([], self.CURRENT, keep=0)
+        with self.assertRaisesRegex(ValueError, "is invalid"):
+            obsolete_nightlies([], "nightly")
+        duplicates = [
+            release(self.CURRENT, "2026-08-17T03:20:00Z"),
+            release(self.CURRENT, "2026-08-17T03:21:00Z"),
+        ]
+        with self.assertRaisesRegex(ValueError, "occurs more than once"):
+            obsolete_nightlies(duplicates, self.CURRENT)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -182,6 +182,11 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("Update the maintained Nightly Discord message", workflow)
         self.assertIn("Collect changes between Nightly builds", workflow)
         self.assertIn("build-support/release/nightly_changes.py", workflow)
+        self.assertIn("Retain the two newest immutable Nightly releases", workflow)
+        self.assertIn("build-support/release/nightly_retention.py", workflow)
+        self.assertIn("--current-tag $env:TAG --keep 2", workflow)
+        self.assertIn("gh release delete $tag", workflow)
+        self.assertIn("--cleanup-tag --yes", workflow)
         self.assertIn("--changes-unchanged", workflow)
         self.assertIn("fetch-depth: 0", workflow)
         self.assertIn("Remove an abandoned draft release", workflow)
@@ -213,6 +218,14 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertLess(immutable_tag_create, draft_release_create)
         self.assertLess(draft_release_create, manifest_upload)
         self.assertLess(manifest_upload, immutable_release_publish)
+        changelog = workflow.index("Collect changes between Nightly builds")
+        retention = workflow.index(
+            "Retain the two newest immutable Nightly releases")
+        notification = workflow.index(
+            "Update the maintained Nightly Discord message")
+        self.assertLess(immutable_release_publish, changelog)
+        self.assertLess(changelog, retention)
+        self.assertLess(retention, notification)
         self.assertIn('"tag_created=true"', workflow)
         self.assertIn("TAG_CREATED: ${{ steps.draft.outputs.tag_created }}", workflow)
         self.assertIn(
@@ -223,7 +236,6 @@ class ChannelPackagingTest(unittest.TestCase):
                 '"repos/$($env:GITHUB_REPOSITORY)/git/refs/tags/$($env:TAG)"'),
             2)
         self.assertIn("$tagRef.object.sha -cne $env:GITHUB_SHA", workflow)
-        self.assertNotIn("--cleanup-tag --yes", workflow)
         legacy_stable = (REPO_ROOT / ".github/workflows/stable-windows-release.yml").read_text(
             encoding="utf-8")
         self.assertIn(

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -7,7 +7,7 @@ are permanent even though the versioned installers behind them change.
 | Type | Permanent entry | Versioned tag | Lifetime |
 |---|---|---|---|
 | Stable | [`releases/latest`](https://github.com/Shederator/wosbot/releases/latest) | `vX.Y.Z` | Permanent |
-| Nightly | [`releases/tag/nightly`](https://github.com/Shederator/wosbot/releases/tag/nightly) | `vX.Y.Z-nightly.YYYYMMDD.N` | Current immutable prerelease plus rolling channel |
+| Nightly | [`releases/tag/nightly`](https://github.com/Shederator/wosbot/releases/tag/nightly) | `vX.Y.Z-nightly.YYYYMMDD.N` | Two newest immutable prereleases plus rolling channel |
 | PR test | Discord `/build-pr` | `pr-test-*` | Temporary |
 
 Do not add a separate `stable` rolling release. GitHub's built-in `latest`
@@ -89,6 +89,14 @@ not rebuild or replace its installer.
 Nightly builds embed only the permanent `nightly` endpoint. The temporary feed
 used by pre-release development builds has been retired and must not be
 recreated.
+
+After a new Nightly is public, its rolling manifest is promoted, and its
+changelog is collected, the release workflow retains the two newest public
+immutable Nightly releases and deletes older matching releases together with
+their tags. The permanent `nightly` release, Stable releases, drafts, PR-test
+releases, and unrelated tags never match this retention policy. A failed or
+unpromoted Nightly does not run retention, and a cleanup failure fails the
+release job visibly.
 
 ### Unpublished Stable release candidates
 


### PR DESCRIPTION
## Summary

- retain only the two newest public immutable Nightly releases
- run retention after the new Nightly feed is promoted and its changelog is collected
- delete each obsolete release together with its tag
- guard Stable, rolling `nightly`, draft, PR-test, and unrelated releases with strict selection rules
- document and test the retention policy

## Why

Daily immutable Nightlies accumulate in GitHub's time-sorted Release list and quickly push the current Stable release out of view. GitHub cannot pin Stable above newer prereleases, so bounded Nightly retention keeps the list readable without replacing the immutable installer URL used by the signed update manifest.

Closes #220

## Validation

- `python -m unittest discover -s build-support/release -p 'test_*.py'` — 61 tests passed
- `python -m unittest discover -s build-support/verification -p 'test_*.py'` — 40 tests passed
- `git diff --check` — passed
- dry run against the public GitHub Release history selected `v3.0.0-nightly.20260813.3`, `.2`, `.1`, and `v3.0.0-nightly.20260812.9` for deletion while retaining the two newest immutable Nightlies

Evidence level: automated tests and read-only verification against current public release metadata. No live release was deleted during validation.

## Risks

The actual deletion path remains live-unverified until the first successful Nightly after merge. Cleanup is gated behind successful publication, rolling-manifest promotion, and changelog collection; selection fails closed if the current release is missing or is not among the two newest immutable Nightlies. Any deletion failure fails the release job visibly and is retried by the next successful Nightly.