### PR TITLE
feat(analytics): collect alliance ranking data

### DIFF
--- a/modules/api/src/main/java/dev/frostguard/api/configs/TpDailyTaskEnum.java
+++ b/modules/api/src/main/java/dev/frostguard/api/configs/TpDailyTaskEnum.java
@@ -18,6 +18,9 @@ import java.util.Set;
  */
 public enum TpDailyTaskEnum {
 
+    GAME_ANALYTICS_LABYRINTH(510, "Collect Alliance Labyrinth Ranking", null, RoutineCategory.ANALYTICS),
+    GAME_ANALYTICS_POWER    (511, "Collect Alliance Power Ranking",     null, RoutineCategory.ANALYTICS),
+
     /* ── alliance ── */
 
     ALLIANCE_AUTOJOIN      (40,  "Alliance Autojoin",            ConfigurationKeyEnum.ALLIANCE_AUTOJOIN_BOOL,                  RoutineCategory.ALLIANCE),
@@ -116,7 +119,7 @@ public enum TpDailyTaskEnum {
 
     /** Broad operational classification of a scheduled routine. */
     public enum RoutineCategory {
-        ALLIANCE, CHIEF_ORDER, CITY, CUSTOM, DAILY_OBJECTIVE,
+        ALLIANCE, ANALYTICS, CHIEF_ORDER, CITY, CUSTOM, DAILY_OBJECTIVE,
         EVENT, LIFECYCLE, MILITARY, PET, RESOURCE, SHOP
     }
 

--- a/modules/api/src/main/java/dev/frostguard/api/domain/AllianceRankingEntryData.java
+++ b/modules/api/src/main/java/dev/frostguard/api/domain/AllianceRankingEntryData.java
@@ -1,0 +1,28 @@
+package dev.frostguard.api.domain;
+
+/** One validated member entry in an alliance-scoped ranking. */
+public record AllianceRankingEntryData(int rank, long playerId, String playerName, Long value,
+                                       boolean playerNameFromCache, boolean powerFromCache) {
+
+    public AllianceRankingEntryData(int rank, long playerId, String playerName, long value) {
+        this(rank, playerId, playerName, value, false, false);
+    }
+
+    public AllianceRankingEntryData(int rank, long playerId, String playerName, long value,
+                                    boolean playerNameFromCache) {
+        this(rank, playerId, playerName, value, playerNameFromCache, false);
+    }
+
+    public AllianceRankingEntryData {
+        if (rank < 1) {
+            throw new IllegalArgumentException("rank must be positive");
+        }
+        if (playerId < 1) {
+            throw new IllegalArgumentException("playerId must be positive");
+        }
+        playerName = playerName == null || playerName.isBlank() ? null : playerName;
+        if (value != null && value < 0) {
+            throw new IllegalArgumentException("value must not be negative");
+        }
+    }
+}

--- a/modules/api/src/main/java/dev/frostguard/api/domain/LabyrinthRankingEntryData.java
+++ b/modules/api/src/main/java/dev/frostguard/api/domain/LabyrinthRankingEntryData.java
@@ -1,0 +1,23 @@
+package dev.frostguard.api.domain;
+
+/** One alliance member found in the Labyrinth ranking response. */
+public record LabyrinthRankingEntryData(int rank, long playerId, String playerName, long score,
+                                        boolean playerNameFromCache) {
+
+    public LabyrinthRankingEntryData(int rank, long playerId, String playerName, long score) {
+        this(rank, playerId, playerName, score, false);
+    }
+
+    public LabyrinthRankingEntryData {
+        if (rank < 1) {
+            throw new IllegalArgumentException("rank must be positive");
+        }
+        if (playerId < 1) {
+            throw new IllegalArgumentException("playerId must be positive");
+        }
+        playerName = playerName == null || playerName.isBlank() ? null : playerName;
+        if (score < 0) {
+            throw new IllegalArgumentException("score must not be negative");
+        }
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/emulator/EmulatorController.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/emulator/EmulatorController.java
@@ -165,6 +165,7 @@ public class EmulatorController {
 
     public void    closeEmulator(String i)                { requireBackend(); backend.closeEmulator(i); backend.invalidateAllCaches(i); }
     public void    launchApp(String i, String pkg)        { requireBackend(); backend.launchApp(i, pkg); }
+    public void    forceStopApp(String i, String pkg)     { requireBackend(); backend.forceStopApp(i, pkg); }
     public void    sendGameToBackground(String i)         { requireBackend(); backend.sendGameToBackground(i); }
     public boolean isRunning(String i)                    { requireBackend(); return backend.isRunning(i); }
     public boolean isPackageRunning(String i, String pkg) { requireBackend(); return backend.isPackageRunning(i, pkg); }

--- a/modules/automation/src/main/java/dev/frostguard/engine/emulator/EmulatorInstance.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/emulator/EmulatorInstance.java
@@ -399,6 +399,18 @@ public abstract class EmulatorInstance {
         }, "launch");
     }
 
+    public void forceStopApp(String idx, String pkg) {
+        withRetries(idx, dev -> {
+            try {
+                dev.executeShellCommand("am force-stop " + pkg, new NullOutputReceiver());
+                LOG.info("Force-stopped {} on {}", pkg, idx);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return Boolean.TRUE;
+        }, "force-stop");
+    }
+
     public void sendGameToBackground(String idx) {
         withRetries(idx, dev -> {
             try { dev.executeShellCommand("input keyevent KEYCODE_HOME", new NullOutputReceiver()); }

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/NavigationHelper.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/NavigationHelper.java
@@ -11,6 +11,7 @@ import dev.frostguard.engine.error.HomeNotFoundException;
 import dev.frostguard.engine.error.ProfileInReconnectStateException;
 import dev.frostguard.engine.input.TapInteractionService;
 import dev.frostguard.engine.nav.ButtonConstants;
+import dev.frostguard.engine.nav.CommonGameAreas;
 import dev.frostguard.engine.nav.SearchConfigConstants;
 import dev.frostguard.engine.schedule.LaunchPoint;
 import dev.frostguard.engine.service.LoggingService;
@@ -29,6 +30,16 @@ public class NavigationHelper {
     private static final int EVENT_TAB_RESET_SWIPES = 3;
     private static final int EVENT_TAB_SCAN_SWIPES = 7;
     private static final long EVENT_TAB_SETTLE_MS = 1000L;
+    private static final PointData LEFT_MENU_SCROLL_FROM = new PointData(400, 800);
+    private static final PointData LEFT_MENU_SCROLL_TO = new PointData(400, 100);
+    private static final AreaData LABYRINTH_LEADERBOARD = area(646, 185, 704, 264);
+    private static final AreaData LABYRINTH_CATEGORY = area(90, 190, 320, 450);
+    private static final AreaData ALLIANCE_POWER_RANKINGS = area(80, 1035, 290, 1100);
+    private static final PointData RANKING_SCROLL_FROM = new PointData(360, 900);
+    private static final PointData RANKING_SCROLL_TO = new PointData(360, 620);
+    private static final int ALLIANCE_POWER_RANKING_SCROLLS = 23;
+    private static final int ALLIANCE_POWER_RANKING_SCROLL_DURATION_MS = 250;
+    private static final long ALLIANCE_POWER_ROW_LOAD_MS = 500;
 
     private final TemplateSearchHelper searcher;
     private final EmulatorController emu;
@@ -68,6 +79,70 @@ public class NavigationHelper {
         if (!hit.isFound()) return false;
         taps.tapInside(hit, 1, 1000);
         return true;
+    }
+
+    public boolean navigateToLabyrinth() {
+        ensureCorrectScreenLocation(LaunchPoint.HOME);
+        taps.tapInside(CommonGameAreas.LEFT_MENU_TRIGGER, 1, 500);
+        taps.tapInside(CommonGameAreas.LEFT_MENU_CITY_TAB, 1, 400);
+        emu.swipeScreen(device, LEFT_MENU_SCROLL_FROM, LEFT_MENU_SCROLL_TO, 500);
+        interruptibleWait(1_300);
+        ImageSearchResultData labyrinth = searcher.locatePattern(
+                TemplatesEnum.LEFT_MENU_LABYRINTH_BUTTON, SearchConfigConstants.SINGLE_WITH_RETRIES);
+        if (!labyrinth.isFound()) {
+            return false;
+        }
+        taps.tapInside(labyrinth, 1, 2_500);
+        return true;
+    }
+
+    public void navigateToLabyrinthRanking() {
+        if (!navigateToLabyrinth()) {
+            throw new IllegalStateException("Labyrinth entry was not found in the city menu");
+        }
+        taps.tapInside(LABYRINTH_LEADERBOARD, 1, 2_500);
+        for (int attempt = 1; attempt <= 3; attempt++) {
+            taps.tapInside(LABYRINTH_CATEGORY, 1, 1_500);
+            if (headerContains("THE LABYRINTH")) {
+                return;
+            }
+        }
+        throw new IllegalStateException("The Labyrinth ranking did not open");
+    }
+
+    public void navigateToPowerRanking() {
+        ensureCorrectScreenLocation(LaunchPoint.HOME);
+        taps.tapInside(CommonGameAreas.BOTTOM_MENU_ALLIANCE_BUTTON, 1, 2_000);
+        ImageSearchResultData allianceAnchor = searcher.locatePattern(
+                TemplatesEnum.ALLIANCE_WAR_BUTTON, SearchConfigConstants.SINGLE_WITH_RETRIES);
+        if (!allianceAnchor.isFound()) {
+            throw new IllegalStateException("Alliance menu did not open");
+        }
+        taps.tapInside(ALLIANCE_POWER_RANKINGS, 1, 2_500);
+        if (!headerContains("ALLIANCE RANKING")) {
+            throw new IllegalStateException("Power Ranking did not open");
+        }
+        interruptibleWait(5_000);
+        for (int index = 0; index < ALLIANCE_POWER_RANKING_SCROLLS; index++) {
+            emu.swipeScreen(device, RANKING_SCROLL_FROM, RANKING_SCROLL_TO,
+                    ALLIANCE_POWER_RANKING_SCROLL_DURATION_MS);
+            interruptibleWait(ALLIANCE_POWER_ROW_LOAD_MS);
+        }
+        interruptibleWait(5_000);
+    }
+
+    private boolean headerContains(String expected) {
+        try {
+            String header = emu.readText(device, new PointData(70, 0), new PointData(500, 80));
+            return header != null && header.toUpperCase(java.util.Locale.ROOT).contains(expected);
+        } catch (Exception exception) {
+            log.warn("Could not verify screen header: " + exception.getMessage());
+            return false;
+        }
+    }
+
+    private static AreaData area(int x1, int y1, int x2, int y2) {
+        return new AreaData(new PointData(x1, y1), new PointData(x2, y2));
     }
 
     // ── event menu ───────────────────────────────────────────────────

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/GameAnalyticsRunRegistry.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/GameAnalyticsRunRegistry.java
@@ -1,0 +1,41 @@
+package dev.frostguard.engine.ranking;
+
+import dev.frostguard.engine.ranking.capture.AllianceRankingCaptureResult;
+import dev.frostguard.engine.ranking.capture.GameAnalyticsCollectionType;
+import dev.frostguard.engine.ranking.history.GameAnalyticsSnapshot;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/** Publishes progress from manually queued analytics tasks to interested UI panels. */
+public final class GameAnalyticsRunRegistry {
+
+    private static final List<Listener> LISTENERS = new CopyOnWriteArrayList<>();
+
+    private GameAnalyticsRunRegistry() {
+    }
+
+    public static void addListener(Listener listener) {
+        if (listener != null) LISTENERS.add(listener);
+    }
+
+    public static void publish(Event event) {
+        LISTENERS.forEach(listener -> listener.onAnalyticsEvent(event));
+    }
+
+    public enum State {
+        RUNNING,
+        SUCCEEDED,
+        FAILED
+    }
+
+    public record Event(Long profileId, GameAnalyticsCollectionType type, State state,
+                        String message, AllianceRankingCaptureResult result,
+                        GameAnalyticsSnapshot snapshot) {
+    }
+
+    @FunctionalInterface
+    public interface Listener {
+        void onAnalyticsEvent(Event event);
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/AllianceRankingCaptureResult.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/AllianceRankingCaptureResult.java
@@ -1,0 +1,14 @@
+package dev.frostguard.engine.ranking.capture;
+
+import dev.frostguard.api.domain.AllianceRankingEntryData;
+import dev.frostguard.api.domain.LabyrinthRankingEntryData;
+
+import java.util.List;
+
+public record AllianceRankingCaptureResult(List<AllianceRankingEntryData> power,
+                                           List<LabyrinthRankingEntryData> labyrinth) {
+    public AllianceRankingCaptureResult {
+        power = List.copyOf(power);
+        labyrinth = List.copyOf(labyrinth);
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/AllianceRankingCaptureSupport.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/AllianceRankingCaptureSupport.java
@@ -1,0 +1,25 @@
+package dev.frostguard.engine.ranking.capture;
+
+import dev.frostguard.engine.emulator.EmulatorType;
+
+import java.util.Locale;
+
+/** Describes whether the first ranking traffic-capture backend can run. */
+public record AllianceRankingCaptureSupport(boolean supported, String message) {
+
+    public static AllianceRankingCaptureSupport evaluate(String operatingSystem, EmulatorType emulatorType) {
+        String os = operatingSystem == null ? "" : operatingSystem.toLowerCase(Locale.ROOT);
+        if (!os.contains("windows")) {
+            return unavailable("Alliance ranking traffic capture is currently only available on Windows with MuMu Player.");
+        }
+        if (emulatorType != EmulatorType.MUMU) {
+            return unavailable("Alliance ranking traffic capture is currently only available for MuMu Player on Windows.");
+        }
+        return new AllianceRankingCaptureSupport(true,
+                "Game ranking collection is available for MuMu Player on Windows.");
+    }
+
+    private static AllianceRankingCaptureSupport unavailable(String message) {
+        return new AllianceRankingCaptureSupport(false, message);
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/GameAnalyticsCollectionType.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/GameAnalyticsCollectionType.java
@@ -1,0 +1,6 @@
+package dev.frostguard.engine.ranking.capture;
+
+public enum GameAnalyticsCollectionType {
+    LABYRINTH,
+    POWER
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/MuMuTcpdumpAnalyticsCapture.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/MuMuTcpdumpAnalyticsCapture.java
@@ -1,0 +1,251 @@
+package dev.frostguard.engine.ranking.capture;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/** Captures one ranking directly on MuMu's virtual network interface. */
+public final class MuMuTcpdumpAnalyticsCapture {
+
+    private static final DateTimeFormatter SESSION_TIME = DateTimeFormatter
+            .ofPattern("uuuuMMdd-HHmmss").withZone(ZoneOffset.UTC);
+
+    private final CaptureDecoder decoder;
+    private final Clock clock;
+    private ActiveCapture active;
+
+    public MuMuTcpdumpAnalyticsCapture() {
+        this(new PowerRankingCaptureDecoder()::decode, Clock.systemUTC());
+    }
+
+    MuMuTcpdumpAnalyticsCapture(CaptureDecoder decoder, Clock clock) {
+        this.decoder = decoder;
+        this.clock = clock;
+    }
+
+    public synchronized Path start(Path workspaceRoot, GameAnalyticsCollectionType type,
+                                   String adbPath, String deviceSerial)
+            throws IOException, InterruptedException {
+        if (active != null) {
+            throw new IllegalStateException("Game analytics traffic capture is already running");
+        }
+        if (workspaceRoot == null || type == null || adbPath == null || adbPath.isBlank()
+                || deviceSerial == null || deviceSerial.isBlank()) {
+            throw new IllegalArgumentException("capture arguments must not be null or blank");
+        }
+
+        Path directory = workspaceRoot.toAbsolutePath().normalize().resolve("diagnostics")
+                .resolve("game-analytics")
+                .resolve(SESSION_TIME.format(Instant.now(clock)) + "-" + UUID.randomUUID());
+        Files.createDirectories(directory);
+        Path capture = directory.resolve("capture.pcap");
+        Path error = directory.resolve("tcpdump-error.log");
+        String remoteId = UUID.randomUUID().toString();
+        String remoteCapture = "/data/local/tmp/frostguard-analytics-" + remoteId + ".pcap";
+
+        run(adbPath, deviceSerial, List.of("root"), 15_000);
+        run(adbPath, deviceSerial, List.of("wait-for-device"), 15_000);
+        CommandResult existing = run(adbPath, deviceSerial,
+                List.of("shell", "pidof", "tcpdump"), 5_000, false);
+        if (!existing.output().isBlank()) {
+            throw new IOException("Another tcpdump process is already running in MuMu");
+        }
+        CommandResult route = run(adbPath, deviceSerial,
+                List.of("shell", "ip", "route", "get", "1.1.1.1"), 5_000);
+        String networkInterface = defaultRouteInterface(route.output());
+
+        Process process = new ProcessBuilder(adbPath, "-s", deviceSerial, "shell", "tcpdump",
+                "-i", networkInterface, "-s", "0", "-U", "-w", remoteCapture,
+                "tcp", "port", "30101")
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(error.toFile())
+                .start();
+        Thread.sleep(750);
+        CommandResult pid = run(adbPath, deviceSerial,
+                List.of("shell", "pidof", "tcpdump"), 5_000, false);
+        if (!process.isAlive() || pid.output().isBlank()) {
+            process.destroyForcibly();
+            throw new IOException("MuMu tcpdump exited during startup: " + readError(error));
+        }
+        String remotePid = pid.output().trim().split("\\s+")[0];
+        active = new ActiveCapture(directory, capture, error, adbPath, deviceSerial,
+                remotePid, remoteCapture, process, type);
+        return directory;
+    }
+
+    public synchronized AllianceRankingCaptureResult stopAndDecode()
+            throws IOException, InterruptedException {
+        ActiveCapture capture = requireActive();
+        try {
+            run(capture.adbPath(), capture.deviceSerial(),
+                    List.of("shell", "kill", "-2", capture.remotePid()), 5_000);
+            waitForRemoteStop(capture, 10_000);
+            if (!capture.process().waitFor(5, TimeUnit.SECONDS)) {
+                capture.process().destroyForcibly();
+                throw new IOException("ADB tcpdump session did not stop cleanly");
+            }
+            pull(capture, capture.remoteCapture(), capture.pcap());
+            removeRemoteFiles(capture);
+            AllianceRankingCaptureResult result = decoder.decode(capture.pcap(), capture.type());
+            boolean empty = capture.type() == GameAnalyticsCollectionType.POWER
+                    ? result.power().isEmpty() : result.labyrinth().isEmpty();
+            if (empty) {
+                throw new IOException("No " + capture.type().name().toLowerCase()
+                        + " ranking response was decoded. Capture files remain in " + capture.directory());
+            }
+            retainLatestDevelopmentPowerCapture(capture);
+            cleanup(capture);
+            return result;
+        } finally {
+            active = null;
+        }
+    }
+
+    public synchronized void cancel() {
+        ActiveCapture capture = active;
+        if (capture == null) return;
+        try {
+            run(capture.adbPath(), capture.deviceSerial(),
+                    List.of("shell", "kill", "-2", capture.remotePid()), 3_000);
+            waitForRemoteStop(capture, 3_000);
+            if (!capture.process().waitFor(3, TimeUnit.SECONDS)) capture.process().destroyForcibly();
+        } catch (Exception ignored) {
+            capture.process().destroyForcibly();
+        } finally {
+            pullIfPresent(capture.adbPath(), capture.deviceSerial(), capture.remoteCapture(), capture.pcap());
+            removeRemoteFiles(capture);
+            active = null;
+        }
+    }
+
+    public synchronized boolean isRunning() {
+        return active != null;
+    }
+
+    static String defaultRouteInterface(String route) throws IOException {
+        if (route != null) {
+            String[] tokens = route.trim().split("\\s+");
+            for (int index = 0; index + 1 < tokens.length; index++) {
+                if ("dev".equals(tokens[index]) && !tokens[index + 1].isBlank()) {
+                    return tokens[index + 1];
+                }
+            }
+        }
+        throw new IOException("Could not determine MuMu's active network interface");
+    }
+
+    private ActiveCapture requireActive() {
+        if (active == null) throw new IllegalStateException("Game analytics capture is not running");
+        return active;
+    }
+
+    private CommandResult run(String adbPath, String serial, List<String> arguments, long timeoutMillis)
+            throws IOException, InterruptedException {
+        return run(adbPath, serial, arguments, timeoutMillis, true);
+    }
+
+    private CommandResult run(String adbPath, String serial, List<String> arguments,
+                              long timeoutMillis, boolean requireSuccess)
+            throws IOException, InterruptedException {
+        List<String> command = new java.util.ArrayList<>();
+        command.add(adbPath);
+        command.add("-s");
+        command.add(serial);
+        command.addAll(arguments);
+        Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+        if (!process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)) {
+            process.destroyForcibly();
+            throw new IOException("ADB command timed out: " + String.join(" ", arguments));
+        }
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        if (requireSuccess && process.exitValue() != 0) {
+            throw new IOException("ADB command failed: " + output);
+        }
+        return new CommandResult(process.exitValue(), output);
+    }
+
+    private void waitForRemoteStop(ActiveCapture capture, long timeoutMillis)
+            throws IOException, InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+        while (System.nanoTime() < deadline) {
+            CommandResult result = run(capture.adbPath(), capture.deviceSerial(),
+                    List.of("shell", "pidof", "tcpdump"), 2_000, false);
+            if (result.output().isBlank()) return;
+            Thread.sleep(200);
+        }
+        throw new IOException("MuMu tcpdump did not stop cleanly");
+    }
+
+    private void pull(ActiveCapture capture, String remote, Path local)
+            throws IOException, InterruptedException {
+        run(capture.adbPath(), capture.deviceSerial(),
+                List.of("pull", remote, local.toString()), 15_000);
+    }
+
+    private void pullIfPresent(String adbPath, String serial, String remote, Path local) {
+        try {
+            run(adbPath, serial, List.of("pull", remote, local.toString()), 10_000);
+        } catch (Exception ignored) {
+            // Optional diagnostic output may not have been created.
+        }
+    }
+
+    private void removeRemoteFiles(ActiveCapture capture) {
+        try {
+            run(capture.adbPath(), capture.deviceSerial(), List.of("shell", "rm", "-f",
+                    capture.remoteCapture()), 5_000);
+        } catch (Exception ignored) {
+            // Remote cleanup is best-effort after the local capture has been pulled.
+        }
+    }
+
+    private String readError(Path error) {
+        try {
+            return Files.isRegularFile(error) ? Files.readString(error).trim() : "";
+        } catch (IOException ignored) {
+            return "";
+        }
+    }
+
+    private void cleanup(ActiveCapture capture) {
+        removeRemoteFiles(capture);
+        try {
+            Files.deleteIfExists(capture.pcap());
+            Files.deleteIfExists(capture.error());
+            Files.deleteIfExists(capture.directory());
+        } catch (IOException ignored) {
+            // Decoded data is already in memory; cleanup is best-effort.
+        }
+    }
+
+    private void retainLatestDevelopmentPowerCapture(ActiveCapture capture) throws IOException {
+        if (capture.type() != GameAnalyticsCollectionType.POWER
+                || !"development".equals(System.getProperty("frostguard.channel"))) {
+            return;
+        }
+        Path latest = capture.directory().getParent().resolve("latest-power.pcap");
+        Files.copy(capture.pcap(), latest, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    interface CaptureDecoder {
+        AllianceRankingCaptureResult decode(Path capture, GameAnalyticsCollectionType type) throws IOException;
+    }
+
+    private record ActiveCapture(Path directory, Path pcap, Path error, String adbPath,
+                                 String deviceSerial, String remotePid, String remoteCapture,
+                                 Process process,
+                                 GameAnalyticsCollectionType type) {
+    }
+
+    private record CommandResult(int exitCode, String output) {
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/PcapngTcpStreamReader.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/PcapngTcpStreamReader.java
@@ -1,0 +1,278 @@
+package dev.frostguard.engine.ranking.capture;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/** Reads and reassembles IPv4 TCP payloads from little-endian PCAP or PCAPNG captures. */
+public final class PcapngTcpStreamReader {
+
+    private static final int SECTION_HEADER_BLOCK = 0x0a0d0d0a;
+    private static final int INTERFACE_DESCRIPTION_BLOCK = 1;
+    private static final int ENHANCED_PACKET_BLOCK = 6;
+    private static final int BYTE_ORDER_MAGIC = 0x1a2b3c4d;
+    private static final int LINKTYPE_ETHERNET = 1;
+
+    public List<byte[]> readInboundStreams(Path capture, int sourcePort) throws IOException {
+        return readStreams(capture, sourcePort, Direction.INBOUND);
+    }
+
+    public List<byte[]> readOutboundStreams(Path capture, int destinationPort) throws IOException {
+        return readStreams(capture, destinationPort, Direction.OUTBOUND);
+    }
+
+    private List<byte[]> readStreams(Path capture, int gamePort, Direction direction) throws IOException {
+        if (capture == null) {
+            throw new IllegalArgumentException("capture must not be null");
+        }
+        if (gamePort < 1 || gamePort > 65535) {
+            throw new IllegalArgumentException("gamePort must be between 1 and 65535");
+        }
+
+        byte[] bytes = Files.readAllBytes(capture);
+        if (bytes.length >= 24 && littleEndianInt(bytes, 0) == 0xa1b2c3d4) {
+            return readClassicPcap(bytes, gamePort, direction);
+        }
+        Map<Integer, Integer> linkTypes = new HashMap<>();
+        Map<ConnectionKey, TreeMap<Long, byte[]>> connections = new LinkedHashMap<>();
+        int nextInterfaceId = 0;
+        int offset = 0;
+        boolean sectionSeen = false;
+        while (offset < bytes.length) {
+            require(bytes, offset, 12, "PCAPNG block header");
+            int blockType = littleEndianInt(bytes, offset);
+            int blockLength = littleEndianInt(bytes, offset + 4);
+            if (blockLength < 12 || (blockLength & 3) != 0) {
+                throw malformed("invalid PCAPNG block length " + blockLength, offset);
+            }
+            require(bytes, offset, blockLength, "PCAPNG block");
+            if (littleEndianInt(bytes, offset + blockLength - 4) != blockLength) {
+                throw malformed("mismatched trailing PCAPNG block length", offset);
+            }
+
+            if (blockType == SECTION_HEADER_BLOCK) {
+                if (littleEndianInt(bytes, offset + 8) != BYTE_ORDER_MAGIC) {
+                    throw malformed("only little-endian PCAPNG sections are supported", offset);
+                }
+                sectionSeen = true;
+                linkTypes.clear();
+                nextInterfaceId = 0;
+            } else if (!sectionSeen) {
+                throw malformed("PCAPNG data appeared before a section header", offset);
+            } else if (blockType == INTERFACE_DESCRIPTION_BLOCK) {
+                require(bytes, offset + 8, blockLength - 12, 8, "interface description");
+                linkTypes.put(nextInterfaceId++, littleEndianUnsignedShort(bytes, offset + 8));
+            } else if (blockType == ENHANCED_PACKET_BLOCK) {
+                readPacket(bytes, offset, blockLength, linkTypes, gamePort, direction, connections);
+            }
+            offset += blockLength;
+        }
+
+        List<byte[]> streams = new ArrayList<>();
+        for (TreeMap<Long, byte[]> segments : connections.values()) {
+            streams.addAll(reassemble(segments));
+        }
+        return List.copyOf(streams);
+    }
+
+    private List<byte[]> readClassicPcap(byte[] bytes, int gamePort, Direction direction) {
+        int linkType = littleEndianInt(bytes, 20);
+        if (linkType != LINKTYPE_ETHERNET) {
+            throw malformed("only Ethernet PCAP captures are supported", 20);
+        }
+        Map<ConnectionKey, TreeMap<Long, byte[]>> connections = new LinkedHashMap<>();
+        int offset = 24;
+        while (offset < bytes.length) {
+            if (bytes.length - offset < 16) break;
+            long capturedLength = Integer.toUnsignedLong(littleEndianInt(bytes, offset + 8));
+            if (capturedLength > Integer.MAX_VALUE) {
+                throw malformed("invalid PCAP packet length", offset);
+            }
+            int packetOffset = offset + 16;
+            if (capturedLength > bytes.length - packetOffset) break;
+            addPacket(bytes, packetOffset, (int) capturedLength, gamePort, direction, connections);
+            offset = packetOffset + (int) capturedLength;
+        }
+        List<byte[]> streams = new ArrayList<>();
+        for (TreeMap<Long, byte[]> segments : connections.values()) {
+            streams.addAll(reassemble(segments));
+        }
+        return List.copyOf(streams);
+    }
+
+    private void readPacket(byte[] bytes, int blockOffset, int blockLength,
+                            Map<Integer, Integer> linkTypes, int gamePort, Direction direction,
+                            Map<ConnectionKey, TreeMap<Long, byte[]>> connections) {
+        int body = blockOffset + 8;
+        require(bytes, body, blockLength - 12, 20, "enhanced packet header");
+        int interfaceId = littleEndianInt(bytes, body);
+        if (linkTypes.getOrDefault(interfaceId, -1) != LINKTYPE_ETHERNET) {
+            return;
+        }
+        long capturedLength = Integer.toUnsignedLong(littleEndianInt(bytes, body + 12));
+        if (capturedLength > Integer.MAX_VALUE || capturedLength > blockLength - 32L) {
+            throw malformed("invalid captured packet length", blockOffset);
+        }
+        int packetOffset = body + 20;
+        int packetLength = (int) capturedLength;
+        addPacket(bytes, packetOffset, packetLength, gamePort, direction, connections);
+    }
+
+    private void addPacket(byte[] bytes, int packetOffset, int packetLength, int gamePort,
+                           Direction direction,
+                           Map<ConnectionKey, TreeMap<Long, byte[]>> connections) {
+        TcpSegment segment = parseEthernetIpv4Tcp(bytes, packetOffset, packetLength, gamePort, direction);
+        if (segment == null || segment.payload().length == 0) {
+            return;
+        }
+
+        TreeMap<Long, byte[]> bySequence = connections.computeIfAbsent(
+                segment.connection(), ignored -> new TreeMap<>());
+        byte[] previous = bySequence.putIfAbsent(segment.sequence(), segment.payload());
+        if (previous != null && !Arrays.equals(previous, segment.payload())) {
+            if (segment.payload().length > previous.length
+                    && startsWith(segment.payload(), previous)) {
+                bySequence.put(segment.sequence(), segment.payload());
+            } else if (!startsWith(previous, segment.payload())) {
+                throw malformed("conflicting TCP retransmission at sequence " + segment.sequence(), packetOffset);
+            }
+        }
+    }
+
+    private TcpSegment parseEthernetIpv4Tcp(byte[] bytes, int offset, int length,
+                                            int gamePort, Direction direction) {
+        if (length < 14 || bigEndianUnsignedShort(bytes, offset + 12) != 0x0800) {
+            return null;
+        }
+        int ipOffset = offset + 14;
+        if (length - 14 < 20 || (bytes[ipOffset] >>> 4) != 4 || (bytes[ipOffset + 9] & 0xff) != 6) {
+            return null;
+        }
+        int ipHeaderLength = (bytes[ipOffset] & 0x0f) * 4;
+        int ipTotalLength = bigEndianUnsignedShort(bytes, ipOffset + 2);
+        if (ipHeaderLength < 20 || ipTotalLength < ipHeaderLength + 20 || ipTotalLength > length - 14) {
+            return null;
+        }
+
+        int tcpOffset = ipOffset + ipHeaderLength;
+        int tcpHeaderLength = ((bytes[tcpOffset + 12] & 0xff) >>> 4) * 4;
+        if (tcpHeaderLength < 20 || ipTotalLength < ipHeaderLength + tcpHeaderLength) {
+            return null;
+        }
+        int actualSourcePort = bigEndianUnsignedShort(bytes, tcpOffset);
+        int destinationPort = bigEndianUnsignedShort(bytes, tcpOffset + 2);
+        if ((direction == Direction.INBOUND && actualSourcePort != gamePort)
+                || (direction == Direction.OUTBOUND && destinationPort != gamePort)) {
+            return null;
+        }
+        long sequence = bigEndianUnsignedInt(bytes, tcpOffset + 4);
+        int payloadOffset = tcpOffset + tcpHeaderLength;
+        int payloadLength = ipTotalLength - ipHeaderLength - tcpHeaderLength;
+        byte[] payload = Arrays.copyOfRange(bytes, payloadOffset, payloadOffset + payloadLength);
+        ConnectionKey connection = new ConnectionKey(
+                ipv4(bytes, ipOffset + 12), actualSourcePort,
+                ipv4(bytes, ipOffset + 16), destinationPort);
+        return new TcpSegment(connection, sequence, payload);
+    }
+
+    private List<byte[]> reassemble(TreeMap<Long, byte[]> segments) {
+        List<byte[]> streams = new ArrayList<>();
+        ByteArrayOutputStream current = new ByteArrayOutputStream();
+        long expected = -1;
+        for (Map.Entry<Long, byte[]> entry : segments.entrySet()) {
+            long sequence = entry.getKey();
+            byte[] payload = entry.getValue();
+            if (expected < 0 || sequence > expected) {
+                if (current.size() > 0) {
+                    streams.add(current.toByteArray());
+                    current.reset();
+                }
+                expected = sequence;
+            }
+
+            long overlap = expected - sequence;
+            if (overlap >= payload.length) {
+                continue;
+            }
+            int payloadOffset = overlap > 0 ? (int) overlap : 0;
+            current.write(payload, payloadOffset, payload.length - payloadOffset);
+            expected = sequence + payload.length;
+        }
+        if (current.size() > 0) {
+            streams.add(current.toByteArray());
+        }
+        return streams;
+    }
+
+    private boolean startsWith(byte[] value, byte[] prefix) {
+        if (value.length < prefix.length) {
+            return false;
+        }
+        for (int index = 0; index < prefix.length; index++) {
+            if (value[index] != prefix[index]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String ipv4(byte[] source, int offset) {
+        return (source[offset] & 0xff) + "." + (source[offset + 1] & 0xff) + "."
+                + (source[offset + 2] & 0xff) + "." + (source[offset + 3] & 0xff);
+    }
+
+    private int littleEndianInt(byte[] source, int offset) {
+        return ByteBuffer.wrap(source, offset, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
+    }
+
+    private int littleEndianUnsignedShort(byte[] source, int offset) {
+        return (source[offset] & 0xff) | ((source[offset + 1] & 0xff) << 8);
+    }
+
+    private int bigEndianUnsignedShort(byte[] source, int offset) {
+        return ((source[offset] & 0xff) << 8) | (source[offset + 1] & 0xff);
+    }
+
+    private long bigEndianUnsignedInt(byte[] source, int offset) {
+        return ((source[offset] & 0xffL) << 24)
+                | ((source[offset + 1] & 0xffL) << 16)
+                | ((source[offset + 2] & 0xffL) << 8)
+                | (source[offset + 3] & 0xffL);
+    }
+
+    private void require(byte[] source, int offset, int available, int required, String part) {
+        if (offset < 0 || available < required || offset > source.length - required) {
+            throw malformed("truncated " + part, offset);
+        }
+    }
+
+    private void require(byte[] source, int offset, int required, String part) {
+        require(source, offset, source.length - offset, required, part);
+    }
+
+    private IllegalArgumentException malformed(String reason, int offset) {
+        return new IllegalArgumentException(reason + " at capture offset " + offset);
+    }
+
+    private record ConnectionKey(String sourceAddress, int sourcePort,
+                                 String destinationAddress, int destinationPort) {
+    }
+
+    private record TcpSegment(ConnectionKey connection, long sequence, byte[] payload) {
+    }
+
+    private enum Direction {
+        INBOUND,
+        OUTBOUND
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/PowerRankingCaptureDecoder.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/capture/PowerRankingCaptureDecoder.java
@@ -1,0 +1,171 @@
+package dev.frostguard.engine.ranking.capture;
+
+import dev.frostguard.api.domain.AllianceRankingEntryData;
+import dev.frostguard.api.domain.LabyrinthRankingEntryData;
+import dev.frostguard.engine.ranking.protocol.LengthPrefixedFrameDecoder;
+import dev.frostguard.engine.ranking.protocol.LabyrinthRankingPayloadDecoder;
+import dev.frostguard.engine.ranking.protocol.AlliancePowerRankListDecoder;
+import dev.frostguard.engine.ranking.protocol.PowerRankingPayloadDecoder;
+import dev.frostguard.engine.ranking.protocol.SprotoRpcHeaderDecoder;
+import dev.frostguard.engine.ranking.protocol.SelfPlayerStateDecoder;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Decodes validated alliance power entries from a bounded PCAPNG capture. */
+public final class PowerRankingCaptureDecoder {
+
+    public static final int GAME_PORT = 30101;
+    private static final int MAXIMUM_FRAME_LENGTH = 32 * 1024;
+
+    private final PcapngTcpStreamReader streamReader;
+    private final PowerRankingPayloadDecoder payloadDecoder;
+    private final LabyrinthRankingPayloadDecoder labyrinthDecoder;
+    private final AlliancePowerRankListDecoder rankListDecoder = new AlliancePowerRankListDecoder();
+    private final SprotoRpcHeaderDecoder headerDecoder = new SprotoRpcHeaderDecoder();
+    private final SelfPlayerStateDecoder selfPlayerStateDecoder = new SelfPlayerStateDecoder();
+
+    public PowerRankingCaptureDecoder() {
+        this(new PcapngTcpStreamReader(), new PowerRankingPayloadDecoder(),
+                new LabyrinthRankingPayloadDecoder());
+    }
+
+    PowerRankingCaptureDecoder(PcapngTcpStreamReader streamReader,
+                               PowerRankingPayloadDecoder payloadDecoder,
+                               LabyrinthRankingPayloadDecoder labyrinthDecoder) {
+        this.streamReader = streamReader;
+        this.payloadDecoder = payloadDecoder;
+        this.labyrinthDecoder = labyrinthDecoder;
+    }
+
+    public List<AllianceRankingEntryData> decode(Path capture) throws IOException {
+        return decodeAll(capture).power();
+    }
+
+    public AllianceRankingCaptureResult decodeAll(Path capture) throws IOException {
+        List<byte[]> frames = readFrames(capture);
+        List<AllianceRankingEntryData> power = payloadDecoder.decode(frames);
+        Map<Long, String> allianceMembers = new LinkedHashMap<>();
+        for (AllianceRankingEntryData entry : power) {
+            allianceMembers.put(entry.playerId(), entry.playerName());
+        }
+        List<LabyrinthRankingEntryData> labyrinth = labyrinthDecoder.decode(frames, allianceMembers);
+        return new AllianceRankingCaptureResult(power, labyrinth);
+    }
+
+    public AllianceRankingCaptureResult decode(Path capture, GameAnalyticsCollectionType type) throws IOException {
+        List<byte[]> inbound = readFrames(capture, true);
+        List<byte[]> outbound = readFrames(capture, false);
+        if (type == GameAnalyticsCollectionType.POWER) {
+            // Startup traffic includes the local player's state, while the ranking screen only
+            // requests protocol 1029 details for other alliance members.
+            List<AllianceRankingEntryData> profiles = payloadDecoder.decode(inbound);
+            Map<Long, AllianceRankingEntryData> profilesById = new LinkedHashMap<>();
+            profiles.forEach(profile -> profilesById.put(profile.playerId(), profile));
+            selfPlayerStateDecoder.decode(inbound).ifPresent(self -> profilesById.put(
+                    self.playerId(), new AllianceRankingEntryData(1, self.playerId(),
+                            self.playerName(), self.power())));
+            var rankedPlayers = rankListDecoder.decode(correlatedResponses(inbound, outbound, 5404));
+            if (rankedPlayers.isEmpty()) {
+                return new AllianceRankingCaptureResult(profiles, List.of());
+            }
+            List<AllianceRankingEntryData> ranked = rankedPlayers.stream().map(player -> {
+                AllianceRankingEntryData profile = profilesById.get(player.playerId());
+                return profile == null
+                        ? new AllianceRankingEntryData(player.rank(), player.playerId(), null,
+                        player.power(), false, false)
+                        : new AllianceRankingEntryData(player.rank(), player.playerId(),
+                        profile.playerName(), player.power(), false, false);
+            }).toList();
+            return new AllianceRankingCaptureResult(ranked, List.of());
+        }
+        List<AllianceRankingEntryData> profiles = payloadDecoder.decode(
+                correlatedResponses(inbound, outbound, 1029));
+        Map<Long, String> memberNames = new LinkedHashMap<>();
+        for (AllianceRankingEntryData profile : profiles) {
+            memberNames.put(profile.playerId(), profile.playerName());
+        }
+        return new AllianceRankingCaptureResult(List.of(), labyrinthDecoder.decode(
+                correlatedResponses(inbound, outbound, 20479), memberNames));
+    }
+
+    public AllianceRankingCaptureResult decodePhases(Path labyrinthCapture, Path powerCapture) throws IOException {
+        List<byte[]> labyrinthFrames = readFrames(labyrinthCapture);
+        List<byte[]> powerFrames = readFrames(powerCapture);
+        List<AllianceRankingEntryData> power = payloadDecoder.decode(powerFrames);
+
+        Map<Long, String> memberNames = new LinkedHashMap<>();
+        for (AllianceRankingEntryData entry : payloadDecoder.decode(labyrinthFrames)) {
+            memberNames.put(entry.playerId(), entry.playerName());
+        }
+        for (AllianceRankingEntryData entry : power) {
+            memberNames.put(entry.playerId(), entry.playerName());
+        }
+        List<LabyrinthRankingEntryData> labyrinth = labyrinthDecoder.decode(labyrinthFrames, memberNames);
+        return new AllianceRankingCaptureResult(power, labyrinth);
+    }
+
+    private List<byte[]> readFrames(Path capture) throws IOException {
+        return readFrames(capture, true);
+    }
+
+    private List<byte[]> readFrames(Path capture, boolean inbound) throws IOException {
+        List<byte[]> frames = new ArrayList<>();
+        List<byte[]> streams = inbound
+                ? streamReader.readInboundStreams(capture, GAME_PORT)
+                : streamReader.readOutboundStreams(capture, GAME_PORT);
+        for (byte[] stream : streams) {
+            LengthPrefixedFrameDecoder frameDecoder = new LengthPrefixedFrameDecoder(MAXIMUM_FRAME_LENGTH);
+            try {
+                frames.addAll(frameDecoder.accept(stream));
+                frameDecoder.requireComplete();
+            } catch (IllegalArgumentException | IllegalStateException incompleteStream) {
+                // Captures can start after an existing connection has already transmitted part of a frame.
+                frames.addAll(scanForFrames(stream));
+            }
+        }
+        return List.copyOf(frames);
+    }
+
+    private List<byte[]> correlatedResponses(List<byte[]> inbound, List<byte[]> outbound,
+                                             long protocolType) {
+        java.util.Set<Long> sessions = outbound.stream()
+                .map(headerDecoder::decode)
+                .flatMap(java.util.Optional::stream)
+                .filter(header -> header.protocolType() != null
+                        && header.protocolType() == protocolType && header.session() != null)
+                .map(SprotoRpcHeaderDecoder.RpcHeader::session)
+                .collect(java.util.stream.Collectors.toSet());
+        if (sessions.isEmpty()) {
+            return List.of();
+        }
+        return inbound.stream()
+                .filter(frame -> headerDecoder.decode(frame)
+                        .map(header -> header.protocolType() == null
+                                && header.session() != null && sessions.contains(header.session()))
+                        .orElse(false))
+                .toList();
+    }
+
+    private List<byte[]> scanForFrames(byte[] stream) {
+        List<byte[]> frames = new ArrayList<>();
+        int offset = 0;
+        while (stream.length - offset >= 2) {
+            int length = ((stream[offset] & 0xff) << 8) | (stream[offset + 1] & 0xff);
+            if (length > 0 && length <= MAXIMUM_FRAME_LENGTH && stream.length - offset - 2 >= length) {
+                byte[] candidate = java.util.Arrays.copyOfRange(stream, offset + 2, offset + 2 + length);
+                if (payloadDecoder.isValidFrame(candidate)) {
+                    frames.add(candidate);
+                    offset += length + 2;
+                    continue;
+                }
+            }
+            offset++;
+        }
+        return frames;
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/export/GameAnalyticsExportService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/export/GameAnalyticsExportService.java
@@ -1,0 +1,86 @@
+package dev.frostguard.engine.ranking.export;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import dev.frostguard.api.domain.AllianceRankingEntryData;
+import dev.frostguard.api.domain.LabyrinthRankingEntryData;
+import dev.frostguard.engine.ranking.capture.GameAnalyticsCollectionType;
+import dev.frostguard.engine.ranking.history.GameAnalyticsSnapshot;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+
+/** Creates an explicit user-requested JSON or CSV export from a saved snapshot. */
+public final class GameAnalyticsExportService {
+
+    private static final char CSV_SEPARATOR = ';';
+    private static final byte[] UTF8_BOM = {(byte) 0xef, (byte) 0xbb, (byte) 0xbf};
+
+    private final ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    public void exportJson(Path target, GameAnalyticsSnapshot snapshot) throws IOException {
+        validate(target, snapshot);
+        writeAtomically(target.toAbsolutePath().normalize(), mapper.writeValueAsBytes(snapshot));
+    }
+
+    public void exportCsv(Path target, GameAnalyticsSnapshot snapshot) throws IOException {
+        validate(target, snapshot);
+        String csv = snapshot.type() == GameAnalyticsCollectionType.POWER
+                ? powerCsv(snapshot.power()) : labyrinthCsv(snapshot.labyrinth());
+        byte[] body = csv.getBytes(StandardCharsets.UTF_8);
+        byte[] excelCompatible = new byte[UTF8_BOM.length + body.length];
+        System.arraycopy(UTF8_BOM, 0, excelCompatible, 0, UTF8_BOM.length);
+        System.arraycopy(body, 0, excelCompatible, UTF8_BOM.length, body.length);
+        writeAtomically(target.toAbsolutePath().normalize(), excelCompatible);
+    }
+
+    private void validate(Path target, GameAnalyticsSnapshot snapshot) throws IOException {
+        if (target == null || snapshot == null) {
+            throw new IllegalArgumentException("export target and snapshot are required");
+        }
+        Path parent = target.toAbsolutePath().normalize().getParent();
+        if (parent != null) Files.createDirectories(parent);
+    }
+
+    private String powerCsv(List<AllianceRankingEntryData> entries) {
+        StringBuilder csv = new StringBuilder(
+                "rank;player_id;player_name;player_name_from_cache;power;power_from_cache\n");
+        for (AllianceRankingEntryData entry : entries) {
+            csv.append(entry.rank()).append(CSV_SEPARATOR).append(entry.playerId()).append(CSV_SEPARATOR)
+                    .append(csvField(entry.playerName())).append(CSV_SEPARATOR)
+                    .append(entry.playerNameFromCache()).append(CSV_SEPARATOR)
+                    .append(entry.value() == null ? "" : entry.value()).append(CSV_SEPARATOR)
+                    .append(entry.powerFromCache()).append('\n');
+        }
+        return csv.toString();
+    }
+
+    private String labyrinthCsv(List<LabyrinthRankingEntryData> entries) {
+        StringBuilder csv = new StringBuilder("rank;player_id;player_name;player_name_from_cache;labyrinth_score\n");
+        for (LabyrinthRankingEntryData entry : entries) {
+            csv.append(entry.rank()).append(CSV_SEPARATOR).append(entry.playerId()).append(CSV_SEPARATOR)
+                    .append(csvField(entry.playerName())).append(CSV_SEPARATOR)
+                    .append(entry.playerNameFromCache()).append(CSV_SEPARATOR).append(entry.score()).append('\n');
+        }
+        return csv.toString();
+    }
+
+    private String csvField(String value) {
+        return value == null ? "" : '"' + value.replace("\"", "\"\"") + '"';
+    }
+
+    private void writeAtomically(Path target, byte[] content) throws IOException {
+        Path temporary = target.resolveSibling(target.getFileName() + ".tmp");
+        Files.write(temporary, content);
+        try {
+            Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException unsupported) {
+            Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/history/GameAnalyticsHistoryService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/history/GameAnalyticsHistoryService.java
@@ -1,0 +1,340 @@
+package dev.frostguard.engine.ranking.history;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.AllianceRankingEntryData;
+import dev.frostguard.api.domain.LabyrinthRankingEntryData;
+import dev.frostguard.engine.emulator.EmulatorType;
+import dev.frostguard.engine.ranking.capture.AllianceRankingCaptureResult;
+import dev.frostguard.engine.ranking.capture.GameAnalyticsCollectionType;
+
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/** Persistent, workspace-local analytics history with an internal versioned schema. */
+public final class GameAnalyticsHistoryService {
+
+    private static final int SCHEMA_VERSION = 1;
+    private static final DateTimeFormatter FILE_TIME = DateTimeFormatter
+            .ofPattern("uuuuMMdd-HHmmss-SSS").withZone(ZoneOffset.UTC);
+    private static final TypeReference<Map<Long, String>> LEGACY_NAME_MAP = new TypeReference<>() { };
+
+    private final ObjectMapper mapper;
+    private final Clock clock;
+
+    public GameAnalyticsHistoryService() {
+        this(new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT), Clock.systemUTC());
+    }
+
+    GameAnalyticsHistoryService(ObjectMapper mapper, Clock clock) {
+        this.mapper = mapper;
+        this.clock = clock;
+    }
+
+    public synchronized GameAnalyticsSnapshot save(Path workspaceRoot, AccountDescriptor profile,
+                                                    EmulatorType emulatorType,
+                                                    GameAnalyticsCollectionType type,
+                                                    AllianceRankingCaptureResult result) throws IOException {
+        validate(profile, emulatorType, type, result);
+        Instant capturedAt = Instant.now(clock);
+        String id = FILE_TIME.format(capturedAt) + "-" + UUID.randomUUID().toString().substring(0, 8);
+        Map<Long, PlayerNameObservation> names = loadNames(workspaceRoot);
+        Map<Long, PlayerPowerObservation> powers = loadPowers(workspaceRoot);
+        observeDirectNames(result, capturedAt.toString(), names);
+        observeDirectPowers(result, capturedAt.toString(), powers);
+        AllianceRankingCaptureResult enriched = enrich(result, names, powers, capturedAt);
+        GameAnalyticsSnapshot snapshot = new GameAnalyticsSnapshot(
+                SCHEMA_VERSION, id, capturedAt.toString(), profile.getAccountId(),
+                profile.getDisplayName(), profile.getDeviceSlot(), emulatorType.name(), type,
+                enriched.power(), enriched.labyrinth());
+        writeSnapshot(workspaceRoot, snapshot);
+        writeNames(workspaceRoot, names);
+        return snapshot;
+    }
+
+    public synchronized List<GameAnalyticsSnapshot> list(Path workspaceRoot, Long profileId) throws IOException {
+        migrateLegacyExports(workspaceRoot, profileId);
+        Path profileRoot = profileRoot(workspaceRoot, profileId);
+        if (!Files.isDirectory(profileRoot)) return List.of();
+        Map<Long, PlayerNameObservation> names = loadNames(workspaceRoot);
+        Map<Long, PlayerPowerObservation> powers = loadPowers(workspaceRoot);
+        List<GameAnalyticsSnapshot> snapshots = new ArrayList<>();
+        try (var files = Files.walk(profileRoot)) {
+            for (Path file : files.filter(path -> path.getFileName().toString().endsWith(".json"))
+                    .filter(path -> !path.getFileName().toString().equals("player-names.json")).toList()) {
+                GameAnalyticsSnapshot snapshot = mapper.readValue(file.toFile(), GameAnalyticsSnapshot.class);
+                AllianceRankingCaptureResult enriched = enrich(
+                        snapshot.result(), names, powers, Instant.parse(snapshot.capturedAt()));
+                snapshots.add(new GameAnalyticsSnapshot(snapshot.schemaVersion(), snapshot.id(),
+                        snapshot.capturedAt(), snapshot.profileId(), snapshot.profileName(),
+                        snapshot.emulatorSlot(), snapshot.emulatorType(), snapshot.type(),
+                        enriched.power(), enriched.labyrinth()));
+            }
+        }
+        snapshots.sort(Comparator.comparing(GameAnalyticsSnapshot::capturedAt).reversed());
+        return List.copyOf(snapshots);
+    }
+
+    private AllianceRankingCaptureResult enrich(AllianceRankingCaptureResult result,
+                                                 Map<Long, PlayerNameObservation> names,
+                                                 Map<Long, PlayerPowerObservation> powers,
+                                                 Instant capturedAt) {
+        List<AllianceRankingEntryData> power = result.power().stream()
+                .map(entry -> enrichPowerEntry(entry, names.get(entry.playerId()),
+                        powers.get(entry.playerId()), capturedAt))
+                .toList();
+        List<LabyrinthRankingEntryData> labyrinth = result.labyrinth().stream()
+                .map(entry -> enrichLabyrinthName(entry, names.get(entry.playerId()), capturedAt))
+                .toList();
+        return new AllianceRankingCaptureResult(power, labyrinth);
+    }
+
+    private AllianceRankingEntryData enrichPowerEntry(AllianceRankingEntryData entry,
+                                                       PlayerNameObservation cachedName,
+                                                       PlayerPowerObservation cachedPower,
+                                                       Instant capturedAt) {
+        String name = entry.playerName();
+        boolean nameFromCache = entry.playerNameFromCache();
+        if (cachedName != null && (name == null || nameFromCache
+                || observedAfter(cachedName, capturedAt))) {
+            name = cachedName.name();
+            nameFromCache = true;
+        }
+        Long power = entry.value();
+        boolean powerFromCache = entry.powerFromCache();
+        if (cachedPower != null && (power == null || powerFromCache)) {
+            power = cachedPower.value();
+            powerFromCache = true;
+        }
+        return new AllianceRankingEntryData(entry.rank(), entry.playerId(), name, power,
+                nameFromCache, powerFromCache);
+    }
+
+    private LabyrinthRankingEntryData enrichLabyrinthName(LabyrinthRankingEntryData entry,
+                                                          PlayerNameObservation cached,
+                                                          Instant capturedAt) {
+        if (cached != null && (entry.playerName() == null || entry.playerNameFromCache()
+                || observedAfter(cached, capturedAt))) {
+            return new LabyrinthRankingEntryData(entry.rank(), entry.playerId(),
+                    cached.name(), entry.score(), true);
+        }
+        return entry;
+    }
+
+    private boolean observedAfter(PlayerNameObservation observation, Instant capturedAt) {
+        try {
+            return Instant.parse(observation.lastObservedAt()).isAfter(capturedAt);
+        } catch (RuntimeException invalidTimestamp) {
+            return true;
+        }
+    }
+
+    private boolean observeDirectNames(AllianceRankingCaptureResult result, String observedAt,
+                                       Map<Long, PlayerNameObservation> names) {
+        boolean powerChanged = result.power().stream()
+                .filter(entry -> !entry.playerNameFromCache())
+                .map(entry -> observeName(names, entry.playerId(), entry.playerName(), observedAt))
+                .reduce(false, Boolean::logicalOr);
+        boolean labyrinthChanged = result.labyrinth().stream()
+                .filter(entry -> !entry.playerNameFromCache())
+                .map(entry -> observeName(names, entry.playerId(), entry.playerName(), observedAt))
+                .reduce(false, Boolean::logicalOr);
+        return powerChanged || labyrinthChanged;
+    }
+
+    private boolean observeName(Map<Long, PlayerNameObservation> names, long playerId,
+                                String playerName, String observedAt) {
+        if (playerName == null || playerName.isBlank()) return false;
+        PlayerNameObservation current = names.get(playerId);
+        if (current != null) {
+            if (!atLeastAsRecent(observedAt, current.lastObservedAt())) return false;
+            if (observedAt.equals(current.lastObservedAt()) && playerName.equals(current.name())) return false;
+        }
+        names.put(playerId, new PlayerNameObservation(playerName, observedAt));
+        return true;
+    }
+
+    private boolean atLeastAsRecent(String candidate, String current) {
+        try {
+            return !Instant.parse(candidate).isBefore(Instant.parse(current));
+        } catch (RuntimeException invalidTimestamp) {
+            return true;
+        }
+    }
+
+    private void observeDirectPowers(AllianceRankingCaptureResult result, String observedAt,
+                                     Map<Long, PlayerPowerObservation> powers) {
+        result.power().stream()
+                .filter(entry -> entry.value() != null && !entry.powerFromCache())
+                .forEach(entry -> observePower(
+                        powers, entry.playerId(), entry.value(), observedAt));
+    }
+
+    private void observePower(Map<Long, PlayerPowerObservation> powers, long playerId,
+                              long value, String observedAt) {
+        PlayerPowerObservation current = powers.get(playerId);
+        if (current != null && !atLeastAsRecent(observedAt, current.lastObservedAt())) return;
+        powers.put(playerId, new PlayerPowerObservation(value, observedAt));
+    }
+
+    private Map<Long, PlayerPowerObservation> loadPowers(Path workspaceRoot) throws IOException {
+        Map<Long, PlayerPowerObservation> powers = new LinkedHashMap<>();
+        Path profiles = analyticsRoot(workspaceRoot).resolve("profiles");
+        if (!Files.isDirectory(profiles)) return powers;
+        try (var files = Files.walk(profiles)) {
+            for (Path snapshotFile : files.filter(path -> path.getFileName().toString().endsWith(".json"))
+                    .filter(path -> !path.getFileName().toString().equals("player-names.json")).toList()) {
+                GameAnalyticsSnapshot snapshot = mapper.readValue(snapshotFile.toFile(),
+                        GameAnalyticsSnapshot.class);
+                snapshot.power().stream()
+                        .filter(entry -> entry.value() != null && !entry.powerFromCache())
+                        .forEach(entry -> observePower(
+                                powers, entry.playerId(), entry.value(), snapshot.capturedAt()));
+            }
+        }
+        return powers;
+    }
+
+    private void validate(AccountDescriptor profile, EmulatorType emulatorType,
+                          GameAnalyticsCollectionType type, AllianceRankingCaptureResult result) throws IOException {
+        if (profile == null || profile.getAccountId() == null || emulatorType == null
+                || type == null || result == null) {
+            throw new IllegalArgumentException("history arguments must not be null");
+        }
+        if (type == GameAnalyticsCollectionType.POWER && result.power().isEmpty()) {
+            throw new IOException("Alliance Power Ranking response was empty");
+        }
+        if (type == GameAnalyticsCollectionType.LABYRINTH && result.labyrinth().isEmpty()) {
+            throw new IOException("Alliance Labyrinth Ranking response was empty");
+        }
+    }
+
+    private void writeSnapshot(Path workspaceRoot, GameAnalyticsSnapshot snapshot) throws IOException {
+        Path directory = profileRoot(workspaceRoot, snapshot.profileId())
+                .resolve(snapshot.type().name().toLowerCase());
+        Files.createDirectories(directory);
+        writeAtomically(directory.resolve(snapshot.id() + ".json"), mapper.writeValueAsBytes(snapshot));
+    }
+
+    private Map<Long, PlayerNameObservation> loadNames(Path workspaceRoot) throws IOException {
+        Path file = analyticsRoot(workspaceRoot).resolve("player-names.json");
+        Map<Long, PlayerNameObservation> names = new LinkedHashMap<>();
+        boolean needsWrite = !Files.isRegularFile(file);
+        if (Files.isRegularFile(file)) {
+            PlayerNameCacheDocument document = mapper.readValue(file.toFile(), PlayerNameCacheDocument.class);
+            if (document.players() != null) {
+                names.putAll(document.players());
+            }
+        }
+        Path profiles = analyticsRoot(workspaceRoot).resolve("profiles");
+        if (Files.isDirectory(profiles)) {
+            try (var files = Files.walk(profiles)) {
+                for (Path legacy : files.filter(path -> path.getFileName().toString()
+                        .equals("player-names.json")).toList()) {
+                    Map<Long, String> oldNames = mapper.readValue(legacy.toFile(), LEGACY_NAME_MAP);
+                    String observedAt = Files.getLastModifiedTime(legacy).toInstant().toString();
+                    oldNames.forEach((id, name) -> {
+                        if (!names.containsKey(id)) {
+                            names.put(id, new PlayerNameObservation(name, observedAt));
+                        }
+                    });
+                    needsWrite = true;
+                }
+            }
+            try (var files = Files.walk(profiles)) {
+                for (Path snapshotFile : files.filter(path -> path.getFileName().toString().endsWith(".json"))
+                        .filter(path -> !path.getFileName().toString().equals("player-names.json")).toList()) {
+                    GameAnalyticsSnapshot snapshot = mapper.readValue(snapshotFile.toFile(),
+                            GameAnalyticsSnapshot.class);
+                    needsWrite |= observeDirectNames(snapshot.result(), snapshot.capturedAt(), names);
+                }
+            }
+        }
+        if (needsWrite && !names.isEmpty()) {
+            writeNames(workspaceRoot, names);
+        }
+        return names;
+    }
+
+    private void writeNames(Path workspaceRoot, Map<Long, PlayerNameObservation> names) throws IOException {
+        Path file = analyticsRoot(workspaceRoot).resolve("player-names.json");
+        Files.createDirectories(file.getParent());
+        writeAtomically(file, mapper.writeValueAsBytes(new PlayerNameCacheDocument(SCHEMA_VERSION, names)));
+    }
+
+    private Path profileRoot(Path workspaceRoot, Long profileId) {
+        return analyticsRoot(workspaceRoot).resolve("profiles").resolve(profileId.toString());
+    }
+
+    private Path analyticsRoot(Path workspaceRoot) {
+        return workspaceRoot.toAbsolutePath().normalize().resolve("data").resolve("game-analytics");
+    }
+
+    private void migrateLegacyExports(Path workspaceRoot, Long requestedProfileId) throws IOException {
+        Path legacyRoot = workspaceRoot.toAbsolutePath().normalize().resolve("game-analytics");
+        if (!Files.isDirectory(legacyRoot)) return;
+        try (var files = Files.walk(legacyRoot)) {
+            for (Path file : files.filter(path -> path.getFileName().toString().equals("analytics.json")).toList()) {
+                JsonNode root = mapper.readTree(file.toFile());
+                Long profileId = root.path("profile").path("id").isNumber()
+                        ? root.path("profile").path("id").asLong() : null;
+                if (profileId == null || !profileId.equals(requestedProfileId)) continue;
+                List<AllianceRankingEntryData> power = mapper.convertValue(root.path("power"),
+                        new TypeReference<>() { });
+                List<LabyrinthRankingEntryData> labyrinth = mapper.convertValue(root.path("labyrinth"),
+                        new TypeReference<>() { });
+                GameAnalyticsCollectionType type = !power.isEmpty()
+                        ? GameAnalyticsCollectionType.POWER : GameAnalyticsCollectionType.LABYRINTH;
+                String capturedAt = root.path("capturedAt").asText();
+                String id = file.getParent().getFileName() + "-" + type.name().toLowerCase();
+                Path target = profileRoot(workspaceRoot, profileId).resolve(type.name().toLowerCase())
+                        .resolve(id + ".json");
+                if (Files.exists(target)) continue;
+                GameAnalyticsSnapshot snapshot = new GameAnalyticsSnapshot(SCHEMA_VERSION, id, capturedAt,
+                        profileId, root.path("profile").path("name").asText(),
+                        root.path("profile").path("emulatorSlot").asText(),
+                        root.path("profile").path("emulatorType").asText(), type, power, labyrinth);
+                Map<Long, PlayerNameObservation> names = loadNames(workspaceRoot);
+                observeDirectNames(snapshot.result(), capturedAt, names);
+                writeSnapshot(workspaceRoot, snapshot);
+                writeNames(workspaceRoot, names);
+            }
+        }
+    }
+
+    private void writeAtomically(Path target, byte[] content) throws IOException {
+        Path temporary = target.resolveSibling(target.getFileName() + ".tmp");
+        Files.write(temporary, content);
+        try {
+            Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException unsupported) {
+            Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    public record PlayerNameObservation(String name, String lastObservedAt) {
+    }
+
+    private record PlayerPowerObservation(long value, String lastObservedAt) {
+    }
+
+    private record PlayerNameCacheDocument(int schemaVersion,
+                                           Map<Long, PlayerNameObservation> players) {
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/history/GameAnalyticsSnapshot.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/history/GameAnalyticsSnapshot.java
@@ -1,0 +1,30 @@
+package dev.frostguard.engine.ranking.history;
+
+import dev.frostguard.api.domain.AllianceRankingEntryData;
+import dev.frostguard.api.domain.LabyrinthRankingEntryData;
+import dev.frostguard.engine.ranking.capture.AllianceRankingCaptureResult;
+import dev.frostguard.engine.ranking.capture.GameAnalyticsCollectionType;
+
+import java.util.List;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+public record GameAnalyticsSnapshot(int schemaVersion, String id, String capturedAt,
+                                    Long profileId, String profileName, String emulatorSlot,
+                                    String emulatorType, GameAnalyticsCollectionType type,
+                                    List<AllianceRankingEntryData> power,
+                                    List<LabyrinthRankingEntryData> labyrinth) {
+
+    private static final DateTimeFormatter DISPLAY_TIME = DateTimeFormatter
+            .ofPattern("dd.MM.yyyy HH:mm:ss").withZone(ZoneId.systemDefault());
+
+    public AllianceRankingCaptureResult result() {
+        return new AllianceRankingCaptureResult(power, labyrinth);
+    }
+
+    @Override
+    public String toString() {
+        return DISPLAY_TIME.format(Instant.parse(capturedAt));
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/AlliancePowerRankListDecoder.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/AlliancePowerRankListDecoder.java
@@ -1,0 +1,70 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Decodes the ordered alliance-member IDs returned by the power-ranking list RPC. */
+public final class AlliancePowerRankListDecoder {
+
+    private final SprotoPackedDecoder packedDecoder = new SprotoPackedDecoder();
+    private final SprotoStructReader structReader = new SprotoStructReader();
+
+    public List<RankedPlayer> decode(List<byte[]> packedFrames) {
+        Map<Long, RankedPlayer> players = new LinkedHashMap<>();
+        for (byte[] packedFrame : packedFrames) {
+            for (RankedPlayer player : decodeFrame(packedFrame)) {
+                players.putIfAbsent(player.playerId(), new RankedPlayer(
+                        players.size() + 1, player.playerId(), player.power()));
+            }
+        }
+        return List.copyOf(players.values());
+    }
+
+    private List<RankedPlayer> decodeFrame(byte[] packedFrame) {
+        byte[] unpacked = packedDecoder.unpack(packedFrame);
+        SprotoStructReader.SprotoStruct rpcHeader = structReader.read(unpacked, 0, unpacked.length);
+        if (rpcHeader.consumedBytes() >= unpacked.length) return List.of();
+        int payloadOffset = rpcHeader.consumedBytes();
+        SprotoStructReader.SprotoStruct response = structReader.read(
+                unpacked, payloadOffset, unpacked.length - payloadOffset);
+        for (byte[] candidate : response.dataFields()) {
+            List<RankedPlayer> players = decodePlayerArray(candidate);
+            if (!players.isEmpty()) return players;
+        }
+        return List.of();
+    }
+
+    private List<RankedPlayer> decodePlayerArray(byte[] array) {
+        List<RankedPlayer> players = new ArrayList<>();
+        int offset = 0;
+        while (offset < array.length) {
+            if (array.length - offset < 4) return List.of();
+            long unsignedLength = SprotoStructReader.uint32(array, offset);
+            if (unsignedLength < 1 || unsignedLength > array.length - offset - 4L) return List.of();
+            int memberLength = (int) unsignedLength;
+            int memberOffset = offset + 4;
+            SprotoStructReader.SprotoStruct member = structReader.read(array, memberOffset, memberLength);
+            if (member.consumedBytes() != memberLength) return List.of();
+            byte[] playerId = member.fields().stream()
+                    .filter(field -> field.tag() == 0 && field.hasData() && field.data().length == 4)
+                    .map(SprotoStructReader.SprotoField::data)
+                    .findFirst().orElse(null);
+            byte[] power = member.fields().stream()
+                    .filter(field -> field.tag() == 1 && field.hasData() && field.data().length == 4)
+                    .map(SprotoStructReader.SprotoField::data)
+                    .findFirst().orElse(null);
+            if (playerId == null || power == null) return List.of();
+            long id = SprotoStructReader.uint32(playerId, 0);
+            long powerValue = SprotoStructReader.uint32(power, 0);
+            if (id < 1 || powerValue < 1) return List.of();
+            players.add(new RankedPlayer(players.size() + 1, id, powerValue));
+            offset = memberOffset + memberLength;
+        }
+        return List.copyOf(players);
+    }
+
+    public record RankedPlayer(int rank, long playerId, long power) {
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/LabyrinthRankingPayloadDecoder.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/LabyrinthRankingPayloadDecoder.java
@@ -1,0 +1,106 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import dev.frostguard.api.domain.LabyrinthRankingEntryData;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/** Joins the Labyrinth response with captured alliance member FIDs. */
+public final class LabyrinthRankingPayloadDecoder {
+
+    private final SprotoPackedDecoder packedDecoder = new SprotoPackedDecoder();
+    private final SprotoStructReader structReader = new SprotoStructReader();
+
+    public List<LabyrinthRankingEntryData> decode(List<byte[]> packedFrames,
+                                                   Map<Long, String> allianceMembers) {
+        if (packedFrames == null || allianceMembers == null) {
+            throw new IllegalArgumentException("packedFrames and allianceMembers must not be null");
+        }
+
+        List<LabyrinthEntry> largestRanking = List.of();
+        for (byte[] packedFrame : packedFrames) {
+            List<LabyrinthEntry> candidate = decodeFrame(packedFrame);
+            if (candidate.size() > largestRanking.size()) {
+                largestRanking = candidate;
+            }
+        }
+
+        List<LabyrinthEntry> ordered = largestRanking.stream()
+                .sorted(Comparator.comparingInt(LabyrinthEntry::rank))
+                .toList();
+        List<LabyrinthRankingEntryData> result = new ArrayList<>(ordered.size());
+        for (LabyrinthEntry entry : ordered) {
+            result.add(new LabyrinthRankingEntryData(entry.rank(), entry.playerId(),
+                    allianceMembers.get(entry.playerId()), entry.score()));
+        }
+        return List.copyOf(result);
+    }
+
+    private List<LabyrinthEntry> decodeFrame(byte[] packedFrame) {
+        try {
+            byte[] unpacked = packedDecoder.unpack(packedFrame);
+            SprotoStructReader.SprotoStruct rpcHeader = structReader.read(unpacked, 0, unpacked.length);
+            if (rpcHeader.consumedBytes() >= unpacked.length) {
+                return List.of();
+            }
+            SprotoStructReader.SprotoStruct response = structReader.read(unpacked,
+                    rpcHeader.consumedBytes(), unpacked.length - rpcHeader.consumedBytes());
+            List<LabyrinthEntry> largest = List.of();
+            for (byte[] data : response.dataFields()) {
+                List<LabyrinthEntry> candidate = decodeRankingArray(data);
+                if (candidate.size() > largest.size()) {
+                    largest = candidate;
+                }
+            }
+            return largest;
+        } catch (IllegalArgumentException malformed) {
+            return List.of();
+        }
+    }
+
+    private List<LabyrinthEntry> decodeRankingArray(byte[] array) {
+        List<LabyrinthEntry> result = new ArrayList<>();
+        int offset = 0;
+        long previousScore = Long.MAX_VALUE;
+        while (offset < array.length) {
+            if (array.length - offset < 4) {
+                return List.of();
+            }
+            long length = SprotoStructReader.uint32(array, offset);
+            if (length < 1 || length > array.length - offset - 4L) {
+                return List.of();
+            }
+            int memberLength = (int) length;
+            SprotoStructReader.SprotoStruct member = structReader.read(array, offset + 4, memberLength);
+            if (member.consumedBytes() != memberLength || member.fields().size() != 3) {
+                return List.of();
+            }
+            SprotoStructReader.SprotoField id = field(member, 0);
+            SprotoStructReader.SprotoField score = field(member, 1);
+            SprotoStructReader.SprotoField category = field(member, 2);
+            if (id == null || !id.hasData() || id.data().length != 4
+                    || score == null || score.hasData() || score.inlineValue() < 0
+                    || category == null || category.hasData() || category.inlineValue() < 0
+                    || score.inlineValue() > previousScore) {
+                return List.of();
+            }
+            long playerId = SprotoStructReader.uint32(id.data(), 0);
+            if (playerId == 0) {
+                return List.of();
+            }
+            result.add(new LabyrinthEntry(result.size() + 1, playerId, score.inlineValue()));
+            previousScore = score.inlineValue();
+            offset += 4 + memberLength;
+        }
+        return result.size() < 2 ? List.of() : List.copyOf(result);
+    }
+
+    private SprotoStructReader.SprotoField field(SprotoStructReader.SprotoStruct struct, int tag) {
+        return struct.fields().stream().filter(field -> field.tag() == tag).findFirst().orElse(null);
+    }
+
+    private record LabyrinthEntry(int rank, long playerId, long score) {
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/LengthPrefixedFrameDecoder.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/LengthPrefixedFrameDecoder.java
@@ -1,0 +1,60 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/** Reassembles two-byte big-endian length-prefixed game protocol frames. */
+public final class LengthPrefixedFrameDecoder {
+
+    private static final int HEADER_BYTES = 2;
+
+    private final int maximumFrameLength;
+    private final ByteArrayOutputStream pending = new ByteArrayOutputStream();
+
+    public LengthPrefixedFrameDecoder(int maximumFrameLength) {
+        if (maximumFrameLength < 1 || maximumFrameLength > 0xffff) {
+            throw new IllegalArgumentException("maximumFrameLength must be between 1 and 65535");
+        }
+        this.maximumFrameLength = maximumFrameLength;
+    }
+
+    public List<byte[]> accept(byte[] chunk) {
+        if (chunk == null) {
+            throw new IllegalArgumentException("chunk must not be null");
+        }
+        pending.writeBytes(chunk);
+
+        byte[] bytes = pending.toByteArray();
+        List<byte[]> frames = new ArrayList<>();
+        int offset = 0;
+        while (bytes.length - offset >= HEADER_BYTES) {
+            int length = ((bytes[offset] & 0xff) << 8) | (bytes[offset + 1] & 0xff);
+            if (length < 1 || length > maximumFrameLength) {
+                throw new IllegalArgumentException("invalid game frame length: " + length);
+            }
+            if (bytes.length - offset - HEADER_BYTES < length) {
+                break;
+            }
+            frames.add(Arrays.copyOfRange(bytes, offset + HEADER_BYTES, offset + HEADER_BYTES + length));
+            offset += HEADER_BYTES + length;
+        }
+
+        if (offset > 0) {
+            pending.reset();
+            pending.writeBytes(Arrays.copyOfRange(bytes, offset, bytes.length));
+        }
+        return List.copyOf(frames);
+    }
+
+    public boolean hasPendingBytes() {
+        return pending.size() > 0;
+    }
+
+    public void requireComplete() {
+        if (hasPendingBytes()) {
+            throw new IllegalStateException("truncated game frame: " + pending.size() + " byte(s) remain");
+        }
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/PowerRankingPayloadDecoder.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/PowerRankingPayloadDecoder.java
@@ -1,0 +1,156 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import dev.frostguard.api.domain.AllianceRankingEntryData;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Extracts alliance power records from validated packed sproto response frames. */
+public final class PowerRankingPayloadDecoder {
+
+    private static final int MINIMUM_MEMBER_DATA_FIELDS = 4;
+    private static final int MAXIMUM_NAME_CODE_POINTS = 64;
+
+    private final SprotoPackedDecoder packedDecoder = new SprotoPackedDecoder();
+    private final SprotoStructReader structReader = new SprotoStructReader();
+
+    public List<AllianceRankingEntryData> decode(List<byte[]> packedFrames) {
+        if (packedFrames == null) {
+            throw new IllegalArgumentException("packedFrames must not be null");
+        }
+
+        Map<Long, DecodedMember> members = new LinkedHashMap<>();
+        for (byte[] packedFrame : packedFrames) {
+            for (DecodedMember member : decodeFrame(packedFrame)) {
+                members.put(member.playerId(), member);
+            }
+        }
+
+        List<DecodedMember> ranked = members.values().stream()
+                .sorted(Comparator.comparingLong(DecodedMember::power).reversed()
+                        .thenComparingLong(DecodedMember::playerId))
+                .toList();
+        List<AllianceRankingEntryData> result = new ArrayList<>(ranked.size());
+        for (int index = 0; index < ranked.size(); index++) {
+            DecodedMember member = ranked.get(index);
+            result.add(new AllianceRankingEntryData(index + 1, member.playerId(), member.playerName(), member.power()));
+        }
+        return List.copyOf(result);
+    }
+
+    /** Returns whether a byte sequence is a complete packed sproto response frame. */
+    public boolean isValidFrame(byte[] packedFrame) {
+        try {
+            byte[] unpacked = packedDecoder.unpack(packedFrame);
+            SprotoStructReader.SprotoStruct rpcHeader = structReader.read(unpacked, 0, unpacked.length);
+            if (rpcHeader.consumedBytes() >= unpacked.length) {
+                return true;
+            }
+            structReader.read(unpacked, rpcHeader.consumedBytes(), unpacked.length - rpcHeader.consumedBytes());
+            return true;
+        } catch (IllegalArgumentException malformed) {
+            return false;
+        }
+    }
+
+    List<DecodedMember> decodeFrame(byte[] packedFrame) {
+        byte[] unpacked = packedDecoder.unpack(packedFrame);
+        SprotoStructReader.SprotoStruct rpcHeader = structReader.read(unpacked, 0, unpacked.length);
+        if (rpcHeader.consumedBytes() >= unpacked.length) {
+            return List.of();
+        }
+
+        int payloadOffset = rpcHeader.consumedBytes();
+        SprotoStructReader.SprotoStruct response = structReader.read(
+                unpacked, payloadOffset, unpacked.length - payloadOffset);
+        for (byte[] candidate : response.dataFields()) {
+            List<DecodedMember> decoded = decodeMemberArray(candidate);
+            if (!decoded.isEmpty()) {
+                return decoded;
+            }
+        }
+        return List.of();
+    }
+
+    private List<DecodedMember> decodeMemberArray(byte[] array) {
+        List<DecodedMember> members = new ArrayList<>();
+        int offset = 0;
+        while (offset < array.length) {
+            if (array.length - offset < 4) {
+                return List.of();
+            }
+            long unsignedLength = SprotoStructReader.uint32(array, offset);
+            if (unsignedLength < 1 || unsignedLength > array.length - offset - 4L) {
+                return List.of();
+            }
+            int memberLength = (int) unsignedLength;
+            int memberOffset = offset + 4;
+            SprotoStructReader.SprotoStruct member;
+            try {
+                member = structReader.read(array, memberOffset, memberLength);
+            } catch (IllegalArgumentException malformed) {
+                return List.of();
+            }
+            if (member.consumedBytes() != memberLength) {
+                return List.of();
+            }
+            decodeMember(member.dataFields()).ifPresent(members::add);
+            offset = memberOffset + memberLength;
+        }
+        return List.copyOf(members);
+    }
+
+    private java.util.Optional<DecodedMember> decodeMember(List<byte[]> dataFields) {
+        if (dataFields.size() < MINIMUM_MEMBER_DATA_FIELDS) {
+            return java.util.Optional.empty();
+        }
+        byte[] playerIdBytes = dataFields.get(1);
+        byte[] powerBytes = dataFields.get(3);
+        if (playerIdBytes.length != 4 || powerBytes.length != 4) {
+            return java.util.Optional.empty();
+        }
+
+        String playerName;
+        try {
+            playerName = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(dataFields.get(0)))
+                    .toString();
+        } catch (CharacterCodingException invalidUtf8) {
+            return java.util.Optional.empty();
+        }
+        if (!validName(playerName)) {
+            return java.util.Optional.empty();
+        }
+
+        long playerId = littleEndianUnsignedInt(playerIdBytes);
+        long power = littleEndianUnsignedInt(powerBytes);
+        if (playerId == 0 || power == 0) {
+            return java.util.Optional.empty();
+        }
+        return java.util.Optional.of(new DecodedMember(playerId, playerName, power));
+    }
+
+    private boolean validName(String value) {
+        if (value.isBlank() || value.codePointCount(0, value.length()) > MAXIMUM_NAME_CODE_POINTS) {
+            return false;
+        }
+        return value.codePoints().noneMatch(Character::isISOControl);
+    }
+
+    private long littleEndianUnsignedInt(byte[] value) {
+        return Integer.toUnsignedLong(ByteBuffer.wrap(value).order(ByteOrder.LITTLE_ENDIAN).getInt());
+    }
+
+    record DecodedMember(long playerId, String playerName, long power) {
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/SelfPlayerStateDecoder.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/SelfPlayerStateDecoder.java
@@ -1,0 +1,94 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+/** Decodes the local player's identity from the protocol 1010 startup state. */
+public final class SelfPlayerStateDecoder {
+
+    private static final long PLAYER_STATE_PROTOCOL = 1010;
+    private static final int MAXIMUM_NAME_CODE_POINTS = 64;
+
+    private final SprotoPackedDecoder packedDecoder = new SprotoPackedDecoder();
+    private final SprotoStructReader structReader = new SprotoStructReader();
+
+    public Optional<PlayerState> decode(List<byte[]> packedFrames) {
+        if (packedFrames == null) throw new IllegalArgumentException("packedFrames must not be null");
+        PlayerState latest = null;
+        for (byte[] frame : packedFrames) {
+            Optional<PlayerState> candidate = decodeFrame(frame);
+            if (candidate.isPresent()) latest = candidate.get();
+        }
+        return Optional.ofNullable(latest);
+    }
+
+    private Optional<PlayerState> decodeFrame(byte[] frame) {
+        try {
+            byte[] unpacked = packedDecoder.unpack(frame);
+            SprotoStructReader.SprotoStruct header = structReader.read(unpacked, 0, unpacked.length);
+            Long protocol = inline(header, 0);
+            if (protocol == null || protocol != PLAYER_STATE_PROTOCOL
+                    || header.consumedBytes() >= unpacked.length) {
+                return Optional.empty();
+            }
+            SprotoStructReader.SprotoStruct payload = structReader.read(unpacked,
+                    header.consumedBytes(), unpacked.length - header.consumedBytes());
+            byte[] nameBytes = data(payload, 0);
+            byte[] playerIdBytes = data(payload, 3);
+            byte[] powerBytes = data(payload, 4);
+            if (nameBytes == null || playerIdBytes == null || playerIdBytes.length != 4
+                    || powerBytes == null || powerBytes.length != 4) {
+                return Optional.empty();
+            }
+            String name = decodeName(nameBytes);
+            long playerId = uint32(playerIdBytes);
+            long power = uint32(powerBytes);
+            if (name == null || playerId < 1 || power < 1) return Optional.empty();
+            return Optional.of(new PlayerState(playerId, name, power));
+        } catch (IllegalArgumentException malformed) {
+            return Optional.empty();
+        }
+    }
+
+    private Long inline(SprotoStructReader.SprotoStruct struct, int tag) {
+        return struct.fields().stream()
+                .filter(field -> field.tag() == tag && !field.hasData())
+                .map(SprotoStructReader.SprotoField::inlineValue)
+                .findFirst().orElse(null);
+    }
+
+    private byte[] data(SprotoStructReader.SprotoStruct struct, int tag) {
+        return struct.fields().stream()
+                .filter(field -> field.tag() == tag && field.hasData())
+                .map(SprotoStructReader.SprotoField::data)
+                .findFirst().orElse(null);
+    }
+
+    private String decodeName(byte[] value) {
+        try {
+            String name = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(value)).toString();
+            if (name.isBlank() || name.codePointCount(0, name.length()) > MAXIMUM_NAME_CODE_POINTS
+                    || name.codePoints().anyMatch(Character::isISOControl)) {
+                return null;
+            }
+            return name;
+        } catch (CharacterCodingException invalidUtf8) {
+            return null;
+        }
+    }
+
+    private long uint32(byte[] value) {
+        return Integer.toUnsignedLong(ByteBuffer.wrap(value).order(ByteOrder.LITTLE_ENDIAN).getInt());
+    }
+
+    public record PlayerState(long playerId, String playerName, long power) {
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/SprotoPackedDecoder.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/SprotoPackedDecoder.java
@@ -1,0 +1,49 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import java.io.ByteArrayOutputStream;
+
+/** Decodes the zero-packing format used by sproto messages. */
+public final class SprotoPackedDecoder {
+
+    private static final int WORD_BYTES = 8;
+
+    public byte[] unpack(byte[] packed) {
+        if (packed == null) {
+            throw new IllegalArgumentException("packed message must not be null");
+        }
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        int offset = 0;
+        while (offset < packed.length) {
+            int tag = packed[offset++] & 0xff;
+            if (tag == 0xff) {
+                if (offset >= packed.length) {
+                    throw malformed("missing raw-run length", offset - 1);
+                }
+                int byteCount = ((packed[offset++] & 0xff) + 1) * WORD_BYTES;
+                if (packed.length - offset < byteCount) {
+                    throw malformed("truncated raw run", offset - 2);
+                }
+                output.write(packed, offset, byteCount);
+                offset += byteCount;
+                continue;
+            }
+
+            for (int bit = 0; bit < WORD_BYTES; bit++) {
+                if ((tag & (1 << bit)) == 0) {
+                    output.write(0);
+                } else {
+                    if (offset >= packed.length) {
+                        throw malformed("truncated packed word", offset - 1);
+                    }
+                    output.write(packed[offset++]);
+                }
+            }
+        }
+        return output.toByteArray();
+    }
+
+    private IllegalArgumentException malformed(String reason, int offset) {
+        return new IllegalArgumentException(reason + " at packed offset " + offset);
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/SprotoRpcHeaderDecoder.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/SprotoRpcHeaderDecoder.java
@@ -1,0 +1,35 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import java.util.Optional;
+
+/** Reads the protocol type and correlation session from a packed sproto RPC frame. */
+public final class SprotoRpcHeaderDecoder {
+
+    private final SprotoPackedDecoder packedDecoder = new SprotoPackedDecoder();
+    private final SprotoStructReader structReader = new SprotoStructReader();
+
+    public Optional<RpcHeader> decode(byte[] packedFrame) {
+        try {
+            byte[] unpacked = packedDecoder.unpack(packedFrame);
+            SprotoStructReader.SprotoStruct header = structReader.read(unpacked, 0, unpacked.length);
+            Long type = inline(header, 0);
+            Long session = inline(header, 1);
+            if (type == null && session == null) {
+                return Optional.empty();
+            }
+            return Optional.of(new RpcHeader(type, session));
+        } catch (IllegalArgumentException malformed) {
+            return Optional.empty();
+        }
+    }
+
+    private Long inline(SprotoStructReader.SprotoStruct header, int tag) {
+        return header.fields().stream()
+                .filter(field -> field.tag() == tag && !field.hasData())
+                .map(SprotoStructReader.SprotoField::inlineValue)
+                .findFirst().orElse(null);
+    }
+
+    public record RpcHeader(Long protocolType, Long session) {
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/SprotoStructReader.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/ranking/protocol/SprotoStructReader.java
@@ -1,0 +1,92 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/** Schema-independent reader for sproto struct field boundaries. */
+final class SprotoStructReader {
+
+    SprotoStruct read(byte[] source, int offset, int length) {
+        requireAvailable(source, offset, length, 2, "struct header");
+        int fieldSlots = uint16(source, offset);
+        int headersLength = 2 + fieldSlots * 2;
+        requireAvailable(source, offset, length, headersLength, "field headers");
+
+        int dataOffset = offset + headersLength;
+        int limit = offset + length;
+        int tag = -1;
+        List<SprotoField> fields = new ArrayList<>();
+        for (int index = 0; index < fieldSlots; index++) {
+            int encoded = uint16(source, offset + 2 + index * 2);
+            tag++;
+            if ((encoded & 1) != 0) {
+                tag += encoded / 2;
+                continue;
+            }
+
+            long inlineValue = encoded / 2L - 1L;
+            if (inlineValue >= 0) {
+                fields.add(SprotoField.inline(tag, inlineValue));
+                continue;
+            }
+
+            if (limit - dataOffset < 4) {
+                throw malformed("missing data-field length", dataOffset);
+            }
+            long unsignedLength = uint32(source, dataOffset);
+            if (unsignedLength > Integer.MAX_VALUE) {
+                throw malformed("data field is too large", dataOffset);
+            }
+            int dataLength = (int) unsignedLength;
+            dataOffset += 4;
+            if (limit - dataOffset < dataLength) {
+                throw malformed("truncated data field", dataOffset);
+            }
+            fields.add(SprotoField.data(tag, Arrays.copyOfRange(source, dataOffset, dataOffset + dataLength)));
+            dataOffset += dataLength;
+        }
+        return new SprotoStruct(List.copyOf(fields), dataOffset - offset);
+    }
+
+    private void requireAvailable(byte[] source, int offset, int length, int required, String part) {
+        if (source == null || offset < 0 || length < 0 || offset > source.length - length || required > length) {
+            throw malformed("truncated " + part, offset);
+        }
+    }
+
+    static int uint16(byte[] source, int offset) {
+        return (source[offset] & 0xff) | ((source[offset + 1] & 0xff) << 8);
+    }
+
+    static long uint32(byte[] source, int offset) {
+        return (source[offset] & 0xffL)
+                | ((source[offset + 1] & 0xffL) << 8)
+                | ((source[offset + 2] & 0xffL) << 16)
+                | ((source[offset + 3] & 0xffL) << 24);
+    }
+
+    private IllegalArgumentException malformed(String reason, int offset) {
+        return new IllegalArgumentException(reason + " at unpacked offset " + offset);
+    }
+
+    record SprotoStruct(List<SprotoField> fields, int consumedBytes) {
+        List<byte[]> dataFields() {
+            return fields.stream().filter(SprotoField::hasData).map(SprotoField::data).toList();
+        }
+    }
+
+    record SprotoField(int tag, long inlineValue, byte[] data) {
+        static SprotoField inline(int tag, long value) {
+            return new SprotoField(tag, value, null);
+        }
+
+        static SprotoField data(int tag, byte[] value) {
+            return new SprotoField(tag, -1, value);
+        }
+
+        boolean hasData() {
+            return data != null;
+        }
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/ranking/capture/AllianceRankingCaptureSupportTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/ranking/capture/AllianceRankingCaptureSupportTest.java
@@ -1,0 +1,25 @@
+package dev.frostguard.engine.ranking.capture;
+
+import dev.frostguard.engine.emulator.EmulatorType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AllianceRankingCaptureSupportTest {
+
+    @Test
+    void supportsOnlyMumuOnWindowsForNow() {
+        assertTrue(AllianceRankingCaptureSupport.evaluate("Windows 11", EmulatorType.MUMU).supported());
+        assertFalse(AllianceRankingCaptureSupport.evaluate("Windows 11", EmulatorType.MEMU).supported());
+        assertFalse(AllianceRankingCaptureSupport.evaluate("Windows 11", EmulatorType.LDPLAYER).supported());
+        assertFalse(AllianceRankingCaptureSupport.evaluate("Linux", EmulatorType.MUMU).supported());
+    }
+
+    @Test
+    void unsupportedMessageNamesTheAvailableBackend() {
+        String message = AllianceRankingCaptureSupport.evaluate("Windows 11", EmulatorType.LDPLAYER).message();
+
+        assertTrue(message.contains("only available for MuMu Player on Windows"));
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/ranking/capture/MuMuTcpdumpAnalyticsCaptureTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/ranking/capture/MuMuTcpdumpAnalyticsCaptureTest.java
@@ -1,0 +1,24 @@
+package dev.frostguard.engine.ranking.capture;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MuMuTcpdumpAnalyticsCaptureTest {
+
+    @Test
+    void selectsInterfaceFromDefaultRoute() throws IOException {
+        String route = "1.1.1.1 via 10.0.2.2 dev wlan0 table wlan0 src 10.0.2.15 uid 0";
+
+        assertEquals("wlan0", MuMuTcpdumpAnalyticsCapture.defaultRouteInterface(route));
+    }
+
+    @Test
+    void rejectsRouteWithoutDevice() {
+        assertThrows(IOException.class,
+                () -> MuMuTcpdumpAnalyticsCapture.defaultRouteInterface("unreachable 1.1.1.1"));
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/ranking/capture/PcapngTcpStreamReaderTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/ranking/capture/PcapngTcpStreamReaderTest.java
@@ -1,0 +1,128 @@
+package dev.frostguard.engine.ranking.capture;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PcapngTcpStreamReaderTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void reassemblesInboundSegmentsAndIgnoresPktmonDuplicates() throws IOException {
+        ByteArrayOutputStream capture = new ByteArrayOutputStream();
+        capture.writeBytes(sectionHeader());
+        capture.writeBytes(interfaceDescription());
+        capture.writeBytes(interfaceDescription());
+        byte[] first = {0, 5, 1, 2};
+        byte[] second = {3, 4, 5};
+        capture.writeBytes(enhancedPacket(0, tcpPacket(30101, 50000, 100, first)));
+        capture.writeBytes(enhancedPacket(1, tcpPacket(30101, 50000, 100, first)));
+        capture.writeBytes(enhancedPacket(0, tcpPacket(30101, 50000, 104, second)));
+        capture.writeBytes(enhancedPacket(0, tcpPacket(13321, 50000, 200, new byte[]{9})));
+        Path file = temporaryDirectory.resolve("capture.pcapng");
+        Files.write(file, capture.toByteArray());
+
+        List<byte[]> streams = new PcapngTcpStreamReader().readInboundStreams(file, 30101);
+
+        assertEquals(1, streams.size());
+        assertArrayEquals(new byte[]{0, 5, 1, 2, 3, 4, 5}, streams.getFirst());
+        assertEquals(0, new PcapngTcpStreamReader().readOutboundStreams(file, 30101).size());
+    }
+
+    @Test
+    void readsClassicTcpdumpPcap() throws IOException {
+        byte[] first = {0, 5, 1, 2};
+        byte[] second = {3, 4, 5};
+        ByteArrayOutputStream capture = new ByteArrayOutputStream();
+        capture.writeBytes(classicHeader());
+        capture.writeBytes(classicPacket(tcpPacket(30101, 50000, 100, first)));
+        capture.writeBytes(classicPacket(tcpPacket(30101, 50000, 104, second)));
+        Path file = temporaryDirectory.resolve("capture.pcap");
+        Files.write(file, capture.toByteArray());
+
+        List<byte[]> streams = new PcapngTcpStreamReader().readInboundStreams(file, 30101);
+
+        assertEquals(1, streams.size());
+        assertArrayEquals(new byte[]{0, 5, 1, 2, 3, 4, 5}, streams.getFirst());
+    }
+
+    @Test
+    void keepsCompletePacketsBeforeTruncatedFinalRecord() throws IOException {
+        byte[] payload = {0, 3, 1, 2, 3};
+        ByteArrayOutputStream capture = new ByteArrayOutputStream();
+        capture.writeBytes(classicHeader());
+        capture.writeBytes(classicPacket(tcpPacket(30101, 50000, 100, payload)));
+        capture.writeBytes(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0});
+        Path file = temporaryDirectory.resolve("truncated.pcap");
+        Files.write(file, capture.toByteArray());
+
+        List<byte[]> streams = new PcapngTcpStreamReader().readInboundStreams(file, 30101);
+
+        assertEquals(1, streams.size());
+        assertArrayEquals(payload, streams.getFirst());
+    }
+
+    private byte[] classicHeader() {
+        ByteBuffer header = littleEndian(24);
+        header.putInt(0xa1b2c3d4).putShort((short) 2).putShort((short) 4);
+        header.putInt(0).putInt(0).putInt(65_535).putInt(1);
+        return header.array();
+    }
+
+    private byte[] classicPacket(byte[] packet) {
+        ByteBuffer record = littleEndian(16 + packet.length);
+        record.putInt(0).putInt(0).putInt(packet.length).putInt(packet.length).put(packet);
+        return record.array();
+    }
+
+    private byte[] sectionHeader() {
+        ByteBuffer block = littleEndian(28);
+        block.putInt(0x0a0d0d0a).putInt(28).putInt(0x1a2b3c4d);
+        block.putShort((short) 1).putShort((short) 0).putLong(-1).putInt(28);
+        return block.array();
+    }
+
+    private byte[] interfaceDescription() {
+        ByteBuffer block = littleEndian(20);
+        block.putInt(1).putInt(20).putShort((short) 1).putShort((short) 0).putInt(65_535).putInt(20);
+        return block.array();
+    }
+
+    private byte[] enhancedPacket(int interfaceId, byte[] packet) {
+        int paddedLength = (packet.length + 3) & ~3;
+        int blockLength = 32 + paddedLength;
+        ByteBuffer block = littleEndian(blockLength);
+        block.putInt(6).putInt(blockLength).putInt(interfaceId).putInt(0).putInt(0);
+        block.putInt(packet.length).putInt(packet.length).put(packet);
+        block.position(blockLength - 4).putInt(blockLength);
+        return block.array();
+    }
+
+    private byte[] tcpPacket(int sourcePort, int destinationPort, long sequence, byte[] payload) {
+        ByteBuffer packet = ByteBuffer.allocate(14 + 20 + 20 + payload.length).order(ByteOrder.BIG_ENDIAN);
+        packet.position(12).putShort((short) 0x0800);
+        packet.put((byte) 0x45).put((byte) 0).putShort((short) (40 + payload.length));
+        packet.putShort((short) 0).putShort((short) 0).put((byte) 64).put((byte) 6).putShort((short) 0);
+        packet.putInt(0x23000001).putInt(0x0a000002);
+        packet.putShort((short) sourcePort).putShort((short) destinationPort).putInt((int) sequence);
+        packet.putInt(0).put((byte) 0x50).put((byte) 0x18).putShort((short) 65_535);
+        packet.putShort((short) 0).putShort((short) 0).put(payload);
+        return packet.array();
+    }
+
+    private ByteBuffer littleEndian(int size) {
+        return ByteBuffer.allocate(size).order(ByteOrder.LITTLE_ENDIAN);
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/ranking/export/GameAnalyticsExportServiceTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/ranking/export/GameAnalyticsExportServiceTest.java
@@ -1,0 +1,47 @@
+package dev.frostguard.engine.ranking.export;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.frostguard.api.domain.AllianceRankingEntryData;
+import dev.frostguard.engine.ranking.capture.GameAnalyticsCollectionType;
+import dev.frostguard.engine.ranking.history.GameAnalyticsSnapshot;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GameAnalyticsExportServiceTest {
+
+    @TempDir
+    Path directory;
+
+    @Test
+    void exportsSelectedSnapshotOnlyWhenRequested() throws Exception {
+        GameAnalyticsSnapshot snapshot = new GameAnalyticsSnapshot(1, "sample",
+                "2026-08-16T03:15:02Z", 7L, "Default", "0", "MUMU",
+                GameAnalyticsCollectionType.POWER,
+                List.of(new AllianceRankingEntryData(1, 42, "Ł; \"B\"", 1234)), List.of());
+        Path json = directory.resolve("ranking.json");
+        Path csv = directory.resolve("ranking.csv");
+
+        GameAnalyticsExportService exporter = new GameAnalyticsExportService();
+        exporter.exportJson(json, snapshot);
+        exporter.exportCsv(csv, snapshot);
+
+        JsonNode document = new ObjectMapper().readTree(json.toFile());
+        assertEquals(1, document.path("schemaVersion").asInt());
+        assertEquals(42, document.path("power").get(0).path("playerId").asLong());
+        byte[] csvBytes = Files.readAllBytes(csv);
+        assertEquals((byte) 0xef, csvBytes[0]);
+        assertEquals((byte) 0xbb, csvBytes[1]);
+        assertEquals((byte) 0xbf, csvBytes[2]);
+        String csvText = Files.readString(csv);
+        assertTrue(csvText.contains("rank;player_id;player_name;player_name_from_cache;power;power_from_cache"));
+        assertTrue(csvText.contains("\"Ł; \"\"B\"\"\";false;1234"));
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/ranking/history/GameAnalyticsHistoryServiceTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/ranking/history/GameAnalyticsHistoryServiceTest.java
@@ -1,0 +1,131 @@
+package dev.frostguard.engine.ranking.history;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.AllianceRankingEntryData;
+import dev.frostguard.api.domain.LabyrinthRankingEntryData;
+import dev.frostguard.engine.emulator.EmulatorType;
+import dev.frostguard.engine.ranking.capture.AllianceRankingCaptureResult;
+import dev.frostguard.engine.ranking.capture.GameAnalyticsCollectionType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GameAnalyticsHistoryServiceTest {
+
+    @TempDir
+    Path workspace;
+
+    @Test
+    void persistsValuesAndRefreshesCachedNamesFromLaterPowerHistory() throws Exception {
+        AtomicInteger seconds = new AtomicInteger();
+        Clock advancingClock = new Clock() {
+            @Override public ZoneOffset getZone() { return ZoneOffset.UTC; }
+            @Override public Clock withZone(java.time.ZoneId zone) { return this; }
+            @Override public Instant instant() {
+                return Instant.parse("2026-08-16T03:15:02Z").plusSeconds(seconds.getAndIncrement());
+            }
+        };
+        GameAnalyticsHistoryService history = new GameAnalyticsHistoryService(
+                new ObjectMapper(), advancingClock);
+        AccountDescriptor profile = new AccountDescriptor(7L, "Default", "0", true, 1L, 30L);
+        history.save(workspace, profile, EmulatorType.MUMU, GameAnalyticsCollectionType.POWER,
+                new AllianceRankingCaptureResult(
+                        List.of(new AllianceRankingEntryData(1, 42, "Member", 1234)), List.of()));
+        history.save(workspace, profile, EmulatorType.MUMU, GameAnalyticsCollectionType.LABYRINTH,
+                new AllianceRankingCaptureResult(List.of(),
+                        List.of(new LabyrinthRankingEntryData(1, 42, null, 607))));
+        history.save(workspace, profile, EmulatorType.MUMU, GameAnalyticsCollectionType.POWER,
+                new AllianceRankingCaptureResult(
+                        List.of(new AllianceRankingEntryData(1, 42, "Renamed Member", 2345)), List.of()));
+
+        List<GameAnalyticsSnapshot> snapshots = history.list(workspace, 7L);
+
+        assertEquals(3, snapshots.size());
+        GameAnalyticsSnapshot labyrinth = snapshots.stream()
+                .filter(value -> value.type() == GameAnalyticsCollectionType.LABYRINTH)
+                .findFirst().orElseThrow();
+        assertEquals(607, labyrinth.labyrinth().getFirst().score());
+        assertEquals("Renamed Member", labyrinth.labyrinth().getFirst().playerName());
+        assertTrue(labyrinth.labyrinth().getFirst().playerNameFromCache());
+    }
+
+    @Test
+    void migratesLegacyAutomaticExportsIntoInternalHistory() throws Exception {
+        Path legacy = workspace.resolve("game-analytics/20260816-031310");
+        Files.createDirectories(legacy);
+        Files.writeString(legacy.resolve("analytics.json"), """
+                {
+                  "schemaVersion": 1,
+                  "capturedAt": "2026-08-16T03:13:10Z",
+                  "profile": {"id": 7, "name": "Default", "emulatorSlot": "0", "emulatorType": "MUMU"},
+                  "power": [],
+                  "labyrinth": [{"rank": 1, "playerId": 42, "playerName": null, "score": 607}]
+                }
+                """);
+
+        List<GameAnalyticsSnapshot> snapshots = new GameAnalyticsHistoryService().list(workspace, 7L);
+
+        assertEquals(1, snapshots.size());
+        assertEquals(GameAnalyticsCollectionType.LABYRINTH, snapshots.getFirst().type());
+        assertEquals(607, snapshots.getFirst().labyrinth().getFirst().score());
+    }
+
+    @Test
+    void migratesProfileNameCacheIntoWorkspaceMemoryWithoutNewRun() throws Exception {
+        Path legacyNames = workspace.resolve("data/game-analytics/profiles/7/player-names.json");
+        Files.createDirectories(legacyNames.getParent());
+        Files.writeString(legacyNames, "{\"42\":\"Member\"}");
+
+        new GameAnalyticsHistoryService().list(workspace, 7L);
+
+        Path sharedNames = workspace.resolve("data/game-analytics/player-names.json");
+        assertTrue(Files.isRegularFile(sharedNames));
+        assertEquals("Member", new ObjectMapper().readTree(sharedNames.toFile())
+                .path("players").path("42").path("name").asText());
+    }
+
+    @Test
+    void storesNamesObservedDirectlyInLabyrinthResponses() throws Exception {
+        GameAnalyticsHistoryService history = new GameAnalyticsHistoryService(new ObjectMapper(),
+                Clock.fixed(Instant.parse("2026-08-16T03:52:47Z"), ZoneOffset.UTC));
+        AccountDescriptor profile = new AccountDescriptor(7L, "Default", "0", true, 1L, 30L);
+
+        history.save(workspace, profile, EmulatorType.MUMU, GameAnalyticsCollectionType.LABYRINTH,
+                new AllianceRankingCaptureResult(List.of(),
+                        List.of(new LabyrinthRankingEntryData(1, 42, "Labyrinth Member", 607))));
+
+        Path sharedNames = workspace.resolve("data/game-analytics/player-names.json");
+        assertEquals("Labyrinth Member", new ObjectMapper().readTree(sharedNames.toFile())
+                .path("players").path("42").path("name").asText());
+    }
+
+    @Test
+    void preservesTrueRanksAndFillsMissingPowerFromPriorSnapshots() throws Exception {
+        GameAnalyticsHistoryService history = new GameAnalyticsHistoryService();
+        AccountDescriptor profile = new AccountDescriptor(7L, "Default", "0", true, 1L, 30L);
+        history.save(workspace, profile, EmulatorType.MUMU, GameAnalyticsCollectionType.POWER,
+                new AllianceRankingCaptureResult(List.of(
+                        new AllianceRankingEntryData(1, 41, "First", 2_000),
+                        new AllianceRankingEntryData(2, 42, "Second", 1_000)), List.of()));
+
+        GameAnalyticsSnapshot snapshot = history.save(workspace, profile, EmulatorType.MUMU,
+                GameAnalyticsCollectionType.POWER, new AllianceRankingCaptureResult(List.of(
+                        new AllianceRankingEntryData(1, 41, "First", 2_100),
+                        new AllianceRankingEntryData(2, 42, null, null, false, false)), List.of()));
+
+        assertEquals(2, snapshot.power().get(1).rank());
+        assertEquals(1_000, snapshot.power().get(1).value());
+        assertTrue(snapshot.power().get(1).powerFromCache());
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/AlliancePowerRankListDecoderTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/AlliancePowerRankListDecoderTest.java
@@ -1,0 +1,78 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AlliancePowerRankListDecoderTest {
+
+    @Test
+    void preservesServerRankOrderForEveryPlayerId() {
+        byte[] members = array(member(2003, 900), member(2001, 800), member(2002, 700));
+        byte[] rpcHeader = {2, 0, 1, 0, 0x42, 0};
+        byte[] response = struct(List.of(members), List.of(0));
+        ByteArrayOutputStream unpacked = new ByteArrayOutputStream();
+        unpacked.writeBytes(rpcHeader);
+        unpacked.writeBytes(response);
+
+        assertEquals(List.of(
+                new AlliancePowerRankListDecoder.RankedPlayer(1, 2003, 900),
+                new AlliancePowerRankListDecoder.RankedPlayer(2, 2001, 800),
+                new AlliancePowerRankListDecoder.RankedPlayer(3, 2002, 700)
+        ), new AlliancePowerRankListDecoder().decode(List.of(pack(unpacked.toByteArray()))));
+    }
+
+    private byte[] member(long playerId, long power) {
+        return struct(List.of(uint32(playerId), uint32(power)), List.of(3));
+    }
+
+    private byte[] array(byte[]... members) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        for (byte[] member : members) {
+            output.writeBytes(uint32(member.length));
+            output.writeBytes(member);
+        }
+        return output.toByteArray();
+    }
+
+    private byte[] struct(List<byte[]> dataFields, List<Integer> inlineValues) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        output.writeBytes(uint16(dataFields.size() + inlineValues.size()));
+        dataFields.forEach(ignored -> output.writeBytes(uint16(0)));
+        inlineValues.forEach(value -> output.writeBytes(uint16((value + 1) * 2)));
+        dataFields.forEach(field -> {
+            output.writeBytes(uint32(field.length));
+            output.writeBytes(field);
+        });
+        return output.toByteArray();
+    }
+
+    private byte[] pack(byte[] unpacked) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        for (int offset = 0; offset < unpacked.length; offset += 8) {
+            int remaining = Math.min(8, unpacked.length - offset);
+            int tag = 0;
+            for (int index = 0; index < remaining; index++) {
+                if (unpacked[offset + index] != 0) tag |= 1 << index;
+            }
+            output.write(tag);
+            for (int index = 0; index < remaining; index++) {
+                if (unpacked[offset + index] != 0) output.write(unpacked[offset + index]);
+            }
+        }
+        return output.toByteArray();
+    }
+
+    private byte[] uint16(int value) {
+        return ByteBuffer.allocate(2).order(ByteOrder.LITTLE_ENDIAN).putShort((short) value).array();
+    }
+
+    private byte[] uint32(long value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt((int) value).array();
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/LabyrinthRankingPayloadDecoderTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/LabyrinthRankingPayloadDecoderTest.java
@@ -1,0 +1,98 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import dev.frostguard.api.domain.LabyrinthRankingEntryData;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LabyrinthRankingPayloadDecoderTest {
+
+    @Test
+    void preservesCompleteAllianceRankingWhenSomeNamesWereCached() {
+        byte[] frame = response(
+                member(101, 586, 3),
+                member(102, 575, 3),
+                member(103, 552, 4));
+
+        List<LabyrinthRankingEntryData> result = new LabyrinthRankingPayloadDecoder().decode(
+                List.of(frame), Map.of(101L, "Member A", 103L, "Member C"));
+
+        assertEquals(List.of(
+                new LabyrinthRankingEntryData(1, 101, "Member A", 586),
+                new LabyrinthRankingEntryData(2, 102, null, 575),
+                new LabyrinthRankingEntryData(3, 103, "Member C", 552)
+        ), result);
+    }
+
+    private byte[] response(byte[]... members) {
+        ByteArrayOutputStream array = new ByteArrayOutputStream();
+        for (byte[] member : members) {
+            array.writeBytes(uint32(member.length));
+            array.writeBytes(member);
+        }
+        byte[] rpcHeader = {2, 0, 1, 0, 0x66, (byte) 0xa0};
+        ByteArrayOutputStream response = new ByteArrayOutputStream();
+        response.writeBytes(uint16(2));
+        response.writeBytes(uint16(2));
+        response.writeBytes(uint16(0));
+        response.writeBytes(uint32(array.size()));
+        response.writeBytes(array.toByteArray());
+        ByteArrayOutputStream unpacked = new ByteArrayOutputStream();
+        unpacked.writeBytes(rpcHeader);
+        unpacked.writeBytes(response.toByteArray());
+        return pack(unpacked.toByteArray());
+    }
+
+    private byte[] member(long playerId, int score, int category) {
+        ByteArrayOutputStream member = new ByteArrayOutputStream();
+        member.writeBytes(uint16(3));
+        member.writeBytes(uint16(0));
+        member.writeBytes(uint16((score + 1) * 2));
+        member.writeBytes(uint16((category + 1) * 2));
+        member.writeBytes(uint32(4));
+        member.writeBytes(uint32(playerId));
+        return member.toByteArray();
+    }
+
+    private byte[] pack(byte[] unpacked) {
+        ByteArrayOutputStream packed = new ByteArrayOutputStream();
+        for (int offset = 0; offset < unpacked.length; offset += 8) {
+            int remaining = Math.min(8, unpacked.length - offset);
+            int tag = 0;
+            for (int index = 0; index < remaining; index++) {
+                if (unpacked[offset + index] != 0) {
+                    tag |= 1 << index;
+                }
+            }
+            if (tag == 0xff) {
+                packed.write(0xff);
+                packed.write(0);
+                for (int index = 0; index < 8; index++) {
+                    packed.write(index < remaining ? unpacked[offset + index] : 0);
+                }
+            } else {
+                packed.write(tag);
+                for (int index = 0; index < remaining; index++) {
+                    if (unpacked[offset + index] != 0) {
+                        packed.write(unpacked[offset + index]);
+                    }
+                }
+            }
+        }
+        return packed.toByteArray();
+    }
+
+    private byte[] uint16(int value) {
+        return ByteBuffer.allocate(2).order(ByteOrder.LITTLE_ENDIAN).putShort((short) value).array();
+    }
+
+    private byte[] uint32(long value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt((int) value).array();
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/LengthPrefixedFrameDecoderTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/LengthPrefixedFrameDecoderTest.java
@@ -1,0 +1,36 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LengthPrefixedFrameDecoderTest {
+
+    @Test
+    void reassemblesFragmentedAndCoalescedFrames() {
+        LengthPrefixedFrameDecoder decoder = new LengthPrefixedFrameDecoder(1024);
+
+        assertTrue(decoder.accept(new byte[]{0, 3, 10}).isEmpty());
+        List<byte[]> frames = decoder.accept(new byte[]{11, 12, 0, 2, 20, 21});
+
+        assertEquals(2, frames.size());
+        assertArrayEquals(new byte[]{10, 11, 12}, frames.get(0));
+        assertArrayEquals(new byte[]{20, 21}, frames.get(1));
+        decoder.requireComplete();
+    }
+
+    @Test
+    void rejectsInvalidAndTruncatedFramesConservatively() {
+        LengthPrefixedFrameDecoder invalid = new LengthPrefixedFrameDecoder(1024);
+        assertThrows(IllegalArgumentException.class, () -> invalid.accept(new byte[]{0, 0}));
+
+        LengthPrefixedFrameDecoder truncated = new LengthPrefixedFrameDecoder(1024);
+        truncated.accept(new byte[]{0, 4, 1, 2});
+        assertThrows(IllegalStateException.class, truncated::requireComplete);
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/PowerRankingPayloadDecoderTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/PowerRankingPayloadDecoderTest.java
@@ -1,0 +1,118 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import dev.frostguard.api.domain.AllianceRankingEntryData;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PowerRankingPayloadDecoderTest {
+
+    private final PowerRankingPayloadDecoder decoder = new PowerRankingPayloadDecoder();
+
+    @Test
+    void decodesSortsAndDeduplicatesCaptureDerivedMemberLayout() {
+        byte[] firstBatch = packedResponse(
+                member("Member 002", 2002, 19_044_772),
+                member("Member 001", 2001, 19_585_025));
+        byte[] secondBatch = packedResponse(
+                member("Member 003", 2003, 18_869_306),
+                member("Member 002 renamed", 2002, 19_044_772));
+
+        List<AllianceRankingEntryData> result = decoder.decode(List.of(firstBatch, secondBatch));
+
+        assertEquals(List.of(
+                new AllianceRankingEntryData(1, 2001, "Member 001", 19_585_025),
+                new AllianceRankingEntryData(2, 2002, "Member 002 renamed", 19_044_772),
+                new AllianceRankingEntryData(3, 2003, "Member 003", 18_869_306)
+        ), result);
+    }
+
+    @Test
+    void ignoresUnrelatedValidSprotoMessages() {
+        assertTrue(decoder.decode(List.of(pack(new byte[]{1, 0, 2, 0}))).isEmpty());
+    }
+
+    private byte[] packedResponse(byte[]... members) {
+        ByteArrayOutputStream memberArray = new ByteArrayOutputStream();
+        for (byte[] member : members) {
+            memberArray.writeBytes(uint32(member.length));
+            memberArray.writeBytes(member);
+        }
+
+        byte[] rpcHeader = {2, 0, 1, 0, 0x66, (byte) 0xa0};
+        byte[] response = struct(List.of(memberArray.toByteArray()), List.of(2));
+        ByteArrayOutputStream unpacked = new ByteArrayOutputStream();
+        unpacked.writeBytes(rpcHeader);
+        unpacked.writeBytes(response);
+        return pack(unpacked.toByteArray());
+    }
+
+    private byte[] member(String name, long playerId, long power) {
+        return struct(List.of(
+                name.getBytes(StandardCharsets.UTF_8),
+                uint32(playerId),
+                uint32(1_700_000_000L + playerId),
+                uint32(power)
+        ), List.of());
+    }
+
+    private byte[] struct(List<byte[]> dataFields, List<Integer> inlineValues) {
+        int fieldCount = dataFields.size() + inlineValues.size();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        output.writeBytes(uint16(fieldCount));
+        for (int ignored = 0; ignored < dataFields.size(); ignored++) {
+            output.writeBytes(uint16(0));
+        }
+        for (int value : inlineValues) {
+            output.writeBytes(uint16((value + 1) * 2));
+        }
+        for (byte[] field : dataFields) {
+            output.writeBytes(uint32(field.length));
+            output.writeBytes(field);
+        }
+        return output.toByteArray();
+    }
+
+    private byte[] pack(byte[] unpacked) {
+        ByteArrayOutputStream packed = new ByteArrayOutputStream();
+        for (int offset = 0; offset < unpacked.length; offset += 8) {
+            int remaining = Math.min(8, unpacked.length - offset);
+            int tag = 0;
+            for (int index = 0; index < remaining; index++) {
+                if (unpacked[offset + index] != 0) {
+                    tag |= 1 << index;
+                }
+            }
+            if (tag == 0xff) {
+                packed.write(0xff);
+                packed.write(0);
+                for (int index = 0; index < 8; index++) {
+                    packed.write(index < remaining ? unpacked[offset + index] : 0);
+                }
+                continue;
+            }
+            packed.write(tag);
+            for (int index = 0; index < remaining; index++) {
+                if (unpacked[offset + index] != 0) {
+                    packed.write(unpacked[offset + index]);
+                }
+            }
+        }
+        return packed.toByteArray();
+    }
+
+    private byte[] uint16(int value) {
+        return ByteBuffer.allocate(2).order(ByteOrder.LITTLE_ENDIAN).putShort((short) value).array();
+    }
+
+    private byte[] uint32(long value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt((int) value).array();
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/SelfPlayerStateDecoderTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/SelfPlayerStateDecoderTest.java
@@ -1,0 +1,67 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SelfPlayerStateDecoderTest {
+
+    @Test
+    void decodesIdentityBoundToTheStartupPlayerId() {
+        ByteArrayOutputStream unpacked = new ByteArrayOutputStream();
+        unpacked.writeBytes(uint16(1));
+        unpacked.writeBytes(uint16((1010 + 1) * 2));
+        unpacked.writeBytes(playerState("Dave", 200217707L, 29452901L));
+
+        assertEquals(new SelfPlayerStateDecoder.PlayerState(200217707L, "Dave", 29452901L),
+                new SelfPlayerStateDecoder().decode(List.of(pack(unpacked.toByteArray()))).orElseThrow());
+    }
+
+    private byte[] playerState(String name, long playerId, long power) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        output.writeBytes(uint16(4));
+        output.writeBytes(uint16(0));
+        output.writeBytes(uint16(3));
+        output.writeBytes(uint16(0));
+        output.writeBytes(uint16(0));
+        writeData(output, name.getBytes(StandardCharsets.UTF_8));
+        writeData(output, uint32(playerId));
+        writeData(output, uint32(power));
+        return output.toByteArray();
+    }
+
+    private void writeData(ByteArrayOutputStream output, byte[] data) {
+        output.writeBytes(uint32(data.length));
+        output.writeBytes(data);
+    }
+
+    private byte[] pack(byte[] unpacked) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        for (int offset = 0; offset < unpacked.length; offset += 8) {
+            int remaining = Math.min(8, unpacked.length - offset);
+            int tag = 0;
+            for (int index = 0; index < remaining; index++) {
+                if (unpacked[offset + index] != 0) tag |= 1 << index;
+            }
+            output.write(tag);
+            for (int index = 0; index < remaining; index++) {
+                if (unpacked[offset + index] != 0) output.write(unpacked[offset + index]);
+            }
+        }
+        return output.toByteArray();
+    }
+
+    private byte[] uint16(int value) {
+        return ByteBuffer.allocate(2).order(ByteOrder.LITTLE_ENDIAN).putShort((short) value).array();
+    }
+
+    private byte[] uint32(long value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt((int) value).array();
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/SprotoPackedDecoderTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/ranking/protocol/SprotoPackedDecoderTest.java
@@ -1,0 +1,32 @@
+package dev.frostguard.engine.ranking.protocol;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SprotoPackedDecoderTest {
+
+    private final SprotoPackedDecoder decoder = new SprotoPackedDecoder();
+
+    @Test
+    void expandsZeroMasksAndRawRuns() {
+        byte[] packed = {
+                0x15, 1, 2, 3,
+                (byte) 0xff, 0,
+                11, 12, 13, 14, 15, 16, 17, 18
+        };
+
+        assertArrayEquals(new byte[]{
+                1, 0, 2, 0, 3, 0, 0, 0,
+                11, 12, 13, 14, 15, 16, 17, 18
+        }, decoder.unpack(packed));
+    }
+
+    @Test
+    void rejectsTruncatedPackedInput() {
+        assertThrows(IllegalArgumentException.class, () -> decoder.unpack(new byte[]{0x03, 1}));
+        assertThrows(IllegalArgumentException.class,
+                () -> decoder.unpack(new byte[]{(byte) 0xff, 1, 1, 2, 3}));
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/analytics/GameAnalyticsLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/analytics/GameAnalyticsLayoutController.java
@@ -1,0 +1,310 @@
+package dev.frostguard.app.panel.analytics;
+
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.configs.TpDailyTaskEnum;
+import dev.frostguard.api.domain.AllianceRankingEntryData;
+import dev.frostguard.api.domain.LabyrinthRankingEntryData;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.app.panel.profile.IProfileLoadListener;
+import dev.frostguard.app.panel.profile.ProfileAux;
+import dev.frostguard.engine.emulator.EmulatorType;
+import dev.frostguard.engine.ranking.GameAnalyticsRunRegistry;
+import dev.frostguard.engine.ranking.capture.AllianceRankingCaptureSupport;
+import dev.frostguard.engine.ranking.capture.GameAnalyticsCollectionType;
+import dev.frostguard.engine.ranking.export.GameAnalyticsExportService;
+import dev.frostguard.engine.ranking.history.GameAnalyticsHistoryService;
+import dev.frostguard.engine.ranking.history.GameAnalyticsSnapshot;
+import dev.frostguard.engine.schedule.TaskQueue;
+import dev.frostguard.engine.service.ConfigService;
+import dev.frostguard.engine.service.ScheduleService;
+import javafx.application.Platform;
+import javafx.beans.property.ReadOnlyIntegerWrapper;
+import javafx.beans.property.ReadOnlyLongWrapper;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.collections.FXCollections;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.stage.FileChooser;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+public final class GameAnalyticsLayoutController implements IProfileLoadListener {
+
+    private final GameAnalyticsHistoryService history = new GameAnalyticsHistoryService();
+    private final GameAnalyticsExportService exporter = new GameAnalyticsExportService();
+    private ProfileAux currentProfile;
+
+    @FXML private Label labelSupport;
+    @FXML private Label labelPowerStatus;
+    @FXML private Label labelLabyrinthStatus;
+    @FXML private Button buttonPower;
+    @FXML private Button buttonLabyrinth;
+    @FXML private ComboBox<GameAnalyticsSnapshot> comboPowerHistory;
+    @FXML private ComboBox<GameAnalyticsSnapshot> comboLabyrinthHistory;
+    @FXML private Button buttonPowerExportJson;
+    @FXML private Button buttonPowerExportCsv;
+    @FXML private Button buttonLabyrinthExportJson;
+    @FXML private Button buttonLabyrinthExportCsv;
+    @FXML private TableView<AllianceRankingEntryData> tableRankings;
+    @FXML private TableColumn<AllianceRankingEntryData, Number> columnRank;
+    @FXML private TableColumn<AllianceRankingEntryData, String> columnPlayer;
+    @FXML private TableColumn<AllianceRankingEntryData, Number> columnPlayerId;
+    @FXML private TableColumn<AllianceRankingEntryData, Number> columnPower;
+    @FXML private TableColumn<AllianceRankingEntryData, String> columnPowerSource;
+    @FXML private TableColumn<AllianceRankingEntryData, String> columnPowerNameSource;
+    @FXML private TableView<LabyrinthRankingEntryData> tableLabyrinth;
+    @FXML private TableColumn<LabyrinthRankingEntryData, Number> columnLabRank;
+    @FXML private TableColumn<LabyrinthRankingEntryData, String> columnLabPlayer;
+    @FXML private TableColumn<LabyrinthRankingEntryData, Number> columnLabPlayerId;
+    @FXML private TableColumn<LabyrinthRankingEntryData, Number> columnLabScore;
+    @FXML private TableColumn<LabyrinthRankingEntryData, String> columnLabNameSource;
+
+    @FXML
+    private void initialize() {
+        columnRank.setCellValueFactory(row -> new ReadOnlyIntegerWrapper(row.getValue().rank()));
+        columnPlayer.setCellValueFactory(row -> new ReadOnlyStringWrapper(row.getValue().playerName()));
+        columnPlayerId.setCellValueFactory(row -> new ReadOnlyLongWrapper(row.getValue().playerId()));
+        columnPower.setCellValueFactory(row -> new ReadOnlyObjectWrapper<>(row.getValue().value()));
+        columnPowerSource.setCellValueFactory(row -> new ReadOnlyStringWrapper(powerSource(row.getValue())));
+        columnPowerNameSource.setCellValueFactory(row -> new ReadOnlyStringWrapper(nameSource(
+                row.getValue().playerName(), row.getValue().playerNameFromCache())));
+        columnLabRank.setCellValueFactory(row -> new ReadOnlyIntegerWrapper(row.getValue().rank()));
+        columnLabPlayer.setCellValueFactory(row -> new ReadOnlyStringWrapper(row.getValue().playerName()));
+        columnLabPlayerId.setCellValueFactory(row -> new ReadOnlyLongWrapper(row.getValue().playerId()));
+        columnLabScore.setCellValueFactory(row -> new ReadOnlyLongWrapper(row.getValue().score()));
+        columnLabNameSource.setCellValueFactory(row -> new ReadOnlyStringWrapper(nameSource(
+                row.getValue().playerName(), row.getValue().playerNameFromCache())));
+        comboPowerHistory.valueProperty().addListener((observable, previous, selected) -> showPower(selected));
+        comboLabyrinthHistory.valueProperty().addListener(
+                (observable, previous, selected) -> showLabyrinth(selected));
+
+        AllianceRankingCaptureSupport support = currentSupport();
+        labelSupport.setText(support.message());
+        labelPowerStatus.setText(initialStatus(support));
+        labelLabyrinthStatus.setText(initialStatus(support));
+        updateCollectionAvailability();
+        updateExportButtons();
+        GameAnalyticsRunRegistry.addListener(this::onAnalyticsEvent);
+        ScheduleService.obtain().addEngineObserver(
+                state -> Platform.runLater(this::updateCollectionAvailability));
+    }
+
+    @Override
+    public void onProfileLoad(ProfileAux profile) {
+        boolean changedProfile = currentProfile == null || profile == null
+                || !currentProfile.getId().equals(profile.getId());
+        currentProfile = profile;
+        if (!changedProfile) return;
+        if (profile == null) {
+            comboPowerHistory.getItems().clear();
+            comboLabyrinthHistory.getItems().clear();
+            updateCollectionAvailability();
+            updateExportButtons();
+            return;
+        }
+        loadHistory(profile.getId());
+        updateCollectionAvailability();
+    }
+
+    @FXML
+    private void handleCollectPower() {
+        collect(GameAnalyticsCollectionType.POWER);
+    }
+
+    @FXML
+    private void handleCollectLabyrinth() {
+        collect(GameAnalyticsCollectionType.LABYRINTH);
+    }
+
+    private void collect(GameAnalyticsCollectionType type) {
+        Label status = statusFor(type);
+        ProfileAux selected = currentProfile;
+        if (selected == null) {
+            status.setText("Select a profile first.");
+            return;
+        }
+        TaskQueue queue = ScheduleService.obtain().getCoordinator().getQueue(selected.getId());
+        if (queue == null || !queue.isActive()) {
+            status.setText("Start the bot first. Analytics runs through the profile task queue.");
+            return;
+        }
+        TpDailyTaskEnum task = type == GameAnalyticsCollectionType.POWER
+                ? TpDailyTaskEnum.GAME_ANALYTICS_POWER
+                : TpDailyTaskEnum.GAME_ANALYTICS_LABYRINTH;
+        queue.runNow(task, false);
+        status.setText("Run queued for " + selected.getName() + ".");
+    }
+
+    private void onAnalyticsEvent(GameAnalyticsRunRegistry.Event event) {
+        ProfileAux selected = currentProfile;
+        if (selected == null || !selected.getId().equals(event.profileId())) return;
+        Platform.runLater(() -> {
+            if (event.state() == GameAnalyticsRunRegistry.State.RUNNING) {
+                setBusy(event.type(), event.message());
+            } else if (event.state() == GameAnalyticsRunRegistry.State.SUCCEEDED) {
+                setCollectionButtonsEnabled();
+                loadHistory(event.profileId());
+                ComboBox<GameAnalyticsSnapshot> historyBox = historyFor(event.type());
+                historyBox.getItems().stream()
+                        .filter(snapshot -> snapshot.id().equals(event.snapshot().id()))
+                        .findFirst().ifPresent(historyBox.getSelectionModel()::select);
+                int entries = event.type() == GameAnalyticsCollectionType.POWER
+                        ? event.result().power().size() : event.result().labyrinth().size();
+                statusFor(event.type()).setText("Saved " + entries
+                        + " entries. Use an export button when needed.");
+            } else {
+                setCollectionButtonsEnabled();
+                statusFor(event.type()).setText("Run failed: " + event.message());
+            }
+        });
+    }
+
+    private void loadHistory(Long profileId) {
+        try {
+            var snapshots = history.list(WorkspacePaths.current().root(), profileId);
+            var power = snapshots.stream().filter(snapshot ->
+                    snapshot.type() == GameAnalyticsCollectionType.POWER).toList();
+            var labyrinth = snapshots.stream().filter(snapshot ->
+                    snapshot.type() == GameAnalyticsCollectionType.LABYRINTH).toList();
+            comboPowerHistory.setItems(FXCollections.observableArrayList(power));
+            comboLabyrinthHistory.setItems(FXCollections.observableArrayList(labyrinth));
+            if (!power.isEmpty()) comboPowerHistory.getSelectionModel().selectFirst();
+            if (!labyrinth.isEmpty()) comboLabyrinthHistory.getSelectionModel().selectFirst();
+            updateExportButtons();
+        } catch (IOException exception) {
+            labelPowerStatus.setText("Could not load history: " + exception.getMessage());
+            labelLabyrinthStatus.setText("Could not load history: " + exception.getMessage());
+        }
+    }
+
+    private void showPower(GameAnalyticsSnapshot snapshot) {
+        tableRankings.setItems(snapshot == null ? FXCollections.emptyObservableList()
+                : FXCollections.observableArrayList(snapshot.power()));
+        updateExportButtons();
+    }
+
+    private void showLabyrinth(GameAnalyticsSnapshot snapshot) {
+        tableLabyrinth.setItems(snapshot == null ? FXCollections.emptyObservableList()
+                : FXCollections.observableArrayList(snapshot.labyrinth()));
+        updateExportButtons();
+    }
+
+    @FXML private void handleExportPowerJson() { exportSelected(GameAnalyticsCollectionType.POWER, "json"); }
+    @FXML private void handleExportPowerCsv() { exportSelected(GameAnalyticsCollectionType.POWER, "csv"); }
+    @FXML private void handleExportLabyrinthJson() { exportSelected(GameAnalyticsCollectionType.LABYRINTH, "json"); }
+    @FXML private void handleExportLabyrinthCsv() { exportSelected(GameAnalyticsCollectionType.LABYRINTH, "csv"); }
+
+    private void exportSelected(GameAnalyticsCollectionType type, String extension) {
+        GameAnalyticsSnapshot snapshot = historyFor(type).getValue();
+        if (snapshot == null) {
+            statusFor(type).setText("Select a saved run first.");
+            return;
+        }
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Export Game Data");
+        chooser.setInitialFileName(type.name().toLowerCase() + "-" + snapshot.id() + "." + extension);
+        chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter(
+                extension.toUpperCase() + " files", "*." + extension));
+        File target = chooser.showSaveDialog(buttonPower.getScene().getWindow());
+        if (target == null) return;
+        try {
+            if ("json".equals(extension)) exporter.exportJson(target.toPath(), snapshot);
+            else exporter.exportCsv(target.toPath(), snapshot);
+            statusFor(type).setText("Exported to " + target.toPath().toAbsolutePath() + ".");
+        } catch (IOException exception) {
+            statusFor(type).setText("Export failed: " + exception.getMessage());
+        }
+    }
+
+    private void setBusy(GameAnalyticsCollectionType type, String status) {
+        buttonPower.setDisable(true);
+        buttonLabyrinth.setDisable(true);
+        statusFor(type).setText(status);
+    }
+
+    private void setCollectionButtonsEnabled() {
+        updateCollectionAvailability();
+    }
+
+    private void updateCollectionAvailability() {
+        AllianceRankingCaptureSupport support = currentSupport();
+        boolean botActive = isSelectedProfileBotActive();
+        boolean enabled = support.supported() && botActive;
+        buttonPower.setDisable(!enabled);
+        buttonLabyrinth.setDisable(!enabled);
+        String buttonText = !support.supported() ? "MuMu Only"
+                : botActive ? "New Run" : "Start Bot First";
+        buttonPower.setText(buttonText);
+        buttonLabyrinth.setText(buttonText);
+        if (!support.supported()) {
+            labelPowerStatus.setText("Traffic collection is unavailable for the selected emulator.");
+            labelLabyrinthStatus.setText("Traffic collection is unavailable for the selected emulator.");
+        } else if (!botActive) {
+            labelPowerStatus.setText("Start the bot to enable a new run.");
+            labelLabyrinthStatus.setText("Start the bot to enable a new run.");
+        } else if (currentProfile != null) {
+            labelPowerStatus.setText("Ready for " + currentProfile.getName() + ".");
+            labelLabyrinthStatus.setText("Ready for " + currentProfile.getName() + ".");
+        }
+    }
+
+    private boolean isSelectedProfileBotActive() {
+        if (currentProfile == null || ScheduleService.obtain().getCoordinator() == null) return false;
+        TaskQueue queue = ScheduleService.obtain().getCoordinator().getQueue(currentProfile.getId());
+        return queue != null && queue.isActive();
+    }
+
+    private void updateExportButtons() {
+        boolean noPower = comboPowerHistory.getValue() == null;
+        boolean noLabyrinth = comboLabyrinthHistory.getValue() == null;
+        buttonPowerExportJson.setDisable(noPower);
+        buttonPowerExportCsv.setDisable(noPower);
+        buttonLabyrinthExportJson.setDisable(noLabyrinth);
+        buttonLabyrinthExportCsv.setDisable(noLabyrinth);
+    }
+
+    private Label statusFor(GameAnalyticsCollectionType type) {
+        return type == GameAnalyticsCollectionType.POWER ? labelPowerStatus : labelLabyrinthStatus;
+    }
+
+    private ComboBox<GameAnalyticsSnapshot> historyFor(GameAnalyticsCollectionType type) {
+        return type == GameAnalyticsCollectionType.POWER ? comboPowerHistory : comboLabyrinthHistory;
+    }
+
+    private String nameSource(String name, boolean fromCache) {
+        if (name == null || name.isBlank()) return "Missing";
+        return fromCache ? "Cache" : "Direct";
+    }
+
+    private String powerSource(AllianceRankingEntryData entry) {
+        if (entry.value() == null) return "Missing";
+        return entry.powerFromCache() ? "Cache" : "Direct";
+    }
+
+    private String initialStatus(AllianceRankingCaptureSupport support) {
+        return support.supported() ? "Start the bot, then select New Run."
+                : "Traffic collection is disabled for the selected emulator.";
+    }
+
+    private AllianceRankingCaptureSupport currentSupport() {
+        return AllianceRankingCaptureSupport.evaluate(System.getProperty("os.name"), currentEmulatorType());
+    }
+
+    private EmulatorType currentEmulatorType() {
+        try {
+            Map<String, String> settings = ConfigService.obtain().loadGlobalSettings();
+            String configured = settings == null ? null
+                    : settings.get(ConfigurationKeyEnum.CURRENT_EMULATOR_STRING.name());
+            return configured == null || configured.isBlank() ? null : EmulatorType.valueOf(configured);
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import dev.frostguard.vision.match.OpenCvPatternLocator;
 import dev.frostguard.app.panel.alliance.AllianceLayoutController;
+import dev.frostguard.app.panel.analytics.GameAnalyticsLayoutController;
 import dev.frostguard.app.shared.AbstractProfileController;
 import dev.frostguard.app.panel.alliance.AllianceChampionshipLayoutController;
 import dev.frostguard.app.panel.combat.BearTrapLayoutController;
@@ -681,6 +682,7 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
 
                 new ModuleDefinition("SkipTutorialLayout",       "Skip Tutorial",        MaterialDesignS.SKIP_NEXT_OUTLINE,          SkipTutorialLayoutController::new),
                 new ModuleDefinition("CharacterLayout",          "Character",            MaterialDesignA.ACCOUNT_OUTLINE,            CharacterLayoutController::new),
+                new ModuleDefinition("GameAnalyticsLayout",      "Game Data",            MaterialDesignV.VIEW_LIST_OUTLINE,          GameAnalyticsLayoutController::new),
                 new ModuleDefinition("StatisticsLayout",         "Statistics",           MaterialDesignV.VIEW_DASHBOARD_OUTLINE,     StatisticsLayoutController::new)
         );
         //@formatter:on

--- a/modules/desktop/src/main/resources/layout/GameAnalyticsLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/GameAnalyticsLayout.fxml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<BorderPane maxHeight="Infinity" maxWidth="Infinity" VBox.vgrow="ALWAYS"
+            xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1">
+    <top>
+        <VBox spacing="10" style="-fx-padding: 16;">
+            <Label text="Game Data" styleClass="module-title" />
+            <Label fx:id="labelSupport" wrapText="true" />
+            <Label text="The initial collection backend supports Windows + MuMu Player only. Start the bot first, then queue one ranking as a one-shot profile task. Normal initialization and emulator coordination apply." wrapText="true" styleClass="label-muted" />
+        </VBox>
+    </top>
+    <center>
+        <TabPane fx:id="rankingTabs" style="-fx-padding: 0 16 16 16;" VBox.vgrow="ALWAYS">
+            <tabs>
+                <Tab fx:id="powerTab" text="Alliance Power Ranking" closable="false">
+                    <BorderPane>
+                        <top>
+                            <VBox spacing="8" style="-fx-padding: 12;">
+                                <HBox spacing="10" alignment="CENTER_LEFT">
+                                    <Button fx:id="buttonPower" text="Start Bot First" onAction="#handleCollectPower" styleClass="action-button-timeline" />
+                                    <Label text="History:" />
+                                    <ComboBox fx:id="comboPowerHistory" prefWidth="230" />
+                                    <Button fx:id="buttonPowerExportJson" text="Export JSON" onAction="#handleExportPowerJson" />
+                                    <Button fx:id="buttonPowerExportCsv" text="Export CSV" onAction="#handleExportPowerCsv" />
+                                </HBox>
+                                <Label text="If player details are missing, run the collection again. Newly observed names are saved in the shared player cache and applied to older snapshots when viewed." wrapText="true" styleClass="label-muted" />
+                                <Label fx:id="labelPowerStatus" wrapText="true" />
+                            </VBox>
+                        </top>
+                        <center>
+                            <TableView fx:id="tableRankings" fixedCellSize="32">
+                                <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>
+                                <columns>
+                                    <TableColumn fx:id="columnRank" text="Rank" prefWidth="100" />
+                                    <TableColumn fx:id="columnPlayer" text="Player" prefWidth="240" />
+                                    <TableColumn fx:id="columnPlayerId" text="Player ID" prefWidth="170" />
+                                    <TableColumn fx:id="columnPower" text="Power" prefWidth="170" />
+                                    <TableColumn fx:id="columnPowerSource" text="Power Source" prefWidth="120" />
+                                    <TableColumn fx:id="columnPowerNameSource" text="Name Source" prefWidth="120" />
+                                </columns>
+                            </TableView>
+                        </center>
+                    </BorderPane>
+                </Tab>
+                <Tab fx:id="labyrinthTab" text="Alliance Labyrinth Ranking" closable="false">
+                    <BorderPane>
+                        <top>
+                            <VBox spacing="8" style="-fx-padding: 12;">
+                                <HBox spacing="10" alignment="CENTER_LEFT">
+                                    <Button fx:id="buttonLabyrinth" text="Start Bot First" onAction="#handleCollectLabyrinth" styleClass="action-button-timeline" />
+                                    <Label text="History:" />
+                                    <ComboBox fx:id="comboLabyrinthHistory" prefWidth="230" />
+                                    <Button fx:id="buttonLabyrinthExportJson" text="Export JSON" onAction="#handleExportLabyrinthJson" />
+                                    <Button fx:id="buttonLabyrinthExportCsv" text="Export CSV" onAction="#handleExportLabyrinthCsv" />
+                                </HBox>
+                                <Label text="Labyrinth responses do not include player names. Missing names are resolved from the shared player cache; run Alliance Power Ranking to populate it more reliably." wrapText="true" styleClass="label-muted" />
+                                <Label fx:id="labelLabyrinthStatus" wrapText="true" />
+                            </VBox>
+                        </top>
+                        <center>
+                            <TableView fx:id="tableLabyrinth" fixedCellSize="32">
+                                <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>
+                                <columns>
+                                    <TableColumn fx:id="columnLabRank" text="Rank" prefWidth="100" />
+                                    <TableColumn fx:id="columnLabPlayer" text="Player" prefWidth="230" />
+                                    <TableColumn fx:id="columnLabPlayerId" text="Player ID" prefWidth="160" />
+                                    <TableColumn fx:id="columnLabScore" text="Labyrinth Score" prefWidth="160" />
+                                    <TableColumn fx:id="columnLabNameSource" text="Name Source" prefWidth="120" />
+                                </columns>
+                            </TableView>
+                        </center>
+                    </BorderPane>
+                </Tab>
+            </tabs>
+        </TabPane>
+    </center>
+</BorderPane>

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/TaskRegistrations.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/TaskRegistrations.java
@@ -6,6 +6,7 @@ import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.DelayedTaskRegistry;
 
 import dev.frostguard.tasks.alliance.*;
+import dev.frostguard.tasks.analytics.GameAnalyticsRoutine;
 import dev.frostguard.tasks.city.*;
 import dev.frostguard.tasks.combat.*;
 import dev.frostguard.tasks.dailies.*;
@@ -28,6 +29,8 @@ public class TaskRegistrations {
 
     private static DelayedTask createTask(TpDailyTaskEnum type, AccountDescriptor profile) {
         return switch (type) {
+            case GAME_ANALYTICS_LABYRINTH, GAME_ANALYTICS_POWER ->
+                    new GameAnalyticsRoutine(profile, type);
             // Heroes
             case HERO_RECRUITMENT -> new HeroRecruitmentRoutine(profile, type);
             case EXPERT_AGNES_INTEL -> new ExpertsAgnesIntelRoutine(profile, type);

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/analytics/GameAnalyticsRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/analytics/GameAnalyticsRoutine.java
@@ -1,0 +1,109 @@
+package dev.frostguard.tasks.analytics;
+
+import dev.frostguard.api.configs.TpDailyTaskEnum;
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.engine.emulator.EmulatorType;
+import dev.frostguard.engine.emulator.EmulatorController;
+import dev.frostguard.engine.ranking.GameAnalyticsRunRegistry;
+import dev.frostguard.engine.ranking.capture.AllianceRankingCaptureResult;
+import dev.frostguard.engine.ranking.capture.GameAnalyticsCollectionType;
+import dev.frostguard.engine.ranking.capture.MuMuTcpdumpAnalyticsCapture;
+import dev.frostguard.engine.ranking.history.GameAnalyticsHistoryService;
+import dev.frostguard.engine.ranking.history.GameAnalyticsSnapshot;
+import dev.frostguard.engine.schedule.DelayedTask;
+import dev.frostguard.engine.schedule.LaunchPoint;
+import dev.frostguard.tasks.lifecycle.InitializeRoutine;
+
+/** One-shot analytics task executed through the regular profile lifecycle. */
+public final class GameAnalyticsRoutine extends DelayedTask {
+
+    private final GameAnalyticsCollectionType collectionType;
+    private final MuMuTcpdumpAnalyticsCapture capture = new MuMuTcpdumpAnalyticsCapture();
+    private final GameAnalyticsHistoryService history = new GameAnalyticsHistoryService();
+
+    public GameAnalyticsRoutine(AccountDescriptor profile, TpDailyTaskEnum task) {
+        super(profile, task);
+        collectionType = switch (task) {
+            case GAME_ANALYTICS_LABYRINTH -> GameAnalyticsCollectionType.LABYRINTH;
+            case GAME_ANALYTICS_POWER -> GameAnalyticsCollectionType.POWER;
+            default -> throw new IllegalArgumentException("Unsupported analytics task: " + task);
+        };
+    }
+
+    @Override
+    protected LaunchPoint getRequiredStartLocation() {
+        return LaunchPoint.HOME;
+    }
+
+    @Override
+    protected boolean acceptsInjections() {
+        return false;
+    }
+
+    @Override
+    public void run() {
+        try {
+            if (collectionType == GameAnalyticsCollectionType.POWER) {
+                GameAnalyticsRunRegistry.publish(new GameAnalyticsRunRegistry.Event(
+                        profile.getId(), collectionType, GameAnalyticsRunRegistry.State.RUNNING,
+                        "Capturing startup and ranking traffic...", null, null));
+                startCapture();
+                emuManager.forceStopApp(EMULATOR_NUMBER, EmulatorController.GAME.getPackageName());
+                new InitializeRoutine(profile, TpDailyTaskEnum.INITIALIZE).run();
+            }
+            super.run();
+        } catch (RuntimeException exception) {
+            capture.cancel();
+            GameAnalyticsRunRegistry.publish(new GameAnalyticsRunRegistry.Event(
+                    profile.getId(), collectionType, GameAnalyticsRunRegistry.State.FAILED,
+                    exception.getMessage(), null, null));
+            throw exception;
+        }
+    }
+
+    @Override
+    protected void execute() {
+        GameAnalyticsRunRegistry.publish(new GameAnalyticsRunRegistry.Event(
+                profile.getId(), collectionType, GameAnalyticsRunRegistry.State.RUNNING,
+                "Collecting " + collectionType.name().toLowerCase() + " analytics...", null, null));
+        try {
+            if (!capture.isRunning()) {
+                startCapture();
+            }
+            if (collectionType == GameAnalyticsCollectionType.LABYRINTH) {
+                navigationHelper.navigateToLabyrinthRanking();
+            } else {
+                navigationHelper.navigateToPowerRanking();
+            }
+            AllianceRankingCaptureResult result = capture.stopAndDecode();
+            GameAnalyticsSnapshot snapshot = history.save(
+                    WorkspacePaths.current().root(), profile, EmulatorType.MUMU, collectionType, result);
+            logInfo("Collected " + entryCount(result) + " "
+                    + collectionType.name().toLowerCase() + " analytics entries");
+            GameAnalyticsRunRegistry.publish(new GameAnalyticsRunRegistry.Event(
+                    profile.getId(), collectionType, GameAnalyticsRunRegistry.State.SUCCEEDED,
+                    "Collection completed", snapshot.result(), snapshot));
+        } catch (Exception exception) {
+            capture.cancel();
+            throw new IllegalStateException("Could not collect "
+                    + collectionType.name().toLowerCase() + " analytics: "
+                    + exception.getMessage(), exception);
+        }
+    }
+
+    private void startCapture() {
+        try {
+            capture.start(WorkspacePaths.current().root(), collectionType,
+                    emuManager.getAdbPath(), emuManager.getDeviceSerial(EMULATOR_NUMBER));
+        } catch (Exception exception) {
+            throw new IllegalStateException("Could not start analytics traffic capture: "
+                    + exception.getMessage(), exception);
+        }
+    }
+
+    private int entryCount(AllianceRankingCaptureResult result) {
+        return collectionType == GameAnalyticsCollectionType.POWER
+                ? result.power().size() : result.labyrinth().size();
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/exploration/DailyLabyrinthRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/exploration/DailyLabyrinthRoutine.java
@@ -26,16 +26,12 @@ public class DailyLabyrinthRoutine extends DelayedTask {
     // =========================== CONSTANTS ===========================
 
     // Navigation points
-    private static final PointData SCROLL_START_POINT = new PointData(400, 800);
-    private static final PointData SCROLL_END_POINT = new PointData(400, 100);
     private static final PointData SKIP_BUTTON = new PointData(71, 827);
     private static final PointData RESULT_SKIP_BUTTON = new PointData(640, 175);
 
     // Timing constants
     private static final int MENU_NAVIGATION_DELAY = 1000;
     private static final int TAB_SWITCH_DELAY = 500;
-    private static final int SCROLL_DELAY = 1300;
-    private static final int LABYRINTH_LOAD_DELAY = 2000;
     private static final int BATTLE_COMPLETION_DELAY = 3000;
 
     // =========================== CONSTRUCTOR ===========================
@@ -88,26 +84,12 @@ public class DailyLabyrinthRoutine extends DelayedTask {
     private boolean navigateToLabyrinthMenu() {
         logInfo("Navigating to the Labyrinth menu...");
 
-        // Open side menu
-        marchHelper.openLeftMenuCitySection(true);
-
-        // Scroll down to find labyrinth
-        swipe(SCROLL_START_POINT, SCROLL_END_POINT);
-        sleepTask(SCROLL_DELAY);
-
-        // Search for labyrinth in menu
-        ImageSearchResultData labyrinthResult = templateSearchHelper.locatePattern(
-                TemplatesEnum.LEFT_MENU_LABYRINTH_BUTTON,
-                SearchConfigConstants.DEFAULT_SINGLE);
-        if (labyrinthResult.isFound()) {
-            tapInside(labyrinthResult);
-            sleepTask(LABYRINTH_LOAD_DELAY);
+        if (navigationHelper.navigateToLabyrinth()) {
             logInfo("Successfully navigated to the Labyrinth menu.");
             return true;
-        } else {
-            logWarning("Labyrinth menu item not found.");
-            return false;
         }
+        logWarning("Labyrinth menu item not found.");
+        return false;
     }
 
     // =========================== CHALLENGE EXECUTION ===========================


### PR DESCRIPTION
## Summary

- add a **Game Data** module for collecting Alliance Power and Alliance Labyrinth rankings as manual one-shot bot tasks
- capture and decode MuMu game traffic, including true server ranks, all power values, the local player identity, and Labyrinth scores
- persist workspace-local snapshot history and a shared player-name cache, with JSON and Excel-compatible CSV exports
- centralize Labyrinth navigation and coordinate collection through the existing profile task queue

## Why

The ranking UI does not expose a reliable export and screen-based collection missed dynamically loaded rows. The game sends complete ranking data through its protocol, while player names arrive through separate profile and startup messages. Joining those messages by immutable player ID produces complete ranks and lets later runs improve names in older history.

Closes #213.

## Validation

- `./mvnw -q -pl modules/desktop -am test`
- `./mvnw -q -pl modules/automation -am -Dtest=GameAnalyticsExportServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- saved real-PCAP verification: decoded 99 ordered Power rows with zero missing power values; local player `200217707` resolved as `Dave` with power `29,452,901`
- live MuMu validation: both ranking tasks navigated and produced persistent snapshots in the development workspace

## Risks

- collection currently supports Windows with MuMu Player only and requires rooted ADB access for `tcpdump`
- protocol-field assumptions may require adjustment after a game protocol update
- player names can remain temporarily unavailable until observed by a Power/startup capture; the shared cache is intentionally refreshed by later runs