### PR TITLE
fix(startup): recover unknown overlays safely

### DIFF
--- a/docs/task/startup.md
+++ b/docs/task/startup.md
@@ -28,11 +28,15 @@ Initialization distinguishes startup blockers before attempting recovery:
   `ACTION REQUIRED` incident, sends no Store input, stops the blocked game
   process, releases the emulator slot, and retries after one hour. Merely seeing
   the original in-game update dialog is not enough to create an incident.
-- An unknown blocker receives one bounded emulator restart. If home/world is
-  still unavailable, Frostguard waits only for passive state change. It does
-  not send speculative navigation input; the same profile-wide cooldown
-  mechanism releases the slot for fifteen minutes instead of entering a
-  restart loop.
+- An unknown blocker first receives ten passive checks. If Whiteout Survival
+  still owns the Android foreground window, Frostguard sends Android Back once
+  and then reuses only verified startup handlers while requiring a fresh
+  home/world postcondition. This covers stacked game-owned event and promotional
+  overlays without depending on every rotating close icon. If the game is not
+  foreground or home/world remains unavailable, no further input is sent. The
+  profile-wide cooldown stops only the game,
+  releases the slot for fifteen minutes, and never cycles the emulator or
+  immediately retries Initialize.
 
 The close-control template `closeableOverlayClose.png` is cropped from the
 redacted real frame

--- a/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/schedule/TaskQueue.java
@@ -543,9 +543,8 @@ public class TaskQueue {
             AnalyticsService.getInstance().trackTaskStarted(task.getTaskName());
             task.setLastExecutionTime(LocalDateTime.now());
             task.run();
-            // Initialize can return normally while requesting one bounded recovery retry.
-            // Keep the initial force flag until the routine reports a non-recurring success;
-            // otherwise the no-imminent-task guard would discard that recovery attempt.
+            // Keep the initial force flag until Initialize reports success. A profile cooldown
+            // persists and re-enqueues Initialize for the requested retry time instead.
             if (task.getTpTask() == TpDailyTaskEnum.INITIALIZE && !task.isRecurring()) {
                 forceInitialInitialize = false;
             }

--- a/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueInitializeRecoveryTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueInitializeRecoveryTest.java
@@ -2,42 +2,60 @@ package dev.frostguard.engine.schedule;
 
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.data.entity.DailyTask;
+import dev.frostguard.data.repository.DailyTaskRepository;
+import dev.frostguard.engine.error.ActionRequiredContext;
+import dev.frostguard.engine.error.ProfileCooldownException;
 import dev.frostguard.engine.service.ProfileService;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TaskQueueInitializeRecoveryTest {
 
     @Test
-    void schedulerRunsBoundedInitializeRetryWithoutAnotherImminentTask() {
+    void unknownOverlayCooldownStopsOnlyGameAndDoesNotImmediatelyRetryInitialize() {
         AccountDescriptor profile = new AccountDescriptor(
                 null, "Initialize recovery " + UUID.randomUUID(), "0", false, 100L, 30L);
         ProfileService.obtain().createAccount(profile);
-        BoundedRecoveryInitialize task = new BoundedRecoveryInitialize(profile);
+        LocalDateTime retryAt = LocalDateTime.now().plusMinutes(15).truncatedTo(ChronoUnit.SECONDS);
+        UnknownOverlayCooldownInitialize task = new UnknownOverlayCooldownInitialize(profile, retryAt);
         RecordingQueue queue = new RecordingQueue(profile);
         queue.enqueue(task);
 
         queue.runSchedulerTick();
 
         assertEquals(1, task.executionCount);
+        assertTrue(task.isRecurring());
+        assertTrue(queue.statusModel.isPaused());
+        assertCloseTo(retryAt, task.getScheduled());
+        assertCloseTo(retryAt, queue.statusModel.getDelayUntil());
         assertEquals(1, queue.getNextQueuedTaskTypes(1).size());
-
-        queue.runSchedulerTick();
-
-        assertEquals(2, task.executionCount,
-                "the recovery Initialize must bypass the no-imminent-task guard once");
-        assertFalse(task.isRecurring());
-        assertEquals(0, queue.getNextQueuedTaskTypes(1).size());
         assertEquals(1, queue.slotAcquisitionCount,
-                "the immediate retry must retain the existing queue session lease");
+                "Initialize must acquire the queue session lease once");
+        assertEquals(1, queue.gameStopCount,
+                "cooldown must stop only the blocked game process");
+        assertEquals(1, queue.slotReleaseCount,
+                "cooldown must release the emulator lease for other profiles");
+        assertEquals(0, queue.idleTransitionCount,
+                "cooldown must bypass normal idle shutdown handling");
+        DailyTask persisted = DailyTaskRepository.getRepository()
+                .findByAccountIdAndTaskType(profile.getId(), TpDailyTaskEnum.INITIALIZE);
+        assertCloseTo(retryAt, persisted.getNextRunAt());
 
         queue.runSchedulerTick();
 
-        assertEquals(2, task.executionCount, "successful Initialize must not be repeated");
+        assertEquals(1, task.executionCount, "cooldown must prevent an immediate Initialize retry");
+        assertEquals(1, queue.gameStopCount, "paused ticks must not repeat game cleanup");
+        assertEquals(1, queue.slotReleaseCount, "paused ticks must not repeat lease cleanup");
+        assertEquals(0, queue.idleTransitionCount, "paused ticks must not fall through to emulator shutdown");
     }
 
     @Test
@@ -64,19 +82,35 @@ class TaskQueueInitializeRecoveryTest {
                 "verified overlay recovery must not create an Initialize retry");
     }
 
-    private static final class BoundedRecoveryInitialize extends DelayedTask {
+    private static final class UnknownOverlayCooldownInitialize extends DelayedTask {
 
+        private final LocalDateTime retryAt;
         private int executionCount;
 
-        private BoundedRecoveryInitialize(AccountDescriptor profile) {
+        private UnknownOverlayCooldownInitialize(AccountDescriptor profile, LocalDateTime retryAt) {
             super(profile, TpDailyTaskEnum.INITIALIZE);
+            this.retryAt = retryAt;
         }
 
         @Override
         protected void execute() {
             executionCount++;
-            setRecurring(executionCount == 1);
+            throw new ProfileCooldownException(
+                    "home/world remained unavailable after bounded in-game recovery",
+                    retryAt,
+                    new ActionRequiredContext(
+                            "startup.home-unavailable-after-game-back",
+                            "Startup remains blocked after automatic recovery",
+                            "home/world",
+                            "unsupported startup screen",
+                            "One bounded Android Back in the foreground game",
+                            "Stop the game, release the slot, and retry after fifteen minutes"));
         }
+    }
+
+    private static void assertCloseTo(LocalDateTime expected, LocalDateTime actual) {
+        assertTrue(Duration.between(expected, actual).abs().compareTo(Duration.ofSeconds(1)) < 0,
+                () -> "expected " + expected + " but was " + actual);
     }
 
     private static final class VerifiedOverlayInitialize extends DelayedTask {
@@ -99,6 +133,10 @@ class TaskQueueInitializeRecoveryTest {
     private static final class RecordingQueue extends TaskQueue {
 
         private int slotAcquisitionCount;
+        private int gameStopCount;
+        private int slotReleaseCount;
+        private int idleTransitionCount;
+
         private RecordingQueue(AccountDescriptor profile) {
             super(profile);
         }
@@ -110,11 +148,27 @@ class TaskQueueInitializeRecoveryTest {
         }
 
         @Override
+        protected boolean stopBlockedGameProcess(DelayedTask task) {
+            gameStopCount++;
+            return true;
+        }
+
+        @Override
+        protected void releaseEmulatorSlotLease() {
+            slotReleaseCount++;
+        }
+
+        @Override
         protected void handleIdleTransitions() {
+            idleTransitionCount++;
         }
 
         @Override
         protected void sleepSchedulerTick(long millis) {
+        }
+
+        @Override
+        protected void sleepPausedTick() {
         }
     }
 }

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/lifecycle/InitializeRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/lifecycle/InitializeRoutine.java
@@ -39,7 +39,7 @@ import java.time.LocalDateTime;
  * <ul>
  * <li>This task does NOT reschedule after execution</li>
  * <li>Sets recurring=false on start to prevent re-execution</li>
- * <li>Unknown startup failures receive one immediate emulator restart</li>
+ * <li>Unknown in-game startup overlays receive one foreground-owned Back recovery</li>
  * <li>Persistent blockers pause the profile until a conservative retry time</li>
  * <li>Exception on success: Task completes without rescheduling</li>
  * </ul>
@@ -49,17 +49,15 @@ import java.time.LocalDateTime;
  * <ul>
  * <li>Game not installed: Throws StopExecutionException (stops queue)</li>
  * <li>Reconnect state detected: Throws ProfileInReconnectStateException</li>
- * <li>Home screen not found: Performs one bounded emulator restart</li>
+ * <li>Home screen not found: Tries one bounded in-game Back action, then pauses the profile</li>
  * <li>Verified Google Play redirect: Requires operator action and releases the
  * emulator slot during a profile cooldown</li>
  * </ul>
  * 
  * <p>
  * <b>State Management:</b>
- * The {@code isStarted} field is instance state that persists between
- * executions.
- * This is intentional - if the task retries (recurring=true), it will re-check
- * emulator status but maintain this flag across retry attempts.
+ * The {@code isStarted} field avoids repeating emulator checks during one
+ * initialization execution.
  */
 public class InitializeRoutine extends DelayedTask {
 
@@ -89,15 +87,17 @@ public class InitializeRoutine extends DelayedTask {
 	private static final String GOOGLE_PLAY_PACKAGE = "com.android.vending";
 	private static final int MAX_WELCOME_BACK_DISMISSALS = 1;
 	private static final int MAX_CLOSEABLE_OVERLAY_DISMISSALS = 3;
+	private static final int UNKNOWN_BLOCKER_BACK_SETTLE_MS = 2000;
+	private static final int MAX_UNKNOWN_BLOCKER_POSTCONDITION_ATTEMPTS = 3;
 	private static final int STARTUP_PATTERN_THRESHOLD = 90;
 
 	// ========== Instance State ==========
 	/**
 	 * Tracks whether the emulator has been successfully started.
-	 * This persists across task executions (when recurring=true triggers retry).
+	 * The flag remains valid for the rest of the current initialization flow.
 	 */
 	boolean isStarted = false;
-	private int emulatorRestartAttempts = 0;
+	private int unknownBlockerBackAttempts = 0;
 	private int welcomeBackDismissals = 0;
 	private int closeableOverlayDismissals = 0;
 	private String lastVerifiedStartupState = "initialization started";
@@ -138,8 +138,7 @@ public class InitializeRoutine extends DelayedTask {
 	 * This task intentionally does not call reschedule(). It either:
 	 * <ul>
 	 * <li>Completes successfully (recurring=false, task stops)</li>
-	 * <li>Fails and sets recurring=true (immediate retry)</li>
-	 * <li>Throws exception (queue handles appropriately)</li>
+	 * <li>Throws a bounded cooldown exception (queue persists the retry)</li>
 	 * </ul>
 	 * 
 	 * @throws StopExecutionException           if game is not installed
@@ -155,7 +154,7 @@ public class InitializeRoutine extends DelayedTask {
 		
 		// Wait for home screen
 		if (!waitForHomeScreen()) {
-			// Home screen not found - already handled (emulator closed, recurring set)
+			// A blocking startup state already selected and logged its bounded outcome.
 			return;
 		}
 		
@@ -257,21 +256,22 @@ public class InitializeRoutine extends DelayedTask {
 	 * ProfileInReconnectStateException.
 	 * 
 	 * <p>
-	 * If home screen is not found after all attempts, the first failure restarts
-	 * the emulator. A subsequent failure enters a profile cooldown and releases
-	 * the emulator slot.
+	 * If home screen is not found after all attempts, one Android Back recovery is
+	 * allowed only while Whiteout Survival is verified in the foreground. A
+	 * remaining blocker enters a profile cooldown and releases the emulator slot.
 	 *
 	 * <p>
 	 * A verified update dialog uses only its detected button, then waits for a
 	 * fresh known postcondition. Only a proven Google Play foreground redirect bypasses the
-	 * restart and escalates immediately.
+	 * generic startup recovery and escalates immediately.
 	 *
 	 * <p>
-	 * The bounded-restart path:
+	 * The bounded unknown-overlay path:
 	 * <ul>
-	 * <li>Closes the emulator</li>
-	 * <li>Resets isStarted flag</li>
-	 * <li>Sets recurring=true (triggers immediate retry)</li>
+	 * <li>Verifies that the game owns the foreground window</li>
+	 * <li>Sends Android Back at most once</li>
+	 * <li>Allows verified startup handlers to reveal a fresh home/world postcondition</li>
+	 * <li>Otherwise stops only the game and enters a profile cooldown</li>
 	 * </ul>
 	 * 
 	 * <p>
@@ -302,8 +302,7 @@ public class InitializeRoutine extends DelayedTask {
 				break;
 			}
 			if (downloadResult == ResourceDownloadResult.TIMED_OUT) {
-				handleHomeScreenNotFound();
-				return false;
+				deferResourceDownloadTimeout();
 			}
 
 			if (dismissWelcomeBackIfPresent()) {
@@ -334,8 +333,7 @@ public class InitializeRoutine extends DelayedTask {
 		}
 
 		if (!homeScreenFound) {
-			handleHomeScreenNotFound();
-			return false;
+			return recoverUnknownStartupBlocker();
 		}
 		
 		return true;
@@ -657,6 +655,23 @@ public class InitializeRoutine extends DelayedTask {
 		TIMED_OUT
 	}
 
+	private void deferResourceDownloadTimeout() {
+		LocalDateTime retryAt = LocalDateTime.now().plus(StartupRecoveryPolicy.UNKNOWN_BLOCKER_COOLDOWN);
+		String reason = "required resources did not finish before the startup timeout";
+		logError("Initialization blocked for profile=" + profile.getName()
+				+ ", expected=resource download completed and home/world"
+				+ ", observed=resource-download-timeout, lastAction=tapped verified Download Now button"
+				+ ", fallback=stop-game-and-release-slot, retryAt=" + retryAt
+				+ ", reason=" + reason + ".");
+		throw new ProfileCooldownException(reason, retryAt, new ActionRequiredContext(
+				"startup.resource-download-timeout",
+				"Required game resources did not finish downloading",
+				"Resource download completed and home/world available",
+				"Resource download remained incomplete for ten minutes",
+				"Tapped the verified Download Now button, then waited without further input",
+				"Stop the game, release the slot, and retry initialization after fifteen minutes"));
+	}
+
 	/**
 	 * Checks for reconnect state popup.
 	 * 
@@ -683,61 +698,73 @@ public class InitializeRoutine extends DelayedTask {
 	 * Handles the case where home screen was not found after all attempts.
 	 * 
 	 * <p>
-	 * Strategy:
+	 * Strategy after known startup-state checks and passive waiting are exhausted:
 	 * <ol>
-	 * <li>Performs an ADB health check (restarts ADB if needed)</li>
-	 * <li>Closes the emulator (clean slate, also invalidates ADB caches)</li>
-	 * <li>Resets isStarted flag (will re-launch emulator on retry)</li>
-	 * <li>Sets recurring=true (triggers immediate re-execution)</li>
+	 * <li>Verify that Whiteout Survival owns the foreground window</li>
+	 * <li>Send Android Back at most once</li>
+	 * <li>Re-run only verified startup handlers while waiting for home/world</li>
+	 * <li>Otherwise enter a cooldown that stops only the game and releases the slot</li>
 	 * </ol>
-	 * 
-	 * <p>
-	 * When the task re-executes after the one permitted restart, it will go
-	 * through the full initialization flow again. If startup is still blocked,
-	 * it enters a visible profile cooldown instead of restarting again.
 	 */
-	private void handleHomeScreenNotFound() {
-		if (StartupRecoveryPolicy.forUnknownBlocker(emulatorRestartAttempts)
-				== StartupRecoveryPolicy.UnknownBlockerAction.COOLDOWN_AND_RELEASE_SLOT) {
-			deferUnknownStartupBlocker();
+	private boolean recoverUnknownStartupBlocker() {
+		boolean gameForeground = isGameForeground();
+		if (StartupRecoveryPolicy.forUnknownBlocker(gameForeground, unknownBlockerBackAttempts)
+				== StartupRecoveryPolicy.UnknownBlockerAction.TRY_GAME_BACK) {
+			unknownBlockerBackAttempts++;
+			lastVerifiedStartupState = "unknown startup screen with Whiteout Survival foreground";
+			logWarning("Home/world remained unavailable after " + MAX_HOME_SCREEN_ATTEMPTS
+					+ " passive checks. Whiteout Survival owns the foreground window; sending bounded Android Back recovery "
+					+ unknownBlockerBackAttempts + "/"
+					+ StartupRecoveryPolicy.MAX_UNKNOWN_BLOCKER_BACK_ATTEMPTS + ".");
+			pressBack();
+			lastVerifiedStartupState = "bounded Android Back sent to foreground game";
+
+			for (int attempt = 1; attempt <= MAX_UNKNOWN_BLOCKER_POSTCONDITION_ATTEMPTS; attempt++) {
+				sleepTask(UNKNOWN_BLOCKER_BACK_SETTLE_MS);
+				if (searchForHomeScreen()) {
+					lastVerifiedStartupState = "home/world screen after bounded Android Back";
+					logInfo("Home screen found after one bounded Android Back recovery.");
+					return true;
+				}
+
+				checkForReconnectState();
+				if (dismissWelcomeBackIfPresent()) {
+					logInfo("Verified Welcome back dialog dismissed after bounded Android Back recovery.");
+					continue;
+				}
+				if (dismissCloseableStartupOverlayIfPresent()) {
+					logInfo("Verified closeable startup overlay dismissed after bounded Android Back recovery.");
+				}
+			}
 		}
 
-		emulatorRestartAttempts++;
-		logError("Home screen not found after " + MAX_HOME_SCREEN_ATTEMPTS
-				+ " attempts. Performing bounded emulator recovery " + emulatorRestartAttempts
-				+ "/" + StartupRecoveryPolicy.MAX_EMULATOR_RESTART_ATTEMPTS + ".");
-
-		// Perform ADB health check before closing emulator
-		// This may restart the ADB bridge if it's degraded
-		logInfo("Performing ADB health check before emulator restart...");
-		boolean adbHealthy = emuManager.performAdbHealthCheck(EMULATOR_NUMBER);
-		if (adbHealthy) {
-			logInfo("ADB health check passed. Proceeding with emulator restart.");
-		} else {
-			logWarning("ADB health check failed even after recovery attempts. "
-					+ "Will still try to restart emulator.");
-		}
-
-		emuManager.closeEmulator(EMULATOR_NUMBER);
-		isStarted = false;
-		setRecurring(true); // Trigger immediate retry
+		deferUnknownStartupBlocker(gameForeground);
+		return false;
 	}
 
-	private void deferUnknownStartupBlocker() {
+	private boolean isGameForeground() {
+		return emuManager.isPackageRunning(EMULATOR_NUMBER, EmulatorController.GAME.getPackageName());
+	}
+
+	private void deferUnknownStartupBlocker(boolean gameForeground) {
 		LocalDateTime retryAt = LocalDateTime.now().plus(StartupRecoveryPolicy.UNKNOWN_BLOCKER_COOLDOWN);
-		String reason = "home/world remained unavailable after bounded emulator recovery";
+		String reason = "home/world remained unavailable after bounded in-game recovery";
 		logError("Initialization blocked for profile=" + profile.getName()
 				+ ", expected=home/world, observed=unknown-startup-blocker"
-				+ ", lastAction=emulator-restart, recoveryAttempts=" + emulatorRestartAttempts
-				+ "/" + StartupRecoveryPolicy.MAX_EMULATOR_RESTART_ATTEMPTS
+				+ ", gameForeground=" + gameForeground
+				+ ", lastAction=" + (unknownBlockerBackAttempts > 0 ? "bounded-android-back" : "none")
+				+ ", recoveryAttempts=" + unknownBlockerBackAttempts
+				+ "/" + StartupRecoveryPolicy.MAX_UNKNOWN_BLOCKER_BACK_ATTEMPTS
 				+ ", fallback=stop-game-and-release-slot, retryAt=" + retryAt
 				+ ", reason=" + reason + ".");
 		throw new ProfileCooldownException(reason, retryAt, new ActionRequiredContext(
-				"startup.home-unavailable-after-restart",
+				"startup.home-unavailable-after-game-back",
 				"Startup remains blocked after automatic recovery",
 				"home/world",
 				"unsupported startup screen",
-				"One bounded emulator restart; no speculative screen input",
+				gameForeground
+						? "One bounded Android Back sent only while Whiteout Survival owned the foreground window"
+						: "No input sent because Whiteout Survival did not own the foreground window",
 				"Stop the game, release the slot, and retry initialization after fifteen minutes"));
 	}
 

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/lifecycle/StartupRecoveryPolicy.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/lifecycle/StartupRecoveryPolicy.java
@@ -4,7 +4,7 @@ import java.time.Duration;
 
 final class StartupRecoveryPolicy {
 
-    static final int MAX_EMULATOR_RESTART_ATTEMPTS = 1;
+    static final int MAX_UNKNOWN_BLOCKER_BACK_ATTEMPTS = 1;
     static final Duration UNKNOWN_BLOCKER_COOLDOWN = Duration.ofMinutes(15);
     static final Duration PLAY_STORE_REDIRECT_COOLDOWN = Duration.ofHours(1);
     static final Duration UPDATE_FOLLOW_UP_COOLDOWN = Duration.ofMinutes(15);
@@ -12,14 +12,14 @@ final class StartupRecoveryPolicy {
     private StartupRecoveryPolicy() {
     }
 
-    static UnknownBlockerAction forUnknownBlocker(int completedRestartAttempts) {
-        return completedRestartAttempts < MAX_EMULATOR_RESTART_ATTEMPTS
-                ? UnknownBlockerAction.RESTART_EMULATOR
+    static UnknownBlockerAction forUnknownBlocker(boolean gameForeground, int completedBackAttempts) {
+        return gameForeground && completedBackAttempts < MAX_UNKNOWN_BLOCKER_BACK_ATTEMPTS
+                ? UnknownBlockerAction.TRY_GAME_BACK
                 : UnknownBlockerAction.COOLDOWN_AND_RELEASE_SLOT;
     }
 
     enum UnknownBlockerAction {
-        RESTART_EMULATOR,
+        TRY_GAME_BACK,
         COOLDOWN_AND_RELEASE_SLOT
     }
 }

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/lifecycle/StartupRecoveryPolicyTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/lifecycle/StartupRecoveryPolicyTest.java
@@ -9,13 +9,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class StartupRecoveryPolicyTest {
 
     @Test
-    void permitsOnlyOneImmediateEmulatorRestart() {
-        assertEquals(StartupRecoveryPolicy.UnknownBlockerAction.RESTART_EMULATOR,
-                StartupRecoveryPolicy.forUnknownBlocker(0));
+    void permitsOnlyOneForegroundGameBack() {
+        assertEquals(StartupRecoveryPolicy.UnknownBlockerAction.TRY_GAME_BACK,
+                StartupRecoveryPolicy.forUnknownBlocker(true, 0));
         assertEquals(StartupRecoveryPolicy.UnknownBlockerAction.COOLDOWN_AND_RELEASE_SLOT,
-                StartupRecoveryPolicy.forUnknownBlocker(1));
+                StartupRecoveryPolicy.forUnknownBlocker(true, 1));
         assertEquals(StartupRecoveryPolicy.UnknownBlockerAction.COOLDOWN_AND_RELEASE_SLOT,
-                StartupRecoveryPolicy.forUnknownBlocker(2));
+                StartupRecoveryPolicy.forUnknownBlocker(true, 2));
+    }
+
+    @Test
+    void sendsNoRecoveryInputOutsideTheForegroundGame() {
+        assertEquals(StartupRecoveryPolicy.UnknownBlockerAction.COOLDOWN_AND_RELEASE_SLOT,
+                StartupRecoveryPolicy.forUnknownBlocker(false, 0));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace unknown-startup emulator restarts with one bounded Android Back action while Whiteout Survival owns the foreground
- reuse only verified startup handlers after Back, then require a fresh home/world postcondition
- persist a fifteen-minute profile cooldown, stop only the game, and release the emulator slot if recovery remains blocked
- cover the scheduling lifecycle and absence of immediate retry, emulator cycling, and unintended idle shutdown

## Why

Rotating startup overlays such as Myriad Bazaar are not reliably covered by a single close-control template. The previous fallback restarted MuMu and immediately scheduled Initialize again, which could launch multiple profiles and overload the host. This restores the formerly useful Android Back behavior with foreground ownership, a one-action bound, and a verified postcondition.

Closes #299.

## Validation

- `mvnw.cmd -pl modules/tasks -am test` — passed
- `mvnw.cmd package` — passed; 600 tests, 0 failures, 0 errors, 0 skipped
- saved real-frame verification — Myriad Bazaar was confirmed as an unsupported startup overlay; the existing close template did not match it reliably
- live account-log confirmation on MuMu emulator 0 — ten passive checks, exactly one foreground-owned Android Back, fresh home/world detection, and one successful Initialize completion
- live negative-path confirmation — an unresolved stacked dialog stopped only the game, released the slot, and persisted a fifteen-minute retry without restarting MuMu or immediately rerunning Initialize

## Stack and dependency

- Stack position: 1/1
- Parent: none
- Child: none
- Shared issue: #299
- Dependency: none
- Merge order: this PR only

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

- The fallback deliberately waits through ten passive checks before sending Back, so recovery can take about one minute.
- Android Back remains limited to one action and only while the game owns the foreground; unknown stacked overlays beyond the verified handlers enter cooldown instead of receiving further blind input.
