### PR TITLE
fix(desktop): identify parallel runtime windows

### DIFF
--- a/build-support/verification/test_verify_app_image.py
+++ b/build-support/verification/test_verify_app_image.py
@@ -39,7 +39,9 @@ class VerifyAppImageTest(unittest.TestCase):
         with zipfile.ZipFile(self.image / "app/frostguard-desktop-3.0.0.jar", "w") as desktop_jar:
             desktop_jar.writestr(
                 verify_app_image.BUILD_METADATA,
-                "pullRequestBuild=false\nauthenticodePublisher=CN=Frostguard Project, O=Frostguard\n",
+                "version=3.0.0\n"
+                "pullRequestBuild=false\n"
+                "authenticodePublisher=CN=Frostguard Project, O=Frostguard\n",
             )
         with zipfile.ZipFile(self.image / "app/lib/frostguard-update-3.0.0.jar", "w") as update_jar:
             update_jar.writestr(
@@ -114,6 +116,17 @@ class VerifyAppImageTest(unittest.TestCase):
     def test_rejects_desktop_jar_without_embedded_identity(self):
         (self.image / "app/frostguard-desktop-3.0.0.jar").write_bytes(b"not a jar")
         self.assertTrue(any("no valid embedded PR-build" in item
+                            for item in verify_app_image.inspect_image(self.image)))
+
+    def test_rejects_desktop_jar_with_mismatched_embedded_version(self):
+        with zipfile.ZipFile(
+                self.image / "app/frostguard-desktop-3.0.0.jar", "w"
+        ) as desktop_jar:
+            desktop_jar.writestr(
+                verify_app_image.BUILD_METADATA,
+                "version=2.1.0\npullRequestBuild=false\nauthenticodePublisher=\n",
+            )
+        self.assertTrue(any("version does not match its filename" in item
                             for item in verify_app_image.inspect_image(self.image)))
 
     def test_rejects_update_jar_without_project_key(self):

--- a/build-support/verification/verify_app_image.py
+++ b/build-support/verification/verify_app_image.py
@@ -156,10 +156,17 @@ def inspect_image(
                     metadata_values = {}
                     break
                 metadata_values[key] = value
-            if (set(metadata_values) != {"pullRequestBuild", "authenticodePublisher"}
+            if (set(metadata_values) != {"version", "pullRequestBuild", "authenticodePublisher"}
                     or metadata_values["pullRequestBuild"] not in {"true", "false"}):
-                problems.append("Desktop JAR has an invalid PR-build update identity")
+                problems.append("Desktop JAR has invalid build metadata")
             else:
+                jar_version = re.fullmatch(
+                    r"frostguard-desktop-(.+)\.jar", desktop_jars[0].name
+                ).group(1)
+                if metadata_values["version"] != jar_version:
+                    problems.append(
+                        "Desktop JAR build metadata version does not match its filename"
+                    )
                 embedded_identity = metadata_values["pullRequestBuild"]
                 for config_path, config_identity in config_identities.items():
                     if config_identity != embedded_identity:

--- a/modules/desktop/src/main/java/dev/frostguard/app/ApplicationTitle.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/ApplicationTitle.java
@@ -1,0 +1,19 @@
+package dev.frostguard.app;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+public final class ApplicationTitle {
+    private ApplicationTitle() {
+    }
+
+    public static String current() {
+        return format(WorkspacePaths.current().channel(), RuntimeVersion.current(),
+                RuntimeInstanceIdentity.current());
+    }
+
+    static String format(RuntimeChannel channel, String version, String instanceLabel) {
+        String title = String.format("%s · %s", channel.productName(), instanceLabel);
+        return version == null || version.isBlank() ? title : title + " · v" + version;
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/BuildMetadata.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/BuildMetadata.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-public record BuildMetadata(boolean pullRequestBuild, String authenticodePublisher) {
+public record BuildMetadata(String version, boolean pullRequestBuild, String authenticodePublisher) {
     private static final String RESOURCE = "/dev/frostguard/app/frostguard-build.properties";
 
     public static BuildMetadata current() {
@@ -13,20 +13,28 @@ public record BuildMetadata(boolean pullRequestBuild, String authenticodePublish
 
     static BuildMetadata read(InputStream input) {
         if (input == null) {
-            return new BuildMetadata(true, "");
+            return unavailable();
         }
         Properties properties = new Properties();
         try (input) {
             properties.load(input);
         } catch (IOException exception) {
-            return new BuildMetadata(true, "");
+            return unavailable();
         }
         String value = properties.getProperty("pullRequestBuild", "").trim();
         if (!value.equals("true") && !value.equals("false")) {
-            return new BuildMetadata(true, "");
+            return unavailable();
         }
-        return new BuildMetadata(Boolean.parseBoolean(value),
+        return new BuildMetadata(normalizeVersion(properties.getProperty("version")), Boolean.parseBoolean(value),
                 properties.getProperty("authenticodePublisher", "").trim());
+    }
+
+    private static BuildMetadata unavailable() {
+        return new BuildMetadata("unknown", true, "");
+    }
+
+    private static String normalizeVersion(String value) {
+        return value == null || value.isBlank() ? "unknown" : value.trim();
     }
 
     private static final class Holder {

--- a/modules/desktop/src/main/java/dev/frostguard/app/RuntimeInstanceIdentity.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/RuntimeInstanceIdentity.java
@@ -1,0 +1,80 @@
+package dev.frostguard.app;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class RuntimeInstanceIdentity {
+    public static final String INSTANCE_LABEL_PROPERTY = "frostguard.instance.label";
+    public static final String INSTANCE_LABEL_ENVIRONMENT = "FROSTGUARD_INSTANCE_LABEL";
+
+    private RuntimeInstanceIdentity() {
+    }
+
+    public static String current() {
+        return Holder.INSTANCE;
+    }
+
+    static String resolve(WorkspacePaths workspace, String explicitLabel) {
+        if (explicitLabel != null && !explicitLabel.isBlank()) {
+            return explicitLabel.trim();
+        }
+        if (workspace.channel() != RuntimeChannel.DEVELOPMENT) {
+            return fileName(workspace.root(), workspace.channel().directoryName());
+        }
+
+        Path projectRoot = developmentProjectRoot(workspace.root());
+        Path gitMetadata = projectRoot.resolve(".git");
+        if (Files.isRegularFile(gitMetadata)) {
+            return fileName(projectRoot, workspace.channel().directoryName());
+        }
+        if (Files.isDirectory(gitMetadata)) {
+            String revision = readRevision(gitMetadata.resolve("HEAD"));
+            if (revision != null) {
+                return revision;
+            }
+        }
+        return fileName(projectRoot, fileName(workspace.root(), workspace.channel().directoryName()));
+    }
+
+    static Path developmentProjectRoot(Path workspaceRoot) {
+        Path fileName = workspaceRoot.getFileName();
+        if (fileName != null && ".frostguard-dev".equals(fileName.toString()) && workspaceRoot.getParent() != null) {
+            return workspaceRoot.getParent();
+        }
+        return workspaceRoot;
+    }
+
+    private static String readRevision(Path head) {
+        try {
+            String value = Files.readString(head).trim();
+            String branchPrefix = "ref: refs/heads/";
+            if (value.startsWith(branchPrefix) && value.length() > branchPrefix.length()) {
+                return value.substring(branchPrefix.length());
+            }
+            if (value.matches("[0-9a-fA-F]{7,64}")) {
+                return value.substring(0, Math.min(8, value.length()));
+            }
+        } catch (IOException ignored) {
+            // The checkout directory remains a useful identity when Git metadata is unavailable.
+        }
+        return null;
+    }
+
+    private static String fileName(Path path, String fallback) {
+        Path fileName = path.getFileName();
+        return fileName == null || fileName.toString().isBlank() ? fallback : fileName.toString();
+    }
+
+    private static String configuredLabel() {
+        String value = System.getProperty(INSTANCE_LABEL_PROPERTY);
+        return value == null || value.isBlank() ? System.getenv(INSTANCE_LABEL_ENVIRONMENT) : value;
+    }
+
+    private static final class Holder {
+        private static final String INSTANCE = resolve(WorkspacePaths.current(), configuredLabel());
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/RuntimeVersion.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/RuntimeVersion.java
@@ -1,0 +1,62 @@
+package dev.frostguard.app;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+public final class RuntimeVersion {
+    private RuntimeVersion() {
+    }
+
+    public static String current() {
+        return Holder.INSTANCE;
+    }
+
+    static String resolve(WorkspacePaths workspace, String buildVersion, Function<Path, String> stableTagResolver) {
+        if (workspace.channel() != RuntimeChannel.DEVELOPMENT) {
+            return buildVersion;
+        }
+        String tag = stableTagResolver.apply(RuntimeInstanceIdentity.developmentProjectRoot(workspace.root()));
+        if (tag != null && tag.matches("v[0-9]+\\.[0-9]+\\.[0-9]+")) {
+            return tag.substring(1) + "-dev";
+        }
+        return null;
+    }
+
+    private static String readStableTag(Path projectRoot) {
+        Process process = null;
+        try {
+            process = new ProcessBuilder("git", "-C", projectRoot.toString(), "describe", "--tags", "--abbrev=0",
+                    "--match=v[0-9]*", "--exclude=*-*")
+                    .redirectErrorStream(true)
+                    .start();
+            if (!process.waitFor(3, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                return null;
+            }
+            if (process.exitValue() != 0) {
+                return null;
+            }
+            return new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        } catch (IOException exception) {
+            return null;
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return null;
+        } finally {
+            if (process != null && process.isAlive()) {
+                process.destroyForcibly();
+            }
+        }
+    }
+
+    private static final class Holder {
+        private static final String INSTANCE = resolve(WorkspacePaths.current(), BuildMetadata.current().version(),
+                RuntimeVersion::readStableTag);
+    }
+}

--- a/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/FXApp.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/bootstrap/FXApp.java
@@ -1,7 +1,7 @@
 package dev.frostguard.app.bootstrap;
 
 import atlantafx.base.theme.PrimerDark;
-import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.app.ApplicationTitle;
 import dev.frostguard.app.bootstrap.WindowBoundsPolicy.WindowBounds;
 import dev.frostguard.app.panel.launcher.ILauncherConstants;
 import dev.frostguard.app.panel.launcher.LauncherLayoutController;
@@ -88,7 +88,7 @@ public class FXApp extends Application {
         stage.setScene(scene);
         stage.setMinWidth(680);
         stage.setMinHeight(460);
-        stage.setTitle(WorkspacePaths.current().channel().productName() + " Control Center");
+        stage.setTitle(ApplicationTitle.current());
         stage.getIcons().add(loadAppIcon());
         WindowResizer.makeResizable(stage);
     }

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/launcher/LauncherLayoutController.java
@@ -2,9 +2,6 @@ package dev.frostguard.app.panel.launcher;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -14,6 +11,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
+import dev.frostguard.app.ApplicationTitle;
+import dev.frostguard.app.BuildMetadata;
 import dev.frostguard.vision.match.OpenCvPatternLocator;
 import dev.frostguard.app.panel.alliance.AllianceLayoutController;
 import dev.frostguard.app.panel.analytics.GameAnalyticsLayoutController;
@@ -50,8 +49,6 @@ import dev.frostguard.app.panel.profile.IProfileObserverInjectable;
 import dev.frostguard.app.panel.profile.ProfileAux;
 import dev.frostguard.app.panel.profile.ProfileManagerLayoutController;
 import dev.frostguard.api.domain.QueueStateData;
-import dev.frostguard.api.runtime.RuntimeChannel;
-import dev.frostguard.api.runtime.WorkspacePaths;
 import dev.frostguard.engine.listener.StaminaChangeListener;
 import dev.frostguard.engine.service.ConfigService;
 import dev.frostguard.engine.service.ScheduleService;
@@ -231,6 +228,7 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
         initializeExternalLibraries();
         initializeTelegramBot();
         showVersion();
+        updateWindowTitle();
         initializeUptime();
         buttonStartStop.setDisable(false);
         buttonPauseResume.setDisable(true);
@@ -312,36 +310,7 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
     }
 
     private void showVersion() { /* internal */
-        String version = getVersion();
-        labelVersion.setText("Version: " + version);
-    }
-
-    private String getVersion() { /* internal */
-        Package pkg = getClass().getPackage();
-        if (pkg != null && pkg.getImplementationVersion() != null) {
-            return pkg.getImplementationVersion();
-        }
-        try {
-            Path parentPomPath = Paths.get("..", "pom.xml");
-            if (!Files.exists(parentPomPath)) {
-                parentPomPath = Paths.get("pom.xml");
-            }
-            List<String> lines = Files.readAllLines(parentPomPath);
-            String revision = null;
-            for (String line : lines) {
-                line = line.trim();
-                if (line.startsWith("<revision>") && line.endsWith("</revision>")) {
-                    revision = line.replace("<revision>", "").replace("</revision>", "").trim();
-                    break;
-                }
-            }
-            if (null != revision) {
-                return revision;
-            }
-        } catch (Exception e) {
-            // Ignore error
-        }
-        return "Unknown";
+        labelVersion.setText("Version: " + BuildMetadata.current().version());
     }
 
     private void initializeEmulatorController() { /* internal */
@@ -726,26 +695,23 @@ public class LauncherLayoutController implements IProfileLoadListener, StaminaCh
     }
 
     private void updateWindowTitle() { /* internal */
-        if (null == currentProfile) {
-            return;
+        String title = ApplicationTitle.current();
+        if (currentProfile != null) {
+            int stamina = StaminaService.getServices().getCurrentStamina(currentProfile.getId());
+            title = formatWindowTitle(title, currentProfile.getName(), stamina);
         }
-
-        String version = getVersion();
-        int stamina = StaminaService.getServices().getCurrentStamina(currentProfile.getId());
-        String title = formatWindowTitle(WorkspacePaths.current().channel(), version,
-                currentProfile.getName(), stamina);
+        String resolvedTitle = title;
 
         Platform.runLater(() -> {
-            stage.setTitle(title);
+            stage.setTitle(resolvedTitle);
             if (null != labelWindowTitle) {
-                labelWindowTitle.setText(title);
+                labelWindowTitle.setText(resolvedTitle);
             }
         });
     }
 
-    static String formatWindowTitle(RuntimeChannel channel, String version, String profileName, int stamina) {
-        return String.format("%s v%s - %s [Stamina: %d]",
-                channel.productName(), version, profileName, stamina);
+    static String formatWindowTitle(String applicationTitle, String profileName, int stamina) {
+        return String.format("%s - %s [Stamina: %d]", applicationTitle, profileName, stamina);
     }
 
     public void onEngineStateTransition(BotStateData botState) { /* bind */

--- a/modules/desktop/src/main/resources/dev/frostguard/app/frostguard-build.properties
+++ b/modules/desktop/src/main/resources/dev/frostguard/app/frostguard-build.properties
@@ -1,2 +1,3 @@
+version=${project.version}
 pullRequestBuild=${frostguard.pull-request-build}
 authenticodePublisher=${frostguard.update.authenticode-publisher}

--- a/modules/desktop/src/test/java/dev/frostguard/app/ApplicationTitleTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/ApplicationTitleTest.java
@@ -1,0 +1,20 @@
+package dev.frostguard.app;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ApplicationTitleTest {
+    @Test
+    void identifiesChannelInstanceAndVersion() {
+        assertEquals("Frostguard · default · v2.1.0",
+                ApplicationTitle.format(RuntimeChannel.STABLE, "2.1.0", "default"));
+        assertEquals("Frostguard Nightly · bot-2 · v26.8.1",
+                ApplicationTitle.format(RuntimeChannel.NIGHTLY, "26.8.1", "bot-2"));
+        assertEquals("Frostguard Development · fix/arena-refresh-budget · v3.0.0-dev",
+                ApplicationTitle.format(RuntimeChannel.DEVELOPMENT, "3.0.0-dev", "fix/arena-refresh-budget"));
+        assertEquals("Frostguard Development · source-export",
+                ApplicationTitle.format(RuntimeChannel.DEVELOPMENT, null, "source-export"));
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/BuildMetadataTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/BuildMetadataTest.java
@@ -13,7 +13,8 @@ class BuildMetadataTest {
     @Test
     void readsFilteredPrBuildIdentity() {
         BuildMetadata release = BuildMetadata.read(stream(
-                "pullRequestBuild=false\nauthenticodePublisher=CN=Frostguard Project, O=Frostguard"));
+                "version=2.1.0\npullRequestBuild=false\nauthenticodePublisher=CN=Frostguard Project, O=Frostguard"));
+        assertEquals("2.1.0", release.version());
         assertFalse(release.pullRequestBuild());
         assertEquals("CN=Frostguard Project, O=Frostguard", release.authenticodePublisher());
         assertTrue(BuildMetadata.read(stream("pullRequestBuild=true")).pullRequestBuild());
@@ -21,8 +22,12 @@ class BuildMetadataTest {
 
     @Test
     void missingOrInvalidIdentityDisablesAutomaticUpdates() {
-        assertTrue(BuildMetadata.read(null).pullRequestBuild());
-        assertTrue(BuildMetadata.read(stream("pullRequestBuild=maybe")).pullRequestBuild());
+        BuildMetadata missing = BuildMetadata.read(null);
+        assertEquals("unknown", missing.version());
+        assertTrue(missing.pullRequestBuild());
+        BuildMetadata invalid = BuildMetadata.read(stream("pullRequestBuild=maybe"));
+        assertEquals("unknown", invalid.version());
+        assertTrue(invalid.pullRequestBuild());
     }
 
     private static ByteArrayInputStream stream(String value) {

--- a/modules/desktop/src/test/java/dev/frostguard/app/RuntimeInstanceIdentityTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/RuntimeInstanceIdentityTest.java
@@ -1,0 +1,65 @@
+package dev.frostguard.app;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RuntimeInstanceIdentityTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void usesWorktreeDirectoryForLinkedDevelopmentWorktree() throws IOException {
+        Path project = Files.createDirectories(tempDir.resolve("wosbot-arena-refresh-budget"));
+        Files.writeString(project.resolve(".git"), "gitdir: ../wosbot/.git/worktrees/arena-refresh-budget");
+
+        assertEquals("wosbot-arena-refresh-budget", resolveDevelopment(project));
+    }
+
+    @Test
+    void usesBranchForNormalDevelopmentClone() throws IOException {
+        Path project = Files.createDirectories(tempDir.resolve("wosbot"));
+        Path git = Files.createDirectories(project.resolve(".git"));
+        Files.writeString(git.resolve("HEAD"), "ref: refs/heads/fix/arena-refresh-budget\n");
+
+        assertEquals("fix/arena-refresh-budget", resolveDevelopment(project));
+    }
+
+    @Test
+    void usesShortCommitForDetachedDevelopmentClone() throws IOException {
+        Path project = Files.createDirectories(tempDir.resolve("wosbot"));
+        Path git = Files.createDirectories(project.resolve(".git"));
+        Files.writeString(git.resolve("HEAD"), "7da0b440c25cc552ae2ea15a9f615331f9238f8b\n");
+
+        assertEquals("7da0b440", resolveDevelopment(project));
+    }
+
+    @Test
+    void fallsBackToProjectDirectoryWithoutReadableGitMetadata() throws IOException {
+        Path project = Files.createDirectories(tempDir.resolve("wosbot-local"));
+
+        assertEquals("wosbot-local", resolveDevelopment(project));
+    }
+
+    @Test
+    void usesNamedReleaseWorkspaceAndAllowsExplicitOverride() {
+        WorkspacePaths nightly = new WorkspacePaths(tempDir.resolve("nightly").resolve("bot-2"),
+                RuntimeChannel.NIGHTLY);
+
+        assertEquals("bot-2", RuntimeInstanceIdentity.resolve(nightly, null));
+        assertEquals("live-test", RuntimeInstanceIdentity.resolve(nightly, " live-test "));
+    }
+
+    private String resolveDevelopment(Path project) {
+        WorkspacePaths workspace = new WorkspacePaths(project.resolve(".frostguard-dev"),
+                RuntimeChannel.DEVELOPMENT);
+        return RuntimeInstanceIdentity.resolve(workspace, null);
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/RuntimeVersionTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/RuntimeVersionTest.java
@@ -1,0 +1,44 @@
+package dev.frostguard.app;
+
+import dev.frostguard.api.runtime.RuntimeChannel;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RuntimeVersionTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void marksLatestStableTagAsDevelopmentBaseline() {
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("repo").resolve(".frostguard-dev"),
+                RuntimeChannel.DEVELOPMENT);
+
+        assertEquals("3.0.0-dev", RuntimeVersion.resolve(workspace, "2.1.0", root -> "v3.0.0"));
+    }
+
+    @Test
+    void omitsMisleadingVersionWhenDevelopmentTagIsUnavailable() {
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("repo").resolve(".frostguard-dev"),
+                RuntimeChannel.DEVELOPMENT);
+
+        assertNull(RuntimeVersion.resolve(workspace, "2.1.0", root -> null));
+        assertNull(RuntimeVersion.resolve(workspace, "2.1.0", root -> "v3.0.0-nightly.1"));
+    }
+
+    @Test
+    void keepsExactEmbeddedVersionForReleaseChannels() {
+        WorkspacePaths workspace = new WorkspacePaths(tempDir.resolve("nightly").resolve("bot-2"),
+                RuntimeChannel.NIGHTLY);
+
+        assertEquals("3.0.0-nightly.20260817.5",
+                RuntimeVersion.resolve(workspace, "3.0.0-nightly.20260817.5", root -> {
+                    throw new AssertionError("Release versions must not inspect Git");
+                }));
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/launcher/LauncherLayoutControllerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/launcher/LauncherLayoutControllerTest.java
@@ -2,7 +2,6 @@ package dev.frostguard.app.panel.launcher;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import dev.frostguard.api.runtime.RuntimeChannel;
 import org.junit.jupiter.api.Test;
 
 class LauncherLayoutControllerTest {
@@ -19,12 +18,9 @@ class LauncherLayoutControllerTest {
     }
 
     @Test
-    void identifiesRuntimeChannelInWindowTitle() {
-        assertEquals("Frostguard v2.1.0 - Main [Stamina: 77]",
-                LauncherLayoutController.formatWindowTitle(RuntimeChannel.STABLE, "2.1.0", "Main", 77));
-        assertEquals("Frostguard Nightly v2.1.0 - Main [Stamina: 77]",
-                LauncherLayoutController.formatWindowTitle(RuntimeChannel.NIGHTLY, "2.1.0", "Main", 77));
-        assertEquals("Frostguard Development v2.1.0 - Main [Stamina: 77]",
-                LauncherLayoutController.formatWindowTitle(RuntimeChannel.DEVELOPMENT, "2.1.0", "Main", 77));
+    void addsProfileContextToApplicationTitle() {
+        assertEquals("Frostguard Development · fix/arena-refresh-budget · v3.0.0-dev - Main [Stamina: 77]",
+                LauncherLayoutController.formatWindowTitle(
+                        "Frostguard Development · fix/arena-refresh-budget · v3.0.0-dev", "Main", 77));
     }
 }


### PR DESCRIPTION
## Summary

- include a stable instance identity in the native and custom Frostguard window titles
- identify linked development worktrees by directory, normal clones by startup branch, and detached clones by short commit
- identify Stable and Nightly instances by workspace name and allow an explicit instance-label override
- display Development builds against their latest reachable Stable Git tag, such as `v3.0.0-dev`
- read exact Stable and Nightly versions from filtered build metadata so packaged builds retain their release identity
- verify that embedded build metadata matches the packaged desktop JAR version

## Why

Parallel Frostguard development instances previously shared titles such as `Frostguard Development vUnknown`, making them difficult to distinguish. The title did not include the runtime workspace or checkout identity, and source version detection depended on the caller's working directory. The Maven `revision` remains `2.1.0` as a legacy default while 3.x release workflows override it, so Development titles now use the latest reachable Stable tag instead of presenting that legacy value as the current source baseline.

## Validation

- Automated Java tests after rebasing onto current `main`: `.\mvnw.cmd -pl modules/desktop -am test`
- Packaging verification tests: `python -m unittest discover -s build-support/verification -p "test_*.py"` (41 passed)
- Live JavaFX verification: started the application from `wosbot-window-instance-title` and observed `Frostguard Development · wosbot-window-instance-title · v3.0.0-dev - Default [Stamina: 0]` as the Windows process title
- Live log verification: no `ERROR`, `FATAL`, or exception was present in the startup log; the test application and its console were closed afterward

## Risks

- The displayed development identity and Stable baseline are captured at startup. Changing branches while Frostguard remains open intentionally does not rename that running window.
- A Development checkout without Git or without a reachable Stable tag omits the version instead of displaying a potentially misleading legacy Maven version.
