### PR TITLE
Apply enabled-task checkbox changes live, no restart required

### DIFF
--- a/modules/automation/src/main/java/dev/frostguard/engine/service/ScheduleService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/ScheduleService.java
@@ -383,6 +383,65 @@ public class ScheduleService {
 		}
 	}
 
+	/**
+	 * matt/2026-08-16: "if I click a box, like, that task won't come up... it doesn't just
+	 * automatically enable it" -- {@link #prepareQueue} only ever reads each task's enabled-bool
+	 * config ONCE, at engine launch, so toggling a checkbox mid-session persisted the new value
+	 * to the DB (via AbstractProfileController -&gt; notifyProfileChange -&gt; saveProfile) but never
+	 * touched the already-running {@link TaskQueue} -- a restart was genuinely the only thing that
+	 * picked it up. Custom tasks already solve this exact problem live (see
+	 * CustomTasksLayoutController.scheduleTask/unscheduleTask calling
+	 * {@link #scheduleCustomTask} / {@link #evictTask}); this generalizes the same pattern to the
+	 * standard {@link ConfigurationKeyEnum}-bool-gated daily tasks (Labyrinth, City Events, etc.)
+	 * so every settings checkbox applies live the moment it's toggled, no restart, no separate
+	 * "Apply" button needed -- these panels already auto-save per-toggle (see
+	 * AbstractProfileController.setupCheckBoxListener), so the same call site just needs to also
+	 * poke the running queue. Intended caller: ProfileManagerLayoutController.notifyProfileChange,
+	 * right after saveProfile succeeds.
+	 *
+	 * <p>No-op (logged, not an error) if the bot isn't currently running for this profile -- the
+	 * DB write alone is correct in that case; the next launch's {@link #prepareQueue} picks it up
+	 * naturally, same as always.
+	 */
+	public void applyEnabledTaskChange(AccountDescriptor account, ConfigurationKeyEnum configKey, boolean nowEnabled) {
+		if (account == null || configKey == null) {
+			return;
+		}
+		TaskQueue queue = dispatcher.getQueue(account.getId());
+		if (queue == null) {
+			log(TpMessageSeverityEnum.INFO, "ScheduleService", account.getName(),
+					"Config " + configKey.name() + " changed to " + nowEnabled
+							+ ", but the bot isn't running for this profile -- will apply on next launch.");
+			return;
+		}
+
+		List<TpDailyTaskEnum> matchingTypes = Stream.of(TpDailyTaskEnum.values())
+				.filter(type -> configKey.equals(type.getConfigKey()))
+				.collect(Collectors.toList());
+		if (matchingTypes.isEmpty()) {
+			return; // this config key isn't a task-activation toggle (e.g. a formation-ratio field)
+		}
+
+		if (!nowEnabled) {
+			matchingTypes.forEach(type -> evictTask(account.getId(), type));
+			return;
+		}
+
+		Map<Integer, DailyTaskStatusData> progressByType = safeProgress(account.getId()).stream()
+				.filter(row -> row != null)
+				.collect(Collectors.toMap(DailyTaskStatusData::getIdTpDailyTask, row -> row, (first, ignored) -> first));
+
+		matchingTypes.forEach(type -> {
+			if (queue.isTaskQueued(type)) {
+				return; // already running/scheduled -- toggling on again is a no-op, not a duplicate
+			}
+			DelayedTask task = DelayedTaskRegistry.create(type, account);
+			enqueuePlannedTask(account, queue, task, progressByType);
+			log(TpMessageSeverityEnum.INFO, "ScheduleService", account.getName(),
+					"Live-enabled " + type.getName() + " (config toggled on, bot already running).");
+		});
+	}
+
 	public void persistEmulatorPath(String settingIdentifier, String path) {
 		Config row = findGlobalRow(settingIdentifier);
 		if (row == null) {

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/profile/ProfileManagerLayoutController.java
@@ -23,6 +23,7 @@ import dev.frostguard.api.domain.ProfileTagData;
 import dev.frostguard.app.bootstrap.WorkspacePreferences;
 import dev.frostguard.engine.service.LoggingService;
 import dev.frostguard.engine.service.ProfileService;
+import dev.frostguard.engine.service.ScheduleService;
 import javafx.animation.TranslateTransition;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
@@ -1117,6 +1118,24 @@ public class ProfileManagerLayoutController implements IProfileChangeObserver {
 				} else if (key == ConfigurationKeyEnum.SKIP_TUTORIAL_ENABLED_BOOL) {
 					LoggingService.obtain().emit(TpMessageSeverityEnum.INFO, "Profile Manager",
 							String.valueOf(profileId), key.name() + " was saved and applies after the next bot restart");
+				}
+				// matt/2026-08-16: "if I click a box... it doesn't just automatically enable it" --
+				// toggling a task's enabled-bool checkbox used to only ever take effect on the NEXT
+				// app launch (ScheduleService.prepareQueue reads config once, at boot). Now that the
+				// save above has genuinely persisted, also poke the already-running queue (if the bot
+				// is running for this profile at all -- applyEnabledTaskChange no-ops otherwise) so
+				// the change applies live, no restart needed. Boolean-only: a text/combo field change
+				// (e.g. a troop-ratio %) isn't a task-activation toggle, and applyEnabledTaskChange
+				// itself no-ops for any config key that isn't one anyway -- this guard just avoids a
+				// pointless lookup for the much-more-common non-boolean edits.
+				if (saved && value instanceof Boolean enabled) {
+					AccountDescriptor account = ProfileService.obtain().fetchAllAccounts().stream()
+							.filter(a -> Objects.equals(a.getId(), profileId))
+							.findFirst()
+							.orElse(null);
+					if (account != null) {
+						ScheduleService.obtain().applyEnabledTaskChange(account, key, enabled);
+					}
 				}
 			});
 		} catch (Exception e) {


### PR DESCRIPTION
Toggling a task's enabled checkbox only ever took effect on the next app launch -- `ScheduleService.prepareQueue()` reads each task's enabled-bool config exactly once, at engine start, to build the fixed TaskQueue. Flipping a checkbox mid-session persisted the new value to the DB fine, but nothing told the already-running queue a task had just become eligible.

Custom tasks already solved this exact problem for their own registry (`CustomTasksLayoutController.scheduleTask/unscheduleTask` against the live `TaskDispatcher`). This generalizes the same live-apply pattern to every standard config-bool-gated daily task:

- `ScheduleService.applyEnabledTaskChange(AccountDescriptor, ConfigurationKeyEnum, boolean)`: finds the `TpDailyTaskEnum`(s) whose `getConfigKey()` matches, and either enqueues them fresh or evicts them against the account's live queue. No-ops safely (logged, not an error) if the bot isn't running for that profile.
- `ProfileManagerLayoutController`: after a boolean config save succeeds, fetches the fresh `AccountDescriptor` and calls `applyEnabledTaskChange`. No new UI needed -- every settings panel already auto-saves per-toggle, so this is a single choke point for every checkbox in the app.

No shared-infrastructure dependency -- compiles and applies standalone. Compiled + full test suite green on my fork before opening this.