### PR TITLE
fix(research): calibrate category tree traversal

### DIFF
--- a/modules/tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java
@@ -36,11 +36,23 @@ private static final int HAND_CLICK_OFFSET_X_VALUE = -73;
 
 private static final int HAND_CLICK_OFFSET_Y_VALUE = 88;
 
-private static final int MAX_SCROLL_ATTEMPTS_LIMIT = 10;
+private static final int RESEARCH_SCROLL_SETTLE_MILLIS = 2000;
 
-private static final int RESEARCH_SCROLL_SETTLE_MILLIS = 1000;
+private static final int RESEARCH_DRAG_DURATION_MILLIS = 750;
 
-private static final int RESEARCH_DRAG_DURATION_MILLIS = 800;
+private static final int RESEARCH_TOP_RESET_SWIPE_COUNT = 4;
+
+private static final int RESEARCH_TOP_RESET_GAP_MILLIS = 2000;
+
+private static final PointData RESEARCH_TOP_RESET_FROM = new PointData(489, 300);
+
+private static final PointData RESEARCH_TOP_RESET_TO = new PointData(489, 1050);
+
+private static final int RESEARCH_TOP_RESET_DURATION_MILLIS = 100;
+
+private static final PointData RESEARCH_SCROLL_DOWN_FROM = new PointData(489, 980);
+
+private static final PointData RESEARCH_SCROLL_DOWN_TO = new PointData(489, 380);
 
 private static final int RESEARCH_ENTRY_ATTEMPTS = 2;
 
@@ -467,7 +479,7 @@ private ImageSearchResultData findResearchInPriorityCategories() {
             tapCategoryTab(category);
             sleepTask(500);
 
-            ImageSearchResultData candidate = findStartableResearchNode();
+            ImageSearchResultData candidate = findStartableResearchNode(category);
             if (!isFound(candidate)) {
                 logInfo(routineLogResearchLine("No available tech node in '" + category.label()
                         + "'. Trying next category."));
@@ -488,17 +500,18 @@ private void tapCategoryTab(ResearchCategoryEnum category) {
         }
     }
 
-private ImageSearchResultData findStartableResearchNode() {
-        logDebug(routineLogResearchLine("Normalizing research menu with swipes..."));
-        for (int i = 0; i < 3; i++) {
-            swipe(new PointData(489, 500), new PointData(489, 850), RESEARCH_DRAG_DURATION_MILLIS);
-            sleepTask(500);
+private ImageSearchResultData findStartableResearchNode(ResearchCategoryEnum category) {
+        logDebug(routineLogResearchLine("Resetting research menu to the top with fast momentum swipes..."));
+        for (int i = 0; i < RESEARCH_TOP_RESET_SWIPE_COUNT; i++) {
+            swipe(RESEARCH_TOP_RESET_FROM, RESEARCH_TOP_RESET_TO,
+                    RESEARCH_TOP_RESET_DURATION_MILLIS);
+            sleepTask(RESEARCH_TOP_RESET_GAP_MILLIS);
         }
 
         boolean topRowRepositioned = false;
-        for (int scrollAttempt = 0; scrollAttempt < MAX_SCROLL_ATTEMPTS_LIMIT; scrollAttempt++) {
+        int maximumDownSwipes = maximumDownSwipes(category);
+        for (int scrollPosition = 0; scrollPosition <= maximumDownSwipes; scrollPosition++) {
             checkPreemption();
-            sleepTask(RESEARCH_SCROLL_SETTLE_MILLIS);
 
             RawImageData researchScreenshot = emuManager.captureScreen(EMULATOR_NUMBER);
             if (researchScreenshot == null) {
@@ -521,6 +534,7 @@ private ImageSearchResultData findStartableResearchNode() {
                 logInfo(routineLogResearchLine(
                         "Top incomplete row is partially hidden; repositioning it below the category header."));
                 swipe(new PointData(489, 430), new PointData(489, 650), RESEARCH_DRAG_DURATION_MILLIS);
+                sleepTask(RESEARCH_SCROLL_SETTLE_MILLIS);
                 topRowRepositioned = true;
                 continue;
             }
@@ -570,11 +584,24 @@ private ImageSearchResultData findStartableResearchNode() {
                 }
             }
 
-            logDebug(routineLogResearchLine("No startable research in the visible frontier, scrolling down (attempt "
-                    + (scrollAttempt + 1) + "/" + MAX_SCROLL_ATTEMPTS_LIMIT + ")"));
-            swipe(new PointData(489, 760), new PointData(489, 500), RESEARCH_DRAG_DURATION_MILLIS);
+            if (scrollPosition == maximumDownSwipes) {
+                break;
+            }
+
+            logDebug(routineLogResearchLine("No startable research in the visible frontier, scrolling down (swipe "
+                    + (scrollPosition + 1) + "/" + maximumDownSwipes + ")"));
+            swipe(RESEARCH_SCROLL_DOWN_FROM, RESEARCH_SCROLL_DOWN_TO, RESEARCH_DRAG_DURATION_MILLIS);
+            sleepTask(RESEARCH_SCROLL_SETTLE_MILLIS);
         }
         return null;
+    }
+
+static int maximumDownSwipes(ResearchCategoryEnum category) {
+        return switch (category) {
+            case GROWTH -> 9;
+            case ECONOMY -> 8;
+            case BATTLE -> 15;
+        };
     }
 
 private List<ResearchNode> detectResearchNodes(RawImageData screenshot) {

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/city/ResearchScrollPlanTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/city/ResearchScrollPlanTest.java
@@ -1,0 +1,16 @@
+package dev.frostguard.tasks.city;
+
+import dev.frostguard.api.configs.ResearchCategoryEnum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ResearchScrollPlanTest {
+
+    @Test
+    void usesLiveCalibratedCategoryTraversalLimits() {
+        assertEquals(9, ResearchRoutine.maximumDownSwipes(ResearchCategoryEnum.GROWTH));
+        assertEquals(8, ResearchRoutine.maximumDownSwipes(ResearchCategoryEnum.ECONOMY));
+        assertEquals(15, ResearchRoutine.maximumDownSwipes(ResearchCategoryEnum.BATTLE));
+    }
+}


### PR DESCRIPTION
## Summary

- reset every Research category with four fast 100 ms momentum flicks
- scan downward using a controlled 600 px / 750 ms drag
- wait two seconds after every downward drag before capturing and pattern-matching the next frame
- use live-calibrated limits of 9 Growth, 8 Economy, and 15 Battle swipes
- scan once more after the final allowed swipe

## Why

The previous three short reset drags did not reliably reach the top, while ten 260 px downward drags did not cover every category. Capturing while residual movement remained also made node detection inconsistent.

Independent follow-up to #257. Tracks #256.

## Validation

- Automated: `mvnw.cmd -pl modules/tasks -am test`
- Live emulator 1 calibration: Growth traversed top-to-bottom in 9 controlled drags, Economy in 8, and Battle in 15
- Combined Storehouse, Intel, and Research integration branch passed the same reactor test after rebasing onto merged `main`

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

The gestures were calibrated against the current 720×1280 MuMu layout. Pattern matching still stops traversal early when a usable frontier is found.