### PR TITLE
perf(ci): reduce redundant PR installer work

### DIFF
--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -40,7 +40,7 @@ env:
 
 jobs:
   package:
-    name: Build and smoke-test Stable and Nightly installers
+    name: Build and smoke-test required Windows installers
     runs-on: windows-latest
     timeout-minutes: 60
 
@@ -48,7 +48,20 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           lfs: true
+
+      - name: Select required Windows channels
+        id: channels
+        shell: pwsh
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python build-support/verification/windows_pr_channels.py `
+              --event-name $env:GITHUB_EVENT_NAME `
+              --base-sha $env:BASE_SHA --head-sha $env:HEAD_SHA `
+              --github-output $env:GITHUB_OUTPUT
 
       - name: Verify Git LFS assets are real binaries
         shell: bash
@@ -142,6 +155,7 @@ jobs:
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Upload Stable application image
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: frostguard-stable-windows-app-image
@@ -159,12 +173,14 @@ jobs:
           retention-days: 14
 
       - name: Reset packaging output before Nightly build
+        if: steps.channels.outputs.nightly == 'true'
         shell: pwsh
         run: |
           $mavenArgs = $env:MAVEN_ARGS -split " "
           & .\mvnw.cmd @mavenArgs -pl packaging/desktop clean
 
       - name: Build Nightly application image and installer
+        if: steps.channels.outputs.nightly == 'true'
         shell: pwsh
         run: |
           $mavenArgs = $env:MAVEN_ARGS -split " "
@@ -172,6 +188,7 @@ jobs:
               "-Pwindows-app-image,windows-installer,windows-nightly" package
 
       - name: Verify Nightly application image
+        if: steps.channels.outputs.nightly == 'true'
         run: >-
           python build-support/verification/verify_app_image.py
           "packaging/desktop/target/app-image/Frostguard Nightly"
@@ -181,6 +198,7 @@ jobs:
           --expected-watcher-launcher-sha256 9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209
 
       - name: Smoke test Nightly launchers and workspace isolation
+        if: steps.channels.outputs.nightly == 'true'
         shell: pwsh
         run: |
           powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
@@ -189,6 +207,7 @@ jobs:
               -Channel nightly -ProductName "Frostguard Nightly"
 
       - name: Verify Nightly installer boundary
+        if: steps.channels.outputs.nightly == 'true'
         id: nightly-installer
         shell: pwsh
         run: |
@@ -204,6 +223,7 @@ jobs:
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Upload Nightly application image
+        if: github.event_name == 'workflow_dispatch' && steps.channels.outputs.nightly == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: frostguard-nightly-windows-app-image
@@ -212,6 +232,7 @@ jobs:
           retention-days: 14
 
       - name: Upload Nightly installer
+        if: steps.channels.outputs.nightly == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: frostguard-nightly-windows-installer

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -47,8 +47,22 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertFalse((workflows / "stable-windows-release.yml").exists())
 
         self.assertIn("name: CI — Windows Installers", installers)
-        self.assertIn("Build and smoke-test Stable and Nightly installers", installers)
+        self.assertIn("Build and smoke-test required Windows installers", installers)
         self.assertIn('java-version: "21.0.12+8.0"', installers)
+        self.assertIn("windows_pr_channels.py", installers)
+        self.assertIn("fetch-depth: 0", installers)
+        self.assertGreaterEqual(
+            installers.count("if: steps.channels.outputs.nightly == 'true'"), 5)
+        self.assertIn(
+            "if: github.event_name == 'workflow_dispatch'\n"
+            "        uses: actions/upload-artifact@v4\n"
+            "        with:\n"
+            "          name: frostguard-stable-windows-app-image",
+            installers)
+        self.assertIn(
+            "if: github.event_name == 'workflow_dispatch' && "
+            "steps.channels.outputs.nightly == 'true'",
+            installers)
 
     def test_pr_test_build_keeps_bundle_verification_and_publication(self):
         workflow = (REPO_ROOT / ".github/workflows/pr-test-build.yml").read_text(

--- a/build-support/verification/test_windows_pr_channels.py
+++ b/build-support/verification/test_windows_pr_channels.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import windows_pr_channels
+
+
+class WindowsPrChannelsTest(unittest.TestCase):
+    def test_ordinary_task_change_needs_only_stable(self):
+        self.assertFalse(windows_pr_channels.requires_nightly([
+            "modules/tasks/src/main/java/dev/frostguard/tasks/city/ResearchRoutine.java",
+            "modules/tasks/src/test/java/dev/frostguard/tasks/city/ResearchRoutineTest.java",
+        ]))
+
+    def test_custom_task_example_needs_only_stable(self):
+        self.assertFalse(windows_pr_channels.requires_nightly([
+            "examples/custom-tasks/bg_telemetry.java",
+        ]))
+
+    def test_channel_and_packaging_paths_need_nightly(self):
+        sensitive_paths = (
+            "pom.xml",
+            "modules/desktop/pom.xml",
+            "packaging/desktop/pom.xml",
+            "modules/update/src/main/java/dev/frostguard/update/UpdateSelector.java",
+            "modules/desktop/src/main/java/dev/frostguard/app/RuntimeVersion.java",
+            "modules/api/src/main/java/dev/frostguard/api/runtime/WorkspacePaths.java",
+            "build-support/release/windows_installer_version.py",
+            "build-support/verification/verify_app_image.py",
+            "tools/windows/Frostguard.exe",
+            ".github/workflows/windows-native-package.yml",
+            ".github/workflows/signed-windows-channel-release.yml",
+        )
+        for path in sensitive_paths:
+            with self.subTest(path=path):
+                self.assertTrue(windows_pr_channels.requires_nightly([path]))
+
+    @patch("windows_pr_channels.changed_paths")
+    def test_pull_request_uses_changed_paths(self, changed_paths):
+        changed_paths.return_value = ["packaging/desktop/pom.xml"]
+
+        nightly, paths = windows_pr_channels.select_nightly(
+            "pull_request", "base", "head")
+
+        self.assertTrue(nightly)
+        self.assertEqual(["packaging/desktop/pom.xml"], paths)
+        changed_paths.assert_called_once_with("base", "head")
+
+    @patch("windows_pr_channels.changed_paths")
+    def test_manual_run_always_builds_both_channels(self, changed_paths):
+        nightly, paths = windows_pr_channels.select_nightly(
+            "workflow_dispatch", "", "")
+
+        self.assertTrue(nightly)
+        self.assertEqual([], paths)
+        changed_paths.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/build-support/verification/windows_pr_channels.py
+++ b/build-support/verification/windows_pr_channels.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Select the Windows channels that a pull request must package."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+
+NIGHTLY_SENSITIVE_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"(^|/)pom\.xml$",
+        r"^packaging/desktop/",
+        r"^modules/update/src/main/",
+        r"^modules/desktop/src/main/",
+        r"^modules/api/src/main/java/dev/frostguard/api/runtime/",
+        r"^build-support/packaging/",
+        r"^build-support/release/",
+        r"^build-support/verification/",
+        r"^tools/",
+        r"^\.github/workflows/windows-native-package\.yml$",
+        r"^\.github/workflows/signed-windows-channel-release\.yml$",
+    )
+)
+
+
+def requires_nightly(paths: Iterable[str]) -> bool:
+    """Return whether any changed path can affect the Nightly identity."""
+    return any(
+        pattern.search(path.replace("\\", "/"))
+        for path in paths
+        for pattern in NIGHTLY_SENSITIVE_PATTERNS
+    )
+
+
+def changed_paths(base_sha: str, head_sha: str) -> list[str]:
+    if not base_sha or not head_sha:
+        raise ValueError("pull-request channel selection requires base and head SHAs")
+    result = subprocess.run(
+        [
+            "git", "diff", "--name-only", "--no-renames",
+            "--diff-filter=ACDMRT", base_sha, head_sha,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def select_nightly(event_name: str, base_sha: str, head_sha: str) -> tuple[bool, list[str]]:
+    if event_name != "pull_request":
+        return True, []
+    paths = changed_paths(base_sha, head_sha)
+    return requires_nightly(paths), paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--base-sha", default="")
+    parser.add_argument("--head-sha", default="")
+    parser.add_argument("--github-output", type=Path, required=True)
+    args = parser.parse_args()
+
+    nightly, paths = select_nightly(args.event_name, args.base_sha, args.head_sha)
+    with args.github_output.open("a", encoding="utf-8") as output:
+        output.write(f"nightly={'true' if nightly else 'false'}\n")
+
+    if args.event_name == "pull_request":
+        reason = "a channel-sensitive path changed" if nightly else "Stable covers these changes"
+        print(f"Nightly required: {str(nightly).lower()} ({reason}).")
+        for path in paths:
+            print(f"- {path}")
+    else:
+        print("Nightly required: true (manual validation builds both channels).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -25,7 +25,7 @@ European local time shown below shifts when daylight-saving time changes.
 | Workflow | Runs | Purpose and side effects |
 |---|---|---|
 | **CI — Java Build and Tests** | Automatically for every pull request and every push to `main` | Builds and tests the complete reactor on Linux. It publishes only short-lived test-report artifacts, never a release. |
-| **CI — Windows Installers** | Automatically for pull requests that touch packaging-related paths | Builds and smoke-tests the Stable and Nightly MSI packages. It uploads short-lived Actions artifacts, never a GitHub Release. |
+| **CI — Windows Installers** | Automatically for pull requests that touch packaging-related paths | Always builds and smoke-tests the Stable MSI; channel-sensitive changes also test Nightly. PR runs upload short-lived MSI artifacts, never a GitHub Release. |
 | **CI — Windows Installers** | Manually with prerelease application and numeric MSI versions | Produces an unpublished Stable release candidate for upgrade testing. It does not change `releases/latest`. |
 | **PR Build — Create Test Release** | Manually in Actions or dispatched through Discord `/build-pr` | Combines selected open pull requests and publishes a temporary `pr-test-*` prerelease. A Discord-originated request receives the result in Discord. |
 | **PR Build — Clean Up Test Releases** | Daily at 04:43 UTC (06:43 CEST / 05:43 CET), or manually | Deletes expired `pr-test-*` releases and their tags, including builds whose selected pull requests are all closed. It never touches Nightly or permanent releases. |


### PR DESCRIPTION
## Summary

- always build and smoke-test the Stable MSI for packaging-relevant pull requests
- add Nightly only when changed paths can affect channel, updater, workspace, packaging, or release behavior
- keep MSI artifacts for PR testing while reserving unpacked application-image uploads for manual candidate builds
- preserve fresh hosted runners, read-only fork permissions, Maven dependency caching, and independent trusted release builds

## Why

Recent successful PR runs spend a median of about 6m22s in Windows CI. Ordinary product changes currently pay for a second Nightly package even though Stable already exercises the shared Java application and native installer path. The sequential Nightly build plus unpacked app-image uploads account for roughly two minutes of avoidable work on those PRs.

The selector fails conservatively for POM, desktop, updater, runtime-channel, packaging, verification, tool, and workflow changes: those still validate both product identities. Manual candidate runs also remain exhaustive.

Closes #264.

## Validation

- `mvnw.cmd package` — passed
- `python -m unittest discover -s build-support/verification -p test_*.py` — 47 tests passed
- `python build-support/verification/test_windows_pr_channels.py` — 5 tests passed
- `python build-support/verification/test_channel_packaging.py` — 7 tests passed
- `python build-support/verification/check_workflow_python.py` — all 3 inline snippets compile
- `git diff --check` — passed

## Expected impact

- ordinary task, automation, vision, watcher, and custom-task PRs: Stable only, expected Windows reduction of about two minutes
- channel-sensitive PRs: Stable and Nightly remain; about 30 seconds of unpacked app-image upload work is removed
- this draft changes the selector and packaging workflow itself, so its first Windows run intentionally exercises both channels

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

- The first real Stable-only hosted run will occur on a later ordinary product PR; this draft can validate only the conservative two-channel path because it changes the workflow itself.
- A future channel-sensitive source area must be added to the selector when introduced. Focused tests document the current boundary.