### PR TITLE
fix(windows): reuse accepted bootstrap for Stable 3.0.2

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -263,7 +263,7 @@ jobs:
           "publisher=$($certificate.Subject)" | Out-File `
               -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-      - name: Build channel application image and installer
+      - name: Build channel application image
         shell: pwsh
         env:
           WINDOWS_VERSION: ${{ steps.identity.outputs.windows_version }}
@@ -271,7 +271,7 @@ jobs:
           AUTHENTICODE_PUBLISHER: ${{ steps.certificate.outputs.publisher }}
         run: |
           $mavenArgs = $env:MAVEN_ARGS -split " "
-          $profiles = "windows-app-image,windows-installer$($env:EXTRA_PROFILE)"
+          $profiles = "windows-app-image$($env:EXTRA_PROFILE)"
           $stableManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/latest/download/frostguard-stable-manifest.json"
           $nightlyManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/download/nightly/frostguard-nightly-manifest.json"
           & .\mvnw.cmd @mavenArgs "-Drevision=$($env:VERSION)" `
@@ -280,6 +280,27 @@ jobs:
               "-Dfrostguard.update.manifest.stable=$stableManifest" `
               "-Dfrostguard.update.manifest.nightly=$nightlyManifest" `
               "-P$profiles" package
+
+      - name: Build accepted Nightly bootstrap donor for Stable
+        if: env.CHANNEL == 'stable'
+        shell: pwsh
+        env:
+          WINDOWS_VERSION: ${{ steps.identity.outputs.windows_version }}
+          AUTHENTICODE_PUBLISHER: ${{ steps.certificate.outputs.publisher }}
+        run: |
+          $mavenArgs = $env:MAVEN_ARGS -split " "
+          $stableManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/latest/download/frostguard-stable-manifest.json"
+          $nightlyManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/download/nightly/frostguard-nightly-manifest.json"
+          & .\mvnw.cmd @mavenArgs -pl packaging/desktop -am -DskipTests `
+              "-Drevision=$($env:VERSION)" `
+              "-Dfrostguard.windows.app-version=$($env:WINDOWS_VERSION)" `
+              "-Dfrostguard.update.authenticode-publisher=$($env:AUTHENTICODE_PUBLISHER)" `
+              "-Dfrostguard.update.manifest.stable=$stableManifest" `
+              "-Dfrostguard.update.manifest.nightly=$nightlyManifest" `
+              "-Pwindows-app-image,windows-nightly" package
+          & build-support/packaging/use_nightly_bootstrap_for_stable.ps1 `
+              -StableImage packaging/desktop/target/app-image/Frostguard `
+              -NightlyImage "packaging/desktop/target/app-image/Frostguard Nightly"
 
       - name: Verify and smoke-test channel application image
         shell: pwsh
@@ -290,25 +311,40 @@ jobs:
           $verificationArgs = @(
               $image, '--channel', $env:CHANNEL, '--product-name', $env:PRODUCT_NAME
           )
-          if ($env:CHANNEL -eq 'nightly') {
-              $verificationArgs += @(
-                  '--expected-desktop-launcher-sha256',
-                  '5c728d3662d64c428d003874f6d62b798bbbe329f595b2b15a2ab5ab1fd1faa9',
-                  '--expected-watcher-launcher-sha256',
-                  '9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209'
-              )
-          } else {
-              $verificationArgs += @(
-                  '--expected-desktop-launcher-sha256',
-                  '06610c6684f6323edf915a713d6a29cbc488d49f044685b80eabcfb1f7ca0a53',
-                  '--expected-watcher-launcher-sha256',
-                  'ed6a92c9e42bf4b205c669771bef4cbcd9e4d8674678f89cf944f965922f714e'
-              )
-          }
+          $verificationArgs += @(
+              '--expected-desktop-launcher-sha256',
+              '5c728d3662d64c428d003874f6d62b798bbbe329f595b2b15a2ab5ab1fd1faa9',
+              '--expected-watcher-launcher-sha256',
+              '9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209'
+          )
           python build-support/verification/verify_app_image.py @verificationArgs
+          $bootstrapArgs = @()
+          if ($env:CHANNEL -eq 'stable') {
+              $bootstrapArgs += @('-BootstrapProductName', 'Frostguard Nightly')
+          }
           powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
               -File build-support/verification/smoke_test_app_image.ps1 `
-              -ImagePath $image -Channel $env:CHANNEL -ProductName $env:PRODUCT_NAME
+              -ImagePath $image -Channel $env:CHANNEL -ProductName $env:PRODUCT_NAME `
+              @bootstrapArgs
+
+      - name: Build installer from verified channel application image
+        shell: pwsh
+        env:
+          WINDOWS_VERSION: ${{ steps.identity.outputs.windows_version }}
+          EXTRA_PROFILE: ${{ steps.identity.outputs.profile }}
+          AUTHENTICODE_PUBLISHER: ${{ steps.certificate.outputs.publisher }}
+        run: |
+          $mavenArgs = $env:MAVEN_ARGS -split " "
+          $profiles = "windows-installer$($env:EXTRA_PROFILE)"
+          $stableManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/latest/download/frostguard-stable-manifest.json"
+          $nightlyManifest = "https://github.com/$($env:GITHUB_REPOSITORY)/releases/download/nightly/frostguard-nightly-manifest.json"
+          & .\mvnw.cmd @mavenArgs -pl packaging/desktop -am -DskipTests `
+              "-Drevision=$($env:VERSION)" `
+              "-Dfrostguard.windows.app-version=$($env:WINDOWS_VERSION)" `
+              "-Dfrostguard.update.authenticode-publisher=$($env:AUTHENTICODE_PUBLISHER)" `
+              "-Dfrostguard.update.manifest.stable=$stableManifest" `
+              "-Dfrostguard.update.manifest.nightly=$nightlyManifest" `
+              "-P$profiles" package
 
       - name: Prepare immutable installer and verify optional Authenticode
         id: installer

--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -101,7 +101,7 @@ jobs:
               throw "Stable release candidate identity is invalid"
           }
 
-      - name: Build Stable application image and installer
+      - name: Build Stable application image
         shell: pwsh
         env:
           CANDIDATE_VERSION: ${{ inputs.stable_candidate_version }}
@@ -116,7 +116,28 @@ jobs:
               )
           }
           & .\mvnw.cmd @mavenArgs @candidateArgs "-Dfrostguard.pull-request-build=true" `
-              "-Pwindows-app-image,windows-installer" package
+              "-Pwindows-app-image" package
+
+      - name: Build accepted Nightly bootstrap donor for Stable
+        shell: pwsh
+        env:
+          CANDIDATE_VERSION: ${{ inputs.stable_candidate_version }}
+          CANDIDATE_WINDOWS_VERSION: ${{ inputs.stable_candidate_windows_version }}
+        run: |
+          $mavenArgs = $env:MAVEN_ARGS -split " "
+          $candidateArgs = @()
+          if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
+              $candidateArgs += @(
+                  "-Drevision=$($env:CANDIDATE_VERSION)",
+                  "-Dfrostguard.windows.app-version=$($env:CANDIDATE_WINDOWS_VERSION)"
+              )
+          }
+          & .\mvnw.cmd @mavenArgs -pl packaging/desktop -am -DskipTests `
+              @candidateArgs "-Dfrostguard.pull-request-build=true" `
+              "-Pwindows-app-image,windows-nightly" package
+          & build-support/packaging/use_nightly_bootstrap_for_stable.ps1 `
+              -StableImage packaging/desktop/target/app-image/Frostguard `
+              -NightlyImage "packaging/desktop/target/app-image/Frostguard Nightly"
 
       - name: Test the application-image verifier
         run: |
@@ -129,15 +150,34 @@ jobs:
         run: >-
           python build-support/verification/verify_app_image.py
           packaging/desktop/target/app-image/Frostguard
-          --expected-desktop-launcher-sha256 06610c6684f6323edf915a713d6a29cbc488d49f044685b80eabcfb1f7ca0a53
-          --expected-watcher-launcher-sha256 ed6a92c9e42bf4b205c669771bef4cbcd9e4d8674678f89cf944f965922f714e
+          --expected-desktop-launcher-sha256 5c728d3662d64c428d003874f6d62b798bbbe329f595b2b15a2ab5ab1fd1faa9
+          --expected-watcher-launcher-sha256 9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209
 
       - name: Smoke test Stable launchers and workspace isolation
         shell: pwsh
         run: |
           powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
               -File build-support/verification/smoke_test_app_image.ps1 `
-              -ImagePath packaging/desktop/target/app-image/Frostguard
+              -ImagePath packaging/desktop/target/app-image/Frostguard `
+              -BootstrapProductName "Frostguard Nightly"
+
+      - name: Build Stable installer from verified application image
+        shell: pwsh
+        env:
+          CANDIDATE_VERSION: ${{ inputs.stable_candidate_version }}
+          CANDIDATE_WINDOWS_VERSION: ${{ inputs.stable_candidate_windows_version }}
+        run: |
+          $mavenArgs = $env:MAVEN_ARGS -split " "
+          $candidateArgs = @()
+          if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
+              $candidateArgs += @(
+                  "-Drevision=$($env:CANDIDATE_VERSION)",
+                  "-Dfrostguard.windows.app-version=$($env:CANDIDATE_WINDOWS_VERSION)"
+              )
+          }
+          & .\mvnw.cmd @mavenArgs -pl packaging/desktop -am -DskipTests `
+              @candidateArgs "-Dfrostguard.pull-request-build=true" `
+              "-Pwindows-installer" package
 
       - name: Verify Stable installer boundary
         id: stable-installer
@@ -172,20 +212,13 @@ jobs:
           compression-level: 0
           retention-days: 14
 
-      - name: Reset packaging output before Nightly build
-        if: steps.channels.outputs.nightly == 'true'
-        shell: pwsh
-        run: |
-          $mavenArgs = $env:MAVEN_ARGS -split " "
-          & .\mvnw.cmd @mavenArgs -pl packaging/desktop clean
-
-      - name: Build Nightly application image and installer
+      - name: Build Nightly application image
         if: steps.channels.outputs.nightly == 'true'
         shell: pwsh
         run: |
           $mavenArgs = $env:MAVEN_ARGS -split " "
           & .\mvnw.cmd @mavenArgs -DskipTests "-Dfrostguard.pull-request-build=true" `
-              "-Pwindows-app-image,windows-installer,windows-nightly" package
+              "-Pwindows-app-image,windows-nightly" package
 
       - name: Verify Nightly application image
         if: steps.channels.outputs.nightly == 'true'
@@ -205,6 +238,15 @@ jobs:
               -File build-support/verification/smoke_test_app_image.ps1 `
               -ImagePath "packaging/desktop/target/app-image/Frostguard Nightly" `
               -Channel nightly -ProductName "Frostguard Nightly"
+
+      - name: Build Nightly installer from verified application image
+        if: steps.channels.outputs.nightly == 'true'
+        shell: pwsh
+        run: |
+          $mavenArgs = $env:MAVEN_ARGS -split " "
+          & .\mvnw.cmd @mavenArgs -pl packaging/desktop -am -DskipTests `
+              "-Dfrostguard.pull-request-build=true" `
+              "-Pwindows-installer,windows-nightly" package
 
       - name: Verify Nightly installer boundary
         if: steps.channels.outputs.nightly == 'true'

--- a/build-support/packaging/use_nightly_bootstrap_for_stable.ps1
+++ b/build-support/packaging/use_nightly_bootstrap_for_stable.ps1
@@ -1,0 +1,37 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $StableImage,
+
+    [Parameter(Mandatory = $true)]
+    [string] $NightlyImage
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$stable = (Resolve-Path -LiteralPath $StableImage).Path
+$nightly = (Resolve-Path -LiteralPath $NightlyImage).Path
+$files = @(
+    @{
+        Source = Join-Path $nightly "Frostguard Nightly.exe"
+        Destination = Join-Path $stable "Frostguard.exe"
+        Sha256 = "5c728d3662d64c428d003874f6d62b798bbbe329f595b2b15a2ab5ab1fd1faa9"
+    },
+    @{
+        Source = Join-Path $nightly "FrostguardNightlyWatcher.exe"
+        Destination = Join-Path $stable "FrostguardWatcher.exe"
+        Sha256 = "9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209"
+    }
+)
+
+foreach ($file in $files) {
+    $sourceHash = (Get-FileHash -LiteralPath $file.Source -Algorithm SHA256).Hash
+    if ($sourceHash -ine $file.Sha256) {
+        throw "Nightly compatibility bootstrap has unexpected SHA-256: $($file.Source)"
+    }
+    Copy-Item -LiteralPath $file.Source -Destination $file.Destination -Force
+    $destinationHash = (Get-FileHash -LiteralPath $file.Destination -Algorithm SHA256).Hash
+    if ($destinationHash -ine $file.Sha256) {
+        throw "Stable compatibility bootstrap copy failed: $($file.Destination)"
+    }
+}

--- a/build-support/verification/smoke_test_app_image.ps1
+++ b/build-support/verification/smoke_test_app_image.ps1
@@ -3,7 +3,8 @@ param(
     [string]$ImagePath,
     [ValidateSet("stable", "nightly")]
     [string]$Channel = "stable",
-    [string]$ProductName = "Frostguard"
+    [string]$ProductName = "Frostguard",
+    [string]$BootstrapProductName = $ProductName
 )
 
 $ErrorActionPreference = "Stop"
@@ -19,9 +20,9 @@ if (-not (Test-Path -LiteralPath $watcherLauncher -PathType Leaf)) {
 }
 
 $versionInfo = (Get-Item -LiteralPath $appLauncher).VersionInfo
-if ($versionInfo.ProductName -ne $ProductName -or
+if ($versionInfo.ProductName -ne $BootstrapProductName -or
         $versionInfo.CompanyName -ne "Frostguard" -or
-        $versionInfo.FileDescription -ne "$ProductName automation desktop application") {
+        $versionInfo.FileDescription -ne "$BootstrapProductName automation desktop application") {
     throw "$ProductName.exe has incomplete Windows application metadata"
 }
 Add-Type -AssemblyName System.Drawing

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -220,22 +220,42 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("Remove an abandoned draft release", workflow)
         self.assertIn('java-version: "21.0.12+8.0"', workflow)
         for launcher_hash in (
-            "06610c6684f6323edf915a713d6a29cbc488d49f044685b80eabcfb1f7ca0a53",
-            "ed6a92c9e42bf4b205c669771bef4cbcd9e4d8674678f89cf944f965922f714e",
             "5c728d3662d64c428d003874f6d62b798bbbe329f595b2b15a2ab5ab1fd1faa9",
             "9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209",
         ):
             self.assertIn(launcher_hash, installers)
             self.assertIn(launcher_hash, workflow)
+        for packaging_contract in (
+            "use_nightly_bootstrap_for_stable.ps1",
+            "Build accepted Nightly bootstrap donor for Stable",
+            "BootstrapProductName",
+            "Build installer from verified channel application image",
+        ):
+            self.assertIn(packaging_contract, workflow)
+        helper = (REPO_ROOT / "build-support/packaging/"
+                  "use_nightly_bootstrap_for_stable.ps1").read_text(encoding="utf-8")
+        self.assertIn('Join-Path $nightly "Frostguard Nightly.exe"', helper)
+        self.assertIn('Join-Path $stable "Frostguard.exe"', helper)
+        self.assertIn("Get-FileHash", helper)
+        self.assertIn("-ine $file.Sha256", helper)
         self.assertIn("stable_candidate_version", installers)
         self.assertIn("stable_candidate_windows_version", installers)
         self.assertIn("--candidate-windows-version", installers)
+        stable_build = installers.index("Build Stable application image")
+        donor_build = installers.index("Build accepted Nightly bootstrap donor for Stable")
+        stable_verify = installers.index("Verify Stable application image")
+        stable_installer = installers.index(
+            "Build Stable installer from verified application image")
         stable_upload = installers.index("Upload Stable installer")
-        packaging_reset = installers.index("Reset packaging output before Nightly build")
-        nightly_build = installers.index("Build Nightly application image and installer")
-        self.assertLess(stable_upload, packaging_reset)
-        self.assertLess(packaging_reset, nightly_build)
-        self.assertIn("-pl packaging/desktop clean", installers)
+        nightly_build = installers.index("Build Nightly application image")
+        nightly_installer = installers.index(
+            "Build Nightly installer from verified application image")
+        self.assertEqual(
+            sorted((stable_build, donor_build, stable_verify, stable_installer,
+                    stable_upload, nightly_build, nightly_installer)),
+            [stable_build, donor_build, stable_verify, stable_installer,
+             stable_upload, nightly_build, nightly_installer])
+        self.assertNotIn("Reset packaging output before Nightly build", installers)
         self.assertIn('gh api --method DELETE `', workflow)
         self.assertIn('releases/$($release.id)', workflow)
         immutable_tag_create = workflow.index(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -274,13 +274,15 @@ the Java/JAR paths retained only for source and temporary PR-test bundles.
 Native packaging is opt-in through Maven profiles so the normal reactor build
 stays platform-neutral.
 
-The Nightly MSI product version remains monotonic for Windows Installer, while
-the unchanged native bootstrap launchers retain the last known-good launcher
-file version until Authenticode signing is enabled. This keeps their bytes and
-Smart App Control reputation stable across Java-only Nightly updates. The
-application reports its release version from packaged build metadata, not from
-the bootstrap file version. A bootstrap, icon, or JDK change still requires a
-new launcher identity and must pass the Windows signing/reputation gate.
+The Nightly MSI product version remains monotonic for Windows Installer. Until
+Authenticode signing is enabled, both channels reuse the unchanged, accepted
+Nightly bootstrap launcher bytes so Smart App Control reputation stays stable
+across Java-only updates. Stable behavior still comes from its separate
+packaged JVM configuration; only the PE bootstrap metadata retains the Nightly
+product name. The application reports its release version from packaged build
+metadata, not from the bootstrap file version. A bootstrap, icon, or JDK change
+still requires a new launcher identity and must pass the Windows
+signing/reputation gate.
 
 The watcher launcher is channel-specific internal infrastructure and does not
 receive Start-menu or desktop shortcuts. The installer exposes only the desktop

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -111,9 +111,9 @@ Windows Installers** with a prerelease application version such as
 `3.0.0-rc.1` and a numeric Windows Installer version below the final release,
 such as `2.99.1`.
 The workflow validates that ordering, builds with release updates disabled,
-verifies the pinned Stable launcher hashes, smoke-tests the image, and uploads
-the MSI only as a short-lived Actions artifact. It does not create a GitHub
-Release or change `releases/latest`.
+injects and verifies the pinned accepted Nightly bootstrap bytes, smoke-tests
+the Stable runtime identity, and uploads the MSI only as a short-lived Actions
+artifact. It does not create a GitHub Release or change `releases/latest`.
 
 Use the artifact to prove a real upgrade from the current Stable installation.
 The candidate's numeric MSI version must be newer than the installed Stable but
@@ -268,14 +268,17 @@ installer must match it exactly.
 
 ### Publication order
 
-1. Build and smoke-test the native application image.
-2. Build the channel-specific installer with its stable upgrade identity.
-3. Optionally Authenticode-sign the final installer and verify its exact subject.
-4. Calculate the final byte size and SHA-256.
-5. Upload and re-download the installer at its immutable versioned HTTPS URL.
-6. Generate the schema-1 payload from that verified file.
-7. Ed25519-sign the exact payload and verify the resulting envelope.
-8. Publish the signed envelope atomically as the final step.
+1. Build the channel-specific native application image.
+2. For Stable, inject the pinned accepted Nightly bootstrap bytes while keeping
+   the Stable JVM configuration and verify both bootstrap hashes.
+3. Smoke-test the application image and its runtime channel identity.
+4. Build the channel-specific installer with its stable upgrade identity.
+5. Optionally Authenticode-sign the final installer and verify its exact subject.
+6. Calculate the final byte size and SHA-256.
+7. Upload and re-download the installer at its immutable versioned HTTPS URL.
+8. Generate the schema-1 payload from that verified file.
+9. Ed25519-sign the exact payload and verify the resulting envelope.
+10. Publish the signed envelope atomically as the final step.
 
 Never publish a PR artifact, unsigned manifest payload, mutable installer
 filename, or envelope whose artifact has not completed the same verification

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -69,13 +69,14 @@ and leaves the current installation untouched. A failed installer upgrade uses
 Windows Installer rollback, attempts to reopen the retained application, and
 shows an update failure instead of silently claiming success.
 
-Until release binaries have an Authenticode publisher, Java-only Stable and
-Nightly updates keep their native desktop and watcher bootstrap files
-byte-identical to the already accepted Stable 2.1.0 and Nightly 26.8.12004
-launchers. The MSI version still increases for every release, and Frostguard
-displays the version embedded in its application JAR. Changes to the bootstrap,
-icon, or packaged JDK require a new Windows reputation decision; Authenticode
-signing remains the durable solution.
+Until release binaries have an Authenticode publisher, both channels reuse the
+already accepted Nightly desktop and watcher bootstrap bytes. Stable still uses
+its own packaged JVM options, application ID, update feed, and workspace; only
+the native PE bootstrap metadata says `Frostguard Nightly`. The MSI version
+still increases for every release, and Frostguard displays the version embedded
+in its application JAR. Changes to the bootstrap, icon, or packaged JDK require
+a new Windows reputation decision; Authenticode signing remains the durable
+solution.
 
 ## Source build commands and native packaging
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	     Build-wide property declarations
 	     ────────────────────────────────────────────── -->
 	<properties>
-		<revision>3.0.1</revision>
+		<revision>3.0.2</revision>
 		<frostguard.pull-request-build>false</frostguard.pull-request-build>
 		<frostguard.update.manifest.stable></frostguard.update.manifest.stable>
 		<frostguard.update.manifest.nightly></frostguard.update.manifest.nightly>


### PR DESCRIPTION
## Summary

- build Stable with its own runtime configuration and installer identity
- replace only the unsigned desktop and watcher bootstraps with the pinned Nightly bytes already accepted by Smart App Control
- verify donor hashes and Stable runtime identity before creating the MSI
- prepare the 3.0.2 hotfix release

## Why

Stable 3.0.1 is blocked by Smart App Control on the affected Windows machine, while Nightly releases from the same day start normally. Code Integrity logs identify the unsigned Stable launcher hash as the blocked file. This bridge reuses the accepted native bootstrap bytes without changing Stable's channel, application ID, update feed, install path, or workspace.

Closes #269.
Relates to the durable Authenticode solution in #267.

## Validation

- `mvnw.cmd package` — full reactor passed
- `python -m unittest discover -s build-support/verification -p test_*.py` — 47 passed
- PowerShell parser for both changed scripts — passed
- `git diff --check` — passed
- native app-image smoke test with the installed accepted Nightly donor — desktop and watcher exited 0 without system Java; Stable channel/application identity remained intact
- real MSI build and Smart App Control launch — pending Windows CI and post-merge release validation

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

This is a compatibility bridge based on current Windows reputation, not a substitute for Authenticode. The renamed Stable launchers retain `Frostguard Nightly` in their PE metadata, although runtime and installer identity remain Stable. Publication must wait for Windows CI, followed by a real install-and-launch check with Smart App Control enabled.

## Review structure

- Stack position: 1/1
- Parent PR: none
- Child PR: none
- Shared issue: #269
- Dependencies: accepted pinned Nightly bootstrap hashes; long-term follow-up #267
- Merge order: this PR only