### PR TITLE
fix(bear): bound rally deployment runtime

### DIFF
--- a/docs/task/bear-trap-runtime.md
+++ b/docs/task/bear-trap-runtime.md
@@ -1,0 +1,22 @@
+# Bear Trap Runtime
+
+Bear Trap prioritizes a configured own rally before joining alliance rallies. After a confirmed own
+deployment, the routine associates the newly occupied rally row in March Queue with that deployment.
+The row becoming idle is the preferred evidence that another own rally may start. The calculated
+rally-set plus round-trip travel time is only a fallback when the row cannot be identified.
+
+Joining deliberately avoids OCRing rally names, player names, capacity, or countdowns. The white plus
+shape locates candidate rows; colour saturation distinguishes an enabled blue or green control from a
+disabled grey control. Each visible row is attempted at most once per pass and rejected rows cool down
+briefly before another fresh scan. Deploy is successful only after the button disappears and the World
+anchor is verified.
+
+The UI does not expose a reliable machine-readable rally identity or departure time. Consequently, a
+missing or rejected Deploy is logged as an aggregate of already joined, full, expired, or insufficient
+capacity rather than claiming a more precise cause. The routine also cannot prove that a joining march
+will arrive before rally departure. Traffic-derived rally IDs, capacity, departure time, membership,
+and leader power can refine these decisions later without changing the bounded UI fallback.
+
+Automated tests cover colour-state classification and own-rally slot tracking. Saved real frames and a
+live Bear Trap account log are still required before treating visual thresholds and end-to-end behavior
+as merge-ready evidence.

--- a/modules/automation/src/main/java/dev/frostguard/engine/emulator/EmulatorController.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/emulator/EmulatorController.java
@@ -242,13 +242,21 @@ public class EmulatorController {
 
     public List<ImageSearchResultData> locateAllPatternsMono(String idx, TemplatesEnum t,
             PointData tl, PointData br, double th, int max) {
-        requireBackend(); RawImageData frame = captureScreen(idx);
+        return locateAllPatternsMono(idx, captureScreen(idx), t, tl, br, th, max);
+    }
+    public List<ImageSearchResultData> locateAllPatternsMono(String idx, RawImageData frame,
+            TemplatesEnum t, PointData tl, PointData br, double th, int max) {
+        requireBackend();
         try { OpenCvPatternLocator.setContextLabel(label(idx));
               return OpenCvPatternLocator.locateAllPatternsMono(frame, regionTpl(t.getTemplate()), tl, br, th, max);
         } finally { OpenCvPatternLocator.clearContextLabel(); }
     }
     public List<ImageSearchResultData> locateAllPatternsMono(String idx, TemplatesEnum t, double th, int max) {
         return locateAllPatternsMono(idx, t, ORIGIN, FULL, th, max);
+    }
+    public List<ImageSearchResultData> locateAllPatternsMono(String idx, RawImageData frame,
+            TemplatesEnum t, double th, int max) {
+        return locateAllPatternsMono(idx, frame, t, ORIGIN, FULL, th, max);
     }
 
     public List<ImageSearchResultData> locateAllPatterns(String idx, TemplatesEnum t,

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/FormationSelectionResult.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/FormationSelectionResult.java
@@ -1,0 +1,20 @@
+package dev.frostguard.engine.helper;
+
+/**
+ * Explainable result of inspecting and optionally selecting a saved formation.
+ */
+public record FormationSelectionResult(Status status, Integer formation, String detail) {
+
+    public enum Status {
+        SELECTED,
+        NOT_CONFIGURED,
+        UNSUPPORTED,
+        LOCKED,
+        EMPTY_OR_MISSING,
+        SCREEN_UNREADABLE
+    }
+
+    public boolean successful() {
+        return status == Status.SELECTED || status == Status.NOT_CONFIGURED;
+    }
+}

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/MarchHelper.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/MarchHelper.java
@@ -222,30 +222,45 @@ public class MarchHelper {
     // A slot is inspected before it is tapped: padlock evidence rejects locked slots, while the
     // measured white-flag signal distinguishes a saved formation from an empty visible tile.
     public boolean selectFlag(Integer flagNumber) {
+        return selectFormation(flagNumber).successful();
+    }
+
+    /**
+     * Selects a saved formation and retains the evidence behind a rejection for callers that need
+     * to distinguish invalid configuration from a transient unreadable screen.
+     */
+    public FormationSelectionResult selectFormation(Integer flagNumber) {
         if (flagNumber == null) {
             log.debug("No formation configured - skipping selection");
-            return true;
+            return new FormationSelectionResult(FormationSelectionResult.Status.NOT_CONFIGURED,
+                    null, "No formation configured");
         }
         if (!FormationSlots.supports(flagNumber)) {
-            log.warn("Formation #" + flagNumber + " is unsupported; supported range is "
-                    + FormationSlots.MIN + "-" + FormationSlots.MAX);
-            return false;
+            String detail = "Supported range is " + FormationSlots.MIN + "-" + FormationSlots.MAX;
+            log.warn("Formation #" + flagNumber + " is unsupported; " + detail.toLowerCase());
+            return new FormationSelectionResult(FormationSelectionResult.Status.UNSUPPORTED,
+                    flagNumber, detail);
         }
         FormationFrame frame = flagNumber <= 8 ? captureFormationFrame(flagNumber) : moveToRightFormationEnd();
         if (frame == null) {
-            return false;
+            return new FormationSelectionResult(FormationSelectionResult.Status.SCREEN_UNREADABLE,
+                    flagNumber, "Formation bar could not be captured or navigated");
         }
         FormationSlotStateClassifier.State state = inspectFormationSlot(flagNumber, frame);
         if (state != FormationSlotStateClassifier.State.SAVED) {
-            log.warn("Formation #" + flagNumber + " is " + state.name().toLowerCase().replace('_', ' ')
-                    + " - not selecting it");
-            return false;
+            String detail = state.name().toLowerCase().replace('_', ' ');
+            log.warn("Formation #" + flagNumber + " is " + detail + " - not selecting it");
+            FormationSelectionResult.Status status = state == FormationSlotStateClassifier.State.LOCKED
+                    ? FormationSelectionResult.Status.LOCKED
+                    : FormationSelectionResult.Status.EMPTY_OR_MISSING;
+            return new FormationSelectionResult(status, flagNumber, detail);
         }
         log.debug("Selecting formation #" + flagNumber);
         // Flag slots are narrow fixed positions — keep the jitter tightly bounded.
         taps.tapNear(RallyFlagCoordinates.pointForFlag(flagNumber), TapJitterPolicy.DEFAULT_POINT_JITTER_RADIUS);
         interruptibleWait(300);
-        return true;
+        return new FormationSelectionResult(FormationSelectionResult.Status.SELECTED,
+                flagNumber, "Saved formation selected");
     }
 
     // Locating every padlock across the strip and mapping each to its nearest slot is immune to the

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/TemplateSearchHelper.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/TemplateSearchHelper.java
@@ -6,6 +6,7 @@ import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.engine.emulator.EmulatorController;
 import dev.frostguard.engine.service.LoggingService;
 import dev.frostguard.vision.logging.ProfileContextLogger;
@@ -74,6 +75,22 @@ public class TemplateSearchHelper {
 
     public List<ImageSearchResultData> locateAllPatternsMono(TemplatesEnum tpl, SearchConfig cfg) {
         return retryMultiSearch(tpl, cfg, true);
+    }
+
+    /** Runs one monochrome multi-match against a caller-owned frame. */
+    public List<ImageSearchResultData> locateAllPatternsMono(
+            TemplatesEnum tpl, RawImageData frame, SearchConfig cfg) {
+        preemptionHook.run();
+        if (cfg.hasArea()) {
+            return emu.locateAllPatternsMono(device, frame, tpl, cfg.getArea().topLeft(),
+                    cfg.getArea().bottomRight(), cfg.getThreshold(), cfg.getMaxResults());
+        }
+        if (cfg.hasCoordinates()) {
+            return emu.locateAllPatternsMono(device, frame, tpl, cfg.getStartPoint(),
+                    cfg.getEndPoint(), cfg.getThreshold(), cfg.getMaxResults());
+        }
+        return emu.locateAllPatternsMono(device, frame, tpl,
+                cfg.getThreshold(), cfg.getMaxResults());
     }
 
     // ── retry loops ──────────────────────────────────────────────────

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearJoinAttemptLedger.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearJoinAttemptLedger.java
@@ -1,0 +1,43 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.api.domain.PointData;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Bounded memory for rally rows the UI already proved ineligible. */
+final class BearJoinAttemptLedger {
+
+    private final Duration rejectionCooldown;
+    private final Map<Integer, Instant> rejectedRows = new HashMap<>();
+
+    BearJoinAttemptLedger(Duration rejectionCooldown) {
+        if (rejectionCooldown.isNegative() || rejectionCooldown.isZero()) {
+            throw new IllegalArgumentException("Rejection cooldown must be positive");
+        }
+        this.rejectionCooldown = rejectionCooldown;
+    }
+
+    boolean canAttempt(PointData point, Instant now) {
+        expire(now);
+        return !rejectedRows.containsKey(rowKey(point));
+    }
+
+    void reject(PointData point, Instant now) {
+        rejectedRows.put(rowKey(point), now.plus(rejectionCooldown));
+    }
+
+    void clear() {
+        rejectedRows.clear();
+    }
+
+    private void expire(Instant now) {
+        rejectedRows.entrySet().removeIf(entry -> !now.isBefore(entry.getValue()));
+    }
+
+    private static int rowKey(PointData point) {
+        return Math.round(point.getY() / 10.0f) * 10;
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearJoinButtonClassifier.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearJoinButtonClassifier.java
@@ -1,0 +1,42 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.api.domain.PointData;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+
+/** Distinguishes an enabled coloured Bear rally plus from the same control in disabled grey. */
+final class BearJoinButtonClassifier {
+
+    private static final int SAMPLE_RADIUS_X = 24;
+    private static final int SAMPLE_RADIUS_Y = 16;
+    private static final float MIN_SATURATION = 0.28f;
+    private static final float MIN_BRIGHTNESS = 0.28f;
+    private static final int MIN_COLOURED_PIXELS = 18;
+
+    private BearJoinButtonClassifier() {
+    }
+
+    static Evidence inspect(BufferedImage image, PointData center) {
+        int left = Math.max(0, center.getX() - SAMPLE_RADIUS_X);
+        int right = Math.min(image.getWidth() - 1, center.getX() + SAMPLE_RADIUS_X);
+        int top = Math.max(0, center.getY() - SAMPLE_RADIUS_Y);
+        int bottom = Math.min(image.getHeight() - 1, center.getY() + SAMPLE_RADIUS_Y);
+        int colouredPixels = 0;
+
+        for (int y = top; y <= bottom; y++) {
+            for (int x = left; x <= right; x++) {
+                Color color = new Color(image.getRGB(x, y), true);
+                float[] hsb = Color.RGBtoHSB(color.getRed(), color.getGreen(), color.getBlue(), null);
+                if (hsb[1] >= MIN_SATURATION && hsb[2] >= MIN_BRIGHTNESS) {
+                    colouredPixels++;
+                }
+            }
+        }
+
+        return new Evidence(colouredPixels >= MIN_COLOURED_PIXELS, colouredPixels);
+    }
+
+    record Evidence(boolean enabled, int colouredPixels) {
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearOwnRallyTracker.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearOwnRallyTracker.java
@@ -1,0 +1,58 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.api.domain.MarchActivityType;
+import dev.frostguard.api.domain.MarchSlotState;
+
+import java.time.Duration;
+import java.util.List;
+
+/** Pure decisions for associating an own Bear rally with its March Queue slot. */
+final class BearOwnRallyTracker {
+
+    private BearOwnRallyTracker() {
+    }
+
+    static Integer identifyNewRallySlot(List<MarchSlotState> before, List<MarchSlotState> after) {
+        for (MarchSlotState current : after) {
+            if (current.activityType() != MarchActivityType.RALLY) {
+                continue;
+            }
+            MarchSlotState previous = find(before, current.slot());
+            if (previous == null || previous.isIdle() || previous.activityType() != MarchActivityType.RALLY) {
+                return current.slot();
+            }
+        }
+        return null;
+    }
+
+    static Observation observe(Integer trackedSlot, List<MarchSlotState> slots) {
+        if (trackedSlot == null || slots.isEmpty()) {
+            return new Observation(State.UNKNOWN, null);
+        }
+        MarchSlotState tracked = find(slots, trackedSlot);
+        if (tracked == null) {
+            return new Observation(State.UNKNOWN, null);
+        }
+        if (tracked.isIdle()) {
+            return new Observation(State.RETURNED, Duration.ZERO);
+        }
+        if (tracked.hasExactReleaseCountdown()) {
+            return new Observation(State.RETURNING, tracked.countdown());
+        }
+        return new Observation(State.ACTIVE, null);
+    }
+
+    private static MarchSlotState find(List<MarchSlotState> slots, int slotNumber) {
+        return slots.stream().filter(slot -> slot.slot() == slotNumber).findFirst().orElse(null);
+    }
+
+    enum State {
+        ACTIVE,
+        RETURNING,
+        RETURNED,
+        UNKNOWN
+    }
+
+    record Observation(State state, Duration releaseCountdown) {
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearTrapRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearTrapRoutine.java
@@ -6,47 +6,52 @@ import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.FormationSlots;
 import dev.frostguard.api.domain.ImageSearchResultData;
+import dev.frostguard.api.domain.MarchSlotState;
 import dev.frostguard.api.domain.PointData;
-import dev.frostguard.api.domain.OcrSettingsData;
+import dev.frostguard.api.domain.RawImageData;
 import dev.frostguard.engine.helper.BearTrapHelper;
+import dev.frostguard.engine.helper.FormationSelectionResult;
 import dev.frostguard.engine.helper.TemplateSearchHelper.SearchConfig;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.BearTrapParticipationSchedule;
 import dev.frostguard.engine.schedule.LaunchPoint;
 import dev.frostguard.engine.schedule.TaskQueue;
-import dev.frostguard.engine.service.BotOcrEngine;
 import dev.frostguard.engine.service.ConfigService;
 import dev.frostguard.engine.service.ProfileService;
-import dev.frostguard.vision.convert.GameTimeUtils;
-import dev.frostguard.vision.convert.RegexNumberParser;
-import dev.frostguard.vision.ocr.ResilientOcrExecutor;
-import java.awt.*;
+import dev.frostguard.vision.convert.ImageConverter;
+
+import java.awt.image.BufferedImage;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
+import java.util.Comparator;
 import java.util.List;
 import static dev.frostguard.api.configs.ConfigurationKeyEnum.*;
 import static dev.frostguard.api.configs.TemplatesEnum.*;
 
 public class BearTrapRoutine extends DelayedTask {
 
-private final AtomicBoolean ownRallyActive = new AtomicBoolean(false);
+private boolean ownRallyActive;
 
-private ScheduledExecutorService rallyScheduler;
+private Integer ownRallySlot;
 
-private ScheduledFuture<?> rallyResetTask;
+private Instant ownRallyFallbackReleaseAt;
+
+private Instant nextOwnRallyCheck = Instant.EPOCH;
+
+private Instant nextOwnRallyAttempt = Instant.EPOCH;
+
+private Instant nextJoinAttempt = Instant.EPOCH;
+
+private int consecutiveOwnRallyFailures;
+
+private final BearJoinAttemptLedger joinAttempts =
+        new BearJoinAttemptLedger(Duration.ofSeconds(JOIN_ROW_RETRY_COOLDOWN_SECONDS));
 
 private List<Integer> joinFlags = new ArrayList<>();
 
 private int currentJoinFlagIndex = 0;
-
-private ResilientOcrExecutor<Duration> durationHelper;
 
 private static final int TRAP_DURATION_MINUTES_VALUE = 30;
 
@@ -54,17 +59,26 @@ private static final int TRAP_ACTIVATION_OFFSET_MINUTES_VALUE = 30;
 
 private static final int STATUS_LOG_INTERVAL_VALUE = 10;
 
-private static final int OWN_RALLY_MIN_REMAINING_SECONDS_VALUE = 360;
+private static final int OWN_RALLY_ABSOLUTE_MIN_REMAINING_SECONDS = 45;
 
-private static final int RALLY_DURATION_BASE_MINUTES_VALUE = 5;
+private static final int DEFAULT_RALLY_SET_TIME_SECONDS = 300;
 
-private static final int RALLY_DURATION_BUFFER_SECONDS_VALUE = 3;
+private static final int RALLY_ARRIVAL_SAFETY_SECONDS = 10;
 
-private static final int RALLY_RETURN_BUFFER_MINUTES_VALUE = 5;
+private static final int OWN_RALLY_STATE_CHECK_SECONDS = 10;
+
+private static final int RETURN_IMMINENT_SECONDS = 15;
+
+private static final int MAX_OWN_RALLY_FAILURES_BEFORE_JOINS = 3;
+
+// A Bear rally normally remains listed through its preparation phase. Keeping a rejected row out
+// for that whole phase prevents the observed "already joined" loop without pretending the UI gave
+// us a stable rally identity.
+private static final int JOIN_ROW_RETRY_COOLDOWN_SECONDS = 300;
+
+private static final int MAX_JOIN_CANDIDATES_PER_PASS = 8;
 
 private static final int MAX_GATHER_RECALL_ATTEMPTS_LIMIT = 120;
-
-private static final int MARCH_TIME_OCR_MAX_RETRIES_MS = 5;
 
 private static final int TEMPLATE_SEARCH_RETRIES_VALUE = 3;
 
@@ -114,14 +128,6 @@ private static final PointData RECALL_CONFIRM_BUTTON_TL_VALUE = new PointData(44
 
 private static final PointData RECALL_CONFIRM_BUTTON_BR_VALUE = new PointData(578, 800);
 
-private static final PointData MARCH_TIME_OCR_TL_MS = new PointData(504, 1134);
-
-private static final PointData MARCH_TIME_OCR_BR_MS = new PointData(622, 1162);
-
-private static final PointData FREE_MARCHES_OCR_TL_VALUE = new PointData(203, 200);
-
-private static final PointData FREE_MARCHES_OCR_BR_VALUE = new PointData(246, 226);
-
 private static final int DEFAULT_TRAP_NUMBER_VALUE = 1;
 
 private static final int DEFAULT_PREPARATION_TIME_MINUTES_MS = 10;
@@ -137,8 +143,6 @@ private static final boolean DEFAULT_JOIN_RALLY_VALUE = false;
 private static final boolean DEFAULT_USE_PETS_VALUE = false;
 
 private static final boolean DEFAULT_RECALL_TROOPS_VALUE = false;
-
-private static final int DEFAULT_FREE_MARCHES_FALLBACK_VALUE = 1;
 
 private boolean callOwnRally;
 
@@ -161,12 +165,6 @@ private LocalDateTime referenceTrapTime;
 
 private boolean isVisuallyTriggered = false;
 
-private static final OcrSettingsData FREE_MARCHES_OCR_SETTINGS_VALUE = OcrSettingsData.assembler()
-            .charWhitelist("0123456789/")
-            .stripBackground(true)
-            .setTextColor(new Color(253, 253, 253))
-            .build();
-
 public BearTrapRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask) {
         super(profile, tpTask);
     }
@@ -188,8 +186,6 @@ public BearTrapRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask) {
 
 
         try {
-            initializeOCRHelpersFlow();
-
             TrapTimingShape timing;
             if (isVisuallyTriggered) {
                 logInfo(routineLogBearTrapLine("Task was Visually Triggered! Bypassing scheduled configuration and forcing 30-minute Active execution."));
@@ -316,11 +312,6 @@ private void requeueDisabledTasksFlow() {
 
     }
 
-private void initializeOCRHelpersFlow() {
-        BotOcrEngine provider = new BotOcrEngine(emuManager, EMULATOR_NUMBER);
-        this.durationHelper = new ResilientOcrExecutor<>(provider);
-    }
-
 private void requeueAutojoinTaskFlow(TaskQueue queue) {
         logInfo(routineLogBearTrapLine("Inspecting autojoin task..."));
 
@@ -413,8 +404,10 @@ private void performTrapActivePhase(LocalDateTime trapEndTime) {
             iterationCount++;
             long secondsRemaining = ChronoUnit.SECONDS.between(now, trapEndTime);
 
-            tryStartOwnRallyFlow(secondsRemaining);
-            handleJoinRallies2();
+            boolean ownRallyNeedsPriority = tryStartOwnRallyFlow(secondsRemaining);
+            if (!ownRallyNeedsPriority) {
+                handleJoinRallies();
+            }
 
             logPeriodicStatusFlow(iterationCount, secondsRemaining);
 
@@ -499,39 +492,111 @@ private void logPeriodicStatusFlow(long iterationCount, long secondsRemaining) {
         }
     }
 
-private void tryStartOwnRallyFlow(long secondsRemaining) {
-        if (!callOwnRally || ownRallyActive.get() || secondsRemaining <= OWN_RALLY_MIN_REMAINING_SECONDS_VALUE) {
-            return;
+private boolean tryStartOwnRallyFlow(long secondsRemaining) {
+        if (!callOwnRally) {
+            return false;
+        }
+
+        Instant now = Instant.now();
+        if (ownRallyActive) {
+            return refreshOwnRallyState(now);
+        }
+        if (secondsRemaining <= OWN_RALLY_ABSOLUTE_MIN_REMAINING_SECONDS) {
+            logInfo(routineLogBearTrapLine("Own rally disabled for this session: only " + secondsRemaining
+                    + "s remain, below the absolute safe-start floor"));
+            callOwnRally = false;
+            return false;
+        }
+        if (now.isBefore(nextOwnRallyAttempt)) {
+            return consecutiveOwnRallyFailures < MAX_OWN_RALLY_FAILURES_BEFORE_JOINS;
         }
 
         try {
-            long marchDurationSeconds = beginOwnRally();
-
-            if (marchDurationSeconds > 0) {
-                LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
-                LocalDateTime returnTime = now.plusSeconds(marchDurationSeconds * 2 + 3)
-                        .plusMinutes(RALLY_RETURN_BUFFER_MINUTES_VALUE);
-
-                logInfo(routineLogBearTrapLine("Own rally started finished cleanly, returning in: " + returnTime.format(TIME_FORMATTER)));
-                ownRallyActive.set(true);
-                queueRallyFlagReset(marchDurationSeconds);
-                sleepTask(500);
-
-            } else {
-                logWarning(routineLogBearTrapLine("Could not start rally (may already be active)"));
+            List<MarchSlotState> before = marchHelper.readMarchQueue();
+            if (!before.isEmpty() && before.stream().noneMatch(MarchSlotState::isIdle)) {
+                nextOwnRallyAttempt = now.plusSeconds(OWN_RALLY_STATE_CHECK_SECONDS);
+                logInfo(routineLogBearTrapLine("Own rally waiting: March Queue has no idle slot"));
+                return true;
             }
+
+            OwnRallyLaunchResult result = beginOwnRally(secondsRemaining);
+            if (result.outcome() == OwnRallyLaunchOutcome.CONFIRMED) {
+                List<MarchSlotState> after = marchHelper.readMarchQueue();
+                ownRallySlot = BearOwnRallyTracker.identifyNewRallySlot(before, after);
+                ownRallyActive = true;
+                consecutiveOwnRallyFailures = 0;
+                ownRallyFallbackReleaseAt = now.plusSeconds(
+                        result.rallySetTimeSeconds() + result.travelTimeSeconds() * 2L
+                                + RALLY_ARRIVAL_SAFETY_SECONDS);
+                nextOwnRallyCheck = now.plusSeconds(OWN_RALLY_STATE_CHECK_SECONDS);
+                logInfo(routineLogBearTrapLine("Own rally confirmed: slot="
+                        + (ownRallySlot == null ? "unresolved" : ownRallySlot)
+                        + " setTime=" + result.rallySetTimeSeconds() + "s travel="
+                        + result.travelTimeSeconds() + "s fallbackRelease=" + ownRallyFallbackReleaseAt));
+                return false;
+            }
+
+            navigationHelper.ensureCorrectScreenLocation(LaunchPoint.ANY);
+            if (result.structural()) {
+                callOwnRally = false;
+                logWarning(routineLogBearTrapLine("Own rally disabled for this session: " + result.detail()));
+                return false;
+            }
+
+            consecutiveOwnRallyFailures++;
+            nextOwnRallyAttempt = now.plusSeconds(5);
+            logWarning(routineLogBearTrapLine("Own rally attempt " + consecutiveOwnRallyFailures + "/"
+                    + MAX_OWN_RALLY_FAILURES_BEFORE_JOINS + " failed: " + result.detail()));
+            return consecutiveOwnRallyFailures < MAX_OWN_RALLY_FAILURES_BEFORE_JOINS;
         } catch (dev.frostguard.engine.error.ADBConnectionException e) {
-            logWarning(routineLogBearTrapLine("ADB connection error during rally startup (emulator may be lagging): " + e.getMessage()));
-            logDebug(routineLogBearTrapLine("Skipping this rally startup attempt, will retry on next cycle"));
-            ownRallyActive.set(false);
-
-
+            consecutiveOwnRallyFailures++;
+            nextOwnRallyAttempt = now.plusSeconds(5);
+            logWarning(routineLogBearTrapLine("ADB connection error during own rally: " + e.getMessage()));
+            return consecutiveOwnRallyFailures < MAX_OWN_RALLY_FAILURES_BEFORE_JOINS;
         } catch (Exception e) {
-            logError(routineLogBearTrapLine("Unexpected error during rally startup: " + e.getMessage()), e);
-            ownRallyActive.set(false);
-
-
+            consecutiveOwnRallyFailures++;
+            nextOwnRallyAttempt = now.plusSeconds(5);
+            logError(routineLogBearTrapLine("Unexpected error during own rally: " + e.getMessage()), e);
+            return consecutiveOwnRallyFailures < MAX_OWN_RALLY_FAILURES_BEFORE_JOINS;
         }
+    }
+
+private boolean refreshOwnRallyState(Instant now) {
+        if (now.isBefore(nextOwnRallyCheck)) {
+            return false;
+        }
+
+        List<MarchSlotState> slots = marchHelper.readMarchQueue();
+        BearOwnRallyTracker.Observation observation = BearOwnRallyTracker.observe(ownRallySlot, slots);
+        if (observation.state() == BearOwnRallyTracker.State.RETURNED) {
+            ownRallyActive = false;
+            ownRallySlot = null;
+            nextOwnRallyAttempt = Instant.EPOCH;
+            logInfo(routineLogBearTrapLine("Own rally march returned according to March Queue; own rally gets priority now"));
+            return true;
+        }
+        if (observation.state() == BearOwnRallyTracker.State.RETURNING
+                && observation.releaseCountdown().getSeconds() <= RETURN_IMMINENT_SECONDS) {
+            nextOwnRallyCheck = now.plusSeconds(2);
+            logDebug(routineLogBearTrapLine("Own rally return is imminent ("
+                    + observation.releaseCountdown().getSeconds() + "s); pausing new joins"));
+            return true;
+        }
+        if (observation.state() == BearOwnRallyTracker.State.UNKNOWN
+                && ownRallyFallbackReleaseAt != null && !now.isBefore(ownRallyFallbackReleaseAt)) {
+            ownRallyActive = false;
+            ownRallySlot = null;
+            nextOwnRallyAttempt = Instant.EPOCH;
+            logWarning(routineLogBearTrapLine("Own rally slot could not be tracked; fallback release time elapsed, retrying conservatively"));
+            return true;
+        }
+
+        long checkDelay = observation.releaseCountdown() == null
+                ? OWN_RALLY_STATE_CHECK_SECONDS
+                : Math.max(2, Math.min(OWN_RALLY_STATE_CHECK_SECONDS,
+                        observation.releaseCountdown().getSeconds()));
+        nextOwnRallyCheck = now.plusSeconds(checkDelay);
+        return false;
     }
 
 private boolean resolveConfigBoolean(ConfigurationKeyEnum key, boolean defaultValue) {
@@ -564,36 +629,6 @@ private void hydrateConfiguration() {
 
 private ConfigurationKeyEnum selectedTrapScheduleKey() {
         return BearTrapParticipationSchedule.scheduleKey(trapNumber);
-    }
-
-private int resolveNextJoinFlag() {
-        if (joinFlags.isEmpty()) {
-            return DEFAULT_JOIN_RALLY_FLAG_VALUE;
-        }
-
-        int flag = joinFlags.get(currentJoinFlagIndex);
-        currentJoinFlagIndex = (currentJoinFlagIndex + 1) % joinFlags.size();
-
-        return flag;
-    }
-
-private void queueRallyFlagReset(long marchSeconds) {
-        long durationSeconds = RALLY_DURATION_BASE_MINUTES_VALUE * 60 +
-                marchSeconds * 2 -
-                RALLY_DURATION_BUFFER_SECONDS_VALUE;
-
-        if (rallyScheduler == null || rallyScheduler.isShutdown() || rallyScheduler.isTerminated()) {
-            rallyScheduler = Executors.newSingleThreadScheduledExecutor();
-        }
-        rallyResetTask = rallyScheduler.schedule(
-                () -> {
-                    ownRallyActive.set(false);
-                    logInfo(routineLogBearTrapLine("Rally active flag automatically reset after duration"));
-                },
-                durationSeconds,
-                TimeUnit.SECONDS);
-
-        logDebug(routineLogBearTrapLine("Scheduled rally flag reset in " + durationSeconds + " seconds"));
     }
 
 private void disableAutojoinFlow() {
@@ -683,51 +718,7 @@ private MarchStatusShape inspectMarchStatus() {
                 marchSpeedup != null && marchSpeedup.isFound());
     }
 
-private int inspectFreeMarches() {
-        checkPreemption();
-
-        emuManager.captureScreen(EMULATOR_NUMBER);
-        ResilientOcrExecutor<Integer> frameReader =
-                new ResilientOcrExecutor<>(provider.reusingLastFrame());
-
-        Integer used = frameReader.attemptRecognition(
-                FREE_MARCHES_OCR_TL_VALUE,
-                FREE_MARCHES_OCR_BR_VALUE,
-                5,
-                10L,
-                FREE_MARCHES_OCR_SETTINGS_VALUE,
-                RegexNumberParser::hasFractionSyntax,
-                RegexNumberParser::numerator);
-
-        checkPreemption();
-
-
-        Integer total = frameReader.attemptRecognition(
-                FREE_MARCHES_OCR_TL_VALUE,
-                FREE_MARCHES_OCR_BR_VALUE,
-                5,
-                10L,
-                FREE_MARCHES_OCR_SETTINGS_VALUE,
-                RegexNumberParser::hasFractionSyntax,
-                RegexNumberParser::denominator);
-
-        int freeMarches;
-
-        if (used != null && total != null) {
-            freeMarches = total - used;
-            logInfo(routineLogBearTrapLine("Free marches: " + freeMarches));
-        } else {
-
-
-            freeMarches = DEFAULT_FREE_MARCHES_FALLBACK_VALUE;
-            logInfo(routineLogBearTrapLine("Could not read marches (counter may not be visible yet), using default value: " + freeMarches));
-        }
-
-        return freeMarches;
-    }
-
-private void handleJoinRallies2() {
-		// Changed by pernerch | Date: 2026-07-02 | Why: skip rally joining on shared emulators while keeping other Bear Trap actions active.
+private void handleJoinRallies() {
         if (!joinRally || sharedEmulator) {
             if (sharedEmulator) {
                 logInfo(routineLogBearTrapLine("Skipping rally joining because this profile shares an emulator with another account."));
@@ -736,81 +727,187 @@ private void handleJoinRallies2() {
             }
             return;
         }
+        if (Instant.now().isBefore(nextJoinAttempt)) {
+            return;
+        }
 
         try {
-            int freeMarches = inspectFreeMarches();
-
-            if (freeMarches > 0) {
-                ImageSearchResultData warButton = templateSearchHelper.locatePattern(
-                        GAME_HOME_WAR,
-                        SearchConfig.builder()
-                                .withThreshold(90)
-                                .withMaxAttempts(TEMPLATE_SEARCH_RETRIES_VALUE)
-                                .build());
-
-                if (warButton.isFound()) {
-                    logInfo(routineLogBearTrapLine("Entering war section to check for rallies"));
-                    tapInside(warButton);
-                    manageJoinRallies(freeMarches);
-                }
+            ImageSearchResultData warButton = templateSearchHelper.locatePattern(
+                    GAME_HOME_WAR,
+                    SearchConfig.builder().withThreshold(90).withMaxAttempts(2).build());
+            if (!warButton.isFound()) {
+                nextJoinAttempt = Instant.now().plusSeconds(3);
+                logDebug(routineLogBearTrapLine("War button unavailable; deferring join scan"));
+                return;
             }
+            tapInside(warButton);
+            sleepTask(500);
+            manageJoinRallies();
         } catch (dev.frostguard.engine.error.ADBConnectionException e) {
             logWarning(routineLogBearTrapLine("ADB connection error during rally joining (emulator may be lagging): " + e.getMessage()));
-            logDebug(routineLogBearTrapLine("Skipping this rally join iteration, will retry on next cycle"));
-
-
+            nextJoinAttempt = Instant.now().plusSeconds(3);
         } catch (Exception e) {
             logError(routineLogBearTrapLine("Unexpected error during rally joining: " + e.getMessage()), e);
-
-
+            nextJoinAttempt = Instant.now().plusSeconds(3);
         }
     }
 
-private void manageJoinRallies(int freeMarches) {
-        ImageSearchResultData plusIcon = templateSearchHelper.locatePattern(
+private void manageJoinRallies() {
+        RawImageData raw = emuManager.captureScreen(EMULATOR_NUMBER);
+        List<ImageSearchResultData> plusIcons = templateSearchHelper.locateAllPatternsMono(
                 BEAR_JOIN_PLUS_ICON,
+                raw,
                 SearchConfig.builder()
-                        .withThreshold(90)
-                        .withMaxAttempts(2)
+                        .withThreshold(80)
+                        .withMaxAttempts(1)
+                        .withMaxResults(MAX_JOIN_CANDIDATES_PER_PASS)
                         .build());
 
-        if (!plusIcon.isFound()) {
-            logWarning(routineLogBearTrapLine("Zero joinable rallies detected (plus icon not present)"));
-            navigationHelper.ensureCorrectScreenLocation(LaunchPoint.ANY);
-            return;
-        }
-
-        int selectedFlag = resolveNextJoinFlag();
-        logInfo(routineLogBearTrapLine("Joining rally with flag #" + selectedFlag + " (rotation: " + joinFlags + ")"));
-
-        tapInside(plusIcon.getPoint(), plusIcon.getPoint(), 1, 100);
-        sleepTask(300);
-
-
-        if (!marchHelper.selectFlag(selectedFlag)) {
-            logWarning(routineLogBearTrapLine(
-                    "Configured join formation #" + selectedFlag + " is unavailable; cancelling this join"));
+        if (plusIcons == null || plusIcons.isEmpty()) {
+            logDebug(routineLogBearTrapLine("No rally plus controls visible"));
             pressBack();
+            nextJoinAttempt = Instant.now().plusSeconds(3);
             return;
         }
 
+        BufferedImage image = ImageConverter.toBufferedImage(raw);
+        List<ImageSearchResultData> candidates = plusIcons.stream()
+                .sorted(Comparator.comparingInt(hit -> hit.getPoint().getY()))
+                .filter(hit -> joinAttempts.canAttempt(hit.getPoint(), Instant.now()))
+                .filter(hit -> {
+                    BearJoinButtonClassifier.Evidence evidence = BearJoinButtonClassifier.inspect(image, hit.getPoint());
+                    if (!evidence.enabled()) {
+                        logDebug(routineLogBearTrapLine("Skipping grey rally plus at " + hit.getPoint()
+                                + " colouredPixels=" + evidence.colouredPixels()));
+                    }
+                    return evidence.enabled();
+                })
+                .toList();
 
-        ImageSearchResultData deploy = templateSearchHelper.locatePattern(
-                BEAR_DEPLOY_BUTTON,
-                SearchConfig.builder()
-                        .withThreshold(90)
-                        .withMaxAttempts(TEMPLATE_SEARCH_RETRIES_MAX_VALUE)
-                        .build());
+        if (candidates.isEmpty()) {
+            logDebug(routineLogBearTrapLine("All visible rally plus controls are grey or cooling down"));
+            pressBack();
+            nextJoinAttempt = Instant.now().plusSeconds(3);
+            return;
+        }
 
-        if (!deploy.isFound()) {
-            logWarning(routineLogBearTrapLine("Deploy button not detected after selecting flag."));
-        } else {
-            tapInside(deploy);
+        for (ImageSearchResultData candidate : candidates) {
+            checkPreemption();
+            logInfo(routineLogBearTrapLine("Trying active rally plus at " + candidate.getPoint()));
+            tapInside(candidate.getPoint(), candidate.getPoint(), 1, 100);
             sleepTask(500);
 
+            if (deploymentHelper.isMarchQueueFull()) {
+                logInfo(routineLogBearTrapLine("Join paused: March Queue is full"));
+                pressBack();
+                nextJoinAttempt = Instant.now().plusSeconds(OWN_RALLY_STATE_CHECK_SECONDS);
+                return;
+            }
+            if (deploymentHelper.hasNoDeployableTroops()) {
+                logWarning(routineLogBearTrapLine("Join paused: formation screen reports no deployable troops"));
+                pressBack();
+                sleepTask(300);
+                pressBack();
+                nextJoinAttempt = Instant.now().plusSeconds(OWN_RALLY_STATE_CHECK_SECONDS);
+                return;
+            }
+
+            FormationSelectionResult formation = selectNextJoinFormation();
+            if (!formation.successful()) {
+                logWarning(routineLogBearTrapLine("Join candidate rejected: no configured formation could be selected; last="
+                        + formation.status() + " detail=" + formation.detail()));
+                pressBack();
+                sleepTask(300);
+                pressBack();
+                if (formation.status() != FormationSelectionResult.Status.SCREEN_UNREADABLE) {
+                    joinRally = false;
+                    logWarning(routineLogBearTrapLine("Joining disabled for this session because every configured formation is structurally unavailable"));
+                } else {
+                    nextJoinAttempt = Instant.now().plusSeconds(OWN_RALLY_STATE_CHECK_SECONDS);
+                }
+                return;
+            }
+
+            ImageSearchResultData deploy = templateSearchHelper.locatePattern(
+                    BEAR_DEPLOY_BUTTON,
+                    SearchConfig.builder().withThreshold(90).withMaxAttempts(3).withDelay(250).build());
+            if (!deploy.isFound()) {
+                logWarning(routineLogBearTrapLine("Join candidate rejected before Deploy: rally may already be joined, full, expired, or unable to fit the selected formation; row="
+                        + candidate.getPoint() + " formation=" + formation.formation()));
+                joinAttempts.reject(candidate.getPoint(), Instant.now());
+                pressBack();
+                sleepTask(400);
+                continue;
+            }
+
+            DeployVerification verification = pressDeployAndVerify(deploy);
+            if (verification == DeployVerification.CONFIRMED) {
+                logInfo(routineLogBearTrapLine("Join confirmed after Deploy: row=" + candidate.getPoint()
+                        + " formation=" + formation.formation()));
+                nextJoinAttempt = Instant.EPOCH;
+                return;
+            }
+
+            logWarning(routineLogBearTrapLine("Join not confirmed after Deploy: outcome=" + verification
+                    + " row=" + candidate.getPoint() + " formation=" + formation.formation()));
+            joinAttempts.reject(candidate.getPoint(), Instant.now());
+            if (verification == DeployVerification.DESTINATION_UNVERIFIED) {
+                navigationHelper.ensureCorrectScreenLocation(LaunchPoint.ANY);
+                nextJoinAttempt = Instant.now().plusSeconds(3);
+                return;
+            }
+            pressBack();
+            sleepTask(400);
         }
 
-        navigationHelper.ensureCorrectScreenLocation(LaunchPoint.ANY);
+        pressBack();
+        nextJoinAttempt = Instant.now().plusSeconds(3);
+    }
+
+private FormationSelectionResult selectNextJoinFormation() {
+        FormationSelectionResult last = new FormationSelectionResult(
+                FormationSelectionResult.Status.EMPTY_OR_MISSING, null, "No join formations configured");
+        for (int attempt = 0; attempt < joinFlags.size(); attempt++) {
+            int flag = joinFlags.get(currentJoinFlagIndex);
+            FormationSelectionResult result = marchHelper.selectFormation(flag);
+            currentJoinFlagIndex = (currentJoinFlagIndex + 1) % joinFlags.size();
+            if (result.successful()) {
+                logInfo(routineLogBearTrapLine("Join formation #" + flag + " selected from rotation " + joinFlags));
+                return result;
+            }
+            logWarning(routineLogBearTrapLine("Join formation #" + flag + " skipped: "
+                    + result.status() + " (" + result.detail() + ")"));
+            last = result;
+        }
+        return last;
+    }
+
+private DeployVerification pressDeployAndVerify(ImageSearchResultData deploy) {
+        tapInside(deploy);
+        sleepTask(2000);
+
+        if (deploymentHelper.isSameTargetDialog()) {
+            pressBack();
+            sleepTask(300);
+            return DeployVerification.REJECTED_BY_DIALOG;
+        }
+        ImageSearchResultData stillVisible = templateSearchHelper.locatePattern(
+                BEAR_DEPLOY_BUTTON,
+                SearchConfig.builder().withThreshold(90).withMaxAttempts(2).withDelay(300).build());
+        if (stillVisible.isFound()) {
+            return DeployVerification.DEPLOY_STILL_VISIBLE;
+        }
+        ImageSearchResultData world = templateSearchHelper.locatePattern(
+                GAME_HOME_WORLD,
+                SearchConfig.builder().withThreshold(90).withMaxAttempts(5).withDelay(400).build());
+        return world.isFound() ? DeployVerification.CONFIRMED : DeployVerification.DESTINATION_UNVERIFIED;
+    }
+
+private enum DeployVerification {
+        CONFIRMED,
+        REJECTED_BY_DIALOG,
+        DEPLOY_STILL_VISIBLE,
+        DESTINATION_UNVERIFIED
     }
 
 private void logTrapTimingFlow(TrapTimingShape timing) {
@@ -961,23 +1058,6 @@ private void enablePetsFlow() {
         navigationHelper.ensureCorrectScreenLocation(LaunchPoint.ANY);
     }
 
-private long scanMarchTime() {
-        Duration marchingTime = durationHelper.attemptRecognition(
-                MARCH_TIME_OCR_TL_MS,
-                MARCH_TIME_OCR_BR_MS,
-                MARCH_TIME_OCR_MAX_RETRIES_MS,
-                200L,
-                null,
-                GameTimeUtils::isAcceptedFormat,
-                GameTimeUtils::parseDuration);
-
-        if (marchingTime != null) {
-            return marchingTime.getSeconds();
-        }
-
-        return 0;
-    }
-
 private boolean reachBearTrap(int trapNumber) {
         tapInside(ALLIANCE_BUTTON_TL_VALUE, ALLIANCE_BUTTON_BR_VALUE);
         sleepTask(3000);
@@ -1012,12 +1092,7 @@ private boolean reachBearTrap(int trapNumber) {
         return success;
     }
 
-private long beginOwnRally() {
-        if (!ownRallyActive.compareAndSet(false, true)) {
-            return 0;
-
-        }
-
+private OwnRallyLaunchResult beginOwnRally(long secondsRemaining) {
         logInfo(routineLogBearTrapLine("Calling own rally..."));
 
         tapInside(BEAR_CENTER_POINT_VALUE, BEAR_CENTER_POINT_VALUE, 1, 200);
@@ -1033,8 +1108,8 @@ private long beginOwnRally() {
 
         if (!rallyButton.isFound()) {
             logError(routineLogBearTrapLine("Rally button not detected!"));
-            ownRallyActive.set(false);
-            return 0;
+            return OwnRallyLaunchResult.transientFailure(OwnRallyLaunchOutcome.RALLY_BUTTON_MISSING,
+                    "Rally button not detected");
         }
 
         logInfo(routineLogBearTrapLine("Entering rally menu..."));
@@ -1051,75 +1126,99 @@ private long beginOwnRally() {
 
         if (!holdRallyButton.isFound()) {
             logError(routineLogBearTrapLine("Hold Rally button not detected!"));
-            ownRallyActive.set(false);
-            return 0;
+            pressBack();
+            return OwnRallyLaunchResult.transientFailure(OwnRallyLaunchOutcome.HOLD_BUTTON_MISSING,
+                    "Hold Rally button not detected");
         }
 
+        int rallySetTimeSeconds = deploymentHelper.readRallySetTimeSeconds(DEFAULT_RALLY_SET_TIME_SECONDS);
         tapInside(holdRallyButton.getPoint(), holdRallyButton.getPoint(), 1, 200);
         sleepTask(300);
 
-
-        if (!marchHelper.selectFlag(ownRallyFlag)) {
-            logWarning(routineLogBearTrapLine(
-                    "Configured rally formation #" + ownRallyFlag + " is unavailable; cancelling own rally"));
+        if (deploymentHelper.hasNoDeployableTroops()) {
             pressBack();
-            ownRallyActive.set(false);
-            return 0;
+            return OwnRallyLaunchResult.transientFailure(OwnRallyLaunchOutcome.NO_TROOPS,
+                    "Formation screen reports no deployable troops");
         }
 
+        FormationSelectionResult formation = marchHelper.selectFormation(ownRallyFlag);
+        if (!formation.successful()) {
+            pressBack();
+            boolean structural = formation.status() == FormationSelectionResult.Status.UNSUPPORTED
+                    || formation.status() == FormationSelectionResult.Status.LOCKED
+                    || formation.status() == FormationSelectionResult.Status.EMPTY_OR_MISSING;
+            return new OwnRallyLaunchResult(OwnRallyLaunchOutcome.FORMATION_UNAVAILABLE,
+                    "Own formation #" + ownRallyFlag + " is " + formation.status()
+                            + " (" + formation.detail() + ")",
+                    structural, 0, rallySetTimeSeconds);
+        }
 
-        long marchSeconds = scanMarchTime();
-
-        if (marchSeconds == 0) {
-            logError(routineLogBearTrapLine("Could not read march time from screen, defaulting to 30 seconds"));
+        long marchSeconds = deploymentHelper.readTravelTimeSeconds();
+        if (marchSeconds <= 0) {
+            logWarning(routineLogBearTrapLine("Own rally travel time unreadable; using conservative 30s estimate"));
             marchSeconds = 30;
-
+        }
+        long requiredArrivalSeconds = rallySetTimeSeconds + marchSeconds + RALLY_ARRIVAL_SAFETY_SECONDS;
+        if (requiredArrivalSeconds >= secondsRemaining) {
+            pressBack();
+            return new OwnRallyLaunchResult(OwnRallyLaunchOutcome.TOO_LATE,
+                    "Rally would reach the trap too late: required=" + requiredArrivalSeconds
+                            + "s remaining=" + secondsRemaining + "s",
+                    true, marchSeconds, rallySetTimeSeconds);
         }
 
         ImageSearchResultData deploy = templateSearchHelper.locatePattern(
                 BEAR_DEPLOY_BUTTON,
                 SearchConfig.builder()
                         .withThreshold(90)
-                        .withMaxAttempts(TEMPLATE_SEARCH_RETRIES_MAX_VALUE)
+                        .withMaxAttempts(3)
+                        .withDelay(250)
                         .build());
 
         if (!deploy.isFound()) {
             logWarning(routineLogBearTrapLine("Deploy button not detected after selecting flag."));
-            ownRallyActive.set(false);
-            return 0;
+            pressBack();
+            return OwnRallyLaunchResult.transientFailure(OwnRallyLaunchOutcome.DEPLOY_MISSING,
+                    "Deploy button not detected after selecting own formation");
         }
 
-        tapInside(deploy);
-        sleepTask(500);
+        DeployVerification verification = pressDeployAndVerify(deploy);
+        if (verification != DeployVerification.CONFIRMED) {
+            pressBack();
+            return OwnRallyLaunchResult.transientFailure(OwnRallyLaunchOutcome.DEPLOY_NOT_CONFIRMED,
+                    "Deploy verification ended with " + verification);
+        }
 
-
-        logInfo(routineLogBearTrapLine("Rally deployed finished cleanly. March time: " + marchSeconds + " seconds"));
-        return marchSeconds;
+        return new OwnRallyLaunchResult(OwnRallyLaunchOutcome.CONFIRMED,
+                "World verified after Deploy", false, marchSeconds, rallySetTimeSeconds);
     }
 
 private void cleanupFlow() {
         logInfo(routineLogBearTrapLine("Cleaning up Bear Trap state"));
 
-        ownRallyActive.set(false);
-
-        if (rallyResetTask != null && !rallyResetTask.isDone()) {
-            rallyResetTask.cancel(false);
-            logDebug(routineLogBearTrapLine("Cancelled pending rally reset task"));
-        }
-
-        if (rallyScheduler != null && !rallyScheduler.isShutdown()) {
-            rallyScheduler.shutdown();
-            try {
-                if (!rallyScheduler.awaitTermination(5, TimeUnit.SECONDS)) {
-                    rallyScheduler.shutdownNow();
-                }
-                logDebug(routineLogBearTrapLine("Rally scheduler shutdown finished cleanly"));
-            } catch (InterruptedException e) {
-                rallyScheduler.shutdownNow();
-                Thread.currentThread().interrupt();
-            }
-        }
+        ownRallyActive = false;
+        ownRallySlot = null;
+        joinAttempts.clear();
 
         requeueDisabledTasksFlow();
+    }
+
+private enum OwnRallyLaunchOutcome {
+        CONFIRMED,
+        RALLY_BUTTON_MISSING,
+        HOLD_BUTTON_MISSING,
+        NO_TROOPS,
+        FORMATION_UNAVAILABLE,
+        TOO_LATE,
+        DEPLOY_MISSING,
+        DEPLOY_NOT_CONFIRMED
+    }
+
+private record OwnRallyLaunchResult(OwnRallyLaunchOutcome outcome, String detail, boolean structural,
+                                    long travelTimeSeconds, int rallySetTimeSeconds) {
+
+        static OwnRallyLaunchResult transientFailure(OwnRallyLaunchOutcome outcome, String detail) {
+            return new OwnRallyLaunchResult(outcome, detail, false, 0, DEFAULT_RALLY_SET_TIME_SECONDS);
+        }
     }
 }

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearJoinAttemptLedgerTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearJoinAttemptLedgerTest.java
@@ -1,0 +1,44 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.api.domain.PointData;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BearJoinAttemptLedgerTest {
+
+    @Test
+    void doesNotRetryRejectedRallyRowDuringItsPreparationWindow() {
+        BearJoinAttemptLedger ledger = new BearJoinAttemptLedger(Duration.ofMinutes(5));
+        PointData row = new PointData(610, 412);
+        Instant rejectedAt = Instant.parse("2026-08-17T20:00:00Z");
+
+        ledger.reject(row, rejectedAt);
+
+        assertFalse(ledger.canAttempt(new PointData(612, 414), rejectedAt.plusSeconds(30)));
+        assertFalse(ledger.canAttempt(row, rejectedAt.plusSeconds(299)));
+    }
+
+    @Test
+    void permitsFreshAttemptAfterCooldownExpires() {
+        BearJoinAttemptLedger ledger = new BearJoinAttemptLedger(Duration.ofMinutes(5));
+        PointData row = new PointData(610, 412);
+        Instant rejectedAt = Instant.parse("2026-08-17T20:00:00Z");
+        ledger.reject(row, rejectedAt);
+
+        assertTrue(ledger.canAttempt(row, rejectedAt.plusSeconds(300)));
+    }
+
+    @Test
+    void doesNotBlockAnotherVisibleRow() {
+        BearJoinAttemptLedger ledger = new BearJoinAttemptLedger(Duration.ofMinutes(5));
+        Instant now = Instant.parse("2026-08-17T20:00:00Z");
+        ledger.reject(new PointData(610, 412), now);
+
+        assertTrue(ledger.canAttempt(new PointData(610, 520), now));
+    }
+}

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearJoinButtonClassifierTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearJoinButtonClassifierTest.java
@@ -1,0 +1,59 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.api.domain.PointData;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BearJoinButtonClassifierTest {
+
+    @Test
+    void acceptsBlueEnabledButtonWithoutDependingOnExactShade() {
+        BufferedImage image = buttonFrame(new Color(42, 126, 218));
+
+        BearJoinButtonClassifier.Evidence evidence =
+                BearJoinButtonClassifier.inspect(image, new PointData(50, 50));
+
+        assertTrue(evidence.enabled());
+        assertTrue(evidence.colouredPixels() >= 18);
+    }
+
+    @Test
+    void acceptsLegacyGreenEnabledButton() {
+        BufferedImage image = buttonFrame(new Color(37, 183, 86));
+
+        assertTrue(BearJoinButtonClassifier.inspect(image, new PointData(50, 50)).enabled());
+    }
+
+    @Test
+    void rejectsGreyDisabledButton() {
+        BufferedImage image = buttonFrame(new Color(135, 135, 135));
+
+        BearJoinButtonClassifier.Evidence evidence =
+                BearJoinButtonClassifier.inspect(image, new PointData(50, 50));
+
+        assertFalse(evidence.enabled());
+    }
+
+    private static BufferedImage buttonFrame(Color buttonColor) {
+        BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            graphics.setColor(new Color(30, 30, 30));
+            graphics.fillRect(0, 0, 100, 100);
+            graphics.setColor(buttonColor);
+            graphics.fillRoundRect(28, 37, 44, 26, 8, 8);
+            graphics.setColor(Color.WHITE);
+            graphics.fillRect(47, 42, 6, 16);
+            graphics.fillRect(42, 47, 16, 6);
+        } finally {
+            graphics.dispose();
+        }
+        return image;
+    }
+}

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearOwnRallyTrackerTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearOwnRallyTrackerTest.java
@@ -1,0 +1,68 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.api.domain.MarchActivityType;
+import dev.frostguard.api.domain.MarchCountdownKind;
+import dev.frostguard.api.domain.MarchMovementPhase;
+import dev.frostguard.api.domain.MarchSlotAvailability;
+import dev.frostguard.api.domain.MarchSlotReleaseConfidence;
+import dev.frostguard.api.domain.MarchSlotState;
+import dev.frostguard.api.domain.MarchSlotStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BearOwnRallyTrackerTest {
+
+    @Test
+    void identifiesRallyThatOccupiedAnIdleSlot() {
+        List<MarchSlotState> before = List.of(idle(1), rally(2, MarchMovementPhase.PREPARING, null));
+        List<MarchSlotState> after = List.of(rally(1, MarchMovementPhase.PREPARING, null),
+                rally(2, MarchMovementPhase.PREPARING, null));
+
+        assertEquals(1, BearOwnRallyTracker.identifyNewRallySlot(before, after));
+    }
+
+    @Test
+    void doesNotClaimAnExistingRallyAsNew() {
+        List<MarchSlotState> before = List.of(rally(2, MarchMovementPhase.PREPARING, null));
+        List<MarchSlotState> after = List.of(rally(2, MarchMovementPhase.PREPARING, null));
+
+        assertNull(BearOwnRallyTracker.identifyNewRallySlot(before, after));
+    }
+
+    @Test
+    void exactReturnCountdownPausesAgainstTheTrackedSlot() {
+        Duration countdown = Duration.ofSeconds(12);
+
+        BearOwnRallyTracker.Observation observation = BearOwnRallyTracker.observe(
+                3, List.of(rally(3, MarchMovementPhase.RETURNING, countdown)));
+
+        assertEquals(BearOwnRallyTracker.State.RETURNING, observation.state());
+        assertEquals(countdown, observation.releaseCountdown());
+    }
+
+    @Test
+    void idleTrackedSlotMeansTheOwnMarchReturned() {
+        BearOwnRallyTracker.Observation observation =
+                BearOwnRallyTracker.observe(4, List.of(idle(4)));
+
+        assertEquals(BearOwnRallyTracker.State.RETURNED, observation.state());
+    }
+
+    private static MarchSlotState idle(int slot) {
+        return MarchSlotState.of(slot, MarchSlotStatus.IDLE);
+    }
+
+    private static MarchSlotState rally(int slot, MarchMovementPhase phase, Duration countdown) {
+        boolean returning = phase == MarchMovementPhase.RETURNING;
+        return new MarchSlotState(slot, MarchSlotStatus.BUSY_UNKNOWN, MarchSlotAvailability.OCCUPIED,
+                MarchActivityType.RALLY, phase, null, countdown,
+                returning ? MarchCountdownKind.RETURN : MarchCountdownKind.RALLY_START,
+                returning ? MarchSlotReleaseConfidence.EXACT : MarchSlotReleaseConfidence.LOWER_BOUND,
+                "test");
+    }
+}


### PR DESCRIPTION
## Summary

- classify Bear rally plus controls from one frame, accepting enabled blue or legacy-green controls while skipping grey controls
- bound visible rally attempts and suppress rejected rows for the rally preparation window
- verify Deploy outcomes instead of leaving the formation screen after a fixed 500 ms delay
- prioritize own rallies and release them from March Queue evidence instead of a scheduled estimate
- expose typed formation-selection failures and recognize no-troop and full-march states
- reject own rallies that cannot reach the trap before the event ends

## Why

Bear Trap could repeatedly enter a rally the account had already joined, report a generic missing Deploy button, and retry the same visible row. It also treated a Deploy tap as successful without verification and reset own-rally availability from an estimated timer, which delayed or mistimed later rally creation.

The UI does not expose stable rally identity, capacity, or departure time. This change therefore makes the UI fallback bounded and evidence-based without claiming that it can distinguish every server-side rejection.

Closes #129.

## Validation

- `mvnw.cmd -pl modules/tasks -am test` ? 363 tests passed, 0 failures, 0 errors, 0 skipped
- new automated coverage verifies enabled blue/green versus disabled grey plus controls
- new automated coverage verifies rejected-row suppression and expiry
- new automated coverage verifies own-rally March Queue slot association and exact return handling
- `git diff --check` ? passed
- saved current Bear-list frame verification ? not performed; no suitable current frame is available
- live Bear Trap run ? not performed; the event cannot be triggered on demand

## Risks

- The active/grey colour threshold has synthetic automated coverage but still needs a saved current game frame.
- A five-minute row ledger prevents the observed retry loop without a stable rally ID; a newly inserted rally occupying the same screen row during that interval may be deferred.
- UI evidence cannot distinguish already joined from full, expired, or insufficient-capacity rejection, so logs report the conservative aggregate outcome.
- Joining-march arrival before rally departure cannot be proven from the current UI flow. Traffic-derived rally identity, capacity, departure time, membership, and leader power remain a follow-up.
- End-to-end navigation and timing require live account-log confirmation before merge readiness.

## Review structure

- Stack position: 1/1
- Parent PR: none
- Child PR: none
- Shared issue: #129
- Dependencies: none
- Merge order: this PR only, after saved-frame and live-event validation

