### PR TITLE
fix(mail): stop retrying persistent unread reports

### DIFF
--- a/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/MailClaimPassPolicy.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/MailClaimPassPolicy.java
@@ -1,0 +1,78 @@
+package dev.frostguard.tasks.dailies;
+
+import dev.frostguard.api.domain.ImageSearchResultData;
+import dev.frostguard.api.domain.PointData;
+import java.util.Comparator;
+import java.util.List;
+
+final class MailClaimPassPolicy {
+
+    private static final int MARKER_POSITION_TOLERANCE_PIXELS = 4;
+
+    private MailClaimPassPolicy() {
+    }
+
+    static Decision decide(Evidence before, Evidence after, int completedPasses, int maxPasses) {
+        if (after.isEmpty()) {
+            return Decision.COMPLETE;
+        }
+        if (before.isEmpty() || before.sameVisualStateAs(after)) {
+            return Decision.STOP_NO_PROGRESS;
+        }
+        if (completedPasses >= maxPasses) {
+            return Decision.STOP_BUDGET_EXHAUSTED;
+        }
+        return Decision.RETRY_AFTER_PROGRESS;
+    }
+
+    enum Decision {
+        COMPLETE,
+        RETRY_AFTER_PROGRESS,
+        STOP_NO_PROGRESS,
+        STOP_BUDGET_EXHAUSTED
+    }
+
+    record Evidence(List<PointData> markers) {
+
+        Evidence {
+            markers = markers == null
+                    ? List.of()
+                    : markers.stream()
+                            .sorted(Comparator.comparingInt(PointData::getY).thenComparingInt(PointData::getX))
+                            .toList();
+        }
+
+        static Evidence fromMatches(List<ImageSearchResultData> matches) {
+            if (matches == null) {
+                return new Evidence(List.of());
+            }
+            return new Evidence(matches.stream()
+                    .filter(ImageSearchResultData::isFound)
+                    .map(ImageSearchResultData::getPoint)
+                    .toList());
+        }
+
+        boolean isEmpty() {
+            return markers.isEmpty();
+        }
+
+        int count() {
+            return markers.size();
+        }
+
+        boolean sameVisualStateAs(Evidence other) {
+            if (other == null || markers.size() != other.markers.size()) {
+                return false;
+            }
+            for (int i = 0; i < markers.size(); i++) {
+                PointData left = markers.get(i);
+                PointData right = other.markers.get(i);
+                if (Math.abs(left.getX() - right.getX()) > MARKER_POSITION_TOLERANCE_PIXELS
+                        || Math.abs(left.getY() - right.getY()) > MARKER_POSITION_TOLERANCE_PIXELS) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/MailRewardsRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/MailRewardsRoutine.java
@@ -13,18 +13,20 @@ import dev.frostguard.engine.schedule.LaunchPoint;
 import dev.frostguard.engine.service.StatisticsService;
 import dev.frostguard.vision.convert.GameTimeUtils;
 import java.time.LocalDateTime;
+import java.util.List;
+
+import static dev.frostguard.tasks.dailies.MailClaimPassPolicy.Decision;
+import static dev.frostguard.tasks.dailies.MailClaimPassPolicy.Evidence;
 
 public class MailRewardsRoutine extends DelayedTask {
 
-private static final int MAX_MAIL_SEARCH_ATTEMPTS_LIMIT = 100;
+private static final int MAX_MAIL_CLAIM_PASSES = 3;
 
 private static final int MAIL_MENU_SEARCH_RETRIES_VALUE = 5;
 
 private static final int MAIL_MENU_OPEN_VERIFICATION_RETRIES_VALUE = 5;
 
 private static final int UNCLAIMED_REWARDS_SEARCH_RETRIES_VALUE = 3;
-
-private static final int SWIPES_PER_PAGE_VALUE = 10;
 
 private static final int MAIL_TAB_COUNT_VALUE = 3;
 
@@ -41,6 +43,10 @@ private static final PointData MAIL_MENU_OPEN_TOP_LEFT_VALUE = new PointData(75,
 
 private static final PointData MAIL_MENU_OPEN_BOTTOM_RIGHT_VALUE = new PointData(175, 60);
 
+private static final PointData MAIL_LIST_INDICATORS_TOP_LEFT_VALUE = new PointData(625, 175);
+
+private static final PointData MAIL_LIST_INDICATORS_BOTTOM_RIGHT_VALUE = new PointData(715, 1160);
+
 private static final PointData CLAIM_BUTTON_TOP_LEFT_VALUE = new PointData(420, 1227);
 
 private static final PointData CLAIM_BUTTON_BOTTOM_RIGHT_VALUE = new PointData(450, 1250);
@@ -48,10 +54,6 @@ private static final PointData CLAIM_BUTTON_BOTTOM_RIGHT_VALUE = new PointData(4
 private static final int CLAIM_BUTTON_TAP_COUNT_VALUE = 4;
 
 private static final int CLAIM_BUTTON_TAP_DELAY_MS = 500;
-
-private static final PointData SCROLL_START_POINT_VALUE = new PointData(40, 913);
-
-private static final PointData SCROLL_END_POINT_VALUE = new PointData(40, 400);
 
 private static final PointData TAB_ALLIANCE_VALUE = new PointData(230, 120);
 
@@ -118,54 +120,57 @@ private void redeemAllVisibleRewards() {
                 CLAIM_BUTTON_TAP_COUNT_VALUE,
                 CLAIM_BUTTON_TAP_DELAY_MS);
         sleepTask(500);
-
-        StatisticsService.obtain().addToCounter(profile, "Mail Rewards Claimed", 1);
     }
 
-private boolean hasUnclaimedRewardsFlow() {
-        ImageSearchResultData unclaimedRewards = templateSearchHelper.locatePattern(
+private Evidence findUnreadMailEvidence() {
+        List<ImageSearchResultData> unreadMarkers = templateSearchHelper.locateAllPatterns(
                 TemplatesEnum.MAIL_UNCLAIMED_REWARDS,
                 SearchConfig.builder()
+                        .withArea(new AreaData(
+                                MAIL_LIST_INDICATORS_TOP_LEFT_VALUE,
+                                MAIL_LIST_INDICATORS_BOTTOM_RIGHT_VALUE))
                         .withMaxAttempts(UNCLAIMED_REWARDS_SEARCH_RETRIES_VALUE)
                         .withDelay(100L)
+                        .withMaxResults(20)
                         .build());
 
-        return unclaimedRewards.isFound();
+        return Evidence.fromMatches(unreadMarkers);
     }
 
-private void scrollDownMailListFlow() {
-        for (int i = 0; i < SWIPES_PER_PAGE_VALUE; i++) {
-
-
-            swipe(SCROLL_START_POINT_VALUE, SCROLL_END_POINT_VALUE);
-            sleepTask(250);
-
-        }
-    }
-
-private void handleOverflowRewards() {
-        int searchAttempts = 0;
-
-        while (hasUnclaimedRewardsFlow()) {
-            if (searchAttempts > 0) {
-                logInfo(routineLogMailRewardsLine("Overflow rewards detected. Scrolling to reveal more mail."));
-                scrollDownMailListFlow();
-            }
-
+private void claimMailRewards(String tabName) {
+        Evidence before = findUnreadMailEvidence();
+        for (int completedPasses = 1; completedPasses <= MAX_MAIL_CLAIM_PASSES; completedPasses++) {
             redeemAllVisibleRewards();
+            Evidence after = findUnreadMailEvidence();
+            Decision decision = MailClaimPassPolicy.decide(
+                    before, after, completedPasses, MAX_MAIL_CLAIM_PASSES);
 
-            searchAttempts++;
-            if (searchAttempts >= MAX_MAIL_SEARCH_ATTEMPTS_LIMIT) {
-                logError(routineLogMailRewardsLine("There is absolutely no way this condition should ever be hit in a normal scenario. " +
-                        "Something is broken. Either you have not checked your mail in DAYS, " +
-                        "or we are stuck somewhere you shouldn't be. " +
-                        "Please report to the devs which menu this was stuck on if you see this message."));
-                break;
+            if (!before.isEmpty() && !before.sameVisualStateAs(after)) {
+                StatisticsService.obtain().addToCounter(profile, "Mail Rewards Claimed", 1);
             }
-        }
 
-        if (searchAttempts > 0) {
-            logDebug(routineLogMailRewardsLine("Processed " + searchAttempts + " overflow reward cycle(s)."));
+            if (decision == Decision.COMPLETE) {
+                logDebug(routineLogMailRewardsLine(tabName + " tab claim pass completed; unread markers "
+                        + before.count() + " -> 0."));
+                return;
+            }
+            if (decision == Decision.STOP_NO_PROGRESS) {
+                logWarning(routineLogMailRewardsLine(tabName + " tab still has " + after.count()
+                        + " unread marker(s) after claim pass " + completedPasses
+                        + "; no claim progress detected, continuing with the next tab."));
+                return;
+            }
+            if (decision == Decision.STOP_BUDGET_EXHAUSTED) {
+                logWarning(routineLogMailRewardsLine(tabName + " tab still has " + after.count()
+                        + " unread marker(s) after the bounded " + MAX_MAIL_CLAIM_PASSES
+                        + " claim passes; continuing with the next tab."));
+                return;
+            }
+
+            logInfo(routineLogMailRewardsLine(tabName + " tab claim progress detected; unread markers "
+                    + before.count() + " -> " + after.count() + ", retrying within pass budget "
+                    + completedPasses + "/" + MAX_MAIL_CLAIM_PASSES + "."));
+            before = after;
         }
     }
 
@@ -203,7 +208,7 @@ private void handleAllMailTabs() {
             String tabName = MAIL_TAB_NAMES[i];
 
             logInfo(routineLogMailRewardsLine("Processing " + tabName + " tab."));
-            handleMailTab(tabButton);
+            handleMailTab(tabButton, tabName);
         }
     }
 
@@ -243,14 +248,9 @@ private boolean openUpMailMenu() {
         return confirmMailMenuOpened();
     }
 
-private void handleMailTab(PointData tabButton) {
+private void handleMailTab(PointData tabButton, String tabName) {
         switchToTabFlow(tabButton);
-
-
-        redeemAllVisibleRewards();
-
-
-        handleOverflowRewards();
+        claimMailRewards(tabName);
     }
 
 private void queueNextRun() {

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/dailies/MailClaimPassPolicyTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/dailies/MailClaimPassPolicyTest.java
@@ -1,0 +1,63 @@
+package dev.frostguard.tasks.dailies;
+
+import dev.frostguard.api.domain.PointData;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static dev.frostguard.tasks.dailies.MailClaimPassPolicy.Decision;
+import static dev.frostguard.tasks.dailies.MailClaimPassPolicy.Evidence;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MailClaimPassPolicyTest {
+
+    @Test
+    void stopsAfterPersistentUnreadReportMakesNoProgress() {
+        Evidence before = evidence(point(685, 250));
+        Evidence after = evidence(point(686, 248));
+
+        assertEquals(Decision.STOP_NO_PROGRESS, MailClaimPassPolicy.decide(before, after, 1, 3));
+    }
+
+    @Test
+    void completesWhenUnreadIndicatorsDisappear() {
+        Evidence before = evidence(point(685, 250), point(685, 395));
+
+        assertEquals(Decision.COMPLETE, MailClaimPassPolicy.decide(before, evidence(), 1, 3));
+    }
+
+    @Test
+    void completesWhenNoUnreadIndicatorsWerePresent() {
+        assertEquals(Decision.COMPLETE, MailClaimPassPolicy.decide(evidence(), evidence(), 1, 3));
+    }
+
+    @Test
+    void retriesWhenClaimingChangesVisibleUnreadEvidence() {
+        Evidence before = evidence(point(685, 250), point(685, 395));
+        Evidence after = evidence(point(685, 395));
+
+        assertEquals(Decision.RETRY_AFTER_PROGRESS, MailClaimPassPolicy.decide(before, after, 1, 3));
+    }
+
+    @Test
+    void stopsAtHardPassBudgetEvenWhileEvidenceChanges() {
+        Evidence before = evidence(point(685, 250), point(685, 395));
+        Evidence after = evidence(point(685, 395));
+
+        assertEquals(Decision.STOP_BUDGET_EXHAUSTED, MailClaimPassPolicy.decide(before, after, 3, 3));
+    }
+
+    @Test
+    void stopsWhenUnreadEvidenceAppearsWithoutPriorClaimEvidence() {
+        assertEquals(
+                Decision.STOP_NO_PROGRESS,
+                MailClaimPassPolicy.decide(evidence(), evidence(point(685, 250)), 1, 3));
+    }
+
+    private static Evidence evidence(PointData... points) {
+        return new Evidence(List.of(points));
+    }
+
+    private static PointData point(int x, int y) {
+        return new PointData(x, y);
+    }
+}


### PR DESCRIPTION
## Summary

- scope unread-marker detection to visible mail rows instead of the full mail screen
- stop retrying a tab as soon as unread evidence remains unchanged
- retain a three-pass hard limit while claim progress is still visible
- count only claim passes that visibly change unread evidence
- add policy tests for persistent, cleared, absent, changing, unexpected, and exhausted-budget states

## Why

`MAIL_UNCLAIMED_REWARDS` represents a generic red unread marker, not proof of a claimable reward. System notices, surveys, and Chief Concierge messages can remain unread after `Read & Claim All`, so the previous loop retried up to 100 times and blocked the account queue for several minutes.

Closes #224.

## Validation

- `mvnw.cmd -pl modules/tasks -am test`: 337 tests passed, 0 failures, 0 errors, 0 skipped; rerun after rebasing onto current `main`
- live account-log confirmation on `lil Dave Farm`, MuMu slot 1:
  - Alliance changed from 7 unread markers to 0
  - System changed from 7 to 2, then remained at 2; the routine logged no progress and continued immediately
  - Reports changed from 1 to 0
  - Mail Rewards completed, rescheduled, and the queue started the next task
- the reporter-provided real frame confirms the affected System notices use the generic unread marker; no saved-frame fixture was committed

## Risks

- Marker comparison permits four pixels of positional jitter. Larger UI movement may consume another pass, but the independent three-pass budget still prevents a loop.
- A legitimate reward state that makes no visible marker progress is deferred to the next scheduled run rather than blocking the queue.
