### PR TITLE
fix(research): adapt research tree entry detection

### DIFF
--- a/docs/task/sidebar-navigation.md
+++ b/docs/task/sidebar-navigation.md
@@ -21,8 +21,13 @@ therefore finds the destination icon and derives the Go area from the detected r
 It resets the section to the top with a bounded gesture count, uses a destination-specific
 bounded scan, and requires the panel to disappear after the Go tap.
 
+City destination icons use the same row-relative Go association. Research Center is migrated
+through its detected Center Research icon. After the Go transition, the building's detected
+Research button is preferred; the detected tutorial hand supplies a relative target only while
+the onboarding overlay occludes that button.
+
 Saved evidence lives under
 `modules/automation/src/test/resources/navigation/sidebar-update-20260817`. It covers City,
-Wilderness, three Daily scroll positions, the active-tab classifier, Arena, Land of Heroes,
+Wilderness, three Daily scroll positions, the active-tab classifier, Research Center, Arena, Land of Heroes,
 Life Essence, and relative Go-area association. Other destinations must not be migrated to a
 guessed section or reused icon without a real post-update frame.

--- a/modules/automation/src/main/java/dev/frostguard/engine/nav/SidebarDestination.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/nav/SidebarDestination.java
@@ -4,6 +4,7 @@ import dev.frostguard.api.configs.TemplatesEnum;
 
 /** Destinations whose sidebar rows have stable visual identity. */
 public enum SidebarDestination {
+    RESEARCH_CENTER(SidebarSection.CITY, TemplatesEnum.GAME_HOME_SHORTCUTS_RESEARCH_CENTER, 0),
     ARENA(SidebarSection.DAILY, TemplatesEnum.SIDEBAR_DAILY_ARENA, 1),
     LAND_OF_HEROES(SidebarSection.DAILY, TemplatesEnum.SIDEBAR_DAILY_LAND_OF_HEROES, 1),
     LIFE_ESSENCE(SidebarSection.DAILY, TemplatesEnum.SIDEBAR_DAILY_LIFE_ESSENCE, 2);

--- a/modules/automation/src/test/java/dev/frostguard/engine/helper/SidebarNavigatorFrameTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/helper/SidebarNavigatorFrameTest.java
@@ -38,6 +38,13 @@ class SidebarNavigatorFrameTest {
     }
 
     @Test
+    void detectsResearchCenterInTheRealCityFrame() throws IOException {
+        byte[] frame = resource("/navigation/sidebar-update-20260817/city.png");
+
+        assertDestination(frame, TemplatesEnum.GAME_HOME_SHORTCUTS_RESEARCH_CENTER, 47, 821);
+    }
+
+    @Test
     void derivesTheGoControlFromTheDetectedRowInsteadOfMatchingAnAmbiguousArrow() {
         ImageSearchResultData icon = ImageSearchResultData.hit(46, 373, 99.0, 44, 44);
 

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
@@ -13,6 +13,7 @@ import dev.frostguard.api.domain.ResearchBadgeData;
 import dev.frostguard.api.domain.OcrSettingsData;
 import dev.frostguard.engine.config.PriorityConfigResolver;
 import dev.frostguard.engine.helper.TemplateSearchHelper.SearchConfig;
+import dev.frostguard.engine.nav.SidebarDestination;
 import dev.frostguard.engine.nav.SearchConfigConstants;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
@@ -358,33 +359,33 @@ private boolean openResearchTree() {
                 pressBack();
                 sleepTask(500);
                 navigationHelper.ensureCorrectScreenLocation(LaunchPoint.HOME);
-                marchHelper.openLeftMenuCitySection(true);
             }
 
-            ImageSearchResultData researchCenter = templateSearchHelper.locatePattern(
-                    TemplatesEnum.GAME_HOME_SHORTCUTS_RESEARCH_CENTER,
+            if (!navigationHelper.navigateToSidebarDestination(SidebarDestination.RESEARCH_CENTER)) {
+                logWarning(routineLogResearchLine("Research Center destination was not reached during entry attempt "
+                        + attempt + "/" + RESEARCH_ENTRY_ATTEMPTS + "."));
+                continue;
+            }
+
+            ImageSearchResultData researchButton = templateSearchHelper.locatePattern(
+                    TemplatesEnum.BUILDING_BUTTON_RESEARCH,
                     SearchConfigConstants.DEFAULT_SINGLE);
-            if (!isFound(researchCenter)) {
-                logWarning(routineLogResearchLine("Research Center shortcut not detected during entry attempt "
-                        + attempt + "/" + RESEARCH_ENTRY_ATTEMPTS + "."));
-                continue;
+            if (isFound(researchButton)) {
+                logInfo(routineLogResearchLine("Research building button detected. Entering Research tree."));
+                tapInside(researchButton);
+            } else {
+                PointData handTarget = findResearchEntryHandTarget();
+                if (handTarget == null) {
+                    logWarning(routineLogResearchLine("Neither Research building button nor entry hand was detected "
+                            + "on attempt " + attempt + "/" + RESEARCH_ENTRY_ATTEMPTS + "."));
+                    continue;
+                }
+
+                logInfo(routineLogResearchLine(
+                        "Research entry hand detected over the button. Entering at its relative target."));
+                tapNear(handTarget);
             }
-
-            logDebug(routineLogResearchLine("Pressing Research Center (entry attempt "
-                    + attempt + "/" + RESEARCH_ENTRY_ATTEMPTS + ")"));
-            tapInside(researchCenter);
-            sleepTask(1000);
-
-            PointData handTarget = findResearchEntryHandTarget();
-            if (handTarget == null) {
-                logWarning(routineLogResearchLine("Research entry hand was not detected on attempt "
-                        + attempt + "/" + RESEARCH_ENTRY_ATTEMPTS + "."));
-                continue;
-            }
-
-            logInfo(routineLogResearchLine("Research entry hand detected. Pressing it with offset."));
-            tapNear(handTarget);
-            sleepTask(300);
+            sleepTask(500);
 
             if (isResearchTreeVisible()) {
                 logInfo(routineLogResearchLine("Research tree screen verified."));


### PR DESCRIPTION
## Summary

- route Research Center through the detected City sidebar destination and row-relative Go control
- prefer the detected Research building button after selecting the building
- retain the detected tutorial-hand-relative target when onboarding occludes the button
- cover the Center Research icon with the saved post-update City frame

## Why

The new sidebar makes the status icon itself non-interactive. The old routine tapped that icon and then searched for the tutorial hand before the building transition, so Research could no longer reach its tree.

Closes #241

## Validation

- `mvnw.cmd -pl modules/tasks -am test` — passed
- `mvnw.cmd package` — passed; 505 tests, 0 failures, 0 errors, 0 skipped
- saved real-frame verification — Center Research detected at `(47, 821)` in the post-update City sidebar fixture
- live account-log confirmation on emulator 0 — detected Center Research, tapped its derived Go area, used the tutorial-hand-relative target, and verified the Research tree
- safety — all research priorities were empty, so the run did not start research or spend resources

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

The normal unobscured Research building button path is covered by existing template behavior but was not encountered live because this account still shows the onboarding tutorial hand.