### PR TITLE
fix(release): sign installed Windows launchers

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -223,7 +223,7 @@ jobs:
               throw "Immutable release $tag already exists"
           }
 
-      - name: Configure optional Authenticode certificate
+      - name: Configure required Authenticode certificate
         id: certificate
         env:
           SIGNING_CERTIFICATE_BASE64: ${{ secrets.FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
@@ -236,14 +236,8 @@ jobs:
               $env:SIGNING_CERTIFICATE_PASSWORD,
               $env:AUTHENTICODE_PUBLISHER
           ).Where({ -not [string]::IsNullOrWhiteSpace($_) }).Count
-          if ($configuredCount -eq 0) {
-              "enabled=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-              "publisher=" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-              Write-Output "Authenticode is not configured; project signing remains mandatory."
-              exit 0
-          }
           if ($configuredCount -ne 3) {
-              throw "Authenticode certificate, password, and publisher must be configured together"
+              throw "Public releases require the Authenticode certificate, password, and publisher"
           }
           $certificatePath = Join-Path $env:RUNNER_TEMP "frostguard-release-signing.pfx"
           [IO.File]::WriteAllBytes($certificatePath,
@@ -259,11 +253,10 @@ jobs:
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "path=$certificatePath" | Out-File `
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "publisher=$($certificate.Subject)" | Out-File `
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-      - name: Build channel application image and installer
+      - name: Build unsigned channel application image
         shell: pwsh
         env:
           WINDOWS_VERSION: ${{ steps.identity.outputs.windows_version }}
@@ -271,7 +264,7 @@ jobs:
           AUTHENTICODE_PUBLISHER: ${{ steps.certificate.outputs.publisher }}
         run: |
           $mavenArgs = $env:MAVEN_ARGS -split " "
-          $profiles = "windows-app-image,windows-installer$($env:EXTRA_PROFILE)"
+          $profiles = "windows-app-image$($env:EXTRA_PROFILE)"
           $stableManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/latest/download/frostguard-stable-manifest.json"
           $nightlyManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/download/nightly/frostguard-nightly-manifest.json"
           & .\mvnw.cmd @mavenArgs "-Drevision=$($env:VERSION)" `
@@ -281,7 +274,7 @@ jobs:
               "-Dfrostguard.update.manifest.nightly=$nightlyManifest" `
               "-P$profiles" package
 
-      - name: Verify and smoke-test channel application image
+      - name: Verify unsigned channel launchers
         shell: pwsh
         env:
           PRODUCT_NAME: ${{ steps.identity.outputs.product_name }}
@@ -306,17 +299,64 @@ jobs:
               )
           }
           python build-support/verification/verify_app_image.py @verificationArgs
+
+      - name: Sign and verify channel launchers
+        shell: pwsh
+        env:
+          PRODUCT_NAME: ${{ steps.identity.outputs.product_name }}
+          CERTIFICATE_THUMBPRINT: ${{ steps.certificate.outputs.thumbprint }}
+          AUTHENTICODE_PUBLISHER: ${{ steps.certificate.outputs.publisher }}
+        run: |
+          $image = "packaging/desktop/target/app-image/$($env:PRODUCT_NAME)"
+          $watcherName = if ($env:CHANNEL -eq 'nightly') {
+              'FrostguardNightlyWatcher'
+          } else {
+              'FrostguardWatcher'
+          }
+          $launchers = @(
+              (Join-Path $image "$($env:PRODUCT_NAME).exe"),
+              (Join-Path $image "$watcherName.exe")
+          )
+          & build-support/release/sign_windows_artifact.ps1 `
+              -Path $launchers `
+              -CertificateThumbprint $env:CERTIFICATE_THUMBPRINT `
+              -Publisher $env:AUTHENTICODE_PUBLISHER
+
+      - name: Smoke-test signed channel application image
+        shell: pwsh
+        env:
+          PRODUCT_NAME: ${{ steps.identity.outputs.product_name }}
+        run: |
+          $image = "packaging/desktop/target/app-image/$($env:PRODUCT_NAME)"
           powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
               -File build-support/verification/smoke_test_app_image.ps1 `
               -ImagePath $image -Channel $env:CHANNEL -ProductName $env:PRODUCT_NAME
 
-      - name: Prepare immutable installer and verify optional Authenticode
+      - name: Build installer from signed channel application image
+        shell: pwsh
+        env:
+          WINDOWS_VERSION: ${{ steps.identity.outputs.windows_version }}
+          EXTRA_PROFILE: ${{ steps.identity.outputs.profile }}
+          AUTHENTICODE_PUBLISHER: ${{ steps.certificate.outputs.publisher }}
+        run: |
+          $mavenArgs = $env:MAVEN_ARGS -split " "
+          $profiles = "windows-installer$($env:EXTRA_PROFILE)"
+          $stableManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/latest/download/frostguard-stable-manifest.json"
+          $nightlyManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/download/nightly/frostguard-nightly-manifest.json"
+          & .\mvnw.cmd @mavenArgs -pl packaging/desktop -am -DskipTests `
+              "-Drevision=$($env:VERSION)" `
+              "-Dfrostguard.windows.app-version=$($env:WINDOWS_VERSION)" `
+              "-Dfrostguard.update.authenticode-publisher=$($env:AUTHENTICODE_PUBLISHER)" `
+              "-Dfrostguard.update.manifest.stable=$stableManifest" `
+              "-Dfrostguard.update.manifest.nightly=$nightlyManifest" `
+              "-P$profiles" package
+
+      - name: Prepare, sign, and verify immutable installer
         id: installer
         shell: pwsh
         env:
           IMMUTABLE_NAME: ${{ steps.identity.outputs.installer_name }}
           CERTIFICATE_THUMBPRINT: ${{ steps.certificate.outputs.thumbprint }}
-          AUTHENTICODE_ENABLED: ${{ steps.certificate.outputs.enabled }}
           AUTHENTICODE_PUBLISHER: ${{ steps.certificate.outputs.publisher }}
         run: |
           $source = @(Get-ChildItem "packaging/desktop/target/installers/$($env:CHANNEL)" `
@@ -326,27 +366,10 @@ jobs:
           }
           $installer = Join-Path $env:RUNNER_TEMP $env:IMMUTABLE_NAME
           Copy-Item -LiteralPath $source[0].FullName -Destination $installer
-          if ($env:AUTHENTICODE_ENABLED -eq 'true') {
-              $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" `
-                  -Recurse -Filter signtool.exe | Where-Object FullName -Match '\\x64\\' `
-                  | Sort-Object FullName -Descending | Select-Object -First 1
-              if ($null -eq $signtool) {
-                  throw "Windows SDK signtool.exe was not found"
-              }
-              & $signtool.FullName sign /sha1 $env:CERTIFICATE_THUMBPRINT /fd SHA256 `
-                  /td SHA256 /tr http://timestamp.digicert.com $installer
-              & $signtool.FullName verify /pa /v $installer
-              if ($LASTEXITCODE -ne 0) {
-                  throw "Authenticode verification failed"
-              }
-              $signature = Get-AuthenticodeSignature -LiteralPath $installer
-              if ($signature.Status -ne 'Valid' -or
-                  $signature.SignerCertificate.Subject -cne $env:AUTHENTICODE_PUBLISHER) {
-                  throw "Signed installer does not match the pinned publisher"
-              }
-          } else {
-              Write-Warning "Installer has no Windows verified publisher; the project-signed manifest is the trust root."
-          }
+          & build-support/release/sign_windows_artifact.ps1 `
+              -Path $installer `
+              -CertificateThumbprint $env:CERTIFICATE_THUMBPRINT `
+              -Publisher $env:AUTHENTICODE_PUBLISHER
           "path=$installer" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Create draft release and verify uploaded installer

--- a/build-support/release/sign_windows_artifact.ps1
+++ b/build-support/release/sign_windows_artifact.ps1
@@ -1,0 +1,42 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string[]] $Path,
+
+    [Parameter(Mandatory = $true)]
+    [string] $CertificateThumbprint,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Publisher
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" `
+    -Recurse -Filter signtool.exe |
+    Where-Object FullName -Match '\\x64\\' |
+    Sort-Object FullName -Descending |
+    Select-Object -First 1
+if ($null -eq $signtool) {
+    throw "Windows SDK signtool.exe was not found"
+}
+
+foreach ($artifactPath in $Path) {
+    $artifact = (Resolve-Path -LiteralPath $artifactPath).Path
+    & $signtool.FullName sign /sha1 $CertificateThumbprint /fd SHA256 `
+        /td SHA256 /tr http://timestamp.digicert.com $artifact
+    if ($LASTEXITCODE -ne 0) {
+        throw "Authenticode signing failed for $artifact"
+    }
+
+    & $signtool.FullName verify /pa /v $artifact
+    if ($LASTEXITCODE -ne 0) {
+        throw "Authenticode verification failed for $artifact"
+    }
+
+    $signature = Get-AuthenticodeSignature -LiteralPath $artifact
+    if ($signature.Status -ne "Valid" -or
+            $signature.SignerCertificate.Subject -cne $Publisher) {
+        throw "Signed artifact does not match the pinned publisher: $artifact"
+    }
+}

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -167,7 +167,11 @@ class ChannelPackagingTest(unittest.TestCase):
         installers = (REPO_ROOT / ".github/workflows/windows-native-package.yml").read_text(
             encoding="utf-8")
         ordered_steps = (
-            "Prepare immutable installer and verify optional Authenticode",
+            "Verify unsigned channel launchers",
+            "Sign and verify channel launchers",
+            "Smoke-test signed channel application image",
+            "Build installer from signed channel application image",
+            "Prepare, sign, and verify immutable installer",
             "Create draft release and verify uploaded installer",
             "Generate and project-sign update manifest",
             "Publish immutable release and channel manifest last",
@@ -177,8 +181,17 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("FROSTGUARD_UPDATE_SIGNING_PRIVATE_KEY_BASE64", workflow)
         self.assertIn("ProjectManifestSigner", workflow)
         self.assertIn("FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_BASE64", workflow)
-        self.assertIn("Configure optional Authenticode certificate", workflow)
-        self.assertIn("Get-AuthenticodeSignature", workflow)
+        self.assertIn("Configure required Authenticode certificate", workflow)
+        self.assertIn("sign_windows_artifact.ps1", workflow)
+        self.assertIn("-pl packaging/desktop -am -DskipTests", workflow)
+        self.assertIn("Public releases require the Authenticode certificate", workflow)
+        self.assertNotIn("Authenticode is not configured", workflow)
+        signer = (REPO_ROOT / "build-support/release/"
+                  "sign_windows_artifact.ps1").read_text(encoding="utf-8")
+        self.assertIn("signtool.exe", signer)
+        self.assertIn("Get-AuthenticodeSignature", signer)
+        self.assertIn("/tr http://timestamp.digicert.com", signer)
+        self.assertIn("SignerCertificate.Subject -cne $Publisher", signer)
         self.assertIn('installer_name = "$assetPrefix-$($env:VERSION)-windows-x64.msi"', workflow)
         self.assertIn("-Filter '*.msi' -File", workflow)
         self.assertIn("windows_installer_version.py", workflow)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ Do not put game task business logic in `modules/desktop`; do not put UI concepts
 - semantic-version, channel, operating-system, and architecture selection;
 - restart-safe downloads below the selected workspace cache;
 - byte-size and SHA-256 verification;
-- optional build-pinned Windows Authenticode verification and token-authorized
+- build-pinned Windows Authenticode verification and token-authorized
   external handoff with passive installer execution and workspace-aware restart.
 
 The desktop module owns presentation and runtime shutdown. Update code does not
@@ -274,13 +274,12 @@ the Java/JAR paths retained only for source and temporary PR-test bundles.
 Native packaging is opt-in through Maven profiles so the normal reactor build
 stays platform-neutral.
 
-The Nightly MSI product version remains monotonic for Windows Installer, while
-the unchanged native bootstrap launchers retain the last known-good launcher
-file version until Authenticode signing is enabled. This keeps their bytes and
-Smart App Control reputation stable across Java-only Nightly updates. The
-application reports its release version from packaged build metadata, not from
-the bootstrap file version. A bootstrap, icon, or JDK change still requires a
-new launcher identity and must pass the Windows signing/reputation gate.
+The Nightly MSI product version remains monotonic for Windows Installer. Release
+packaging first verifies the known unsigned bootstrap bytes, Authenticode-signs
+the desktop and watcher launchers, and then builds the MSI from that signed app
+image. The application reports its release version from packaged build metadata,
+not from the bootstrap file version. A bootstrap, icon, or JDK change still
+requires a new launcher identity and must pass the Windows signing gate.
 
 The watcher launcher is channel-specific internal infrastructure and does not
 receive Start-menu or desktop shortcuts. The installer exposes only the desktop
@@ -317,8 +316,8 @@ running files.
 The release feed is a signed envelope whose Ed25519 signature covers the exact
 manifest bytes. The embedded project public key is the primary update trust
 root. The manifest then binds the immutable installer URL, filename, size, and
-SHA-256. Authenticode is an additional check when a release build embeds a
-publisher identity; it is not required for project-signed releases.
+SHA-256. Public Windows releases also embed a required Authenticode publisher;
+the installed launchers and downloaded installer must match it exactly.
 
 `modules/watcher` builds a separate shaded watcher jar.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -62,16 +62,17 @@ Ed25519 private key matching the public key committed in
 Keep a second, access-controlled backup of the private key because GitHub
 Actions secrets cannot be exported again.
 
-Authenticode is optional. Configure all three of
+Authenticode is required for public Windows releases. Configure all three of
 `FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_BASE64`,
 `FROSTGUARD_WINDOWS_SIGNING_CERTIFICATE_PASSWORD`, and
-`FROSTGUARD_AUTHENTICODE_PUBLISHER`, or leave all three unset. A partial
-configuration fails the release.
+`FROSTGUARD_AUTHENTICODE_PUBLISHER`. Missing or partial configuration fails the
+release before packaging.
 
 Stable and Nightly use different application IDs, upgrade UUIDs, install
-directories, shortcuts, workspaces, and feeds. The workflow builds and smokes
-the selected identity, optionally Authenticode-signs the installer, uploads and
-re-downloads the immutable installer, derives its final size and SHA-256,
+directories, shortcuts, workspaces, and feeds. The workflow verifies the
+selected identity's unsigned launcher hashes, signs and smokes both launchers,
+builds and signs the installer, uploads and re-downloads the immutable
+installer, derives its final size and SHA-256,
 project-signs the manifest, verifies it, and publishes it last. Stable exposes
 its manifest through the latest immutable release. Nightly stores the installer
 in an immutable `v<version>` release and updates the manifest asset on the
@@ -141,7 +142,7 @@ The current immutable preview with its own app and settings:
 https://github.com/Shederator/wosbot/releases/tag/nightly
 
 Download the Windows x64 MSI from the selected release. The installer includes
-Java. A Windows Unknown publisher or SmartScreen warning is currently expected.
+Java and must show the configured Frostguard publisher before installation.
 ```
 
 The Stable guide links to GitHub's Latest release because the immutable MSI
@@ -268,14 +269,16 @@ installer must match it exactly.
 
 ### Publication order
 
-1. Build and smoke-test the native application image.
-2. Build the channel-specific installer with its stable upgrade identity.
-3. Optionally Authenticode-sign the final installer and verify its exact subject.
-4. Calculate the final byte size and SHA-256.
-5. Upload and re-download the installer at its immutable versioned HTTPS URL.
-6. Generate the schema-1 payload from that verified file.
-7. Ed25519-sign the exact payload and verify the resulting envelope.
-8. Publish the signed envelope atomically as the final step.
+1. Build the native application image and verify its known unsigned launchers.
+2. Authenticode-sign both launchers and verify their exact subject.
+3. Smoke-test the signed application image.
+4. Build the channel-specific installer from that signed image.
+5. Authenticode-sign the final installer and verify its exact subject.
+6. Calculate the final byte size and SHA-256.
+7. Upload and re-download the installer at its immutable versioned HTTPS URL.
+8. Generate the schema-1 payload from that verified file.
+9. Ed25519-sign the exact payload and verify the resulting envelope.
+10. Publish the signed envelope atomically as the final step.
 
 Never publish a PR artifact, unsigned manifest payload, mutable installer
 filename, or envelope whose artifact has not completed the same verification
@@ -302,8 +305,8 @@ If the private key is lost, restore it from the offline backup; the GitHub
 secret cannot be read back. If compromise is suspected, stop channel
 publication, remove or replace the Actions secret, preserve release evidence,
 and prepare a bridge release and manual recovery instructions before resuming.
-Adding a Windows code-signing certificate later is additive: configure the
-three Authenticode secrets above; the signed-envelope format does not change.
+Rotating the Windows code-signing certificate requires updating the three
+Authenticode secrets together. The signed-envelope format does not change.
 
 ### Runtime and recovery
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -69,13 +69,12 @@ and leaves the current installation untouched. A failed installer upgrade uses
 Windows Installer rollback, attempts to reopen the retained application, and
 shows an update failure instead of silently claiming success.
 
-Until release binaries have an Authenticode publisher, Java-only Stable and
-Nightly updates keep their native desktop and watcher bootstrap files
-byte-identical to the already accepted Stable 2.1.0 and Nightly 26.8.12004
-launchers. The MSI version still increases for every release, and Frostguard
-displays the version embedded in its application JAR. Changes to the bootstrap,
-icon, or packaged JDK require a new Windows reputation decision; Authenticode
-signing remains the durable solution.
+Public Stable and Nightly releases Authenticode-sign both native launchers and
+the MSI with the same pinned publisher. Release packaging verifies the known
+unsigned launcher bytes before signing them, then builds the MSI from that
+signed application image. Frostguard displays the version embedded in its
+application JAR while Windows Installer continues to use a monotonically
+increasing numeric product version.
 
 ## Source build commands and native packaging
 
@@ -135,10 +134,10 @@ The application currently packages Windows ADB and Tesseract assets from `tools/
 
 ## Starting Frostguard
 
-After downloading a Frostguard 3.0 installer from the official GitHub release,
-complete the per-user installation. The installer currently has no Windows
-verified publisher, so an **Unknown publisher** or SmartScreen warning is
-expected. Run the installed `Frostguard.exe` or `Frostguard Nightly.exe`.
+After downloading a Frostguard 3 installer from the official GitHub release,
+verify that Windows shows the expected Frostguard publisher and complete the
+per-user installation. Run the installed `Frostguard.exe` or
+`Frostguard Nightly.exe`.
 The per-user installer defaults to `%LOCALAPPDATA%\Frostguard`, while
 all mutable databases, configuration, logs, watcher state, and custom tasks
 remain in the selected workspace below `%USERPROFILE%\.frostguard`. The

--- a/packaging/desktop/pom.xml
+++ b/packaging/desktop/pom.xml
@@ -19,8 +19,8 @@
     <properties>
         <frostguard.release.channel>stable</frostguard.release.channel>
         <frostguard.windows.app-version>${project.version}</frostguard.windows.app-version>
-        <!-- Keep the unchanged bootstrap byte-identical while releases are
-             project-signed but do not yet have an Authenticode publisher. -->
+        <!-- Keep the unsigned bootstrap byte-identical so release packaging can
+             verify its expected bytes before applying Authenticode. -->
         <frostguard.windows.launcher-version>2.1.0</frostguard.windows.launcher-version>
         <frostguard.product.name>Frostguard</frostguard.product.name>
         <frostguard.product.identifier>dev.frostguard.desktop</frostguard.product.identifier>
@@ -376,8 +376,8 @@
             <id>windows-nightly</id>
             <properties>
                 <frostguard.release.channel>nightly</frostguard.release.channel>
-                <!-- Keep the unchanged bootstrap byte-identical while releases are
-                     project-signed but do not yet have an Authenticode publisher. -->
+                <!-- Keep the unsigned bootstrap byte-identical so release packaging can
+                     verify its expected bytes before applying Authenticode. -->
                 <frostguard.windows.launcher-version>26.8.12004</frostguard.windows.launcher-version>
                 <frostguard.product.name>Frostguard Nightly</frostguard.product.name>
                 <frostguard.product.identifier>dev.frostguard.desktop.nightly</frostguard.product.identifier>


### PR DESCRIPTION
## Summary

- require Authenticode credentials before publishing Stable or Nightly
- verify the known unsigned launcher bytes, then sign both native launchers
- build the MSI from the signed application image and sign the MSI with the same publisher
- centralize timestamped signing and exact-publisher verification in a PowerShell helper
- update release architecture, operator documentation, and workflow contract tests

## Why

Smart App Control blocks the installed Stable 3.0.1 launcher with Code Integrity events 3033 and 3077, while current Nightly launchers remain accepted. Both channels are unsigned and their launcher hashes still match the pinned legacy binaries. This proves that retaining identical unsigned bytes does not reliably retain Windows reputation.

The existing optional Authenticode path signed only the final MSI. It did not sign the installed `Frostguard.exe` and watcher launcher that Smart App Control evaluates.

Closes #267.

## Validation

- `python -m unittest build-support.verification.test_channel_packaging build-support.verification.test_verify_app_image build-support.release.test_write_update_manifest build-support.release.test_windows_installer_version` — 31 tests passed
- `mvnw.cmd package` — full Maven reactor passed
- local Windows app-image build with a test release identity — passed
- split installer build preserved the existing app image and reached `jpackage`; final MSI creation was not performed locally because WiX is not installed on this machine
- live Windows evidence: Stable 3.0.1 consistently produced Code Integrity 3033/3077; Nightly 20260819.1 and .2 started successfully

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

- A publicly trusted Windows code-signing certificate must be configured in all three documented repository secrets before the release workflow can run.
- The complete signed app-image/MSI path still needs CI verification with the real certificate, followed by installation and startup on a Smart App Control-enabled Windows system.
