### PR TITLE
fix(life-essence): retry failures without disabling task

### DIFF
--- a/modules/tasks/src/main/java/dev/frostguard/tasks/pets/LifeEssenceRetryPolicy.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/pets/LifeEssenceRetryPolicy.java
@@ -1,0 +1,26 @@
+package dev.frostguard.tasks.pets;
+
+import java.time.Duration;
+
+final class LifeEssenceRetryPolicy {
+
+    private static final int SHORT_BACKOFF_FAILURE_LIMIT = 5;
+    private static final int SHORT_BACKOFF_STEP_MINUTES = 5;
+    private static final int SATURATED_FAILURE_COUNT = SHORT_BACKOFF_FAILURE_LIMIT + 1;
+    private static final Duration LONG_RETRY_DELAY = Duration.ofHours(1);
+
+    private LifeEssenceRetryPolicy() {
+    }
+
+    static Decision afterFailure(int persistedFailures) {
+        int normalizedFailures = Math.clamp(persistedFailures, 0, SATURATED_FAILURE_COUNT);
+        int nextFailures = Math.min(normalizedFailures + 1, SATURATED_FAILURE_COUNT);
+        Duration retryDelay = nextFailures <= SHORT_BACKOFF_FAILURE_LIMIT
+                ? Duration.ofMinutes((long) SHORT_BACKOFF_STEP_MINUTES * nextFailures)
+                : LONG_RETRY_DELAY;
+        return new Decision(nextFailures, retryDelay);
+    }
+
+    record Decision(int persistedFailures, Duration retryDelay) {
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/pets/LifeEssenceRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/pets/LifeEssenceRoutine.java
@@ -1,6 +1,7 @@
 package dev.frostguard.tasks.pets;
 
 import java.time.DayOfWeek;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -34,21 +35,17 @@ public class LifeEssenceRoutine extends DelayedTask {
 			new PointData(720, 1280));
 
 	// Retry limits
-	private static final int MAX_NAVIGATION_FAILURES = 5;
 	private static final int MAX_CLAIM_SEARCH_ATTEMPTS = 5;
 	private static final int MAX_CLAIM_RESULTS = 5;
 
 	// Default configuration values
 	private static final int DEFAULT_OFFSET_MINUTES = Integer.parseInt(
 			ConfigurationKeyEnum.LIFE_ESSENCE_OFFSET_INT.getDefaultValue());
-	private static final int BACKOFF_MULTIPLIER = 5;
-	private static final int MAX_BACKOFF_MINUTES = 30;
-
 	// Configuration (loaded fresh each execution)
 	private int offsetMinutes;
 	private boolean buyWeeklyScroll;
 
-	// Execution state (reset each execution)
+	// Persisted retry state loaded at the start of each execution
 	private int consecutiveFailures = 0;
 
 	public LifeEssenceRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDailyTask) {
@@ -61,10 +58,7 @@ public class LifeEssenceRoutine extends DelayedTask {
 		// Load configuration
 		loadConfiguration();
 
-		// Check if we should stop trying after too many failures
-		if (shouldStopRetrying()) {
-			return;
-		}
+		loadFailureState();
 
 		// Navigate to Life Essence menu
 		if (!navigateToLifeEssenceMenu()) {
@@ -123,25 +117,11 @@ public class LifeEssenceRoutine extends DelayedTask {
 				", buyWeeklyScroll=" + buyWeeklyScroll);
 	}
 
-	/**
-	 * Check if task should stop retrying after consecutive failures
-	 */
-	private boolean shouldStopRetrying() {
-		// Get consecutive failure count from profile config (persisted)
+	private void loadFailureState() {
 		Integer failures = profile.getConfig(
 				ConfigurationKeyEnum.LIFE_ESSENCE_CONSECUTIVE_FAILURES_INT,
 				Integer.class);
-
-		consecutiveFailures = (failures != null) ? failures : 0;
-
-		if (consecutiveFailures >= MAX_NAVIGATION_FAILURES) {
-			logWarning("Maximum consecutive failures (" + MAX_NAVIGATION_FAILURES +
-					") reached. Disabling task. Re-enable in configs to retry.");
-			setRecurring(false);
-			return true;
-		}
-
-		return false;
+		consecutiveFailures = failures == null ? 0 : Math.max(0, failures);
 	}
 
 	/**
@@ -330,21 +310,20 @@ public class LifeEssenceRoutine extends DelayedTask {
 	 * Handle navigation failure by incrementing failure count and rescheduling
 	 */
 	private void handleNavigationFailure() {
-		consecutiveFailures++;
+		LifeEssenceRetryPolicy.Decision decision =
+				LifeEssenceRetryPolicy.afterFailure(consecutiveFailures);
+		consecutiveFailures = decision.persistedFailures();
 
 		writeProfileSetting(ConfigurationKeyEnum.LIFE_ESSENCE_CONSECUTIVE_FAILURES_INT, consecutiveFailures);
 
-		logWarning("Navigation failed. Consecutive failures: " + consecutiveFailures +
-				"/" + MAX_NAVIGATION_FAILURES);
-
-		// Calculate backoff time: 5, 10, 15, 20, 25 minutes (max 30)
-		int backoffMinutes = Math.min(BACKOFF_MULTIPLIER * consecutiveFailures, MAX_BACKOFF_MINUTES);
-		LocalDateTime nextAttempt = LocalDateTime.now().plusMinutes(backoffMinutes);
+		Duration retryDelay = decision.retryDelay();
+		LocalDateTime nextAttempt = LocalDateTime.now().plus(retryDelay);
 
 		reschedule(nextAttempt);
 
-		logInfo("Rescheduling with " + backoffMinutes + " minute backoff. Next attempt: " +
-				GameTimeUtils.formatCountdown(nextAttempt));
+		logWarning("Navigation failed. Consecutive failures: " + consecutiveFailures
+				+ ". Task remains enabled and will retry in " + retryDelay.toMinutes()
+				+ " minutes at " + GameTimeUtils.formatCountdown(nextAttempt));
 	}
 
 	/**

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/pets/LifeEssenceRetryPolicyTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/pets/LifeEssenceRetryPolicyTest.java
@@ -1,0 +1,38 @@
+package dev.frostguard.tasks.pets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class LifeEssenceRetryPolicyTest {
+
+    @Test
+    void increasesShortBackoffForTheFirstFiveFailures() {
+        assertDecision(0, 1, Duration.ofMinutes(5));
+        assertDecision(1, 2, Duration.ofMinutes(10));
+        assertDecision(2, 3, Duration.ofMinutes(15));
+        assertDecision(3, 4, Duration.ofMinutes(20));
+        assertDecision(4, 5, Duration.ofMinutes(25));
+    }
+
+    @Test
+    void retriesHourlyWithoutGrowingFailureStateAfterTheSixthFailure() {
+        assertDecision(5, 6, Duration.ofHours(1));
+        assertDecision(6, 6, Duration.ofHours(1));
+        assertDecision(Integer.MAX_VALUE, 6, Duration.ofHours(1));
+    }
+
+    @Test
+    void treatsMalformedNegativeFailureStateAsNoPreviousFailure() {
+        assertDecision(-7, 1, Duration.ofMinutes(5));
+    }
+
+    private void assertDecision(int previousFailures, int expectedFailures, Duration expectedDelay) {
+        LifeEssenceRetryPolicy.Decision decision = LifeEssenceRetryPolicy.afterFailure(previousFailures);
+
+        assertEquals(expectedFailures, decision.persistedFailures());
+        assertEquals(expectedDelay, decision.retryDelay());
+    }
+}


### PR DESCRIPTION
## Summary

- keep Life Essence enabled after repeated navigation failures
- retain bounded 5/10/15/20/25-minute retries, then retry hourly
- saturate persisted failure state at six and reset it after recovery

## Why

The routine previously stopped recurring after five navigation failures. That permanently removed Life Essence from the queue until an operator manually re-enabled it, turning a temporary navigation problem into a silent long-lived outage.

Closes #236.

## Validation

- `mvnw.cmd package` — 503 tests, 0 failures, 0 errors, 0 skipped
- Live MuMu emulator 0 failure path — persisted failures advanced from 5 to 6, the task remained enabled, and the next execution was scheduled 60 minutes later
- Live MuMu emulator 0 recovery path — the sidebar destination matched at 99.952%, three Life Essence items were claimed, the counter reset from 6 to 0, and the configured 360-minute interval was restored

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

The first five failures intentionally retain the existing short backoff. Continued failures settle at one attempt per hour, so a persistent visual break remains visible in logs without creating a hot interaction loop.
