### PR TITLE
fix(release): verify publication before promotion

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -455,6 +455,8 @@ jobs:
         env:
           TAG: ${{ steps.identity.outputs.tag }}
           MANIFEST: ${{ steps.manifest.outputs.path }}
+          MANIFEST_NAME: ${{ steps.identity.outputs.manifest_name }}
+          INSTALLER_NAME: ${{ steps.identity.outputs.installer_name }}
         run: |
           gh release upload $env:TAG $env:MANIFEST --repo $env:GITHUB_REPOSITORY
           if ($LASTEXITCODE -ne 0) {
@@ -465,11 +467,65 @@ jobs:
               if ($LASTEXITCODE -ne 0) {
                   throw "Stable release could not be published"
               }
+              $publishedRelease = $null
+              for ($attempt = 1; $attempt -le 6; $attempt++) {
+                  $publishedJson = gh api `
+                      "repos/$($env:GITHUB_REPOSITORY)/releases/tags/$($env:TAG)" `
+                      2>$null
+                  if ($LASTEXITCODE -eq 0) {
+                      $candidate = $publishedJson | ConvertFrom-Json
+                      $manifestAssets = @($candidate.assets |
+                          Where-Object { $_.name -ceq $env:MANIFEST_NAME })
+                      $installerAssets = @($candidate.assets |
+                          Where-Object { $_.name -ceq $env:INSTALLER_NAME })
+                      if (-not $candidate.draft -and -not $candidate.prerelease -and
+                          $manifestAssets.Count -eq 1 -and
+                          $installerAssets.Count -eq 1) {
+                          $publishedRelease = $candidate
+                          break
+                      }
+                  }
+                  if ($attempt -lt 6) {
+                      Start-Sleep -Seconds 5
+                  }
+              }
+              if ($null -eq $publishedRelease) {
+                  throw "Stable immutable release did not become publicly visible"
+              }
+              "immutable_published=true" | Out-File `
+                  -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           } else {
               gh release edit $env:TAG --repo $env:GITHUB_REPOSITORY --draft=false --prerelease
               if ($LASTEXITCODE -ne 0) {
                   throw "Nightly immutable release could not be published"
               }
+              $publishedRelease = $null
+              for ($attempt = 1; $attempt -le 6; $attempt++) {
+                  $publishedJson = gh api `
+                      "repos/$($env:GITHUB_REPOSITORY)/releases/tags/$($env:TAG)" `
+                      2>$null
+                  if ($LASTEXITCODE -eq 0) {
+                      $candidate = $publishedJson | ConvertFrom-Json
+                      $manifestAssets = @($candidate.assets |
+                          Where-Object { $_.name -ceq $env:MANIFEST_NAME })
+                      $installerAssets = @($candidate.assets |
+                          Where-Object { $_.name -ceq $env:INSTALLER_NAME })
+                      if (-not $candidate.draft -and $candidate.prerelease -and
+                          $manifestAssets.Count -eq 1 -and
+                          $installerAssets.Count -eq 1) {
+                          $publishedRelease = $candidate
+                          break
+                      }
+                  }
+                  if ($attempt -lt 6) {
+                      Start-Sleep -Seconds 5
+                  }
+              }
+              if ($null -eq $publishedRelease) {
+                  throw "Nightly immutable release did not become publicly visible"
+              }
+              "immutable_published=true" | Out-File `
+                  -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
               $releaseTags = @(gh release list --repo $env:GITHUB_REPOSITORY `
                   --limit 1000 --json tagName --jq '.[].tagName')
               if ($LASTEXITCODE -ne 0) {
@@ -569,16 +625,23 @@ jobs:
           TAG: ${{ steps.identity.outputs.tag }}
         run: |
           $history = Join-Path $env:RUNNER_TEMP "nightly-retention-history.json"
-          gh api --paginate --slurp `
-              "repos/$($env:GITHUB_REPOSITORY)/releases?per_page=100" |
-              Out-File -LiteralPath $history -Encoding utf8
-          if ($LASTEXITCODE -ne 0) {
-              throw "Could not list immutable Nightly releases for retention"
-          }
-          $obsoleteTags = @(python build-support/release/nightly_retention.py `
-              --release-history $history --current-tag $env:TAG --keep 2)
-          if ($LASTEXITCODE -ne 0) {
-              throw "Could not select obsolete immutable Nightly releases"
+          $obsoleteTags = $null
+          for ($attempt = 1; $attempt -le 6; $attempt++) {
+              gh api --paginate --slurp `
+                  "repos/$($env:GITHUB_REPOSITORY)/releases?per_page=100" |
+                  Out-File -LiteralPath $history -Encoding utf8
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Could not list immutable Nightly releases for retention"
+              }
+              $obsoleteTags = @(python build-support/release/nightly_retention.py `
+                  --release-history $history --current-tag $env:TAG --keep 2)
+              if ($LASTEXITCODE -eq 0) {
+                  break
+              }
+              if ($attempt -eq 6) {
+                  throw "Could not select obsolete immutable Nightly releases"
+              }
+              Start-Sleep -Seconds 5
           }
           foreach ($tag in $obsoleteTags) {
               gh release delete $tag --repo $env:GITHUB_REPOSITORY `
@@ -627,6 +690,7 @@ jobs:
         env:
           TAG: ${{ steps.identity.outputs.tag }}
           TAG_CREATED: ${{ steps.draft.outputs.tag_created }}
+          IMMUTABLE_PUBLISHED: ${{ steps.publish.outputs.immutable_published }}
         run: |
           $releasesJson = gh api "repos/$($env:GITHUB_REPOSITORY)/releases?per_page=100"
           if ($LASTEXITCODE -ne 0) {
@@ -636,14 +700,16 @@ jobs:
           $release = $releases | Where-Object { $_.tag_name -ceq $env:TAG } |
               Select-Object -First 1
           $publishedReleaseExists = $null -ne $release -and -not $release.draft
-          if ($null -ne $release -and $release.draft) {
+          $immutablePublished = $env:IMMUTABLE_PUBLISHED -eq 'true'
+          if ($null -ne $release -and $release.draft -and -not $immutablePublished) {
               gh api --method DELETE `
                   "repos/$($env:GITHUB_REPOSITORY)/releases/$($release.id)"
               if ($LASTEXITCODE -ne 0) {
                   throw "Abandoned draft release could not be removed"
               }
           }
-          if ($env:TAG_CREATED -eq 'true' -and -not $publishedReleaseExists) {
+          if ($env:TAG_CREATED -eq 'true' -and -not $immutablePublished -and
+              -not $publishedReleaseExists) {
               $tagRef = gh api `
                   "repos/$($env:GITHUB_REPOSITORY)/git/refs/tags/$($env:TAG)" |
                   ConvertFrom-Json

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -172,11 +172,15 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn('"download_url=$publicInstallerUrl"', workflow)
         self.assertNotIn("$asset.browser_download_url", workflow)
         self.assertNotIn("updates-nightly", workflow)
-        self.assertNotIn("releases/tags/$($env:TAG)", workflow)
         self.assertGreaterEqual(
             workflow.count("Where-Object { $_.tag_name -ceq $env:TAG }"), 2)
         self.assertIn("gh release upload nightly $env:MANIFEST", workflow)
         self.assertIn("releases/download/nightly/frostguard-nightly-manifest.json", workflow)
+        self.assertIn("Nightly immutable release did not become publicly visible", workflow)
+        self.assertIn("Stable immutable release did not become publicly visible", workflow)
+        self.assertIn('"immutable_published=true"', workflow)
+        self.assertIn("$manifestAssets.Count -eq 1", workflow)
+        self.assertIn("$installerAssets.Count -eq 1", workflow)
         self.assertIn('          $tag = "v$($env:VERSION)"', workflow)
         self.assertIn("next_nightly_version.py", workflow)
         self.assertIn("Update the maintained Nightly Discord message", workflow)
@@ -187,6 +191,8 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("--current-tag $env:TAG --keep 2", workflow)
         self.assertIn("gh release delete $tag", workflow)
         self.assertIn("--cleanup-tag --yes", workflow)
+        self.assertGreaterEqual(
+            workflow.count("for ($attempt = 1; $attempt -le 6; $attempt++)"), 2)
         self.assertIn("--changes-unchanged", workflow)
         self.assertIn("fetch-depth: 0", workflow)
         self.assertIn("Remove an abandoned draft release", workflow)
@@ -229,7 +235,10 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn('"tag_created=true"', workflow)
         self.assertIn("TAG_CREATED: ${{ steps.draft.outputs.tag_created }}", workflow)
         self.assertIn(
-            "if ($env:TAG_CREATED -eq 'true' -and -not $publishedReleaseExists)",
+            "IMMUTABLE_PUBLISHED: ${{ steps.publish.outputs.immutable_published }}",
+            workflow)
+        self.assertIn(
+            "if ($env:TAG_CREATED -eq 'true' -and -not $immutablePublished -and",
             workflow)
         self.assertGreaterEqual(
             workflow.count(

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -98,6 +98,14 @@ releases, and unrelated tags never match this retention policy. A failed or
 unpromoted Nightly does not run retention, and a cleanup failure fails the
 release job visibly.
 
+GitHub release publication can be eventually consistent. Before promoting the
+rolling feed, the workflow therefore waits until the immutable Nightly is
+visible as a public prerelease with exactly its signed manifest and installer.
+Once that public state has been confirmed, later failure cleanup must never
+delete the release or tag, even if a subsequent API read temporarily reports
+stale draft metadata. Retention separately retries its release-history read
+before failing closed.
+
 ### Unpublished Stable release candidates
 
 Before promoting a new Stable major or minor version, manually run **CI —


### PR DESCRIPTION
## Summary

- verify an immutable Stable or Nightly release is publicly visible with exactly its signed manifest and installer before considering publication complete
- promote the rolling Nightly feed only after that public state is confirmed
- persist the confirmed-public state so downstream failure cleanup can never delete a promoted release based on stale draft metadata
- retry Nightly retention history reads to tolerate GitHub release-list propagation delay
- document the eventual-consistency safety boundary

## Why

Live Nightly `3.0.0-nightly.20260817.4` exposed a GitHub read-after-write race. `gh release edit --draft=false` returned success and the workflow promoted the rolling manifest, but subsequent release-list reads reported the immutable release as missing/draft. Retention failed, then the abandoned-draft cleanup deleted the already promoted release and tag, leaving the rolling feed pointing at a missing installer.

The rolling feed was manually recovered to the still-public `.3` release using its exact immutable manifest. This PR prevents the same sequence from recurring.

Refs #220

## Validation

- `python -m unittest discover -s build-support/release -p 'test_*.py'` — 61 tests passed
- `python -m unittest discover -s build-support/verification -p 'test_*.py'` — 40 tests passed
- `git diff --check` — passed
- restored rolling and immutable `.3` manifests are byte-identical: SHA-256 `B0FDC9F90E6D5BF934C63711A2F2CB01376D7C9F3A52388A2856EF33D516234D`

Evidence level: automated tests plus live release-incident evidence and public-feed recovery. End-to-end confirmation requires one successful Nightly after merge.

## Risks

The bounded publication and retention retries can add up to 25 seconds each during GitHub propagation delays. A persistent inconsistency fails closed before feed promotion; once publication has been confirmed, later cleanup preserves the release and tag.