### PR TITLE
fix(desktop): integrate native Windows snapping

### DIFF
--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/FXApp.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/FXApp.java
@@ -2,6 +2,7 @@ package dev.frostguard.app.bootstrap;
 
 import atlantafx.base.theme.PrimerDark;
 import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.app.bootstrap.WindowBoundsPolicy.WindowBounds;
 import dev.frostguard.app.panel.launcher.ILauncherConstants;
 import dev.frostguard.app.panel.launcher.LauncherLayoutController;
 import dev.frostguard.app.panel.misc.GiftCodeAutomationService;
@@ -22,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.List;
 import java.util.Objects;
 import java.util.prefs.Preferences;
 
@@ -37,6 +39,7 @@ public class FXApp extends Application {
     private static final double MIN_VISIBLE_AREA = 100;
 
     private Preferences preferences;
+    private WindowBounds normalWindowBounds;
 
     public static void main(String[] args) {
         launch(args);
@@ -60,6 +63,8 @@ public class FXApp extends Application {
         stage.show();
         GiftCodeAutomationService.getInstance().start();
         restoreWindowBounds(stage);
+        trackNormalWindowBounds(stage);
+        WindowsWindowManager.install(stage).ifPresent(controller::enableNativeWindowing);
         maybeAutoStart(controller);
         stage.setOnCloseRequest(event -> shutdownFromUi(stage));
     }
@@ -99,16 +104,21 @@ public class FXApp extends Application {
         double x = preferences.getDouble(KEY_X, Double.NaN);
         double y = preferences.getDouble(KEY_Y, Double.NaN);
 
-        stage.setWidth(width);
-        stage.setHeight(height);
+        width = Double.isFinite(width) && width > 0 ? width : DEFAULT_W;
+        height = Double.isFinite(height) && height > 0 ? height : DEFAULT_H;
 
-        if (!Double.isNaN(x) && !Double.isNaN(y) && isWindowRecoverable(x, y, width, height)) {
-            stage.setX(x);
-            stage.setY(y);
+        WindowBounds saved = new WindowBounds(x, y, width, height);
+        List<Rectangle2D> screens = Screen.getScreens().stream().map(Screen::getVisualBounds).toList();
+        var recovered = WindowBoundsPolicy.recover(saved, screens, MIN_VISIBLE_AREA);
+        if (recovered.isPresent()) {
+            applyWindowBounds(stage, recovered.get());
+            persistWindowBounds(recovered.get());
             return;
         }
 
-        centerOnPrimaryScreen(stage, width, height);
+        stage.setWidth(Math.min(width, Screen.getPrimary().getVisualBounds().getWidth()));
+        stage.setHeight(Math.min(height, Screen.getPrimary().getVisualBounds().getHeight()));
+        centerOnPrimaryScreen(stage, stage.getWidth(), stage.getHeight());
     }
 
     private void maybeAutoStart(LauncherLayoutController controller) {
@@ -123,34 +133,47 @@ public class FXApp extends Application {
     }
 
     private void rememberWindowBounds(Stage stage) {
-        preferences.putDouble(KEY_X, stage.getX());
-        preferences.putDouble(KEY_Y, stage.getY());
-        preferences.putDouble(KEY_W, stage.getWidth());
-        preferences.putDouble(KEY_H, stage.getHeight());
+        captureNormalWindowBounds(stage);
+        if (normalWindowBounds != null) {
+            persistWindowBounds(normalWindowBounds);
+        }
     }
 
-    private boolean isWindowRecoverable(double x, double y, double width, double height) {
-        return Screen.getScreens().stream()
-            .map(Screen::getVisualBounds)
-            .anyMatch(bounds -> visibleArea(bounds, x, y, width, height) >= MIN_VISIBLE_AREA * MIN_VISIBLE_AREA);
+    private void trackNormalWindowBounds(Stage stage) {
+        captureNormalWindowBounds(stage);
+        stage.xProperty().addListener((observable, oldValue, newValue) -> captureNormalWindowBounds(stage));
+        stage.yProperty().addListener((observable, oldValue, newValue) -> captureNormalWindowBounds(stage));
+        stage.widthProperty().addListener((observable, oldValue, newValue) -> captureNormalWindowBounds(stage));
+        stage.heightProperty().addListener((observable, oldValue, newValue) -> captureNormalWindowBounds(stage));
     }
 
-    private double visibleArea(Rectangle2D bounds, double x, double y, double width, double height) {
-        double visibleLeft = Math.max(x, bounds.getMinX());
-        double visibleTop = Math.max(y, bounds.getMinY());
-        double visibleRight = Math.min(x + width, bounds.getMaxX());
-        double visibleBottom = Math.min(y + height, bounds.getMaxY());
-        double visibleWidth = Math.max(0, visibleRight - visibleLeft);
-        double visibleHeight = Math.max(0, visibleBottom - visibleTop);
-        return visibleWidth * visibleHeight;
+    private void captureNormalWindowBounds(Stage stage) {
+        if (!stage.isMaximized() && !stage.isIconified()) {
+            normalWindowBounds = new WindowBounds(
+                    stage.getX(), stage.getY(), stage.getWidth(), stage.getHeight());
+        }
+    }
+
+    private void applyWindowBounds(Stage stage, WindowBounds bounds) {
+        stage.setWidth(bounds.width());
+        stage.setHeight(bounds.height());
+        stage.setX(bounds.x());
+        stage.setY(bounds.y());
+    }
+
+    private void persistWindowBounds(WindowBounds bounds) {
+        preferences.putDouble(KEY_X, bounds.x());
+        preferences.putDouble(KEY_Y, bounds.y());
+        preferences.putDouble(KEY_W, bounds.width());
+        preferences.putDouble(KEY_H, bounds.height());
     }
 
     private void centerOnPrimaryScreen(Stage stage, double width, double height) {
         Rectangle2D bounds = Screen.getPrimary().getVisualBounds();
         double x = bounds.getMinX() + (bounds.getWidth() - width) / 2;
         double y = bounds.getMinY() + (bounds.getHeight() - height) / 2;
-        stage.setX(Math.max(bounds.getMinX(), Math.min(x, bounds.getMaxX() - width)));
-        stage.setY(Math.max(bounds.getMinY(), Math.min(y, bounds.getMaxY() - height)));
+        stage.setX(Math.max(bounds.getMinX(), Math.min(x, bounds.getMaxX() - stage.getWidth())));
+        stage.setY(Math.max(bounds.getMinY(), Math.min(y, bounds.getMaxY() - stage.getHeight())));
         logger.info("Window restored to the primary display");
     }
 

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/WindowBoundsPolicy.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/WindowBoundsPolicy.java
@@ -1,0 +1,55 @@
+package dev.frostguard.app.bootstrap;
+
+import javafx.geometry.Rectangle2D;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+final class WindowBoundsPolicy {
+
+    private WindowBoundsPolicy() {
+    }
+
+    static Optional<WindowBounds> recover(WindowBounds saved, List<Rectangle2D> screens,
+                                           double minimumVisibleSide) {
+        if (!saved.isValid() || screens.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<Rectangle2D> bestScreen = screens.stream()
+                .max(Comparator.comparingDouble(screen -> visibleArea(screen, saved)));
+        if (bestScreen.isEmpty()
+                || visibleArea(bestScreen.get(), saved) < minimumVisibleSide * minimumVisibleSide) {
+            return Optional.empty();
+        }
+
+        Rectangle2D screen = bestScreen.get();
+        double width = Math.min(saved.width(), screen.getWidth());
+        double height = Math.min(saved.height(), screen.getHeight());
+        double x = clamp(saved.x(), screen.getMinX(), screen.getMaxX() - width);
+        double y = clamp(saved.y(), screen.getMinY(), screen.getMaxY() - height);
+        return Optional.of(new WindowBounds(x, y, width, height));
+    }
+
+    private static double visibleArea(Rectangle2D screen, WindowBounds window) {
+        double visibleLeft = Math.max(window.x(), screen.getMinX());
+        double visibleTop = Math.max(window.y(), screen.getMinY());
+        double visibleRight = Math.min(window.x() + window.width(), screen.getMaxX());
+        double visibleBottom = Math.min(window.y() + window.height(), screen.getMaxY());
+        return Math.max(0, visibleRight - visibleLeft) * Math.max(0, visibleBottom - visibleTop);
+    }
+
+    private static double clamp(double value, double minimum, double maximum) {
+        return Math.max(minimum, Math.min(value, maximum));
+    }
+
+    record WindowBounds(double x, double y, double width, double height) {
+
+        boolean isValid() {
+            return Double.isFinite(x) && Double.isFinite(y)
+                    && Double.isFinite(width) && width > 0
+                    && Double.isFinite(height) && height > 0;
+        }
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/WindowsWindowManager.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/WindowsWindowManager.java
@@ -1,0 +1,288 @@
+package dev.frostguard.app.bootstrap;
+
+import com.sun.jna.CallbackReference;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.User32;
+import com.sun.jna.platform.win32.WinDef.HWND;
+import com.sun.jna.platform.win32.WinDef.LPARAM;
+import com.sun.jna.platform.win32.WinDef.LRESULT;
+import com.sun.jna.platform.win32.WinDef.POINT;
+import com.sun.jna.platform.win32.WinDef.RECT;
+import com.sun.jna.platform.win32.WinDef.WPARAM;
+import com.sun.jna.platform.win32.WinUser.HMONITOR;
+import com.sun.jna.platform.win32.WinUser.MONITORINFO;
+import com.sun.jna.platform.win32.WinUser.WindowProc;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.W32APIOptions;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Enables Windows' native move and snap handling without replacing Frostguard's custom title bar.
+ */
+public final class WindowsWindowManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(WindowsWindowManager.class);
+
+    private static final int GWL_STYLE = -16;
+    private static final int GWL_WNDPROC = -4;
+    private static final int WS_POPUP = 0x80000000;
+    private static final int WS_CAPTION = 0x00C00000;
+    private static final int WS_SYSMENU = 0x00080000;
+    private static final int WS_THICKFRAME = 0x00040000;
+    private static final int WS_MINIMIZEBOX = 0x00020000;
+    private static final int WS_MAXIMIZEBOX = 0x00010000;
+    private static final int REQUIRED_SNAP_STYLES = WS_CAPTION | WS_SYSMENU | WS_THICKFRAME
+            | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+
+    private static final int WM_NCCALCSIZE = 0x0083;
+    private static final int WM_NCHITTEST = 0x0084;
+    private static final int HTCLIENT = 1;
+    private static final int HTCAPTION = 2;
+    private static final int HTLEFT = 10;
+    private static final int HTBOTTOMRIGHT = 17;
+
+    private static final int CUSTOM_TITLE_BAR_HEIGHT = 32;
+    private static final int WINDOW_CONTROL_WIDTH = 46;
+    private static final int WINDOW_CONTROL_COUNT = 3;
+
+    private static final int SWP_NOSIZE = 0x0001;
+    private static final int SWP_NOMOVE = 0x0002;
+    private static final int SWP_NOZORDER = 0x0004;
+    private static final int SWP_NOACTIVATE = 0x0010;
+    private static final int SWP_FRAMECHANGED = 0x0020;
+    private static final int MONITOR_DEFAULTTONEAREST = 2;
+
+    private final HWND window;
+    private final int originalStyle;
+    private final Pointer originalWindowProcedure;
+    // JNA callbacks must remain strongly reachable for as long as native code can invoke them.
+    private final WindowProc borderlessWindowProcedure;
+    private boolean installed = true;
+
+    private WindowsWindowManager(HWND window, int originalStyle, Pointer originalWindowProcedure,
+                                 WindowProc borderlessWindowProcedure) {
+        this.window = window;
+        this.originalStyle = originalStyle;
+        this.originalWindowProcedure = originalWindowProcedure;
+        this.borderlessWindowProcedure = borderlessWindowProcedure;
+    }
+
+    public static Optional<WindowsWindowManager> install(Stage stage) {
+        if (!isWindows(System.getProperty("os.name"))) {
+            return Optional.empty();
+        }
+
+        try {
+            HWND window = findCurrentProcessWindow(stage.getTitle());
+            if (window == null) {
+                logger.warn("Native Windows snapping unavailable: launcher window handle was not found");
+                return Optional.empty();
+            }
+
+            int currentStyle = User32.INSTANCE.GetWindowLong(window, GWL_STYLE);
+            int snapStyle = enableSnapStyles(currentStyle);
+            Pointer originalProcedure = User32.INSTANCE.GetWindowLongPtr(window, GWL_WNDPROC).toPointer();
+            BorderlessWindowProcedure borderlessProcedure =
+                    new BorderlessWindowProcedure(originalProcedure);
+            Native.setLastError(0);
+            Pointer replacedProcedure = User32.INSTANCE.SetWindowLongPtr(window, GWL_WNDPROC,
+                    CallbackReference.getFunctionPointer(borderlessProcedure));
+            int procedureError = Native.getLastError();
+            if (replacedProcedure == null && procedureError != 0) {
+                logger.warn("Native Windows snapping unavailable: failed to install window procedure ({})",
+                        procedureError);
+                return Optional.empty();
+            }
+
+            WindowsWindowManager manager = new WindowsWindowManager(window, currentStyle,
+                    originalProcedure, borderlessProcedure);
+            if (snapStyle != currentStyle) {
+                Native.setLastError(0);
+                int previousStyle = User32.INSTANCE.SetWindowLong(window, GWL_STYLE, snapStyle);
+                int error = Native.getLastError();
+                if (previousStyle == 0 && error != 0) {
+                    logger.warn("Native Windows snapping unavailable: failed to update window style ({})", error);
+                    manager.uninstall();
+                    return Optional.empty();
+                }
+                boolean refreshed = User32.INSTANCE.SetWindowPos(window, null, 0, 0, 0, 0,
+                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+                if (!refreshed) {
+                    logger.warn("Native Windows snapping unavailable: failed to refresh the window frame ({})",
+                            Native.getLastError());
+                    manager.uninstall();
+                    return Optional.empty();
+                }
+            }
+
+            stage.addEventHandler(WindowEvent.WINDOW_HIDDEN, event -> manager.uninstall());
+            logger.info("Native Windows move and snap handling enabled");
+            return Optional.of(manager);
+        } catch (Throwable error) {
+            logger.warn("Native Windows snapping unavailable; using JavaFX window handling", error);
+            return Optional.empty();
+        }
+    }
+
+    private void uninstall() {
+        if (!installed) {
+            return;
+        }
+        installed = false;
+        if (!User32.INSTANCE.IsWindow(window)) {
+            return;
+        }
+
+        User32.INSTANCE.SetWindowLongPtr(window, GWL_WNDPROC, originalWindowProcedure);
+        User32.INSTANCE.SetWindowLong(window, GWL_STYLE, originalStyle);
+        User32.INSTANCE.SetWindowPos(window, null, 0, 0, 0, 0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+    }
+
+    static boolean isWindows(String osName) {
+        return osName != null && osName.toLowerCase(Locale.ROOT).contains("win");
+    }
+
+    static int enableSnapStyles(int currentStyle) {
+        return (currentStyle & ~WS_POPUP) | REQUIRED_SNAP_STYLES;
+    }
+
+    static boolean hasSnapStyles(int style) {
+        return (style & REQUIRED_SNAP_STYLES) == REQUIRED_SNAP_STYLES && (style & WS_POPUP) == 0;
+    }
+
+    static boolean isCaptionHit(int screenX, int screenY, RECT windowBounds) {
+        return isTitleBarHit(screenX, screenY, windowBounds)
+                && !isWindowControlsHit(screenX, windowBounds);
+    }
+
+    static boolean isTitleBarHit(int screenX, int screenY, RECT windowBounds) {
+        int titleBarBottom = windowBounds.top + CUSTOM_TITLE_BAR_HEIGHT;
+        return screenX >= windowBounds.left && screenX < windowBounds.right
+                && screenY >= windowBounds.top && screenY < titleBarBottom;
+    }
+
+    private static boolean isWindowControlsHit(int screenX, RECT windowBounds) {
+        int controlsLeft = windowBounds.right - WINDOW_CONTROL_WIDTH * WINDOW_CONTROL_COUNT;
+        return screenX >= controlsLeft;
+    }
+
+    static boolean isResizeHit(int hitTestResult) {
+        return hitTestResult >= HTLEFT && hitTestResult <= HTBOTTOMRIGHT;
+    }
+
+    private static HWND findCurrentProcessWindow(String title) {
+        int processId = Kernel32.INSTANCE.GetCurrentProcessId();
+        AtomicReference<HWND> match = new AtomicReference<>();
+
+        User32.INSTANCE.EnumWindows((candidate, data) -> {
+            IntByReference candidateProcessId = new IntByReference();
+            User32.INSTANCE.GetWindowThreadProcessId(candidate, candidateProcessId);
+            if (candidateProcessId.getValue() != processId || !User32.INSTANCE.IsWindowVisible(candidate)) {
+                return true;
+            }
+
+            int titleLength = User32.INSTANCE.GetWindowTextLength(candidate);
+            char[] titleBuffer = new char[titleLength + 1];
+            User32.INSTANCE.GetWindowText(candidate, titleBuffer, titleBuffer.length);
+            if (title.equals(Native.toString(titleBuffer))) {
+                match.set(candidate);
+                return false;
+            }
+            return true;
+        }, Pointer.NULL);
+        return match.get();
+    }
+
+    private interface User32Extensions extends StdCallLibrary {
+        User32Extensions INSTANCE = Native.load("user32", User32Extensions.class, W32APIOptions.DEFAULT_OPTIONS);
+
+        boolean IsZoomed(HWND hwnd);
+
+        boolean ClientToScreen(HWND hwnd, POINT point);
+    }
+
+    private static final class BorderlessWindowProcedure implements WindowProc {
+
+        private final Pointer originalProcedure;
+
+        private BorderlessWindowProcedure(Pointer originalProcedure) {
+            this.originalProcedure = originalProcedure;
+        }
+
+        @Override
+        public LRESULT callback(HWND hwnd, int message, WPARAM wParam, LPARAM lParam) {
+            if (message == WM_NCCALCSIZE) {
+                constrainMaximizedClientArea(hwnd, lParam);
+                return new LRESULT(0);
+            }
+            if (message == WM_NCHITTEST) {
+                LRESULT defaultHit = User32.INSTANCE.CallWindowProc(
+                        originalProcedure, hwnd, message, wParam, lParam);
+                if (isResizeHit(defaultHit.intValue())) {
+                    return defaultHit;
+                }
+
+                int packedPoint = lParam.intValue();
+                int screenX = (short) (packedPoint & 0xFFFF);
+                int screenY = (short) ((packedPoint >>> 16) & 0xFFFF);
+                RECT clientBounds = getClientBoundsOnScreen(hwnd);
+                if (clientBounds != null) {
+                    if (isCaptionHit(screenX, screenY, clientBounds)) {
+                        return new LRESULT(HTCAPTION);
+                    }
+                    if (isTitleBarHit(screenX, screenY, clientBounds)) {
+                        return new LRESULT(HTCLIENT);
+                    }
+                }
+                return defaultHit;
+            }
+            return User32.INSTANCE.CallWindowProc(originalProcedure, hwnd, message, wParam, lParam);
+        }
+
+        private void constrainMaximizedClientArea(HWND hwnd, LPARAM lParam) {
+            if (lParam.longValue() == 0 || !User32Extensions.INSTANCE.IsZoomed(hwnd)) {
+                return;
+            }
+
+            RECT clientBounds = Structure.newInstance(RECT.class, new Pointer(lParam.longValue()));
+            clientBounds.read();
+            HMONITOR monitor = User32.INSTANCE.MonitorFromRect(clientBounds, MONITOR_DEFAULTTONEAREST);
+            MONITORINFO monitorInfo = new MONITORINFO();
+            if (monitor == null || !User32.INSTANCE.GetMonitorInfo(monitor, monitorInfo).booleanValue()) {
+                return;
+            }
+
+            clientBounds.left = monitorInfo.rcWork.left;
+            clientBounds.top = monitorInfo.rcWork.top;
+            clientBounds.right = monitorInfo.rcWork.right;
+            clientBounds.bottom = monitorInfo.rcWork.bottom;
+            clientBounds.write();
+        }
+
+        private RECT getClientBoundsOnScreen(HWND hwnd) {
+            RECT clientBounds = new RECT();
+            POINT clientOrigin = new POINT();
+            if (!User32.INSTANCE.GetClientRect(hwnd, clientBounds)
+                    || !User32Extensions.INSTANCE.ClientToScreen(hwnd, clientOrigin)) {
+                return null;
+            }
+            clientBounds.right += clientOrigin.x;
+            clientBounds.bottom += clientOrigin.y;
+            clientBounds.left = clientOrigin.x;
+            clientBounds.top = clientOrigin.y;
+            return clientBounds;
+        }
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
@@ -86,6 +86,7 @@ import javafx.util.Duration;
 import dev.frostguard.app.panel.alliance.AllianceShopController;
 import dev.frostguard.app.panel.misc.TelegramLayoutController;
 import dev.frostguard.app.bootstrap.ApplicationLifecycle;
+import dev.frostguard.app.bootstrap.WindowsWindowManager;
 import dev.frostguard.app.panel.update.UpdateLayoutController;
 import dev.frostguard.engine.service.TelegramBotService;
 import org.kordamp.ikonli.javafx.FontIcon;
@@ -148,6 +149,7 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
 
     private double xOffset = 0;
     private double yOffset = 0;
+    private WindowsWindowManager windowsWindowManager;
     // Window snap state tracking
     private boolean isCustomMaximized = false;
     private double restoreX, restoreY, restoreW, restoreH;
@@ -237,6 +239,12 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
         initializeQuickNav();
         initializeSearch();
         setupSocialIcons();
+        stage.maximizedProperty().addListener((observable, oldValue, maximized) -> updateMaximizeButton(maximized));
+        updateMaximizeButton(stage.isMaximized());
+    }
+
+    public void enableNativeWindowing(WindowsWindowManager windowManager) {
+        this.windowsWindowManager = Objects.requireNonNull(windowManager);
     }
 
     private void initializeUptime() { /* internal */
@@ -852,11 +860,16 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
 
     @FXML
     private void handleTitleBarMouseDragged(javafx.scene.input.MouseEvent event) { /* internal */
+        if (windowsWindowManager != null) {
+            return;
+        }
+
         // If currently maximized/snapped, un-snap first, then start dragging
         if (isCustomMaximized) {
             double oldW = stage.getWidth();
             isCustomMaximized = false;
             btnMaximize.setText("☐");
+            stage.setMaximized(false);
             // Reposition so the cursor stays proportionally in the restored window
             double ratio = xOffset / oldW;
             stage.setWidth(restoreW);
@@ -902,6 +915,8 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
 
     @FXML
     private void handleTitleBarMouseReleased(javafx.scene.input.MouseEvent event) { /* internal */
+        if (windowsWindowManager != null) return;
+
         hideSnapPreview();
         if (isCustomMaximized) return; // already snapped, don't re-snap
         double screenX = event.getScreenX();
@@ -978,19 +993,26 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
 
     @FXML
     private void handleTitleBarMouseClicked(javafx.scene.input.MouseEvent event) { /* internal */
-        if (event.getClickCount() == 2) {
+        if (event.getClickCount() == 2 && !isWindowControl(event.getTarget())) {
             handleMaximize(null);
         }
     }
 
+    private boolean isWindowControl(Object target) {
+        Node node = target instanceof Node ? (Node) target : null;
+        while (node != null && node != titleBar) {
+            if (node instanceof ButtonBase) {
+                return true;
+            }
+            node = node.getParent();
+        }
+        return false;
+    }
+
     /** Snap window to fill the entire visual bounds (respects taskbar). */
     private void snapToFull(javafx.geometry.Rectangle2D bounds) { /* internal */
-        stage.setX(bounds.getMinX());
-        stage.setY(bounds.getMinY());
-        stage.setWidth(bounds.getWidth());
-        stage.setHeight(bounds.getHeight());
+        stage.setMaximized(true);
         isCustomMaximized = true;
-        btnMaximize.setText("❐");
     }
 
     /** Snap window to fill the left half of the screen. */
@@ -1073,9 +1095,15 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
 
     @FXML
     private void handleMaximize(ActionEvent event) { /* internal */
+        if (windowsWindowManager != null) {
+            stage.setMaximized(!stage.isMaximized());
+            return;
+        }
+
         if (isCustomMaximized) {
             // Restore from snap/maximize
             isCustomMaximized = false;
+            stage.setMaximized(false);
             stage.setX(restoreX);
             stage.setY(restoreY);
             stage.setWidth(restoreW);
@@ -1092,6 +1120,12 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
                 stage.getY() + stage.getHeight() / 2
             );
             snapToFull(bounds);
+        }
+    }
+
+    private void updateMaximizeButton(boolean maximized) {
+        if (btnMaximize != null) {
+            btnMaximize.setText(maximized ? "❐" : "☐");
         }
     }
 

--- a/modules/desktop/src/main/resources/styles/style.css
+++ b/modules/desktop/src/main/resources/styles/style.css
@@ -213,7 +213,6 @@
     -fx-spacing: 16;
     -fx-alignment: CENTER_LEFT;
     -fx-min-height: 48;
-    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.4), 10, 0, 0, -2);
 }
 
 /* Base button defaults */

--- a/modules/desktop/src/test/java/dev/frostguard/app/bootstrap/WindowBoundsPolicyTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/bootstrap/WindowBoundsPolicyTest.java
@@ -1,0 +1,43 @@
+package dev.frostguard.app.bootstrap;
+
+import dev.frostguard.app.bootstrap.WindowBoundsPolicy.WindowBounds;
+import javafx.geometry.Rectangle2D;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WindowBoundsPolicyTest {
+
+    @Test
+    void clampsOversizedSavedBoundsToTheMonitorWorkArea() {
+        WindowBounds saved = new WindowBounds(-7, -7, 2575, 1407);
+
+        WindowBounds recovered = WindowBoundsPolicy.recover(saved,
+                List.of(new Rectangle2D(0, 0, 2560, 1392)), 100).orElseThrow();
+
+        assertEquals(new WindowBounds(0, 0, 2560, 1392), recovered);
+    }
+
+    @Test
+    void preservesBoundsOnTheBestMatchingSecondaryMonitor() {
+        WindowBounds saved = new WindowBounds(-1800, 700, 960, 560);
+        List<Rectangle2D> screens = List.of(
+                new Rectangle2D(0, 0, 2560, 1392),
+                new Rectangle2D(-1920, 550, 1920, 1032));
+
+        WindowBounds recovered = WindowBoundsPolicy.recover(saved, screens, 100).orElseThrow();
+
+        assertEquals(saved, recovered);
+    }
+
+    @Test
+    void rejectsBoundsThatAreNoLongerRecoverableAfterTopologyChange() {
+        WindowBounds disconnected = new WindowBounds(3840, 537, 960, 560);
+
+        assertTrue(WindowBoundsPolicy.recover(disconnected,
+                List.of(new Rectangle2D(0, 0, 2560, 1392)), 100).isEmpty());
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/bootstrap/WindowsWindowManagerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/bootstrap/WindowsWindowManagerTest.java
@@ -1,0 +1,71 @@
+package dev.frostguard.app.bootstrap;
+
+import com.sun.jna.platform.win32.WinDef.RECT;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WindowsWindowManagerTest {
+
+    @Test
+    void enablesSnapStylesAndRemovesPopupWindowMode() {
+        int originalStyle = 0x80000000 | 0x10000000;
+
+        int nativeStyle = WindowsWindowManager.enableSnapStyles(originalStyle);
+
+        assertTrue(WindowsWindowManager.hasSnapStyles(nativeStyle));
+        assertTrue((nativeStyle & 0x10000000) != 0, "unrelated window styles should be preserved");
+    }
+
+    @Test
+    void rejectsIncompleteNativeSnapStyle() {
+        assertFalse(WindowsWindowManager.hasSnapStyles(0));
+        assertFalse(WindowsWindowManager.hasSnapStyles(0x80000000));
+    }
+
+    @Test
+    void detectsWindowsWithoutDependingOnPropertyCapitalization() {
+        assertTrue(WindowsWindowManager.isWindows("Windows 11"));
+        assertTrue(WindowsWindowManager.isWindows("WINDOWS"));
+        assertFalse(WindowsWindowManager.isWindows("Linux"));
+        assertFalse(WindowsWindowManager.isWindows(null));
+    }
+
+    @Test
+    void mapsOnlyFreeTitleBarSpaceToNativeCaption() {
+        RECT bounds = rectangle(-1920, 0, 0, 1200);
+
+        assertTrue(WindowsWindowManager.isCaptionHit(-1800, 16, bounds));
+        assertFalse(WindowsWindowManager.isCaptionHit(-20, 16, bounds),
+                "window controls must remain clickable JavaFX client content");
+        assertTrue(WindowsWindowManager.isTitleBarHit(-20, 16, bounds));
+        assertFalse(WindowsWindowManager.isCaptionHit(-1800, 40, bounds));
+    }
+
+    @Test
+    void usesJavaFxLogicalCoordinatesAcrossMonitorOrigins() {
+        RECT bounds = rectangle(100, 200, 2020, 1400);
+
+        assertTrue(WindowsWindowManager.isCaptionHit(500, 231, bounds));
+        assertFalse(WindowsWindowManager.isCaptionHit(1900, 220, bounds));
+        assertFalse(WindowsWindowManager.isCaptionHit(500, 232, bounds));
+    }
+
+    @Test
+    void preservesNativeResizeHitTestResults() {
+        assertTrue(WindowsWindowManager.isResizeHit(10));
+        assertTrue(WindowsWindowManager.isResizeHit(17));
+        assertFalse(WindowsWindowManager.isResizeHit(2));
+        assertFalse(WindowsWindowManager.isResizeHit(9));
+    }
+
+    private RECT rectangle(int left, int top, int right, int bottom) {
+        RECT rectangle = new RECT();
+        rectangle.left = left;
+        rectangle.top = top;
+        rectangle.right = right;
+        rectangle.bottom = bottom;
+        return rectangle;
+    }
+}


### PR DESCRIPTION
## Summary

- enable native Windows snap layouts, edge snapping, maximize/restore, and Win+Arrow handling while retaining Frostguard's custom title bar
- keep maximized client bounds inside each monitor's work area and recover persisted bounds after monitor-topology changes
- restore pointer input for the Config horizontal scrollbar by removing the status-bar shadow that overlapped its pick area

## Why

The undecorated JavaFX stage did not expose the native Windows frame behavior required for snap layouts. Persisted or maximized bounds also needed to remain safe around taskbars and changed monitor layouts. During live verification, the Config scrollbar exposed a pre-existing JavaFX picking issue: the footer's outer shadow expanded over the scrollbar and intercepted its mouse input.

Closes #196.

## Validation

- `mvnw.cmd package` — 471 tests passed; desktop bundle built
- `mvnw.cmd -pl modules/desktop -am test` after the scrollbar follow-up — 471 tests passed, 0 failures/errors/skips
- live three-monitor Windows probe — custom maximize/restore, top snap, cross-monitor snap, drag-from-maximized restore, and Win+Arrow passed; snapped/maximized clients matched monitor work areas
- DPI-corrected live-window input probe — the Config scrollbar thumb did not move before the footer fix and moved to the opposite edge with the same drag afterward

## Risks

- Native input behavior is Windows-specific and cannot be fully covered by unit tests; the live probe covered the available three-monitor, mixed-position desktop.
- Visual taskbar flicker during repeated snap transitions still benefits from human observation during normal use.
