### PR TITLE
fix(intel): resume active mission cycles

### DIFF
--- a/docs/task/intel.md
+++ b/docs/task/intel.md
@@ -10,6 +10,13 @@ switches to Wilderness, and opens Intel through the right-side Intel shortcut.
 Mission completion returns through that same Wilderness shortcut; it must not
 route through City or the Lighthouse.
 
+The green `Intel Gain` label describes new missions, not an Intel cycle that is
+already in progress. After the routine deploys a Beast and schedules its return
+ETA, a follow-up run keeps the cycle active and re-enters through Wilderness even
+when Daily is no longer green. The cycle ends only after the Intel cooldown is
+read successfully. When Daily is not green and no cycle is active, schedule the
+next 00:00, 08:00, or 16:00 UTC Intel refresh instead of polling every ten minutes.
+
 `Hide after mission completion` may remove completed rows and shift every row
 below them. Navigation must not change that account preference. A missing
 Lighthouse Intel icon after the bounded icon scan is treated as unavailable,
@@ -40,6 +47,8 @@ Intel Beast deployment follows these constraints:
 - accept a read travel time only when it is greater than zero and below five
   minutes;
 - reserve the Intel march until `travel time * 2` has elapsed;
+- refresh elapsed Intel ETAs again after Survivor/Journey processing and settle
+  waits, before deciding that only occupied march-bound missions remain;
 - when a flag formation is configured, allow only one Intel Beast march at a
   time and retry at its calculated return time.
 

--- a/modules/automation/src/main/java/dev/frostguard/engine/helper/IntelScreenHelper.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/helper/IntelScreenHelper.java
@@ -104,6 +104,11 @@ public class IntelScreenHelper {
         enterIntelFromWilderness();
     }
 
+    /** Continues a previously started Intel cycle after Daily no longer reports new missions. */
+    public void resumeIntelCycleFromWilderness() {
+        enterIntelFromWilderness();
+    }
+
     private void enterIntelFromWilderness() {
         nav.ensureCorrectScreenLocation(LaunchPoint.WORLD);
         for (int pass = 1; pass <= MAX_NAV_PASSES; pass++) {

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/IntelCyclePolicy.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/IntelCyclePolicy.java
@@ -1,0 +1,60 @@
+package dev.frostguard.tasks.dailies;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+final class IntelCyclePolicy {
+
+    private static final int[] INTEL_REFRESH_HOURS_UTC = {0, 8, 16};
+
+    private boolean cycleInProgress;
+
+    Decision evaluateDailyAvailability(boolean available, LocalDateTime now, ZoneId localZone) {
+        if (available) {
+            cycleInProgress = true;
+            return new Decision(Action.START_AVAILABLE_CYCLE, null);
+        }
+        if (cycleInProgress) {
+            return new Decision(Action.RESUME_ACTIVE_CYCLE, null);
+        }
+        return new Decision(Action.WAIT_FOR_NEXT_REFRESH, nextRefresh(now, localZone));
+    }
+
+    void completeCycle() {
+        cycleInProgress = false;
+    }
+
+    boolean isCycleInProgress() {
+        return cycleInProgress;
+    }
+
+    static LocalDateTime nextRefresh(LocalDateTime now, ZoneId localZone) {
+        ZonedDateTime nowUtc = now.atZone(localZone).withZoneSameInstant(ZoneOffset.UTC);
+        LocalDate utcDate = nowUtc.toLocalDate();
+
+        for (int hour : INTEL_REFRESH_HOURS_UTC) {
+            ZonedDateTime candidate = ZonedDateTime.of(
+                    utcDate, LocalTime.of(hour, 0, 1), ZoneOffset.UTC);
+            if (candidate.isAfter(nowUtc)) {
+                return candidate.withZoneSameInstant(localZone).toLocalDateTime();
+            }
+        }
+
+        return ZonedDateTime.of(utcDate.plusDays(1), LocalTime.of(0, 0, 1), ZoneOffset.UTC)
+                .withZoneSameInstant(localZone)
+                .toLocalDateTime();
+    }
+
+    enum Action {
+        START_AVAILABLE_CYCLE,
+        RESUME_ACTIVE_CYCLE,
+        WAIT_FOR_NEXT_REFRESH
+    }
+
+    record Decision(Action action, LocalDateTime nextRun) {
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/IntelligenceRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/dailies/IntelligenceRoutine.java
@@ -24,6 +24,7 @@ import dev.frostguard.engine.service.TaskManagementService;
 import dev.frostguard.vision.convert.GameTimeUtils;
 import dev.frostguard.vision.ocr.ResilientOcrExecutor;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -114,6 +115,8 @@ private int consecutiveNoProgressCycles;
 
 private final IntelPatternPreference intelPatternPreference = new IntelPatternPreference();
 
+private final IntelCyclePolicy intelCyclePolicy = new IntelCyclePolicy();
+
 // Changed by pernerch | Date: 2026-07-02 | Why: ensure gather and autojoin can be resumed after Intel priority handling.
 private boolean shouldRequeueGatherAfterIntel;
 
@@ -164,12 +167,21 @@ public IntelligenceRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask) {
 		MarchesAvailable marchesAvailable = new MarchesAvailable(true, null);
 		int initiallyIdleMarches = resolveConfiguredIntelMarchesFlow();
 
-		if (!intelScreenHelper.enterIntelFromDailyIfAvailable()) {
-			logInfo(routineLogIntelligenceLine(
-					"Daily sidebar has no green Intel availability evidence. Retrying in 10 minutes."));
-			reschedule(LocalDateTime.now().plusMinutes(10));
+		boolean dailyIntelAvailable = intelScreenHelper.enterIntelFromDailyIfAvailable();
+		IntelCyclePolicy.Decision entryDecision = intelCyclePolicy.evaluateDailyAvailability(
+				dailyIntelAvailable, LocalDateTime.now(), ZoneId.systemDefault());
+		if (entryDecision.action() == IntelCyclePolicy.Action.WAIT_FOR_NEXT_REFRESH) {
+			logInfo(routineLogIntelligenceLine("Daily sidebar has no green Intel availability evidence and no "
+					+ "Intel cycle is active. Planning the next UTC Intel refresh at: "
+					+ entryDecision.nextRun().format(DATETIME_FORMATTER)));
+			reschedule(entryDecision.nextRun());
 			processingTask = false;
 			return;
+		}
+		if (entryDecision.action() == IntelCyclePolicy.Action.RESUME_ACTIVE_CYCLE) {
+			logInfo(routineLogIntelligenceLine("Daily no longer reports new Intel, but the current cycle still "
+					+ "has pending mission completion. Resuming through the Wilderness shortcut."));
+			intelScreenHelper.resumeIntelCycleFromWilderness();
 		}
 		boolean intelMissionsDetected = hasVisibleIntelMissionFlow();
 		if (!intelMissionsDetected) {
@@ -187,7 +199,11 @@ public IntelligenceRoutine(AccountDescriptor profile, TpDailyTaskEnum tpTask) {
 			processingTask = false;
 			return;
 		}
-		logInfo(routineLogIntelligenceLine("Daily sidebar visually confirmed available Intel."));
+		if (entryDecision.action() == IntelCyclePolicy.Action.START_AVAILABLE_CYCLE) {
+			logInfo(routineLogIntelligenceLine("Daily sidebar visually confirmed available Intel."));
+		} else {
+			logInfo(routineLogIntelligenceLine("Active Intel cycle entry confirmed from Wilderness."));
+		}
 
 		autoJoinTask = TaskManagementService.shared().lookupTaskState(profile.getId(),
 				TpDailyTaskEnum.ALLIANCE_AUTOJOIN.getId());
@@ -379,6 +395,7 @@ private void tryRescheduleFromCooldownFlow() {
 		}
 
 		reschedule(cooldown);
+		intelCyclePolicy.completeCycle();
 		pressBack();
 
 		logInfo(routineLogIntelligenceLine("Zero new intel detected. Planning next run task to run at: " + cooldown.format(DATETIME_FORMATTER)));
@@ -940,6 +957,8 @@ private void manageRescheduling(boolean anyIntelProcessed, boolean nonBeastIntel
 		sleepTask(500);
 
 		intelScreenHelper.ensureOnIntelScreen();
+		releaseElapsedIntelMarchesFlow();
+		marchQueueLimitReached = !marchesAvailable.available() || intelMarchesRemaining <= 0;
 		boolean nonMarchBoundMissionAvailable = hasNonMarchBoundIntelMissionAvailableFlow();
 		boolean missionsStillAvailable = nonMarchBoundMissionAvailable || hasMarchBoundIntelMissionAvailableFlow();
 		boolean onlyMarchBoundMissionsLeft = missionsStillAvailable && !nonMarchBoundMissionAvailable;

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/dailies/IntelCyclePolicyTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/dailies/IntelCyclePolicyTest.java
@@ -1,0 +1,51 @@
+package dev.frostguard.tasks.dailies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.Test;
+
+class IntelCyclePolicyTest {
+
+    private static final ZoneId BERLIN = ZoneId.of("Europe/Berlin");
+
+    @Test
+    void beastFollowUpBypassesMissingDailyGainUntilCooldownCompletes() {
+        IntelCyclePolicy policy = new IntelCyclePolicy();
+        LocalDateTime firstRun = LocalDateTime.of(2026, 8, 21, 13, 59);
+
+        IntelCyclePolicy.Decision available = policy.evaluateDailyAvailability(true, firstRun, BERLIN);
+        assertEquals(IntelCyclePolicy.Action.START_AVAILABLE_CYCLE, available.action());
+        assertNull(available.nextRun());
+        assertTrue(policy.isCycleInProgress());
+
+        IntelCyclePolicy.Decision followUp = policy.evaluateDailyAvailability(
+                false, firstRun.plusMinutes(4), BERLIN);
+        assertEquals(IntelCyclePolicy.Action.RESUME_ACTIVE_CYCLE, followUp.action());
+        assertNull(followUp.nextRun());
+        assertTrue(policy.isCycleInProgress());
+
+        policy.completeCycle();
+        IntelCyclePolicy.Decision empty = policy.evaluateDailyAvailability(
+                false, firstRun.plusMinutes(5), BERLIN);
+        assertEquals(IntelCyclePolicy.Action.WAIT_FOR_NEXT_REFRESH, empty.action());
+        assertEquals(LocalDateTime.of(2026, 8, 21, 18, 0, 1), empty.nextRun());
+        assertFalse(policy.isCycleInProgress());
+    }
+
+    @Test
+    void emptyRunMovesAcrossMidnightUsingUtcRefreshBoundaries() {
+        IntelCyclePolicy policy = new IntelCyclePolicy();
+
+        IntelCyclePolicy.Decision decision = policy.evaluateDailyAvailability(
+                false, LocalDateTime.of(2026, 8, 21, 18, 0, 1), BERLIN);
+
+        assertEquals(IntelCyclePolicy.Action.WAIT_FOR_NEXT_REFRESH, decision.action());
+        assertEquals(LocalDateTime.of(2026, 8, 22, 2, 0, 1), decision.nextRun());
+    }
+}

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/dailies/IntelCycleSchedulingOrchestrationTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/dailies/IntelCycleSchedulingOrchestrationTest.java
@@ -1,0 +1,142 @@
+package dev.frostguard.tasks.dailies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.configs.TpDailyTaskEnum;
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.TaskStateData;
+import dev.frostguard.engine.schedule.DelayedTask;
+import dev.frostguard.engine.schedule.TaskQueue;
+import dev.frostguard.engine.service.ProfileService;
+import dev.frostguard.engine.service.TaskManagementService;
+
+class IntelCycleSchedulingOrchestrationTest {
+
+    @Test
+    void activeCycleFollowUpPersistsFutureScheduleAndDoesNotHotLoopOrReleaseResources() {
+        AccountDescriptor profile = new AccountDescriptor(
+                null, "Intel cycle " + UUID.randomUUID(), "0", false, 100L, 30L);
+        profile.setConfig(ConfigurationKeyEnum.INTEL_BOOL, true);
+        assertTrue(ProfileService.obtain().createAccount(profile));
+
+        PolicyDrivenIntelTask task = new PolicyDrivenIntelTask(profile);
+        RecordingQueue queue = new RecordingQueue(profile);
+        queue.enqueue(task);
+
+        runSchedulerTick(queue);
+        assertEquals(1, task.executionCount);
+        assertEquals(IntelCyclePolicy.Action.START_AVAILABLE_CYCLE, task.lastAction);
+
+        int executionsBeforeWaitingTick = task.executionCount;
+        runSchedulerTick(queue);
+        assertEquals(executionsBeforeWaitingTick, task.executionCount,
+                "the future Beast ETA must not execute again on the next scheduler tick");
+
+        task.reschedule(LocalDateTime.now().minusSeconds(1));
+        runSchedulerTick(queue);
+        assertEquals(2, task.executionCount);
+        assertEquals(IntelCyclePolicy.Action.RESUME_ACTIVE_CYCLE, task.lastAction);
+        assertTrue(task.getScheduled().isAfter(LocalDateTime.now().plusHours(1)));
+
+        TaskStateData persisted = TaskManagementService.shared().lookupTaskState(
+                profile.getId(), TpDailyTaskEnum.INTEL.getId());
+        assertNotNull(persisted);
+        assertTrue(persisted.getNextExecutionTime().isAfter(LocalDateTime.now().plusHours(1)));
+        assertEquals(0, queue.gameStopCount);
+        assertEquals(0, queue.slotReleaseCount);
+
+        int completedExecutions = task.executionCount;
+        runSchedulerTick(queue);
+        assertEquals(completedExecutions, task.executionCount,
+                "the completed cycle must remain parked until its persisted refresh time");
+    }
+
+    private static void runSchedulerTick(TaskQueue queue) {
+        try {
+            Method tick = TaskQueue.class.getDeclaredMethod("runSchedulerTick");
+            tick.setAccessible(true);
+            tick.invoke(queue);
+        } catch (NoSuchMethodException | IllegalAccessException exception) {
+            throw new AssertionError(exception);
+        } catch (InvocationTargetException exception) {
+            throw new AssertionError(exception.getCause());
+        }
+    }
+
+    private static final class PolicyDrivenIntelTask extends DelayedTask {
+
+        private final IntelCyclePolicy policy = new IntelCyclePolicy();
+        private int executionCount;
+        private IntelCyclePolicy.Action lastAction;
+
+        private PolicyDrivenIntelTask(AccountDescriptor profile) {
+            super(profile, TpDailyTaskEnum.INTEL);
+        }
+
+        @Override
+        public void run() {
+            execute();
+        }
+
+        @Override
+        protected void execute() {
+            executionCount++;
+            boolean dailyAvailable = executionCount == 1;
+            IntelCyclePolicy.Decision decision = policy.evaluateDailyAvailability(
+                    dailyAvailable, LocalDateTime.now(), ZoneId.systemDefault());
+            lastAction = decision.action();
+            if (decision.action() == IntelCyclePolicy.Action.START_AVAILABLE_CYCLE) {
+                reschedule(LocalDateTime.now().plusSeconds(30));
+                return;
+            }
+
+            policy.completeCycle();
+            reschedule(IntelCyclePolicy.nextRefresh(LocalDateTime.now(), ZoneId.systemDefault()));
+        }
+    }
+
+    private static final class RecordingQueue extends TaskQueue {
+
+        private int gameStopCount;
+        private int slotReleaseCount;
+
+        private RecordingQueue(AccountDescriptor profile) {
+            super(profile);
+        }
+
+        @Override
+        protected void acquireSlot() {
+            markSlotAcquired();
+        }
+
+        @Override
+        protected boolean stopBlockedGameProcess(DelayedTask task) {
+            gameStopCount++;
+            return true;
+        }
+
+        @Override
+        protected void releaseEmulatorSlotLease() {
+            slotReleaseCount++;
+        }
+
+        @Override
+        protected void handleIdleTransitions() {
+        }
+
+        @Override
+        protected void sleepSchedulerTick(long millis) {
+        }
+    }
+}

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/dailies/IntelligenceRoutineMarchCapacityTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/dailies/IntelligenceRoutineMarchCapacityTest.java
@@ -28,6 +28,16 @@ class IntelligenceRoutineMarchCapacityTest {
     }
 
     @Test
+    void survivorSettleTimeStillReleasesAnElapsedBeastEtaBeforeRescheduling() {
+        LocalDateTime deployedAt = LocalDateTime.of(2026, 8, 21, 18, 48, 48);
+        LocalDateTime returnEta = deployedAt.plusSeconds(30);
+        LocalDateTime afterSurvivorSettle = returnEta.plusSeconds(20);
+
+        assertEquals(1, IntelligenceRoutine.countElapsedIntelMarches(
+                afterSurvivorSettle, List.of(returnEta)));
+    }
+
+    @Test
     void configuredFlagLimitsBeastDeploymentToOneMarch() {
         assertEquals(1, IntelligenceRoutine.resolveIntelMarchCapacity(6, 3, true));
     }


### PR DESCRIPTION
## Summary

- preserve an active Intel cycle when the Daily green availability marker disappears after deployment
- resume pending Intel work directly through the Wilderness shortcut
- release Intel march capacity from the captured travel-time ×2 ETA and schedule exact march-return follow-ups
- schedule completed/no-active cycles at the next UTC Intel refresh instead of polling every ten minutes
- add policy, orchestration, march-timing, and documentation coverage

## Why

Intel could lose its in-memory mission context after deploying a beast march. The next run then treated the missing Daily green marker as no Intel and entered ineffective retries instead of returning to the Intel map, claiming completed rewards, and reading the cooldown.

Closes #274

## Validation

- `mvnw.cmd package` — passed
- tasks reactor — 149 tests passed
- saved-frame coverage — Intel marker/navigation frames passed
- live emulator 0 / Fire Crystal profile — passed on commit `0d97b7a2`: all enabled Intel categories completed across multiple batches; Flag #8 was reused; travel ×2 ETAs released march capacity; exact follow-up scheduling occurred; Claim All collected final rewards; cooldown OCR read `05:12:45`; next run persisted at `2026-08-22 02:00:01`; no Intel errors
- prior live active-cycle frame — missing Daily green marker resumed through Wilderness and completed cleanly

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

- Deployment stamina OCR remained unreadable in the live run and used the existing conservative cost fallback of 10; this behavior is unchanged.
- A newly observed store popup can delay initialization until dismissed. This is a separate startup-screen coverage gap, not part of the Intel cycle.