### PR TITLE
fix(scheduling): release slot for sibling profile handover

### DIFF
--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -906,7 +906,7 @@ public class TaskQueue {
                 }
             }
 
-            suspendDevice(statusModel.getDelayUntil(), false);
+            suspendDevice(statusModel.getDelayUntil(), hasEnabledSiblingOnSameEmulator());
                     // Changed by pernerch | Date: 2026-07-02 | Why: force immediate activation of the
                     // selected peer queue after slot handover to eliminate idle dead time.
             statusModel.setIdleTimeExceeded(true);


### PR DESCRIPTION
## Summary
- release the emulator slot when an idle profile has enabled sibling profiles on the same emulator
- allow newly configured profiles without overdue tasks to acquire the slot
- preserve the existing overdue-peer handover and single-profile behavior

## Bug report
Closes #283

In multi-account mode, the idle fallback could send the game to the background with `freeSlot=false`. When a new sibling profile had no overdue task yet, peer selection found no candidate and the slot remained occupied. The next profile waited indefinitely for the device slot.

## Validation
- `mvnw.cmd -pl modules/automation -am test`
- isolated branch based directly on `main`
- signed commit `56a286a`

## Scope
This PR contains only the multi-account profile-switching fix. Intel scheduling remains in PR #282.