### PR TITLE
OCR: honor OcrSettingsData.language() instead of hardcoding eng

### DIFF
--- a/modules/api/src/main/java/dev/frostguard/api/domain/OcrSettingsData.java
+++ b/modules/api/src/main/java/dev/frostguard/api/domain/OcrSettingsData.java
@@ -31,6 +31,24 @@ public class OcrSettingsData {
     private final Color targetColor;
     private final boolean diagnosticMode;
     private final String allowedGlyphs;
+    // Language used to be hardcoded to "eng" in TesseractOcrProvider regardless of what any
+    // caller configured - Whiteout's Alliance/World chat is genuinely multilingual and an
+    // English-only model cannot read non-Latin scripts, it just emits near-random glyph guesses.
+    // Only "eng" and "chi_sim" have trained-data models actually packaged with the app (see
+    // TesseractOcrProvider#SUPPORTED_LANGUAGES). null (every pre-existing caller, since none of
+    // them ever set this field) keeps behaviour identical -- falls back to "eng". A non-null
+    // request for a language with no packaged model fails loudly instead
+    // (UnsupportedOcrLanguageException) rather than silently substituting "eng": a caller that
+    // explicitly asked for a specific script deserves an honest failure, not confident-looking
+    // garbage from running the wrong model against it.
+    //
+    // The consumer this exists for is chat reading. A chat panel is the one screen that is
+    // routinely not in the operator's own language, and reading it with the English model yields
+    // confident nonsense rather than an error, so the language has to be selectable per call site
+    // rather than fixed for the process. That reader is proposed separately; until it lands this
+    // field simply stays unset, which is what every existing call site already does.
+    private final String language;
+    private final boolean preserveLineBreaks;
 
     /* ---- private: construction via Configurator only ---- */
 
@@ -40,6 +58,8 @@ public class OcrSettingsData {
         this.targetColor       = cfg.targetColor;
         this.diagnosticMode    = cfg.diagnosticMode;
         this.allowedGlyphs    = cfg.allowedGlyphs;
+        this.language           = cfg.language;
+        this.preserveLineBreaks = cfg.preserveLineBreaks;
     }
 
     /* ---- pre-configured presets ---- */
@@ -96,7 +116,9 @@ public class OcrSettingsData {
                 && !isolateForeground
                 && targetColor == null
                 && !diagnosticMode
-                && (allowedGlyphs == null || allowedGlyphs.isEmpty());
+                && (allowedGlyphs == null || allowedGlyphs.isEmpty())
+                && language == null
+                && !preserveLineBreaks;
     }
 
     /**
@@ -111,7 +133,9 @@ public class OcrSettingsData {
                 .isolateForeground(this.isolateForeground)
                 .targetColor(this.targetColor)
                 .diagnosticMode(this.diagnosticMode)
-                .allowedGlyphs(this.allowedGlyphs);
+                .allowedGlyphs(this.allowedGlyphs)
+                .language(this.language)
+                .preserveLineBreaks(this.preserveLineBreaks);
     }
 
     /* ---- primary accessors ---- */
@@ -130,6 +154,32 @@ public class OcrSettingsData {
 
     /** Restricted character set for recognition (whitelist). */
     public String allowedGlyphs()                { return allowedGlyphs; }
+
+    /**
+     * Tesseract language code(s), e.g. {@code "eng"} or {@code "eng+chi_sim"}. Null means the caller
+     * never asked, and recognition defaults to {@code "eng"}.
+     *
+     * <p>It exists for reading multi-line, mixed-language player text -- world and alliance chat,
+     * where one screen routinely carries Latin, Cyrillic, Arabic and Chinese at once and an
+     * English-only model returns confident nonsense for most of it. The per-message chat reader
+     * that consumes it is proposed separately and depends on this change; until that lands, a null
+     * language with {@code preserveLineBreaks == false} reproduces exactly the behaviour every
+     * existing call site had before these options existed.
+     *
+     * <p>Recorded here so the next reader does not mistake an option with no current call site for
+     * dead configuration. The language cannot be a process-wide setting: the same run reads English
+     * countdowns and non-Latin chat minutes apart, so it has to be chosen per call site.
+     */
+    public String language()                     { return language; }
+
+    /**
+     * Whether recognised text keeps its original line breaks; the default flattens it to one line.
+     *
+     * <p>Same status as {@link #language()} -- see there. It matters for the same case: a chat
+     * panel is inherently multi-line, and flattening it destroys the message boundaries that make
+     * the text usable at all.
+     */
+    public boolean preserveLineBreaks()           { return preserveLineBreaks; }
 
     /* ---- presence checks ---- */
 
@@ -166,23 +216,28 @@ public class OcrSettingsData {
         if (!(other instanceof OcrSettingsData that)) return false;
         return isolateForeground == that.isolateForeground
             && diagnosticMode    == that.diagnosticMode
+            && preserveLineBreaks == that.preserveLineBreaks
             && textLayout        == that.textLayout
             && Objects.equals(targetColor,   that.targetColor)
-            && Objects.equals(allowedGlyphs, that.allowedGlyphs);
+            && Objects.equals(allowedGlyphs, that.allowedGlyphs)
+            && Objects.equals(language,      that.language);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
                 textLayout, isolateForeground,
-                targetColor, diagnosticMode, allowedGlyphs);
+                targetColor, diagnosticMode, allowedGlyphs,
+                language, preserveLineBreaks);
     }
 
     @Override
     public String toString() {
         return "OCR{layout=" + textLayout
                 + ", fgIsolation=" + isolateForeground
-                + ", glyphs=" + allowedGlyphs + "}";
+                + ", glyphs=" + allowedGlyphs
+                + ", language=" + language
+                + ", preserveLineBreaks=" + preserveLineBreaks + "}";
     }
 
     /**
@@ -196,6 +251,8 @@ public class OcrSettingsData {
         private Color targetColor;
         private boolean diagnosticMode;
         private String allowedGlyphs;
+        private String language;
+        private boolean preserveLineBreaks = false;
 
         /* ---- primary setters ---- */
 
@@ -221,6 +278,16 @@ public class OcrSettingsData {
 
         public Configurator allowedGlyphs(String glyphs) {
             this.allowedGlyphs = glyphs;
+            return this;
+        }
+
+        public Configurator language(String lang) {
+            this.language = lang;
+            return this;
+        }
+
+        public Configurator preserveLineBreaks(boolean preserve) {
+            this.preserveLineBreaks = preserve;
             return this;
         }
 

--- a/modules/api/src/test/java/dev/frostguard/api/domain/OcrSettingsDataTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/domain/OcrSettingsDataTest.java
@@ -1,0 +1,80 @@
+package dev.frostguard.api.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OcrSettingsDataTest {
+
+    @Test
+    void defaultConfigurationHasNoLanguageOrLineBreakPreservation() {
+        OcrSettingsData defaults = OcrSettingsData.configurator().build();
+        assertTrue(defaults.isDefaultConfiguration());
+        assertEquals(null, defaults.language());
+        assertFalse(defaults.preserveLineBreaks());
+    }
+
+    @Test
+    void settingLanguageBreaksDefaultConfiguration() {
+        OcrSettingsData cfg = OcrSettingsData.configurator().language("chi_sim").build();
+        assertFalse(cfg.isDefaultConfiguration());
+        assertEquals("chi_sim", cfg.language());
+    }
+
+    @Test
+    void settingPreserveLineBreaksBreaksDefaultConfiguration() {
+        OcrSettingsData cfg = OcrSettingsData.configurator().preserveLineBreaks(true).build();
+        assertFalse(cfg.isDefaultConfiguration());
+        assertTrue(cfg.preserveLineBreaks());
+    }
+
+    @Test
+    void equalsAndHashCodeConsiderLanguageAndPreserveLineBreaks() {
+        OcrSettingsData a = OcrSettingsData.configurator().language("eng").preserveLineBreaks(true).build();
+        OcrSettingsData b = OcrSettingsData.configurator().language("eng").preserveLineBreaks(true).build();
+        OcrSettingsData differentLanguage = OcrSettingsData.configurator().language("chi_sim").preserveLineBreaks(true).build();
+        OcrSettingsData differentLineBreaks = OcrSettingsData.configurator().language("eng").preserveLineBreaks(false).build();
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, differentLanguage);
+        assertNotEquals(a, differentLineBreaks);
+    }
+
+    @Test
+    void toConfiguratorRoundTripsLanguageAndPreserveLineBreaks() {
+        OcrSettingsData original = OcrSettingsData.configurator()
+                .language("eng+chi_sim")
+                .preserveLineBreaks(true)
+                .build();
+
+        OcrSettingsData copy = original.toConfigurator().build();
+
+        assertEquals(original, copy);
+        assertEquals("eng+chi_sim", copy.language());
+        assertTrue(copy.preserveLineBreaks());
+    }
+
+    @Test
+    void toStringIncludesLanguageAndPreserveLineBreaks() {
+        OcrSettingsData cfg = OcrSettingsData.configurator()
+                .language("chi_sim")
+                .preserveLineBreaks(true)
+                .build();
+
+        String text = cfg.toString();
+        assertTrue(text.contains("language=chi_sim"));
+        assertTrue(text.contains("preserveLineBreaks=true"));
+    }
+
+    @Test
+    void presetsRemainUnaffectedByLanguageDefaults() {
+        assertTrue(OcrSettingsData.forNumberRecognition().language() == null);
+        assertTrue(OcrSettingsData.forTextBlock().language() == null);
+        assertTrue(OcrSettingsData.forSingleWord().language() == null);
+        assertTrue(OcrSettingsData.forWhiteTextOnDark().language() == null);
+    }
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/TesseractOcrProvider.java
@@ -61,11 +61,13 @@ public final class TesseractOcrProvider implements OcrProvider {
         requireValidCapture(preparedImage);
 
         long step = System.currentTimeMillis();
-        Tesseract engine = configureTesseract(cfg);
+        Tesseract engine = configureTesseract(cfg); // throws UnsupportedOcrLanguageException for an explicit, unsatisfiable language request
         log.debug("Engine config: {} ms", System.currentTimeMillis() - step);
 
         step = System.currentTimeMillis();
-        String recognised = executeRecognition(engine, preparedImage);
+        String recognised = cfg.preserveLineBreaks()
+                ? executeRecognitionMultiline(engine, preparedImage)
+                : executeRecognition(engine, preparedImage);
         log.debug("Engine execution: {} ms", System.currentTimeMillis() - step);
 
         log.debug("=== Recognition Finished === elapsed={} ms, text='{}'",
@@ -87,11 +89,30 @@ public final class TesseractOcrProvider implements OcrProvider {
         return t;
     }
 
-    /** Builds an engine whose behaviour is controlled by {@code cfg}. */
-    private static Tesseract configureTesseract(OcrSettingsData cfg) {
+    /**
+     * Builds an engine whose behaviour is controlled by {@code cfg}.
+     *
+     * <p>Language used to be hardcoded to "eng" here regardless of what any caller configured -
+     * fine for HUD numbers, but silently corrupted anything non-Latin-script (chat is genuinely
+     * multilingual). Honours {@link OcrSettingsData#language()}, falling back to "eng" so every
+     * pre-existing caller (which never sets a language at all) is unaffected.
+     *
+     * <p>Only "eng" and "chi_sim" trained-data models are actually packaged with the app (see
+     * {@link #SUPPORTED_LANGUAGES}). {@link #resolveSupportedLanguage} validates an explicit
+     * request against what's genuinely available and throws {@link UnsupportedOcrLanguageException}
+     * -- via this method's {@code throws OcrException} -- rather than silently substituting "eng":
+     * running an unsupported script through the English model doesn't fail visibly, it produces
+     * plausible-but-wrong glyph guesses, which is worse than an honest error for a caller that
+     * asked for a specific language on purpose.
+     *
+     * <p>Package-private (not {@code private}) specifically so tests can inspect the {@link
+     * Tesseract} instance this method configures -- see {@code TesseractOcrProviderTest} -- rather
+     * than only asserting on {@link #resolveSupportedLanguage}'s return value in isolation.
+     */
+    static Tesseract configureTesseract(OcrSettingsData cfg) throws OcrException {
         Tesseract t = new Tesseract();
         t.setDatapath(locateTessdata());
-        t.setLanguage("eng");
+        t.setLanguage(resolveSupportedLanguage(cfg.language()));
         t.setConfigs(Collections.singletonList("quiet"));
 
         if (cfg.hasTextLayout()) {
@@ -100,12 +121,54 @@ public final class TesseractOcrProvider implements OcrProvider {
             t.setPageSegMode(3); // AUTO
         }
 
-        t.setOcrEngineMode(1); // Default to LSTM_ONLY for our use cases
+        t.setOcrEngineMode(1); // LSTM_ONLY -- the only mode this app has ever shipped with
 
         if (cfg.hasAllowedChars()) {
             t.setVariable("tessedit_char_whitelist", cfg.getAllowedChars());
         }
         return t;
+    }
+
+    /** Trained-data models actually packaged with the app (see tools/tesseract/*.traineddata).
+     *  "osd" (orientation/script detection) is packaged too but is never a valid recognition
+     *  language on its own, so it's deliberately excluded here. */
+    private static final java.util.Set<String> SUPPORTED_LANGUAGES = java.util.Set.of("eng", "chi_sim");
+
+    /**
+     * Validates a requested Tesseract language string (which may combine multiple languages with
+     * "+", e.g. "eng+chi_sim") against what's actually packaged.
+     *
+     * <p>{@code null}/blank means the caller never asked for a language at all -- every
+     * pre-existing call site before multilingual support existed -- and safely defaults to "eng",
+     * unaffected. A non-blank request with ANY unsupported component is a caller explicitly
+     * asking this app to read a script it cannot: that fails loudly via {@link
+     * UnsupportedOcrLanguageException} instead of silently downgrading to English, which would
+     * otherwise return confident-looking garbage for genuinely non-Latin text.
+     */
+    static String resolveSupportedLanguage(String requested) throws UnsupportedOcrLanguageException {
+        if (requested == null || requested.isBlank()) {
+            return "eng";
+        }
+        List<String> validated = new ArrayList<>();
+        List<String> unsupported = new ArrayList<>();
+        for (String part : requested.split("\\+")) {
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) continue;
+            if (SUPPORTED_LANGUAGES.contains(trimmed)) {
+                validated.add(trimmed);
+            } else {
+                unsupported.add(trimmed);
+            }
+        }
+        if (!unsupported.isEmpty()) {
+            throw new UnsupportedOcrLanguageException(unsupported, SUPPORTED_LANGUAGES);
+        }
+        if (validated.isEmpty()) {
+            // Requested something like "+" or all-whitespace components -- not a real language
+            // request either way, so treat it the same as no request at all.
+            return "eng";
+        }
+        return String.join("+", validated);
     }
 
     private static int mapTextLayout(TextLayout layout) {
@@ -123,10 +186,48 @@ public final class TesseractOcrProvider implements OcrProvider {
     private static String executeRecognition(Tesseract engine, BufferedImage img)
             throws OcrException {
         try {
-            return engine.doOCR(img).replace("\n", "").replace("\r", "").trim();
+            return normalizeSingleLine(engine.doOCR(img));
         } catch (TesseractException e) {
             throw new OcrException("Tesseract OCR failed", e);
         }
+    }
+
+    /**
+     * Same as {@link #executeRecognition}, but keeps line breaks intact.
+     *
+     * <p>Multi-message reads (chat) NEED the line structure Tesseract already produces -
+     * flattening was silently destroying it, a real reason chat capture was coming back as one
+     * giant run-on blob instead of one line per message.
+     */
+    private static String executeRecognitionMultiline(Tesseract engine, BufferedImage img)
+            throws OcrException {
+        try {
+            return normalizeMultiline(engine.doOCR(img));
+        } catch (TesseractException e) {
+            throw new OcrException("Tesseract OCR failed", e);
+        }
+    }
+
+    /**
+     * Flattens Tesseract's raw output to a single line: both {@code \n} and {@code \r} (so
+     * Windows {@code \r\n}, bare {@code \r}, and bare {@code \n} line endings are all handled
+     * identically) are dropped, then the result is trimmed. Split out from {@link
+     * #executeRecognition} as a pure string transform -- no engine or image needed -- so it's
+     * directly testable with literal strings instead of only reachable through a real OCR run.
+     */
+    static String normalizeSingleLine(String raw) {
+        return raw.replace("\n", "").replace("\r", "").trim();
+    }
+
+    /**
+     * Keeps line breaks but strips {@code \r} so a Windows {@code \r\n} collapses cleanly to the
+     * {@code \n} Tesseract already emits on this platform -- downstream line-splitting (one chat
+     * message per line) never sees a stray {@code \r} riding along with it. Split out from {@link
+     * #executeRecognitionMultiline} for the same testability reason as {@link
+     * #normalizeSingleLine}.
+     */
+    static String normalizeMultiline(String raw) {
+        return raw.replace("\r", "").trim();
     }
 
     // =====================================================================

--- a/modules/vision/src/main/java/dev/frostguard/vision/ocr/UnsupportedOcrLanguageException.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/ocr/UnsupportedOcrLanguageException.java
@@ -1,0 +1,29 @@
+package dev.frostguard.vision.ocr;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Thrown when a caller explicitly requests an OCR language with no packaged trained-data model.
+ *
+ * <p>Silently falling back to "eng" for an explicit, unsupported request (e.g.
+ * "ara", "rus") used to look successful -- Tesseract still returned text -- but that text was
+ * Latin-model glyph guesses run against a script it cannot read, plausible-looking and wrong. A
+ * caller that never asked for a specific language at all (the common case -- {@code null}/blank)
+ * still gets the safe "eng" default unaffected; only an explicit, unsatisfiable request fails.</p>
+ */
+public class UnsupportedOcrLanguageException extends OcrException {
+
+    private final List<String> requestedUnsupported;
+    private final Set<String> supported;
+
+    public UnsupportedOcrLanguageException(List<String> requestedUnsupported, Set<String> supported) {
+        super("OCR language(s) " + requestedUnsupported + " have no packaged trained-data model "
+                + "(supported: " + supported + ")");
+        this.requestedUnsupported = List.copyOf(requestedUnsupported);
+        this.supported = Set.copyOf(supported);
+    }
+
+    public List<String> getRequestedUnsupported() { return requestedUnsupported; }
+    public Set<String> getSupported()             { return supported; }
+}

--- a/modules/vision/src/test/java/dev/frostguard/vision/ocr/TesseractOcrProviderTest.java
+++ b/modules/vision/src/test/java/dev/frostguard/vision/ocr/TesseractOcrProviderTest.java
@@ -1,0 +1,276 @@
+package dev.frostguard.vision.ocr;
+
+import dev.frostguard.api.domain.OcrSettingsData;
+import net.sourceforge.tess4j.Tesseract;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.GraphicsEnvironment;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Behavioural contract for multilingual OCR support.
+ *
+ * <p>Two properties matter, and both are here because getting them wrong fails silently rather than
+ * loudly:
+ * <ul>
+ *   <li>An explicitly requested but unsupported language (say "ara" or "rus") must FAIL rather than
+ *       quietly downgrade to "eng". A downgrade does not produce an error; it produces plausible
+ *       Latin guesses at non-Latin glyphs -- output that reads as a successful recognition and is
+ *       simply wrong.</li>
+ *   <li>The contract is exercised end to end rather than against the settings object: the resolved
+ *       language actually reaching the Tesseract engine, the packaged chi_sim model being genuinely
+ *       usable rather than merely present, what preserveLineBreaks does to real recognition output,
+ *       and LF/CRLF normalisation.</li>
+ * </ul>
+ */
+class TesseractOcrProviderTest {
+
+    // ------------------------------------------------------------------
+    // resolveSupportedLanguage
+    // ------------------------------------------------------------------
+
+    @Test
+    void noExplicitRequestFallsBackToEnglish() throws OcrException {
+        // null/blank means the caller never asked for a language at all -- every pre-existing
+        // call site before multilingual support existed. Must stay unaffected.
+        assertEquals("eng", TesseractOcrProvider.resolveSupportedLanguage(null));
+        assertEquals("eng", TesseractOcrProvider.resolveSupportedLanguage(""));
+        assertEquals("eng", TesseractOcrProvider.resolveSupportedLanguage("   "));
+    }
+
+    @Test
+    void packagedLanguagesPassThroughUnchanged() throws OcrException {
+        assertEquals("eng", TesseractOcrProvider.resolveSupportedLanguage("eng"));
+        assertEquals("chi_sim", TesseractOcrProvider.resolveSupportedLanguage("chi_sim"));
+        assertEquals("eng+chi_sim", TesseractOcrProvider.resolveSupportedLanguage("eng+chi_sim"));
+    }
+
+    @Test
+    void explicitlyRequestingAnUnpackagedLanguageFailsLoudlyInsteadOfSilentlyUsingEnglish() {
+        // Arabic/Russian/Portuguese/Czech/French were selectable in config despite no trained-data
+        // model ever being packaged for them. Silently substituting "eng" here used to return
+        // confident-looking garbage for genuinely non-Latin text instead of an honest failure.
+        UnsupportedOcrLanguageException ara = assertThrows(UnsupportedOcrLanguageException.class,
+                () -> TesseractOcrProvider.resolveSupportedLanguage("ara"));
+        assertEquals(List.of("ara"), ara.getRequestedUnsupported());
+
+        UnsupportedOcrLanguageException rus = assertThrows(UnsupportedOcrLanguageException.class,
+                () -> TesseractOcrProvider.resolveSupportedLanguage("rus"));
+        assertEquals(List.of("rus"), rus.getRequestedUnsupported());
+    }
+
+    @Test
+    void mixedRequestFailsOnTheUnsupportedComponentRatherThanSilentlyDroppingIt() {
+        // A caller combining "eng+ara" explicitly wants Arabic read too -- silently returning
+        // eng-only results without ever saying so would look like success while quietly failing
+        // half the request.
+        UnsupportedOcrLanguageException ex = assertThrows(UnsupportedOcrLanguageException.class,
+                () -> TesseractOcrProvider.resolveSupportedLanguage("eng+ara"));
+        assertEquals(List.of("ara"), ex.getRequestedUnsupported());
+    }
+
+    @Test
+    void requestWithOnlyUnsupportedLanguagesFailsListingAllOfThem() {
+        UnsupportedOcrLanguageException ex = assertThrows(UnsupportedOcrLanguageException.class,
+                () -> TesseractOcrProvider.resolveSupportedLanguage("ara+rus"));
+        assertEquals(List.of("ara", "rus"), ex.getRequestedUnsupported());
+    }
+
+    // ------------------------------------------------------------------
+    // configureTesseract -- proves the resolved language actually reaches the engine, not just
+    // that resolveSupportedLanguage's return value looks right in isolation.
+    // ------------------------------------------------------------------
+
+    @Test
+    void resolvedLanguageIsActuallyAppliedToTheRealTesseractEngine() throws Exception {
+        OcrSettingsData cfg = OcrSettingsData.configurator().language("chi_sim").build();
+
+        Tesseract engine = TesseractOcrProvider.configureTesseract(cfg);
+
+        // Tesseract (tess4j) exposes no public getter for the language it was configured with --
+        // reflection on its private field is the only way to prove the setter was actually called
+        // with OUR resolved value, not just that resolveSupportedLanguage() returns the right
+        // string when called on its own.
+        Field languageField = Tesseract.class.getDeclaredField("language");
+        languageField.setAccessible(true);
+        assertEquals("chi_sim", languageField.get(engine));
+    }
+
+    @Test
+    void configureTesseractPropagatesTheUnsupportedLanguageFailure() {
+        OcrSettingsData cfg = OcrSettingsData.configurator().language("ara").build();
+
+        assertThrows(UnsupportedOcrLanguageException.class,
+                () -> TesseractOcrProvider.configureTesseract(cfg));
+    }
+
+    // ------------------------------------------------------------------
+    // The packaged chi_sim model is genuinely usable, not just present on disk.
+    // ------------------------------------------------------------------
+
+    @Test
+    void chiSimTrainedDataModelLoadsAndRunsARealRecognitionPassWithoutError() {
+        // The floor: tessdata lookup, native library load, chi_sim.traineddata load and a real
+        // inference pass all complete. Runs anywhere, including a runner with no CJK font.
+        OcrSettingsData cfg = OcrSettingsData.configurator().language("chi_sim").build();
+        BufferedImage image = renderText(new String[]{"12345"}, 300, 80);
+
+        assertDoesNotThrow(() -> new TesseractOcrProvider().recognizeText(image, cfg));
+    }
+
+    @Test
+    void chiSimActuallyRecognisesChineseRatherThanGuessingLatinAtIt() throws OcrException {
+        // The property that matters, and the one the test above does not reach: a model that loads
+        // is not a model that reads. The failure being guarded is silent -- English pointed at
+        // Chinese returns plausible Latin glyphs, so whether Chinese characters come back at all is
+        // the only way to tell a working configuration from a broken one.
+        //
+        // Rendered rather than captured, deliberately. A real chat frame carries player names and
+        // alliance tags and would need redacting to ship, and redacting the text is redacting the
+        // thing under test. Synthesised glyphs are the same characters with none of that.
+        Font cjk = firstFontThatCanDisplay(CHINESE_SAMPLE);
+        assumeTrue(cjk != null,
+                "no CJK-capable font here, so genuine Chinese cannot be rendered to read back");
+
+        BufferedImage image = renderText(new String[]{CHINESE_SAMPLE}, 360, 110, cjk.deriveFont(Font.PLAIN, 48f));
+        OcrSettingsData cfg = OcrSettingsData.configurator().language("chi_sim").build();
+
+        String recognized = new TesseractOcrProvider().recognizeText(image, cfg);
+
+        // Asserted by script rather than exact string. Per-glyph accuracy varies with font and
+        // rendering, but a Latin-only configuration cannot emit a CJK codepoint at all, so its
+        // presence is the discriminating signal and does not go flaky on the font.
+        assertTrue(recognized.codePoints().anyMatch(TesseractOcrProviderTest::isCjk),
+                "chi_sim should return Chinese for Chinese input, got: '" + recognized + "'");
+    }
+
+    @Test
+    void englishModelPointedAtChineseReturnsNoChinese() throws OcrException {
+        // The other half of the same claim, and what the original bug looked like: same image,
+        // "eng", and nothing Chinese comes back -- just Latin guesswork that reads like a success.
+        // Without this, the test above could pass on a provider that ignored the language entirely
+        // and happened to default somewhere useful.
+        Font cjk = firstFontThatCanDisplay(CHINESE_SAMPLE);
+        assumeTrue(cjk != null, "no CJK-capable font here");
+
+        BufferedImage image = renderText(new String[]{CHINESE_SAMPLE}, 360, 110, cjk.deriveFont(Font.PLAIN, 48f));
+        OcrSettingsData cfg = OcrSettingsData.configurator().language("eng").build();
+
+        String recognized = new TesseractOcrProvider().recognizeText(image, cfg);
+
+        assertFalse(recognized.codePoints().anyMatch(TesseractOcrProviderTest::isCjk),
+                "the English model cannot produce Chinese; if it did, the language never reached the engine: '"
+                        + recognized + "'");
+    }
+
+    /** "Chinese chat" -- ordinary characters, no player data, nothing to redact. */
+    private static final String CHINESE_SAMPLE = "中文聊天";
+
+    private static boolean isCjk(int codePoint) {
+        return Character.UnicodeScript.of(codePoint) == Character.UnicodeScript.HAN;
+    }
+
+    /** The first installed font able to render every character of {@code text}, or null. */
+    private static Font firstFontThatCanDisplay(String text) {
+        for (Font font : GraphicsEnvironment.getLocalGraphicsEnvironment().getAllFonts()) {
+            if (font.canDisplayUpTo(text) == -1) {
+                return font;
+            }
+        }
+        return null;
+    }
+
+    // ------------------------------------------------------------------
+    // preserveLineBreaks -- real effect on real recognition output, not just a flag being read.
+    // ------------------------------------------------------------------
+
+    @Test
+    void preserveLineBreaksKeepsMultipleLinesSeparateInRealRecognitionOutput() throws OcrException {
+        BufferedImage image = renderText(new String[]{"first line", "second line"}, 400, 140);
+        OcrSettingsData cfg = OcrSettingsData.configurator()
+                .textLayout(OcrSettingsData.TextLayout.TEXT_BLOCK)
+                .preserveLineBreaks(true)
+                .build();
+
+        String recognized = new TesseractOcrProvider().recognizeText(image, cfg);
+
+        assertTrue(recognized.contains("\n"),
+                "Two visually separate lines should still be two lines in the output: '" + recognized + "'");
+    }
+
+    @Test
+    void defaultBehaviorFlattensMultipleLinesIntoOne() throws OcrException {
+        BufferedImage image = renderText(new String[]{"first line", "second line"}, 400, 140);
+        OcrSettingsData cfg = OcrSettingsData.configurator()
+                .textLayout(OcrSettingsData.TextLayout.TEXT_BLOCK)
+                .preserveLineBreaks(false)
+                .build();
+
+        String recognized = new TesseractOcrProvider().recognizeText(image, cfg);
+
+        assertFalse(recognized.contains("\n"),
+                "Without preserveLineBreaks the result should be flattened to one line: '" + recognized + "'");
+    }
+
+    // ------------------------------------------------------------------
+    // LF/CRLF normalization -- pure string transforms, no engine/image needed.
+    // ------------------------------------------------------------------
+
+    @Test
+    void normalizeSingleLineDropsEveryLineEndingStyle() {
+        assertEquals("ab", TesseractOcrProvider.normalizeSingleLine("a\nb"));
+        assertEquals("ab", TesseractOcrProvider.normalizeSingleLine("a\r\nb"));
+        assertEquals("ab", TesseractOcrProvider.normalizeSingleLine("a\rb"));
+        assertEquals("hello", TesseractOcrProvider.normalizeSingleLine("  hello  \n"));
+    }
+
+    @Test
+    void normalizeMultilineStripsCrSoWindowsLineEndingsCollapseToPlainLf() {
+        // Tesseract emits plain \n on this platform; \r\n only shows up if something upstream
+        // (or the OS pipe) reintroduces it. Stripping \r turns \r\n into a clean \n rather than
+        // leaving a stray \r riding along on every line.
+        assertEquals("a\nb", TesseractOcrProvider.normalizeMultiline("a\r\nb"));
+        assertEquals("a\nb", TesseractOcrProvider.normalizeMultiline("a\nb"));
+        assertEquals("ab", TesseractOcrProvider.normalizeMultiline("a\rb")); // bare \r alone isn't a line break, just noise -- dropped
+        assertEquals("a\nb", TesseractOcrProvider.normalizeMultiline("  a\nb  "));
+    }
+
+    // ------------------------------------------------------------------
+
+    /** Renders plain black text on a white background -- real Latin glyphs, guaranteed available
+     *  on every JDK/CI image (unlike CJK fonts), for genuine end-to-end recognition tests. */
+    private static BufferedImage renderText(String[] lines, int width, int height) {
+        return renderText(lines, width, height, new Font("SansSerif", Font.PLAIN, 28));
+    }
+
+    /** Same, with an explicit font, so a CJK-capable face can be supplied when one exists. */
+    private static BufferedImage renderText(String[] lines, int width, int height, Font font) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = image.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        g.setColor(Color.WHITE);
+        g.fillRect(0, 0, width, height);
+        g.setColor(Color.BLACK);
+        g.setFont(font);
+        int y = 40;
+        for (String line : lines) {
+            g.drawString(line, 15, y);
+            y += 45;
+        }
+        g.dispose();
+        return image;
+    }
+}


### PR DESCRIPTION
<!-- BEARGUARD-TRACKING-START -->

**Tracking:** Relates to #212 (evaluate and introduce pluggable OCR providers safely) — this is the concrete language-handling correctness fix within that theme. #294 consumes it.

<!-- BEARGUARD-TRACKING-END -->

## Summary

Honour `OcrSettingsData.language()` on every OCR path.

`TesseractOcrProvider` honours the language it is passed in one path (`t.setLanguage(lang)`) but a
second path hardcoded `t.setLanguage("eng")`, so a profile configured for a non-English server was
silently read as English there. The failure mode is quiet rather than loud: non-Latin text does not
error, it returns plausible-looking Latin gibberish, and the bot then acts confidently on a misread.

`UnsupportedOcrLanguageException` replaces the previous silent fallback, so an unavailable language
fails loudly instead of degrading to English without saying so.

### Description correction (2026-09-02)

This description previously referenced `reuseFrame()` and `recognitionEngine()`. Neither appears
anywhere in this PR's surface -- the five changed files are:

```
modules/api/.../OcrSettingsData.java              (+ its test)
modules/vision/.../TesseractOcrProvider.java      (+ its test)
modules/vision/.../UnsupportedOcrLanguageException.java
```

**Scope:** 5 files.

## Known gap, stated plainly

There is still no production caller on upstream `main`. The chat-capture consumer lives in the fork
and is proposed separately as #294, which stacks on this commit. This is a real dependency, not an
oversight: merging #253 first shrinks #294's diff, but #253 on its own fixes a latent correctness
bug rather than enabling a shipped upstream feature.

## Stack position and merge order

```
upstream/main
  └── #250  feature/bg-telemetry-dashboard-panel   (telemetry collection + TelemetryReport)
        └── #251  feature/stats-timeframe-dropdown (Statistics dashboard, reads TelemetryReport)

upstream/main
  └── #253  feature/multilingual-chat-ocr          (OCR language handling)
        └── #294  feature/chat-discord-transcript  (chat capture, consumes the OCR change)

upstream/main
  ├── #252  feature/schedule-jitter-and-quit-dialog-guard   (independent)
  ├── #254  feature/resource-stockpile-tracking             (independent of #250 as of this head)
  ├── #259  feature/labyrinth-multi-zone-formations         (independent)
  └── #298  feature/life-essence-badge-detection            (independent)
```

**Merge order that matters:** #250 before #251, and #253 before #294. The other four are independent of each other and of the two stacks; each is cut from `upstream/main` directly and is currently 0 behind.

### Upstream CI is currently red for every branch, not just this one

Both required workflows fail inside `Check out repository`, before anything is compiled:

```
failed to fetch some objects from 'https://github.com/Shederator/wosbot.git/info/lfs'
The process '/usr/bin/git' failed with exit code 2
```

Your own `fix/telegram-watcher-startup` branch fails at the same step with the same three LFS errors, and the pointers involved (`tools/adb/adb.exe`, `modules/vision/.../opencv_java4110.dll`, the tesseract `.traineddata` files) are upstream's own files, not anything added here. Until those objects are fetchable again no branch can produce a green Linux or Windows run, so the "checks must pass on the final head" gate is not currently reachable by a contributor. Flagging it because the checks list only shows a red X.

<!-- BEARGUARD-COMPARE-START -->

## Frostguard today vs. this PR

*Upstream behaviour below was checked against `upstream/main` on 2026-09-02, not recalled.*

### What Frostguard does today

`TesseractOcrProvider` honours the language it is passed in one path
(`t.setLanguage(lang)`, line 83) but a second path hardcodes `t.setLanguage("eng")` (line 94). A
profile configured for a non-English server is therefore silently read as English on that path,
and `OcrSettingsData.language()` is ignored.

### What this PR does

Honour `OcrSettingsData.language()` on every path, and add recognition tests that exercise
real CJK text rather than digits.

### The difference

The setting already exists and is already configurable. Upstream just does not always use it.

### Why this is an improvement

This is a correctness bug with a quiet failure mode: non-Latin text does not error, it comes
back as plausible-looking Latin gibberish, so the bot acts confidently on a misread. The fix is
small (5 files) and the tests are the point -- the previous coverage was digits-only, which cannot
fail in the way this bug fails.

### Verification status

DCO green. Java CI has never run on this branch. **#294 stacks on this commit
(`c3a31a2`)** -- merging this one first shrinks #294's diff.

<!-- BEARGUARD-COMPARE-END -->