### PR TITLE
chore(release): prepare 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	     Build-wide property declarations
 	     ────────────────────────────────────────────── -->
 	<properties>
-		<revision>3.0.0</revision>
+		<revision>3.0.1</revision>
 		<frostguard.pull-request-build>false</frostguard.pull-request-build>
 		<frostguard.update.manifest.stable></frostguard.update.manifest.stable>
 		<frostguard.update.manifest.nightly></frostguard.update.manifest.nightly>


### PR DESCRIPTION
## Summary

- advance the reactor revision from `3.0.0` to `3.0.1`
- enable the authenticated Stable workflow to publish the current tested `main` state as the first publicly announced Frostguard 3 Stable

## Why

The Stable release workflow requires the requested release version to match the Maven revision. Its first `3.0.1` attempt stopped safely before packaging or publication because the repository still declared `3.0.0`.

Related: #235

## Validation

- `mvnw.cmd package` — passed 541 tests with 0 failures, 0 errors, and 0 skipped; built the 3.0.1 desktop bundle
- Nightly `3.0.0-nightly.20260819.1` published successfully from the parent `main` commit through run https://github.com/Shederator/wosbot/actions/runs/32212962331
- Stable run https://github.com/Shederator/wosbot/actions/runs/32213299538 stopped at version validation before creating a tag, installer, or release

Evidence level: automated tests and authenticated Nightly release verification. Stable publication remains pending this PR's merge.

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

The version bump changes no runtime behavior. Stable `3.0.1` must be published only after this commit reaches `main` and the release workflow re-verifies the installer.