### PR TITLE
fix(gift-code): stop retrying recharge requirements

### DIFF
--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/GiftCodeRedeemer.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/misc/GiftCodeRedeemer.java
@@ -89,7 +89,8 @@ final class GiftCodeRedeemer {
         }
         if (normalized.contains("EXPIRED") || normalized.contains("NOT FOUND")
                 || normalized.contains("LIMIT") || normalized.contains("REQUIREMENT")
-                || normalized.contains("SPEND MORE") || normalized.contains("TIME ERROR")
+                || normalized.contains("SPEND MORE") || normalized.contains("RECHARGE MONEY")
+                || normalized.contains("TIME ERROR")
                 || normalized.contains("ROLE NOT EXIST") || normalized.contains("PLAYER NOT EXIST")) {
             return RedeemResult.failed(message);
         }

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/GiftCodeRedeemerTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/misc/GiftCodeRedeemerTest.java
@@ -37,4 +37,12 @@ class GiftCodeRedeemerTest {
         assertTrue(GiftCodeRedeemer.classify("SUCCESS").terminal());
         assertFalse(GiftCodeRedeemer.classify("Server busy").terminal());
     }
+
+    @Test
+    void treatsRechargeRequirementsAsTerminalFailures() {
+        var result = GiftCodeRedeemer.classify("RECHARGE_MONEY ERROR.");
+
+        assertEquals(RedeemOutcome.FAILED, result.outcome());
+        assertTrue(result.terminal());
+    }
 }


### PR DESCRIPTION
## Summary

- classify `RECHARGE_MONEY ERROR.` responses as terminal gift-code failures
- persist those results in shared claim history instead of retrying them every hour
- cover the observed Century Games response with a regression test

## Why

The Nightly account log showed `VIP0815` returning `RECHARGE_MONEY ERROR.` for every recipient. The generic fallback classified that response as retryable, so each hourly run made three more requests per player even though the in-game UI confirms that the account does not satisfy the redemption requirements.

## Validation

- `mvnw.cmd -pl modules/desktop -am test`
- 499 tests passed with 0 failures, errors, or skips
- Live Nightly log and supplied in-game screenshot confirm the real response and its terminal requirement semantics

## Risks

- A player who later becomes eligible for the same code will remain skipped because the failure is stored as terminal, matching the existing handling for other unmet redemption requirements.
