### PR TITLE
fix(tundra): use redesigned daily navigation

### DIFF
--- a/docs/task/sidebar-navigation.md
+++ b/docs/task/sidebar-navigation.md
@@ -26,6 +26,12 @@ through its detected Center Research icon. After the Go transition, the building
 Research button is preferred; the detected tutorial hand supplies a relative target only while
 the onboarding overlay occludes that button.
 
+Trek Supplies is a conditional Daily destination: it is absent after the timed reward has
+already been claimed and on accounts without Dawn Academy. The claim routine treats absence as
+unavailable rather than scanning the unrelated City queues. When present, the existing supply
+icon identifies its row; the routine then accepts either direct claim-panel entry or Dawn Academy
+entry followed by the supply counter.
+
 Saved evidence lives under
 `modules/automation/src/test/resources/navigation/sidebar-update-20260817`. It covers City,
 Wilderness, three Daily scroll positions, the active-tab classifier, Research Center, Arena, Land of Heroes,

--- a/modules/automation/src/main/java/dev/frostguard/engine/nav/SidebarDestination.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/nav/SidebarDestination.java
@@ -7,7 +7,8 @@ public enum SidebarDestination {
     RESEARCH_CENTER(SidebarSection.CITY, TemplatesEnum.GAME_HOME_SHORTCUTS_RESEARCH_CENTER, 0),
     ARENA(SidebarSection.DAILY, TemplatesEnum.SIDEBAR_DAILY_ARENA, 1),
     LAND_OF_HEROES(SidebarSection.DAILY, TemplatesEnum.SIDEBAR_DAILY_LAND_OF_HEROES, 1),
-    LIFE_ESSENCE(SidebarSection.DAILY, TemplatesEnum.SIDEBAR_DAILY_LIFE_ESSENCE, 2);
+    LIFE_ESSENCE(SidebarSection.DAILY, TemplatesEnum.SIDEBAR_DAILY_LIFE_ESSENCE, 2),
+    TUNDRA_TREK_SUPPLIES(SidebarSection.DAILY, TemplatesEnum.TUNDRA_TREK_SUPPLIES, 2);
 
     private final SidebarSection section;
     private final TemplatesEnum rowIcon;

--- a/modules/automation/src/test/java/dev/frostguard/engine/helper/SidebarNavigatorFrameTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/helper/SidebarNavigatorFrameTest.java
@@ -1,6 +1,7 @@
 package dev.frostguard.engine.helper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -49,6 +50,19 @@ class SidebarNavigatorFrameTest {
         ImageSearchResultData icon = ImageSearchResultData.hit(46, 373, 99.0, 44, 44);
 
         assertEquals(AreaData.of(383, 348, 429, 398), SidebarNavigator.goButtonFor(icon));
+    }
+
+    @Test
+    void doesNotConfuseTrekSuppliesWithPersistentDailyRows() throws IOException {
+        for (String frameName : new String[] { "daily-top.png", "daily-middle.png", "daily-bottom.png" }) {
+            byte[] frame = resource("/navigation/sidebar-update-20260817/" + frameName);
+            ImageSearchResultData hit = OpenCvPatternLocator.locatePattern(frame,
+                    TemplatesEnum.TUNDRA_TREK_SUPPLIES,
+                    CommonGameAreas.SIDEBAR_ROW_ICON_COLUMN.topLeft(),
+                    CommonGameAreas.SIDEBAR_ROW_ICON_COLUMN.bottomRight(), 88);
+
+            assertFalse(hit.isFound(), () -> "Trek Supplies false positive in " + frameName + ": " + hit);
+        }
     }
 
     private void assertDestination(byte[] frame, TemplatesEnum template, int expectedX, int expectedY) {

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/exploration/TundraTrekRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/exploration/TundraTrekRoutine.java
@@ -4,17 +4,20 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 
 import dev.frostguard.vision.convert.GameTimeUtils;
-import dev.frostguard.vision.convert.GameTimeUtils;
 import dev.frostguard.api.configs.TemplatesEnum;
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.engine.nav.SidebarDestination;
 import dev.frostguard.engine.schedule.DelayedTask;
 import dev.frostguard.engine.schedule.LaunchPoint;
 import dev.frostguard.engine.nav.SearchConfigConstants;
 
 public class TundraTrekRoutine extends DelayedTask {
+
+    private static final PointData SUPPLY_COUNTER_TOP_LEFT = new PointData(500, 29);
+    private static final PointData SUPPLY_COUNTER_BOTTOM_RIGHT = new PointData(590, 49);
 
     public TundraTrekRoutine(AccountDescriptor profile, TpDailyTaskEnum tpDailyTask) {
         super(profile, tpDailyTask);
@@ -22,7 +25,7 @@ public class TundraTrekRoutine extends DelayedTask {
 
     @Override
     public LaunchPoint getRequiredStartLocation() {
-        return LaunchPoint.ANY;
+        return LaunchPoint.HOME;
     }
 
     @Override
@@ -68,29 +71,22 @@ public class TundraTrekRoutine extends DelayedTask {
     private boolean navigateToTrekSupplies() {
         logInfo("Navigating to Tundra Trek Supplies...");
 
-        // Open left menu on city section
-        marchHelper.openLeftMenuCitySection(true);
-
-        for (int i = 0; i < 5; i++) { // Try up to 5 times (swipes)
-            ImageSearchResultData trekSupplies = templateSearchHelper.locatePattern(
-                    TemplatesEnum.TUNDRA_TREK_SUPPLIES,
-                    SearchConfigConstants.DEFAULT_SINGLE);
-
-            if (trekSupplies.isFound()) {
-                logInfo("Found the Tundra Trek Supplies button.");
-                tapInside(trekSupplies);
-                sleepTask(1000);
-
-                // Open supplies claim screen
-                tapInside(new PointData(500, 29), new PointData(590, 49));
-                sleepTask(2000);
-                return true;
-            } else {
-                logInfo("Tundra Trek Supplies not visible. Swiping down to search... (Attempt " + (i + 1) + "/5)");
-                swipe(new PointData(320, 765), new PointData(50, 500));
-                sleepTask(1000);
-            }
+        if (!navigationHelper.navigateToSidebarDestination(SidebarDestination.TUNDRA_TREK_SUPPLIES)) {
+            logWarning("Trek Supplies destination is not available in the Daily sidebar");
+            return false;
         }
-        return false;
+
+        // The Daily shortcut may open either Dawn Academy or the claim panel directly.
+        if (!isClaimButtonVisible()) {
+            tapInside(SUPPLY_COUNTER_TOP_LEFT, SUPPLY_COUNTER_BOTTOM_RIGHT);
+            sleepTask(2000);
+        }
+        return true;
+    }
+
+    private boolean isClaimButtonVisible() {
+        return templateSearchHelper.locatePattern(
+                TemplatesEnum.TUNDRA_TREK_CLAIM_BUTTON,
+                SearchConfigConstants.DEFAULT_SINGLE).isFound();
     }
 }


### PR DESCRIPTION
## What changed

- route Tundra Trek Supplies through the verified `Daily` sidebar navigator
- remove the stale City-section swipe loop that could drift across unrelated queue rows
- preserve both direct claim-panel and Dawn Academy entry behavior
- treat a missing conditional Trek destination conservatively
- add real-frame negative coverage for the existing Trek icon against the persistent Daily rows

## Why

The August sidebar redesign moved destination navigation behind verified sections and row-relative Go targets. Trek Supplies still used the legacy City scan, reproducing five failed swipes and a one-hour retry on Bot 2 / MuMu emulator 1.

Closes #242

## Validation

- `mvnw.cmd -pl modules/tasks -am test`: 356 tests, 0 failures/errors/skips after rebasing onto current `main`
- saved real-frame regression coverage rejects false Trek matches in Daily top/middle/bottom frames
- live Bot 2 / MuMu emulator 1: original failure reproduced; fixed routine selected Daily, performed a bounded scan, and exited without unrelated taps when Trek was unavailable

## Remaining risk

The successful destination-open and claim path was not live-confirmed because Trek Supplies was unavailable on the test account. The PR intentionally preserves both known entry variants, but that positive path remains opportunistic live validation.