### PR TITLE
fix(storehouse): expose reward bubbles after selection

### DIFF
--- a/modules/tasks/src/main/java/dev/frostguard/tasks/economy/StorehouseChestRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/economy/StorehouseChestRoutine.java
@@ -51,6 +51,7 @@ public class StorehouseChestRoutine extends DelayedTask {
     private static final AreaData STOREHOUSE_TITLE_AREA = new AreaData(
             new PointData(245, 515), new PointData(505, 575));
     private static final int STOREHOUSE_SELECTION_SETTLE_MILLIS = 2_200;
+    private static final int STOREHOUSE_DESELECTION_SETTLE_MILLIS = 800;
     private static final PointData STOREHOUSE_SCROLL_START = new PointData(1, 636);
     private static final PointData STOREHOUSE_SCROLL_END = new PointData(2, 636);
 
@@ -172,6 +173,11 @@ public class StorehouseChestRoutine extends DelayedTask {
                         .build());
         if (selected.isFound()) {
             logInfo("Storehouse selected and verified by its title anchor.");
+            // The reward bubbles are only actionable after Android Back closes the
+            // building's Details/Upgrade selection controls.
+            pressBack();
+            sleepTask(STOREHOUSE_DESELECTION_SETTLE_MILLIS);
+            logInfo("Storehouse selection controls closed; reward bubbles are now accessible.");
             return true;
         }
 


### PR DESCRIPTION
## Summary

- press Android Back after the Storehouse title anchor confirms the selected building
- expose the chest and stamina reward bubbles before their existing template searches run

## Why

Selecting Storehouse can leave the building Details/Upgrade controls open. The title match succeeds in that state, but the overlay hides the reward bubbles and makes the routine report no claimable reward.

Independent follow-up to #257. Tracks #256.

## Validation

- Automated: `mvnw.cmd -pl modules/tasks -am test`
- Live evidence: Storehouse navigation and title anchoring were confirmed on the account; screenshots confirmed that Android Back transitions from the matched Details state to the reward-bubble state
- Remaining risk: an actually available chest/stamina reward was not observed during the final live run

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

The transition is deliberately gated by the Storehouse title anchor, so Back is not pressed on an unverified building.