### PR TITLE
perf(navigation): avoid redundant sidebar reset cycles

### DIFF
--- a/docs/task/sidebar-navigation.md
+++ b/docs/task/sidebar-navigation.md
@@ -16,6 +16,11 @@ exists in the supplied open-panel frames. That tap is allowed only while a Home 
 anchor is present, is issued once, and must produce a classified selected tab. Section taps,
 scrolls, and close taps likewise require the expected panel state.
 
+Queue inspection opens or reuses its verified City or Wilderness section without changing the
+scroll position. This avoids unconditional reset gestures and allows one logical operation to
+inspect and act on the same frame. Callers that scan destination rows still request a known top
+origin explicitly; only those calls perform the bounded three-swipe reset.
+
 Daily destination icons provide row identity. The identical Go arrows do not. The navigator
 therefore finds the destination icon and derives the Go area from the detected row geometry.
 It resets the section to the top with a bounded gesture count, uses a destination-specific

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/MarchHelper.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/MarchHelper.java
@@ -6,6 +6,7 @@ import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.FormationSlots;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.MarchResourceType;
+import dev.frostguard.api.domain.MarchSlotAvailability;
 import dev.frostguard.api.domain.MarchSlotState;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.RawImageData;
@@ -84,7 +85,7 @@ public class MarchHelper {
     // line is classified by colour (white "Idle", orange "Unlock", red "Unavailable", nothing at all
     // for stationed troops) and the activity by its icon. Only the countdown needs OCR.
     public List<MarchSlotState> readMarchQueue() {
-        openLeftMenuCitySection(false);
+        openLeftMenuSection(false);
         try {
             return readVisibleMarchQueue();
         } finally {
@@ -97,7 +98,7 @@ public class MarchHelper {
      * for flows that already normalize their world state and do not need legacy multi-tap recovery.
      */
     public List<MarchSlotState> readMarchQueueSinglePass() {
-        openLeftMenuCitySectionOnce(false);
+        openLeftMenuSection(false);
         try {
             return readVisibleMarchQueue();
         } finally {
@@ -106,10 +107,27 @@ public class MarchHelper {
     }
 
     /**
-     * Reads the already-open wilderness March Queue panel without changing its state. This is for
-     * workflows such as Intel recall that must inspect rows and then interact with the same panel.
+     * Reads the already-open wilderness March Queue panel. A reset is used only when every row lacks
+     * queue evidence, which indicates that the preserved scroll position cannot be trusted.
      */
     public List<MarchSlotState> readVisibleMarchQueue() {
+        List<MarchSlotState> slots = readVisibleMarchQueueOnce();
+        if (hasReliableQueueEvidence(slots)) {
+            return slots;
+        }
+
+        log.warn("March Queue rows were not visible at the preserved position; resetting Wilderness once");
+        if (!sidebar.openSectionAtTop(SidebarSection.WILDERNESS)) {
+            return List.of();
+        }
+        return readVisibleMarchQueueOnce();
+    }
+
+    static boolean hasReliableQueueEvidence(List<MarchSlotState> slots) {
+        return slots.stream().anyMatch(slot -> slot.availability() != MarchSlotAvailability.UNKNOWN);
+    }
+
+    private List<MarchSlotState> readVisibleMarchQueueOnce() {
         try {
             RawImageData frame = emu.captureScreen(device);
             BufferedImage image = dev.frostguard.vision.convert.ImageConverter.toBufferedImage(frame);
@@ -311,7 +329,7 @@ public class MarchHelper {
     }
 
     public void openLeftMenuCitySection(boolean cityTab) {
-        log.debug("Left menu — " + (cityTab ? "city" : "wilderness"));
+        log.debug("Left menu at top - " + (cityTab ? "city" : "wilderness"));
         if (!sidebar.openSectionAtTop(cityTab ? SidebarSection.CITY : SidebarSection.WILDERNESS)) {
             throw new IllegalStateException("Could not open the requested sidebar section");
         }
@@ -322,13 +340,12 @@ public class MarchHelper {
         dismissLeftPanel();
     }
 
-    /**
-     * Compatibility entry point for flows that own the panel lifecycle and guarantee a matching
-     * {@link #closeLeftMenu()} in a finally block. State verification is identical to the normal path.
-     */
-    public void openLeftMenuCitySectionOnce(boolean cityTab) {
-        log.debug("Left menu single-pass - " + (cityTab ? "city" : "wilderness"));
-        openLeftMenuCitySection(cityTab);
+    /** Opens or reuses the requested section without changing its current scroll position. */
+    public void openLeftMenuSection(boolean cityTab) {
+        log.debug("Left menu without scroll reset - " + (cityTab ? "city" : "wilderness"));
+        if (!sidebar.openSection(cityTab ? SidebarSection.CITY : SidebarSection.WILDERNESS)) {
+            throw new IllegalStateException("Could not open the requested sidebar section");
+        }
     }
 
     private void dismissLeftPanel() {

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/SidebarNavigator.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/SidebarNavigator.java
@@ -45,35 +45,7 @@ public final class SidebarNavigator {
     }
 
     public boolean openSection(SidebarSection target) {
-        Optional<SidebarSection> current = selectedSection();
-        if (current.isEmpty()) {
-            if (!isRootScreen()) {
-                log.warn("Refusing to tap the sidebar trigger without a Home or World anchor");
-                return false;
-            }
-            log.debug("Sidebar closed; opening it once before selecting " + target);
-            taps.tapInside(CommonGameAreas.LEFT_MENU_TRIGGER, 1, SECTION_SETTLE_MS);
-            current = selectedSection();
-            if (current.isEmpty()) {
-                log.warn("Sidebar did not open after one verified trigger tap");
-                return false;
-            }
-        }
-
-        if (current.get() == target) {
-            log.debug("Sidebar section already selected: " + target);
-            return true;
-        }
-
-        taps.tapInside(CommonGameAreas.sidebarTab(target), 1, SECTION_SETTLE_MS);
-        Optional<SidebarSection> selected = selectedSection();
-        if (selected.orElse(null) != target) {
-            log.warn("Sidebar section selection failed: requested=" + target
-                    + " observed=" + selected.map(Enum::name).orElse("closed/unknown"));
-            return false;
-        }
-        log.debug("Sidebar section selected: " + target);
-        return true;
+        return openSection(target, false);
     }
 
     public boolean navigateTo(SidebarDestination destination) {
@@ -123,7 +95,67 @@ public final class SidebarNavigator {
     }
 
     public boolean openSectionAtTop(SidebarSection section) {
-        return openSection(section) && resetToTop(section);
+        return openSection(section, true);
+    }
+
+    static NextOpenAction nextOpenAction(Optional<SidebarSection> current, SidebarSection target,
+                                         boolean resetRequested, boolean resetComplete) {
+        if (current.isEmpty()) {
+            return NextOpenAction.OPEN_PANEL;
+        }
+        if (current.get() != target) {
+            return NextOpenAction.SELECT_SECTION;
+        }
+        if (resetRequested && !resetComplete) {
+            return NextOpenAction.RESET_TO_TOP;
+        }
+        return NextOpenAction.DONE;
+    }
+
+    private boolean openSection(SidebarSection target, boolean resetRequested) {
+        Optional<SidebarSection> current = selectedSection();
+        boolean resetComplete = false;
+
+        while (true) {
+            NextOpenAction action = nextOpenAction(current, target, resetRequested, resetComplete);
+            switch (action) {
+                case OPEN_PANEL -> {
+                    if (!isRootScreen()) {
+                        log.warn("Refusing to tap the sidebar trigger without a Home or World anchor");
+                        return false;
+                    }
+                    log.debug("Sidebar closed; opening it once before selecting " + target);
+                    taps.tapInside(CommonGameAreas.LEFT_MENU_TRIGGER, 1, SECTION_SETTLE_MS);
+                    current = selectedSection();
+                    if (current.isEmpty()) {
+                        log.warn("Sidebar did not open after one verified trigger tap");
+                        return false;
+                    }
+                }
+                case SELECT_SECTION -> {
+                    taps.tapInside(CommonGameAreas.sidebarTab(target), 1, SECTION_SETTLE_MS);
+                    current = selectedSection();
+                    if (current.orElse(null) != target) {
+                        log.warn("Sidebar section selection failed: requested=" + target
+                                + " observed=" + current.map(Enum::name).orElse("closed/unknown"));
+                        return false;
+                    }
+                    log.debug("Sidebar section selected: " + target);
+                }
+                case RESET_TO_TOP -> {
+                    if (!resetToTop(target)) {
+                        return false;
+                    }
+                    resetComplete = true;
+                    current = Optional.of(target);
+                }
+                case DONE -> {
+                    log.debug("Sidebar section ready: " + target
+                            + (resetRequested ? " at top" : " without scroll reset"));
+                    return true;
+                }
+            }
+        }
     }
 
     static AreaData goButtonFor(ImageSearchResultData rowIcon) {
@@ -178,5 +210,12 @@ public final class SidebarNavigator {
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
         }
+    }
+
+    enum NextOpenAction {
+        OPEN_PANEL,
+        SELECT_SECTION,
+        RESET_TO_TOP,
+        DONE
     }
 }

--- a/modules/automation/src/test/java/dev/frostguard/engine/helper/MarchHelperQueueEvidenceTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/helper/MarchHelperQueueEvidenceTest.java
@@ -1,0 +1,42 @@
+package dev.frostguard.engine.helper;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.frostguard.api.domain.MarchActivityType;
+import dev.frostguard.api.domain.MarchCountdownKind;
+import dev.frostguard.api.domain.MarchMovementPhase;
+import dev.frostguard.api.domain.MarchSlotAvailability;
+import dev.frostguard.api.domain.MarchSlotState;
+import dev.frostguard.api.domain.MarchSlotStatus;
+
+class MarchHelperQueueEvidenceTest {
+
+    @Test
+    void acceptsAVisibleQueueWithoutRequestingAReset() {
+        assertTrue(MarchHelper.hasReliableQueueEvidence(List.of(
+                MarchSlotState.of(1, MarchSlotStatus.IDLE),
+                MarchSlotState.of(2, MarchSlotStatus.GATHERING))));
+    }
+
+    @Test
+    void rejectsRowsThatContainNoQueueEvidence() {
+        MarchSlotState unknown = new MarchSlotState(
+                1,
+                MarchSlotStatus.BUSY_UNKNOWN,
+                MarchSlotAvailability.UNKNOWN,
+                MarchActivityType.UNKNOWN,
+                MarchMovementPhase.UNKNOWN,
+                null,
+                null,
+                MarchCountdownKind.NONE,
+                "no-status");
+
+        assertFalse(MarchHelper.hasReliableQueueEvidence(List.of(unknown)));
+        assertFalse(MarchHelper.hasReliableQueueEvidence(List.of()));
+    }
+}

--- a/modules/automation/src/test/java/dev/frostguard/engine/helper/SidebarNavigatorOpenPolicyTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/helper/SidebarNavigatorOpenPolicyTest.java
@@ -1,0 +1,42 @@
+package dev.frostguard.engine.helper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import dev.frostguard.engine.nav.SidebarSection;
+
+class SidebarNavigatorOpenPolicyTest {
+
+    @Test
+    void opensOnlyWhenThePanelIsClosed() {
+        assertEquals(SidebarNavigator.NextOpenAction.OPEN_PANEL,
+                SidebarNavigator.nextOpenAction(Optional.empty(), SidebarSection.CITY, false, false));
+    }
+
+    @Test
+    void reusesAnAlreadySelectedSectionWithoutInteractions() {
+        assertEquals(SidebarNavigator.NextOpenAction.DONE,
+                SidebarNavigator.nextOpenAction(
+                        Optional.of(SidebarSection.WILDERNESS), SidebarSection.WILDERNESS, false, false));
+    }
+
+    @Test
+    void selectsOnlyWhenAnotherSectionIsVisible() {
+        assertEquals(SidebarNavigator.NextOpenAction.SELECT_SECTION,
+                SidebarNavigator.nextOpenAction(
+                        Optional.of(SidebarSection.DAILY), SidebarSection.CITY, false, false));
+    }
+
+    @Test
+    void resetsOnlyWhenTheCallerRequiresAKnownOrigin() {
+        assertEquals(SidebarNavigator.NextOpenAction.RESET_TO_TOP,
+                SidebarNavigator.nextOpenAction(
+                        Optional.of(SidebarSection.DAILY), SidebarSection.DAILY, true, false));
+        assertEquals(SidebarNavigator.NextOpenAction.DONE,
+                SidebarNavigator.nextOpenAction(
+                        Optional.of(SidebarSection.DAILY), SidebarSection.DAILY, true, true));
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/city/TrainingRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/city/TrainingRoutine.java
@@ -207,7 +207,6 @@ protected void loadConfiguration() {
 
         logInfo(routineLogTrainingLine("Verifying final queue states via sidebar."));
         navigationHelper.ensureCorrectScreenLocation(LaunchPoint.HOME);
-        marchHelper.openLeftMenuCitySection(true);
         List<QueueSlot> verifiedQueues = inspectAllQueues();
         allCompletionTimes.clear();
         allCompletionTimes.addAll(extractExistingCompletionTimesFlow(verifiedQueues));
@@ -1439,22 +1438,24 @@ private boolean performPromotion(TemplatesEnum template, ImageSearchResultData p
     }
 
 private List<QueueSlot> inspectAllQueues() {
-        marchHelper.openLeftMenuCitySection(true);
-        List<QueueSlot> result = new ArrayList<>();
+        marchHelper.openLeftMenuSection(true);
+        try {
+            List<QueueSlot> result = new ArrayList<>();
 
-        emuManager.captureScreen(EMULATOR_NUMBER);
+            emuManager.captureScreen(EMULATOR_NUMBER);
 
-        for (int i = 0; i < queuesToCheck.size(); i++) {
-            AreaData queueArea = queuesToCheck.get(i);
-            TroopTypeShape troopType = enabledTroopTypes.get(i);
+            for (int i = 0; i < queuesToCheck.size(); i++) {
+                AreaData queueArea = queuesToCheck.get(i);
+                TroopTypeShape troopType = enabledTroopTypes.get(i);
 
-            logInfo(routineLogTrainingLine("Analyzing queue for " + troopType.name()));
-            QueueSlot queueInfo = inspectQueueState(queueArea, troopType);
-            result.add(queueInfo);
+                logInfo(routineLogTrainingLine("Analyzing queue for " + troopType.name()));
+                QueueSlot queueInfo = inspectQueueState(queueArea, troopType);
+                result.add(queueInfo);
+            }
+
+            return retryUnknownQueuesFlow(result);
+        } finally {
+            marchHelper.closeLeftMenu();
         }
-
-        result = retryUnknownQueuesFlow(result);
-        marchHelper.closeLeftMenu();
-        return result;
     }
 }

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/IntelligenceRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/IntelligenceRoutine.java
@@ -586,7 +586,7 @@ private void recallGatherTroopsFlow() {
 	// tab-open cycle so a found recall button can be acted on immediately without UI drift.
 	private TabRecallResult inspectAndRecallForTabFlow(boolean cityTab, SearchConfig searchConfig) {
 		int tapped = 0;
-		marchHelper.openLeftMenuCitySection(cityTab);
+		marchHelper.openLeftMenuSection(cityTab);
 		sleepTask(350);
 		try {
 			ImageSearchResultData returningArrow = locatePatternWithMonoFallback(
@@ -698,102 +698,98 @@ private List<GatherMarchCandidate> collectVisibleGatherRowsForRecallFlow() {
 
 private int recallDuplicateGatherMarchesForSmartProcessingFlow() {
 		int recalled = 0;
-		int idleMarches = countIdleMarchesFlow();
 
-		while (idleMarches < SMART_PROCESSING_MIN_IDLE_MARCHES_FOR_INTEL) {
-			GatherMarchCandidate candidate = findLongestDuplicateGatherMarchFlow();
-			if (candidate == null) {
-				break;
+		while (recalled < MARCH_QUEUE_REGIONS.length) {
+			marchHelper.openLeftMenuSection(false);
+			try {
+				List<MarchSlotState> slots = marchHelper.readVisibleMarchQueue();
+				if (countIdleMarchesFlow(slots) >= SMART_PROCESSING_MIN_IDLE_MARCHES_FOR_INTEL) {
+					break;
+				}
+
+				GatherMarchCandidate candidate = findLongestDuplicateGatherMarchFlow(slots);
+				if (candidate == null || !recallGatherMarchByQueueFromOpenPanelFlow(candidate.queueIndex())) {
+					break;
+				}
+				recalled++;
+			} finally {
+				marchHelper.closeLeftMenu();
 			}
-
-			if (!recallGatherMarchByQueueFlow(candidate.queueIndex())) {
-				break;
-			}
-
-			recalled++;
 			sleepTask(250);
-			idleMarches = countIdleMarchesFlow();
 		}
 
 		return recalled;
 	}
 
-private GatherMarchCandidate findLongestDuplicateGatherMarchFlow() {
-		marchHelper.openLeftMenuCitySection(false);
-		try {
-			Map<MarchResourceType, List<GatherMarchCandidate>> groupedByType = marchHelper.readVisibleMarchQueue()
-					.stream()
-					.filter(MarchSlotState::isGather)
-					.map(this::gatherCandidateFromSlot)
-					.filter(java.util.Objects::nonNull)
-					.collect(java.util.stream.Collectors.groupingBy(GatherMarchCandidate::type));
+private GatherMarchCandidate findLongestDuplicateGatherMarchFlow(List<MarchSlotState> slots) {
+		Map<MarchResourceType, List<GatherMarchCandidate>> groupedByType = slots
+				.stream()
+				.filter(MarchSlotState::isGather)
+				.map(this::gatherCandidateFromSlot)
+				.filter(java.util.Objects::nonNull)
+				.collect(java.util.stream.Collectors.groupingBy(GatherMarchCandidate::type));
 
-			List<GatherMarchCandidate> duplicates = new ArrayList<>();
-			for (List<GatherMarchCandidate> candidates : groupedByType.values()) {
-				if (candidates.size() >= 2) {
-					duplicates.addAll(candidates);
-				}
+		List<GatherMarchCandidate> duplicates = new ArrayList<>();
+		for (List<GatherMarchCandidate> candidates : groupedByType.values()) {
+			if (candidates.size() >= 2) {
+				duplicates.addAll(candidates);
 			}
-
-			if (duplicates.isEmpty()) {
-				logInfo(routineLogIntelligenceLine("Smart processing found no duplicate gather marches to recall."));
-				return null;
-			}
-
-			GatherMarchCandidate selected = duplicates.stream()
-					.max(Comparator.comparing(GatherMarchCandidate::returnAt))
-					.orElse(null);
-
-			if (selected != null) {
-				logInfo(routineLogIntelligenceLine("Smart processing selected duplicate "
-						+ selected.type().name().toLowerCase()
-						+ " gather march on queue #" + (selected.queueIndex() + 1)
-						+ " with longest return time for recall."));
-			}
-
-			return selected;
-		} finally {
-			marchHelper.closeLeftMenu();
 		}
+
+		if (duplicates.isEmpty()) {
+			logInfo(routineLogIntelligenceLine("Smart processing found no duplicate gather marches to recall."));
+			return null;
+		}
+
+		GatherMarchCandidate selected = duplicates.stream()
+				.max(Comparator.comparing(GatherMarchCandidate::returnAt))
+				.orElse(null);
+
+		if (selected != null) {
+			logInfo(routineLogIntelligenceLine("Smart processing selected duplicate "
+					+ selected.type().name().toLowerCase()
+					+ " gather march on queue #" + (selected.queueIndex() + 1)
+					+ " with longest return time for recall."));
+		}
+
+		return selected;
 	}
 
-private boolean recallGatherMarchByQueueFlow(int queueIndex) {
-		marchHelper.openLeftMenuCitySection(false);
-		try {
-			List<ImageSearchResultData> recallButtons = templateSearchHelper.locateAllPatterns(
-					TemplatesEnum.MARCHES_AREA_RECALL_BUTTON,
-					SearchConfig.builder()
-							.withArea(new AreaData(MARCH_QUEUE_REGIONS[0].topLeft(), MARCH_QUEUE_REGIONS[MARCH_QUEUE_REGIONS.length - 1].bottomRight()))
-							.withMaxAttempts(3)
-							.withDelay(3)
-							.withMaxResults(MARCH_QUEUE_REGIONS.length)
-							.build());
+private boolean recallGatherMarchByQueueFromOpenPanelFlow(int queueIndex) {
+		List<ImageSearchResultData> recallButtons = templateSearchHelper.locateAllPatterns(
+				TemplatesEnum.MARCHES_AREA_RECALL_BUTTON,
+				SearchConfig.builder()
+						.withArea(new AreaData(MARCH_QUEUE_REGIONS[0].topLeft(), MARCH_QUEUE_REGIONS[MARCH_QUEUE_REGIONS.length - 1].bottomRight()))
+						.withMaxAttempts(3)
+						.withDelay(3)
+						.withMaxResults(MARCH_QUEUE_REGIONS.length)
+						.build());
 
-			if (recallButtons.isEmpty()) {
-				return false;
-			}
-
-			int targetRowCenterY = (MARCH_QUEUE_REGIONS[queueIndex].topLeft().getY() + MARCH_QUEUE_REGIONS[queueIndex].bottomRight().getY()) / 2;
-			ImageSearchResultData bestRowButton = recallButtons.stream()
-					.min(Comparator.comparingInt(button -> Math.abs(button.getPoint().getY() - targetRowCenterY)))
-					.orElse(null);
-
-			if (bestRowButton == null) {
-				return false;
-			}
-
-			tapInside(bestRowButton.getPoint(), bestRowButton.getPoint(), 1, 200);
-			tapInside(MARCH_RECALL_CONFIRM_TOP_LEFT, MARCH_RECALL_CONFIRM_BOTTOM_RIGHT, 1, 200);
-			logInfo(routineLogIntelligenceLine("Recalled gather march from queue #" + (queueIndex + 1)
-					+ " for smart Intel prioritization."));
-			return true;
-		} finally {
-			marchHelper.closeLeftMenu();
+		if (recallButtons.isEmpty()) {
+			return false;
 		}
+
+		int targetRowCenterY = (MARCH_QUEUE_REGIONS[queueIndex].topLeft().getY() + MARCH_QUEUE_REGIONS[queueIndex].bottomRight().getY()) / 2;
+		ImageSearchResultData bestRowButton = recallButtons.stream()
+				.min(Comparator.comparingInt(button -> Math.abs(button.getPoint().getY() - targetRowCenterY)))
+				.orElse(null);
+
+		if (bestRowButton == null) {
+			return false;
+		}
+
+		tapInside(bestRowButton.getPoint(), bestRowButton.getPoint(), 1, 200);
+		tapInside(MARCH_RECALL_CONFIRM_TOP_LEFT, MARCH_RECALL_CONFIRM_BOTTOM_RIGHT, 1, 200);
+		logInfo(routineLogIntelligenceLine("Recalled gather march from queue #" + (queueIndex + 1)
+				+ " for smart Intel prioritization."));
+		return true;
 	}
 
 private int countIdleMarchesFlow() {
-		List<MarchSlotState> slots = marchHelper.readMarchQueue();
+		return countIdleMarchesFlow(marchHelper.readMarchQueue());
+}
+
+private int countIdleMarchesFlow(List<MarchSlotState> slots) {
 		if (slots.isEmpty()) {
 			logWarning(routineLogIntelligenceLine("Could not classify march slots while counting idle capacity."));
 			return 0;

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/economy/GatherRoutine.java
@@ -577,7 +577,7 @@ public class GatherRoutine extends DelayedTask {
     private RecallAttempt recallGatherMarchByQueueFlow(ActiveGatherMarchCandidate candidate, RecallReason reason) {
         navigationHelper.ensureCorrectScreenLocation(LaunchPoint.WORLD);
         sleepTask(250);
-        marchHelper.openLeftMenuCitySectionOnce(false);
+        marchHelper.openLeftMenuSection(false);
         try {
             RecallAttempt attempt = recallGatherMarchFromOpenPanelFlow(candidate, reason);
             if (attempt == RecallAttempt.CONTROLS_NOT_FOUND) {


### PR DESCRIPTION
## Summary

- separate verified sidebar section reuse from explicit reset-to-top navigation
- preserve visible City/Wilderness queue positions and reset once only when queue-row evidence is absent
- reuse one open Wilderness snapshot for Smart Intel classification, duplicate selection, and recall
- remove Training's nested City-section opening and guarantee panel cleanup with `finally`
- retain explicit bounded top resets for destination scans and ambiguous Training retries

## Why

Queue reads were routed through `openSectionAtTop()`, so every read performed three reset swipes even when the requested section was already visible. Smart Intel then closed and reopened Wilderness for two identical snapshots and again for the action, while Training opened City immediately before a helper opened it again.

Closes #238

## Validation

- focused navigation policy, queue evidence, and saved-frame tests: 12 passed
- `mvnw.cmd -pl modules/tasks -am test` — passed
- `mvnw.cmd package` — passed; 511 tests, 0 failures, 0 errors, 0 skipped
- saved real-frame verification — current City, Wilderness, and Daily sidebar frames still classify correctly; destination icon/row association remains covered
- live emulator 0 probe — Wilderness opened with one trigger tap and one section tap, classified all six queue rows, then reused the open section with no tap or swipe; City showed the same no-interaction reuse; each panel closed once
- live safety — no Arena, recall, gather deployment, training, research, or other game action was executed

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

The live probe exercised the shared navigation paths directly. Smart Intel's actual recall branch and Training's full post-training verification were not triggered because doing so would mutate live game state; their orchestration changes are covered by the same verified panel lifecycle and the full automated suite.