### PR TITLE
feat(bear): add advanced rally filtering

### DIFF
--- a/modules/api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
+++ b/modules/api/src/main/java/dev/frostguard/api/configs/ConfigurationKeyEnum.java
@@ -120,6 +120,12 @@ public enum ConfigurationKeyEnum {
     /* ─────────── events ─────────── */
 
     BEAR_TRAP_ACTIVE_PETS_BOOL                  ("false",   Boolean.class,       ConfigCategory.EVENTS),
+    BEAR_TRAP_ADVANCED_JOIN_ENABLED_BOOL        ("false",   Boolean.class,       ConfigCategory.EVENTS),
+    BEAR_TRAP_FRENZY_MODE_ENABLED_BOOL          ("false",   Boolean.class,       ConfigCategory.EVENTS),
+    BEAR_TRAP_FRENZY_START_MINUTE_INT           ("22",      Integer.class,       ConfigCategory.EVENTS),
+    BEAR_TRAP_MIN_MEMBER_COUNT_INT              ("0",       Integer.class,       ConfigCategory.EVENTS),
+    BEAR_TRAP_MIN_RALLY_CAPACITY_INT            ("0",       Integer.class,       ConfigCategory.EVENTS),
+    BEAR_TRAP_MIN_REMAINING_CAPACITY_INT        ("0",       Integer.class,       ConfigCategory.EVENTS),
     BEAR_TRAP_CALL_RALLY_BOOL                   ("false",   Boolean.class,       ConfigCategory.EVENTS),
     BEAR_TRAP_EVENT_BOOL                        ("false",   Boolean.class,       ConfigCategory.EVENTS),
     BEAR_TRAP_ICON_PARTICIPATION_FALLBACK_BOOL  ("false",   Boolean.class,       ConfigCategory.EVENTS),
@@ -140,6 +146,12 @@ public enum ConfigurationKeyEnum {
     BEAST_HUNTING_ENABLED_BOOL                  ("false",   Boolean.class,       ConfigCategory.EVENTS),
     BEAST_HUNTING_LEVEL_INT                     ("30",      Integer.class,       ConfigCategory.EVENTS),
     BEAST_HUNTING_MARCHES_INT                   ("3",       Integer.class,       ConfigCategory.EVENTS),
+    BEAR_TRAP_JOIN_MARCH_1_FLAG_STRING          ("No Flag", String.class,        ConfigCategory.EVENTS),
+    BEAR_TRAP_JOIN_MARCH_2_FLAG_STRING          ("No Flag", String.class,        ConfigCategory.EVENTS),
+    BEAR_TRAP_JOIN_MARCH_3_FLAG_STRING          ("No Flag", String.class,        ConfigCategory.EVENTS),
+    BEAR_TRAP_JOIN_MARCH_4_FLAG_STRING          ("No Flag", String.class,        ConfigCategory.EVENTS),
+    BEAR_TRAP_JOIN_MARCH_5_FLAG_STRING          ("No Flag", String.class,        ConfigCategory.EVENTS),
+    BEAR_TRAP_JOIN_MARCH_6_FLAG_STRING          ("No Flag", String.class,        ConfigCategory.EVENTS),
     // Shared stamina reserve kept back for Intel/Rally; overflow sinks (Beast/Polar Terror) only spend above it.
     STAMINA_RESERVE_INT                         ("130",     Integer.class,       ConfigCategory.EVENTS),
     BOOL_CHIEF_ORDER_PRODUCTIVITY_DAY           ("false",   Boolean.class,       ConfigCategory.EVENTS),

--- a/modules/automation/src/main/java/dev/frostguard/engine/nav/CommonGameAreas.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/nav/CommonGameAreas.java
@@ -183,4 +183,25 @@ public final class CommonGameAreas {
     public static final int CHARACTER_NAME_ABOVE_FURNACE_BOTTOM_OFFSET_Y = 10;
     public static final int CHARACTER_NAME_ABOVE_FURNACE_X_START          = 210;
     public static final int CHARACTER_NAME_ABOVE_FURNACE_X_END            = 500;
+
+    // Bear rally OCR areas are relative to the detected join button's top edge.
+    public static final int BEAR_TRAP_INITIATOR_X1 = 281;
+    public static final int BEAR_TRAP_INITIATOR_X2 = 691;
+    public static final int BEAR_TRAP_INITIATOR_DY1 = -102;
+    public static final int BEAR_TRAP_INITIATOR_DY2 = -63;
+
+    public static final int BEAR_TRAP_MEMBERS_X1 = 626;
+    public static final int BEAR_TRAP_MEMBERS_X2 = 688;
+    public static final int BEAR_TRAP_MEMBERS_DY1 = -57;
+    public static final int BEAR_TRAP_MEMBERS_DY2 = -24;
+
+    public static final int BEAR_TRAP_CAPACITY_X1 = 284;
+    public static final int BEAR_TRAP_CAPACITY_X2 = 521;
+    public static final int BEAR_TRAP_CAPACITY_DY1 = -57;
+    public static final int BEAR_TRAP_CAPACITY_DY2 = -25;
+
+    public static final int BEAR_TRAP_COUNTDOWN_X1 = 571;
+    public static final int BEAR_TRAP_COUNTDOWN_X2 = 691;
+    public static final int BEAR_TRAP_COUNTDOWN_DY1 = -163;
+    public static final int BEAR_TRAP_COUNTDOWN_DY2 = -124;
 }

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/combat/BearTrapLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/combat/BearTrapLayoutController.java
@@ -93,6 +93,34 @@ public class BearTrapLayoutController extends AbstractProfileController {
     @FXML
     private CheckComboBox<Integer> checkComboBoxJoinFlag;
 
+    @FXML private ComboBox<String> comboBoxJoinFlag1;
+    @FXML private ComboBox<String> comboBoxJoinFlag2;
+    @FXML private ComboBox<String> comboBoxJoinFlag3;
+    @FXML private ComboBox<String> comboBoxJoinFlag4;
+    @FXML private ComboBox<String> comboBoxJoinFlag5;
+    @FXML private ComboBox<String> comboBoxJoinFlag6;
+
+    @FXML
+    private CheckBox checkBoxAdvancedJoin;
+
+    @FXML
+    private javafx.scene.layout.VBox vBoxAdvancedJoinOptions;
+
+    @FXML
+    private TextField textFieldMinMemberCount;
+
+    @FXML
+    private TextField textFieldMinRallyCapacity;
+
+    @FXML
+    private TextField textFieldMinRemainingCapacity;
+
+    @FXML
+    private CheckBox checkBoxFrenzyMode;
+
+    @FXML
+    private TextField textFieldFrenzyStartMin;
+
     private List<TimerBinding> timerBindings;
     private boolean loadingParticipationTrigger;
     private boolean loadingProtectionModes;
@@ -130,14 +158,33 @@ public class BearTrapLayoutController extends AbstractProfileController {
         checkBoxMappings.put(checkBoxRecallTroops, ConfigurationKeyEnum.BEAR_TRAP_RECALL_TROOPS_BOOL);
         checkBoxMappings.put(checkBoxCallRally, ConfigurationKeyEnum.BEAR_TRAP_CALL_RALLY_BOOL);
         checkBoxMappings.put(checkBoxEnableJoin, ConfigurationKeyEnum.BEAR_TRAP_JOIN_RALLY_BOOL);
+        checkBoxMappings.put(checkBoxAdvancedJoin, ConfigurationKeyEnum.BEAR_TRAP_ADVANCED_JOIN_ENABLED_BOOL);
+        checkBoxMappings.put(checkBoxFrenzyMode, ConfigurationKeyEnum.BEAR_TRAP_FRENZY_MODE_ENABLED_BOOL);
 
         registerTextField(textFieldPreparationTime, labelPreparationTimeError,
                 ConfigurationKeyEnum.BEAR_TRAP_PREPARATION_TIME_INT);
+        registerTextField(textFieldMinMemberCount,
+                ConfigurationKeyEnum.BEAR_TRAP_MIN_MEMBER_COUNT_INT);
+        registerTextField(textFieldMinRallyCapacity,
+                ConfigurationKeyEnum.BEAR_TRAP_MIN_RALLY_CAPACITY_INT);
+        registerTextField(textFieldMinRemainingCapacity,
+                ConfigurationKeyEnum.BEAR_TRAP_MIN_REMAINING_CAPACITY_INT);
+        registerTextField(textFieldFrenzyStartMin,
+                ConfigurationKeyEnum.BEAR_TRAP_FRENZY_START_MINUTE_INT);
 
         comboBoxMappings.put(comboBoxTrapNumber, ConfigurationKeyEnum.BEAR_TRAP_NUMBER_INT);
         comboBoxMappings.put(comboBoxRallyFlag, ConfigurationKeyEnum.BEAR_TRAP_RALLY_FLAG_INT);
         checkComboBoxMappings.put(checkComboBoxJoinFlag, ConfigurationKeyEnum.BEAR_TRAP_JOIN_FLAG_INT);
+        comboBoxMappings.put(comboBoxJoinFlag1, ConfigurationKeyEnum.BEAR_TRAP_JOIN_MARCH_1_FLAG_STRING);
+        comboBoxMappings.put(comboBoxJoinFlag2, ConfigurationKeyEnum.BEAR_TRAP_JOIN_MARCH_2_FLAG_STRING);
+        comboBoxMappings.put(comboBoxJoinFlag3, ConfigurationKeyEnum.BEAR_TRAP_JOIN_MARCH_3_FLAG_STRING);
+        comboBoxMappings.put(comboBoxJoinFlag4, ConfigurationKeyEnum.BEAR_TRAP_JOIN_MARCH_4_FLAG_STRING);
+        comboBoxMappings.put(comboBoxJoinFlag5, ConfigurationKeyEnum.BEAR_TRAP_JOIN_MARCH_5_FLAG_STRING);
+        comboBoxMappings.put(comboBoxJoinFlag6, ConfigurationKeyEnum.BEAR_TRAP_JOIN_MARCH_6_FLAG_STRING);
     }
+
+    private static final List<String> FLAG_OPTIONS = List.of(
+            "No Flag", "1", "2", "3", "4", "5", "6", "7", "8");
 
     private void populateFlagControls() {
         comboBoxTrapNumber.setConverter(new StringConverter<>() {
@@ -153,6 +200,10 @@ public class BearTrapLayoutController extends AbstractProfileController {
         });
         comboBoxRallyFlag.getItems().setAll(FormationSlots.numbers());
         checkComboBoxJoinFlag.getItems().setAll(FormationSlots.numbers());
+        for (ComboBox<String> cb : joinFlagComboBoxes()) {
+            cb.getItems().setAll(FLAG_OPTIONS);
+            cb.setValue("No Flag");
+        }
     }
 
     private void configureParticipationTrigger() {
@@ -299,10 +350,28 @@ public class BearTrapLayoutController extends AbstractProfileController {
         checkBoxEnableJoin.disableProperty().bind(disabledUntilEnabled);
 
         comboBoxRallyFlag.disableProperty().bind(disabledUntilEnabled.or(checkBoxCallRally.selectedProperty().not()));
-        checkComboBoxJoinFlag.disableProperty().bind(disabledUntilEnabled.or(checkBoxEnableJoin.selectedProperty().not()));
+        BooleanExpression joinDisabled = disabledUntilEnabled.or(checkBoxEnableJoin.selectedProperty().not());
+        for (ComboBox<String> cb : joinFlagComboBoxes()) {
+            cb.disableProperty().bind(joinDisabled);
+        }
+
+        checkBoxAdvancedJoin.disableProperty().bind(joinDisabled);
+        if (vBoxAdvancedJoinOptions != null) {
+            bindManagedVisibility(vBoxAdvancedJoinOptions, checkBoxAdvancedJoin.selectedProperty().and(joinDisabled.not()));
+        }
+        BooleanExpression advancedDisabled = joinDisabled.or(checkBoxAdvancedJoin.selectedProperty().not());
+        checkBoxFrenzyMode.disableProperty().bind(advancedDisabled);
+        textFieldFrenzyStartMin.disableProperty().bind(advancedDisabled.or(checkBoxFrenzyMode.selectedProperty().not()));
+        textFieldMinMemberCount.disableProperty().bind(advancedDisabled);
+        textFieldMinRallyCapacity.disableProperty().bind(advancedDisabled);
+        textFieldMinRemainingCapacity.disableProperty().bind(advancedDisabled);
 
         bindManagedVisibility(comboBoxRallyFlag, checkBoxCallRally.selectedProperty());
-        bindManagedVisibility(checkComboBoxJoinFlag, checkBoxEnableJoin.selectedProperty());
+    }
+
+    private List<ComboBox<String>> joinFlagComboBoxes() {
+        return List.of(comboBoxJoinFlag1, comboBoxJoinFlag2, comboBoxJoinFlag3,
+                comboBoxJoinFlag4, comboBoxJoinFlag5, comboBoxJoinFlag6);
     }
 
     private void bindTimerState(TimerBinding timer) {

--- a/modules/desktop/src/main/resources/layout/BearTrapLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/BearTrapLayout.fxml
@@ -134,11 +134,72 @@
                             </HBox>
                             <CheckBox fx:id="checkBoxEnableJoin" mnemonicParsing="false"
                                       text="Enable Join Rally" />
-                            <HBox alignment="CENTER_LEFT" spacing="10">
-                                <Label minWidth="90.0" styleClass="task-field-label"
-                                       text="Join Flag" />
-                                <CheckComboBox fx:id="checkComboBoxJoinFlag" prefWidth="100.0" />
-                            </HBox>
+                            <GridPane hgap="8" vgap="4">
+                                <columnConstraints>
+                                    <ColumnConstraints percentWidth="50" />
+                                    <ColumnConstraints percentWidth="50" />
+                                </columnConstraints>
+                                <HBox alignment="CENTER_LEFT" spacing="6" GridPane.columnIndex="0" GridPane.rowIndex="0">
+                                    <Label minWidth="55" styleClass="task-field-label" text="Formation 1" />
+                                    <ComboBox fx:id="comboBoxJoinFlag1" prefWidth="90.0" />
+                                </HBox>
+                                <HBox alignment="CENTER_LEFT" spacing="6" GridPane.columnIndex="1" GridPane.rowIndex="0">
+                                    <Label minWidth="55" styleClass="task-field-label" text="Formation 2" />
+                                    <ComboBox fx:id="comboBoxJoinFlag2" prefWidth="90.0" />
+                                </HBox>
+                                <HBox alignment="CENTER_LEFT" spacing="6" GridPane.columnIndex="0" GridPane.rowIndex="1">
+                                    <Label minWidth="55" styleClass="task-field-label" text="Formation 3" />
+                                    <ComboBox fx:id="comboBoxJoinFlag3" prefWidth="90.0" />
+                                </HBox>
+                                <HBox alignment="CENTER_LEFT" spacing="6" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                                    <Label minWidth="55" styleClass="task-field-label" text="Formation 4" />
+                                    <ComboBox fx:id="comboBoxJoinFlag4" prefWidth="90.0" />
+                                </HBox>
+                                <HBox alignment="CENTER_LEFT" spacing="6" GridPane.columnIndex="0" GridPane.rowIndex="2">
+                                    <Label minWidth="55" styleClass="task-field-label" text="Formation 5" />
+                                    <ComboBox fx:id="comboBoxJoinFlag5" prefWidth="90.0" />
+                                </HBox>
+                                <HBox alignment="CENTER_LEFT" spacing="6" GridPane.columnIndex="1" GridPane.rowIndex="2">
+                                    <Label minWidth="55" styleClass="task-field-label" text="Formation 6" />
+                                    <ComboBox fx:id="comboBoxJoinFlag6" prefWidth="90.0" />
+                                </HBox>
+                            </GridPane>
+                            <CheckComboBox fx:id="checkComboBoxJoinFlag" prefWidth="100.0" visible="false" managed="false" />
+                            <Separator style="-fx-opacity: 0.25;" />
+                            <CheckBox fx:id="checkBoxAdvancedJoin" mnemonicParsing="false"
+                                      text="Enable Advanced Rally Filtering" />
+                            <VBox fx:id="vBoxAdvancedJoinOptions" spacing="8" style="-fx-padding: 0 0 0 18;">
+                                <HBox alignment="CENTER_LEFT" spacing="10">
+                                    <Label minWidth="130.0" styleClass="task-field-label"
+                                           text="Minimum Members" />
+                                    <TextField fx:id="textFieldMinMemberCount" prefWidth="70.0" promptText="0" text="0" />
+                                    <Label styleClass="task-card-description"
+                                           text="Only join rallies with at least this many members (0 = no limit)" wrapText="true" />
+                                </HBox>
+                                <HBox alignment="CENTER_LEFT" spacing="10">
+                                    <Label minWidth="130.0" styleClass="task-field-label"
+                                           text="Minimum Capacity" />
+                                    <TextField fx:id="textFieldMinRallyCapacity" prefWidth="70.0" promptText="0" text="0" />
+                                    <Label styleClass="task-card-description"
+                                           text="Only join rallies with at least this total capacity (0 = no limit)" wrapText="true" />
+                                </HBox>
+                                <HBox alignment="CENTER_LEFT" spacing="10">
+                                    <Label minWidth="130.0" styleClass="task-field-label"
+                                           text="Minimum Remaining" />
+                                    <TextField fx:id="textFieldMinRemainingCapacity" prefWidth="70.0" promptText="0" text="0" />
+                                    <Label styleClass="task-card-description"
+                                           text="Only join when at least this much capacity remains (0 = no limit)" wrapText="true" />
+                                </HBox>
+                                <CheckBox fx:id="checkBoxFrenzyMode" mnemonicParsing="false"
+                                          text="Enable Frenzy Mode (relax member limit near event end)" />
+                                <HBox alignment="CENTER_LEFT" spacing="10">
+                                    <Label minWidth="130.0" styleClass="task-field-label"
+                                           text="Frenzy Start Minute" />
+                                    <TextField fx:id="textFieldFrenzyStartMin" prefWidth="70.0" promptText="22" text="22" />
+                                    <Label styleClass="task-card-description"
+                                           text="Minutes after event start before Frenzy Mode activates" wrapText="true" />
+                                </HBox>
+                            </VBox>
                         </VBox>
                     </VBox>
                 </HBox>

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearRallyCandidate.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearRallyCandidate.java
@@ -1,0 +1,59 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.api.domain.AreaData;
+import dev.frostguard.api.domain.PointData;
+import java.time.Duration;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.util.Locale;
+
+/**
+ * Parsed candidate card representation from the alliance rally list during Bear Trap event.
+ */
+public record BearRallyCandidate(
+        PointData joinButtonPoint,
+        AreaData joinButtonArea,
+        AreaData cardArea,
+        String hostName,
+        int currentMembers,
+        int maxMembers,
+        long currentTroops,
+        long rallyCapacity,
+        long remainingCapacity,
+        Duration countdown,
+        Instant observedAt,
+        boolean isJoinable
+) {
+    public BearRallyCandidate(PointData joinButtonPoint, AreaData cardArea, String hostName,
+            int currentMembers, int maxMembers, long currentTroops, long rallyCapacity,
+            long remainingCapacity, Duration countdown, Instant observedAt, boolean isJoinable) {
+        this(joinButtonPoint, pointArea(joinButtonPoint), cardArea, hostName, currentMembers,
+                maxMembers, currentTroops, rallyCapacity, remainingCapacity, countdown,
+                observedAt, isJoinable);
+    }
+
+    private static AreaData pointArea(PointData point) {
+        return point == null ? null : new AreaData(point, point);
+    }
+
+    public String getCandidateKey() {
+        String cleanHost = hostName == null || hostName.isBlank()
+                ? "unknown"
+                : hostName.trim().toLowerCase(Locale.ROOT);
+        long completionBucket = completionBucket();
+        return cleanHost + ":members=" + currentMembers + "/" + maxMembers
+                + ":troops=" + currentTroops + "/" + rallyCapacity
+                + ":remaining=" + remainingCapacity + ":completion=" + completionBucket;
+    }
+
+    private long completionBucket() {
+        if (observedAt == null || countdown == null || countdown.isNegative()) {
+            return -1;
+        }
+        try {
+            return Math.floorDiv(observedAt.plus(countdown).getEpochSecond(), 15);
+        } catch (DateTimeException | ArithmeticException invalidTime) {
+            return -1;
+        }
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearRallyDecisionPolicy.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearRallyDecisionPolicy.java
@@ -1,0 +1,114 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.domain.AccountDescriptor;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+/**
+ * Decision policy for evaluating whether to join a Bear Trap rally candidate based on configuration thresholds
+ * and frenzy mode status.
+ */
+public final class BearRallyDecisionPolicy {
+
+    public enum DecisionResult {
+        JOIN,
+        SKIP_NOT_JOINABLE,
+        SKIP_MIN_MEMBERS_NOT_MET,
+        SKIP_MIN_RALLY_CAPACITY_NOT_MET,
+        SKIP_MIN_REMAINING_CAPACITY_NOT_MET,
+        SKIP_INVALID_CANDIDATE,
+        SKIP_ADVANCED_JOIN_DISABLED
+    }
+
+    public record Decision(DecisionResult result, String reason, boolean frenzyActive) {}
+
+    private BearRallyDecisionPolicy() {
+        // Policy utility
+    }
+
+    public static Decision evaluate(BearRallyCandidate candidate, AccountDescriptor profile, LocalDateTime trapStartTime, Clock clock) {
+        if (candidate == null || !candidate.isJoinable()) {
+            return new Decision(DecisionResult.SKIP_NOT_JOINABLE, "Candidate card is greyed out or not joinable", false);
+        }
+
+        Boolean advancedEnabled = profile.getConfig(ConfigurationKeyEnum.BEAR_TRAP_ADVANCED_JOIN_ENABLED_BOOL, Boolean.class);
+        if (!Boolean.TRUE.equals(advancedEnabled)) {
+            return new Decision(DecisionResult.JOIN, "Advanced join policy disabled; using standard join path", false);
+        }
+
+        if (!isCandidateValid(candidate)) {
+            return new Decision(DecisionResult.SKIP_INVALID_CANDIDATE,
+                    "Candidate fields are incomplete or internally inconsistent", false);
+        }
+
+        Boolean frenzyEnabled = profile.getConfig(ConfigurationKeyEnum.BEAR_TRAP_FRENZY_MODE_ENABLED_BOOL, Boolean.class);
+        Integer frenzyStartMinute = profile.getConfig(ConfigurationKeyEnum.BEAR_TRAP_FRENZY_START_MINUTE_INT, Integer.class);
+        if (frenzyStartMinute == null || frenzyStartMinute < 0 || frenzyStartMinute >= 30) {
+            frenzyStartMinute = 22;
+        }
+
+        boolean frenzyActive = false;
+        if (Boolean.TRUE.equals(frenzyEnabled) && trapStartTime != null) {
+            LocalDateTime now = LocalDateTime.now(clock);
+            long elapsedMinutes = Duration.between(trapStartTime, now).toMinutes();
+            if (elapsedMinutes >= frenzyStartMinute) {
+                frenzyActive = true;
+            }
+        }
+
+        // Check 1: Minimum member count threshold
+        Integer minMembers = profile.getConfig(ConfigurationKeyEnum.BEAR_TRAP_MIN_MEMBER_COUNT_INT, Integer.class);
+        if (!frenzyActive && minMembers != null && minMembers > 0) {
+            if (candidate.currentMembers() < minMembers) {
+                return new Decision(DecisionResult.SKIP_MIN_MEMBERS_NOT_MET,
+                        "Candidate members (" + candidate.currentMembers() + "/" + candidate.maxMembers()
+                                + ") below threshold " + minMembers, false);
+            }
+        }
+
+        // Check 2: Minimum total rally capacity threshold (别人最大集结量门槛)
+        Integer minRallyCapacity = profile.getConfig(ConfigurationKeyEnum.BEAR_TRAP_MIN_RALLY_CAPACITY_INT, Integer.class);
+        if (minRallyCapacity != null && minRallyCapacity > 0) {
+            if (candidate.rallyCapacity() < minRallyCapacity) {
+                return new Decision(DecisionResult.SKIP_MIN_RALLY_CAPACITY_NOT_MET,
+                        "Candidate rally capacity (" + candidate.rallyCapacity() + ") below threshold " + minRallyCapacity, false);
+            }
+        }
+
+        // Check 3: Minimum remaining capacity threshold (别人集结剩余可加入兵量门槛)
+        Integer minRemainingCapacity = profile.getConfig(ConfigurationKeyEnum.BEAR_TRAP_MIN_REMAINING_CAPACITY_INT, Integer.class);
+        if (minRemainingCapacity != null && minRemainingCapacity > 0) {
+            if (candidate.remainingCapacity() < minRemainingCapacity) {
+                return new Decision(DecisionResult.SKIP_MIN_REMAINING_CAPACITY_NOT_MET,
+                        "Candidate remaining capacity (" + candidate.remainingCapacity()
+                                + ") below threshold " + minRemainingCapacity, false);
+            }
+        }
+
+        String reason = frenzyActive
+                ? "Frenzy mode active; member threshold relaxed while capacity thresholds remain enforced"
+                : "Candidate met all threshold criteria";
+        return new Decision(DecisionResult.JOIN, reason, frenzyActive);
+    }
+
+    private static boolean isCandidateValid(BearRallyCandidate candidate) {
+        return candidate.joinButtonPoint() != null
+                && candidate.cardArea() != null
+                && candidate.hostName() != null
+                && !candidate.hostName().isBlank()
+                && candidate.currentMembers() >= 0
+                && candidate.maxMembers() > 0
+                && candidate.currentMembers() <= candidate.maxMembers()
+                && candidate.currentTroops() >= 0
+                && candidate.rallyCapacity() > 0
+                && candidate.currentTroops() <= candidate.rallyCapacity()
+                && candidate.remainingCapacity() >= 0
+                && candidate.remainingCapacity() <= candidate.rallyCapacity()
+                && candidate.countdown() != null
+                && !candidate.countdown().isNegative()
+                && !candidate.countdown().isZero()
+                && candidate.observedAt() != null;
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearRallyDedupCache.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearRallyDedupCache.java
@@ -1,0 +1,144 @@
+package dev.frostguard.tasks.combat;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Thread-safe candidate deduplication TTL cache for Bear Trap rally join requests.
+ */
+public class BearRallyDedupCache {
+
+    private static final Duration DEFAULT_TTL = Duration.ofSeconds(300);
+    private static final int DEFAULT_MAX_ENTRIES = 256;
+    private static final Duration CLOCK_ROLLBACK_TOLERANCE = Duration.ofSeconds(60);
+    private final Map<CacheKey, Instant> cache = new LinkedHashMap<>(16, 0.75f, true);
+    private final Clock clock;
+    private final Duration ttl;
+    private final int maxEntries;
+    private Instant lastObservedTime;
+
+    public record Scope(String profileId, String activityInstanceId) {
+        public Scope {
+            if (profileId == null || profileId.isBlank() || activityInstanceId == null || activityInstanceId.isBlank()) {
+                throw new IllegalArgumentException("Profile and activity instance are required");
+            }
+        }
+    }
+
+    private record CacheKey(Scope scope, String candidateKey) {}
+
+    public BearRallyDedupCache() {
+        this(Clock.systemUTC(), DEFAULT_TTL, DEFAULT_MAX_ENTRIES);
+    }
+
+    public BearRallyDedupCache(Clock clock, Duration ttl) {
+        this(clock, ttl, DEFAULT_MAX_ENTRIES);
+    }
+
+    public BearRallyDedupCache(Clock clock, Duration ttl, int maxEntries) {
+        if (clock == null || ttl == null || ttl.isZero() || ttl.isNegative() || maxEntries <= 0) {
+            throw new IllegalArgumentException("Clock, positive TTL, and positive capacity are required");
+        }
+        this.clock = clock;
+        this.ttl = ttl;
+        this.maxEntries = maxEntries;
+        this.lastObservedTime = clock.instant();
+    }
+
+    public synchronized boolean isDuplicate(Scope scope, String key) {
+        Objects.requireNonNull(scope, "scope");
+        if (key == null || key.isBlank()) {
+            return false;
+        }
+
+        Instant now = observeTime();
+        cleanExpired(now);
+        CacheKey scopedKey = new CacheKey(scope, key);
+        Instant expiry = cache.get(scopedKey);
+        if (expiry == null) {
+            return false;
+        }
+
+        if (!now.isBefore(expiry)) {
+            cache.remove(scopedKey);
+            return false;
+        }
+
+        return true;
+    }
+
+    public synchronized void markJoined(Scope scope, String key) {
+        Objects.requireNonNull(scope, "scope");
+        if (key == null || key.isBlank()) {
+            return;
+        }
+
+        Instant now = observeTime();
+        cleanExpired(now);
+        CacheKey cacheKey = new CacheKey(scope, key);
+        if (!cache.containsKey(cacheKey) && cache.size() >= maxEntries) {
+            cache.keySet().stream().findFirst().ifPresent(cache::remove);
+        }
+        cache.put(cacheKey, now.plus(ttl));
+    }
+
+    public synchronized void clearScope(Scope scope) {
+        Objects.requireNonNull(scope, "scope");
+        cache.keySet().removeIf(key -> key.scope().equals(scope));
+    }
+
+    public synchronized void clear() {
+        cache.clear();
+    }
+
+    synchronized int size() {
+        return cache.size();
+    }
+
+    static Set<String> uniqueCandidateKeys(List<BearRallyCandidate> candidates) {
+        Map<String, Integer> counts = new HashMap<>();
+        if (candidates != null) {
+            for (BearRallyCandidate candidate : candidates) {
+                if (candidate != null) {
+                    counts.merge(candidate.getCandidateKey(), 1, Integer::sum);
+                }
+            }
+        }
+        Set<String> uniqueKeys = new HashSet<>();
+        counts.forEach((key, count) -> {
+            if (count == 1) {
+                uniqueKeys.add(key);
+            }
+        });
+        return uniqueKeys;
+    }
+
+    static String positionalCandidateKey(BearRallyCandidate candidate) {
+        Objects.requireNonNull(candidate, "candidate");
+        if (candidate.joinButtonPoint() == null) {
+            throw new IllegalArgumentException("Candidate position is required");
+        }
+        return candidate.getCandidateKey() + ":screenY=" + candidate.joinButtonPoint().getY();
+    }
+
+    private Instant observeTime() {
+        Instant now = clock.instant();
+        if (now.isBefore(lastObservedTime.minus(CLOCK_ROLLBACK_TOLERANCE))) {
+            cache.clear();
+        }
+        lastObservedTime = now;
+        return now;
+    }
+
+    private void cleanExpired(Instant now) {
+        cache.entrySet().removeIf(entry -> !now.isBefore(entry.getValue()));
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearRallyScanner.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearRallyScanner.java
@@ -1,0 +1,204 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.api.configs.TemplatesEnum;
+import dev.frostguard.api.domain.AreaData;
+import dev.frostguard.api.domain.ImageSearchResultData;
+import dev.frostguard.api.domain.PointData;
+import dev.frostguard.engine.nav.CommonGameAreas;
+import dev.frostguard.engine.helper.TemplateSearchHelper;
+import dev.frostguard.engine.service.BotOcrEngine;
+import dev.frostguard.engine.emulator.EmulatorController;
+import dev.frostguard.vision.convert.CompactGameNumberParser;
+import dev.frostguard.vision.convert.GameTimeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class BearRallyScanner {
+
+    private static final Logger log = LoggerFactory.getLogger(BearRallyScanner.class);
+    private static final int SCREEN_WIDTH = 720;
+    private static final int SCREEN_HEIGHT = 1280;
+    private static final int MAX_VISIBLE_RALLIES = 8;
+    private static final int DUPLICATE_HIT_TOLERANCE = 8;
+
+    @FunctionalInterface
+    public interface PatternLocator {
+        List<ImageSearchResultData> locate(TemplatesEnum template, TemplateSearchHelper.SearchConfig config);
+    }
+
+    @FunctionalInterface
+    public interface TextExtractor {
+        String extract(PointData topLeft, PointData bottomRight);
+    }
+
+    private final PatternLocator patternLocator;
+    private final TextExtractor textExtractor;
+
+    public BearRallyScanner(EmulatorController emulator, BotOcrEngine ocrEngine, TemplateSearchHelper searchHelper) {
+        this.patternLocator = searchHelper != null ? searchHelper::locateAllPatterns : (t, c) -> List.of();
+        BotOcrEngine frameOcr = ocrEngine != null ? ocrEngine.reusingLastFrame() : null;
+        this.textExtractor = frameOcr != null ? (tl, br) -> {
+            try {
+                return frameOcr.extractText(null, tl, br);
+            } catch (Exception e) {
+                return null;
+            }
+        } : (tl, br) -> null;
+    }
+
+    public BearRallyScanner(PatternLocator patternLocator, TextExtractor textExtractor) {
+        this.patternLocator = patternLocator != null ? patternLocator : (t, c) -> List.of();
+        this.textExtractor = textExtractor != null ? textExtractor : (tl, br) -> null;
+    }
+
+    /**
+     * Scans the current screen for bear rally candidates.
+     * Extracts all joinable cards and parses their details from the same frame.
+     */
+    public List<BearRallyCandidate> scanCandidates(Instant now) {
+        List<BearRallyCandidate> candidates = new ArrayList<>();
+
+        // Use the default matching params but maybe higher confidence.
+        List<ImageSearchResultData> joinButtons = patternLocator.locate(
+                TemplatesEnum.BEAR_JOIN_PLUS_ICON,
+                TemplateSearchHelper.SearchConfig.builder()
+                        .withThreshold(80)
+                        .withMaxResults(MAX_VISIBLE_RALLIES)
+                        .build()
+        );
+
+        if (joinButtons == null || joinButtons.isEmpty()) {
+            return candidates;
+        }
+
+        // Process from top to bottom
+        List<ImageSearchResultData> sortedButtons = joinButtons.stream()
+                .filter(BearRallyScanner::isUsableHit)
+                .sorted(Comparator.comparingInt(img -> img.getPoint().getY()))
+                .toList();
+
+        PointData previousAcceptedPoint = null;
+        for (ImageSearchResultData btn : sortedButtons) {
+            PointData p = btn.getPoint();
+            if (previousAcceptedPoint != null
+                    && Math.abs(previousAcceptedPoint.getX() - p.getX()) <= DUPLICATE_HIT_TOLERANCE
+                    && Math.abs(previousAcceptedPoint.getY() - p.getY()) <= DUPLICATE_HIT_TOLERANCE) {
+                log.debug("Ignoring duplicate Bear join-button match at {}", p);
+                continue;
+            }
+            // OCR offsets are calibrated from the template's top-left edge, while match points are centers.
+            int anchorY = btn.hasMatchedArea() ? btn.getMatchedArea().topLeft().getY() : p.getY();
+            PointData anchor = new PointData(p.getX(), anchorY);
+            if (!hasValidOcrGeometry(anchorY)) {
+                log.debug("Ignoring Bear join-button match with out-of-bounds OCR geometry at {}", p);
+                continue;
+            }
+            previousAcceptedPoint = p;
+            AreaData joinButtonArea = btn.hasMatchedArea()
+                    ? btn.getMatchedArea()
+                    : new AreaData(p, p);
+
+            // Reconstruct full card AreaData for debugging
+            AreaData cardArea = new AreaData(
+                new PointData(0, Math.max(0, anchorY + CommonGameAreas.BEAR_TRAP_COUNTDOWN_DY1 - 10)),
+                new PointData(SCREEN_WIDTH - 1, Math.min(SCREEN_HEIGHT - 1, anchorY + 60))
+            );
+
+            String hostName = readHostName(anchor);
+            String membersRaw = readMembers(anchor);
+            String capacityRaw = readCapacity(anchor);
+            String countdownRaw = readCountdown(anchor);
+
+            // Parse Capacity: "Remaining / Total"
+            long remaining = -1, total = -1;
+            if (capacityRaw != null && capacityRaw.contains("/")) {
+                String[] parts = capacityRaw.split("/", 2);
+                remaining = CompactGameNumberParser.parseCompactNumber(parts[0]);
+                total = CompactGameNumberParser.parseCompactNumber(parts[1]);
+            }
+
+            // Parse Members: "Current / Max"
+            int currentMem = -1, maxMem = -1;
+            if (membersRaw != null && membersRaw.contains("/")) {
+                String[] parts = membersRaw.split("/", 2);
+                currentMem = (int) CompactGameNumberParser.parseCompactNumber(parts[0]);
+                maxMem = (int) CompactGameNumberParser.parseCompactNumber(parts[1]);
+            }
+
+            // Parse Countdown
+            Duration cd = GameTimeUtils.parseMinutesSeconds(countdownRaw);
+
+            // Calculate current troops based on remaining and total.
+            long currentTroops = -1;
+            if (total != -1 && remaining != -1 && total >= remaining) {
+                currentTroops = total - remaining;
+            }
+
+            BearRallyCandidate candidate = new BearRallyCandidate(
+                p, joinButtonArea, cardArea, hostName, currentMem, maxMem,
+                currentTroops, total, remaining, cd, now, true
+            );
+
+            log.info("Scanned Bear candidate at y={}: members={}/{}, capacity={}, remaining={}, countdown={}s",
+                    p.getY(), currentMem, maxMem, total, remaining,
+                    cd == null ? -1 : cd.getSeconds());
+            candidates.add(candidate);
+        }
+
+        return candidates;
+    }
+
+    private static boolean isUsableHit(ImageSearchResultData hit) {
+        return hit != null && hit.isFound() && hit.getPoint() != null;
+    }
+
+    private static boolean hasValidOcrGeometry(int anchorY) {
+        int minY = Math.min(
+                Math.min(CommonGameAreas.BEAR_TRAP_INITIATOR_DY1, CommonGameAreas.BEAR_TRAP_MEMBERS_DY1),
+                Math.min(CommonGameAreas.BEAR_TRAP_CAPACITY_DY1, CommonGameAreas.BEAR_TRAP_COUNTDOWN_DY1));
+        int maxY = Math.max(
+                Math.max(CommonGameAreas.BEAR_TRAP_INITIATOR_DY2, CommonGameAreas.BEAR_TRAP_MEMBERS_DY2),
+                Math.max(CommonGameAreas.BEAR_TRAP_CAPACITY_DY2, CommonGameAreas.BEAR_TRAP_COUNTDOWN_DY2));
+        return anchorY + minY >= 0 && anchorY + maxY <= SCREEN_HEIGHT
+                && CommonGameAreas.BEAR_TRAP_INITIATOR_X1 >= 0
+                && CommonGameAreas.BEAR_TRAP_COUNTDOWN_X2 <= SCREEN_WIDTH;
+    }
+
+    private String readHostName(PointData btnPoint) {
+        AreaData area = new AreaData(
+            new PointData(CommonGameAreas.BEAR_TRAP_INITIATOR_X1, btnPoint.getY() + CommonGameAreas.BEAR_TRAP_INITIATOR_DY1),
+            new PointData(CommonGameAreas.BEAR_TRAP_INITIATOR_X2, btnPoint.getY() + CommonGameAreas.BEAR_TRAP_INITIATOR_DY2)
+        );
+        return textExtractor.extract(area.topLeft(), area.bottomRight());
+    }
+
+    private String readMembers(PointData btnPoint) {
+        AreaData area = new AreaData(
+            new PointData(CommonGameAreas.BEAR_TRAP_MEMBERS_X1, btnPoint.getY() + CommonGameAreas.BEAR_TRAP_MEMBERS_DY1),
+            new PointData(CommonGameAreas.BEAR_TRAP_MEMBERS_X2, btnPoint.getY() + CommonGameAreas.BEAR_TRAP_MEMBERS_DY2)
+        );
+        return textExtractor.extract(area.topLeft(), area.bottomRight());
+    }
+
+    private String readCapacity(PointData btnPoint) {
+        AreaData area = new AreaData(
+            new PointData(CommonGameAreas.BEAR_TRAP_CAPACITY_X1, btnPoint.getY() + CommonGameAreas.BEAR_TRAP_CAPACITY_DY1),
+            new PointData(CommonGameAreas.BEAR_TRAP_CAPACITY_X2, btnPoint.getY() + CommonGameAreas.BEAR_TRAP_CAPACITY_DY2)
+        );
+        return textExtractor.extract(area.topLeft(), area.bottomRight());
+    }
+
+    private String readCountdown(PointData btnPoint) {
+        AreaData area = new AreaData(
+            new PointData(CommonGameAreas.BEAR_TRAP_COUNTDOWN_X1, btnPoint.getY() + CommonGameAreas.BEAR_TRAP_COUNTDOWN_DY1),
+            new PointData(CommonGameAreas.BEAR_TRAP_COUNTDOWN_X2, btnPoint.getY() + CommonGameAreas.BEAR_TRAP_COUNTDOWN_DY2)
+        );
+        return textExtractor.extract(area.topLeft(), area.bottomRight());
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearTrapRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/BearTrapRoutine.java
@@ -4,6 +4,7 @@ import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import dev.frostguard.api.configs.TemplatesEnum;
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.AreaData;
 import dev.frostguard.api.domain.FormationSlots;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
@@ -25,6 +26,7 @@ import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -767,6 +769,12 @@ private void handleJoinRallies2() {
     }
 
 private void manageJoinRallies(int freeMarches) {
+        Boolean advancedEnabled = profile.getConfig(ConfigurationKeyEnum.BEAR_TRAP_ADVANCED_JOIN_ENABLED_BOOL, Boolean.class);
+        if (Boolean.TRUE.equals(advancedEnabled)) {
+            manageAdvancedJoinRallies(freeMarches);
+            return;
+        }
+
         ImageSearchResultData plusIcon = templateSearchHelper.locatePattern(
                 BEAR_JOIN_PLUS_ICON,
                 SearchConfig.builder()
@@ -807,10 +815,174 @@ private void manageJoinRallies(int freeMarches) {
         } else {
             tapInside(deploy);
             sleepTask(500);
-
+            if (!confirmBearDeployment()) {
+                logWarning(routineLogBearTrapLine("Bear deployment was not confirmed."));
+                pressBack();
+            }
         }
 
         navigationHelper.ensureCorrectScreenLocation(LaunchPoint.ANY);
+    }
+
+    private BearRallyDedupCache dedupCache = new BearRallyDedupCache();
+    private BearRallyDedupCache positionalDedupCache = new BearRallyDedupCache(
+            Clock.systemUTC(), Duration.ofSeconds(5));
+    private static final int ADVANCED_JOIN_MAX_SCAN_CYCLES = 3;
+
+    private void manageAdvancedJoinRallies(int freeMarches) {
+        if (freeMarches <= 0) {
+            logInfo(routineLogBearTrapLine("Zero free marches available for Advanced Rally Join"));
+            navigationHelper.ensureCorrectScreenLocation(LaunchPoint.ANY);
+            return;
+        }
+
+        logInfo(routineLogBearTrapLine("Scanning for joinable Bear Rally candidates (Advanced Mode)..."));
+
+        BotOcrEngine ocrProvider = new BotOcrEngine(emuManager, EMULATOR_NUMBER);
+        BearRallyScanner scanner = new BearRallyScanner(this.emuManager, ocrProvider, this.templateSearchHelper);
+
+        String activityInstanceId = this.trapNumber + ":" + String.valueOf(this.referenceTrapTime);
+        BearRallyDedupCache.Scope scope = new BearRallyDedupCache.Scope(
+                profile.getId().toString(), activityInstanceId);
+        Clock clock = Clock.systemUTC();
+
+        scanCycle:
+        for (int scanAttempt = 1; scanAttempt <= ADVANCED_JOIN_MAX_SCAN_CYCLES; scanAttempt++) {
+            List<BearRallyCandidate> candidates = scanner.scanCandidates(Instant.now());
+            if (candidates.isEmpty()) {
+                logWarning(routineLogBearTrapLine("Zero joinable rallies detected (advanced scan)"));
+                break;
+            }
+
+            Set<String> uniqueCandidateKeys = BearRallyDedupCache.uniqueCandidateKeys(candidates);
+
+            for (BearRallyCandidate candidate : candidates) {
+                BearRallyDecisionPolicy.Decision decision = BearRallyDecisionPolicy.evaluate(
+                        candidate, profile, this.referenceTrapTime, clock);
+
+                String key = candidate.getCandidateKey();
+                boolean dedupEligible = uniqueCandidateKeys.contains(key);
+                String positionalKey = BearRallyDedupCache.positionalCandidateKey(candidate);
+                if (decision.result() == BearRallyDecisionPolicy.DecisionResult.JOIN
+                        && ((dedupEligible && dedupCache.isDuplicate(scope, key))
+                        || positionalDedupCache.isDuplicate(scope, positionalKey))) {
+                    logDebug(routineLogBearTrapLine(
+                            "Skipping duplicate candidate at card y=" + candidate.joinButtonPoint().getY()));
+                    continue;
+                }
+
+                if (decision.result() == BearRallyDecisionPolicy.DecisionResult.JOIN) {
+
+                    ImageSearchResultData currentJoinButton = templateSearchHelper.locatePattern(
+                            BEAR_JOIN_PLUS_ICON,
+                            SearchConfig.builder()
+                                    .withArea(expandToScreen(candidate.joinButtonArea(), 12))
+                                    .withThreshold(80)
+                                    .withMaxAttempts(1)
+                                    .build());
+                    if (currentJoinButton == null || !currentJoinButton.isFound()) {
+                        logDebug(routineLogBearTrapLine(
+                                "Candidate join button changed after scanning; discarding the stale scan at y="
+                                        + candidate.joinButtonPoint().getY()));
+                        continue scanCycle;
+                    }
+
+                    int selectedFlag = resolveNextJoinFlag();
+                    logInfo(routineLogBearTrapLine("Joining candidate at card y="
+                            + candidate.joinButtonPoint().getY() + " with flag #" + selectedFlag
+                            + (decision.frenzyActive() ? " (Frenzy Active)" : "")));
+
+                    tapInside(currentJoinButton);
+                    sleepTask(500);
+
+                    if (!marchHelper.selectFlag(selectedFlag)) {
+                        logWarning(routineLogBearTrapLine("Configured join formation #" + selectedFlag
+                                + " is unavailable; cancelling this join"));
+                        pressBack();
+                        sleepTask(500);
+                        continue scanCycle;
+                    }
+
+                    ImageSearchResultData deploy = templateSearchHelper.locatePattern(
+                            BEAR_DEPLOY_BUTTON,
+                            SearchConfig.builder()
+                                    .withThreshold(90)
+                                    .withMaxAttempts(TEMPLATE_SEARCH_RETRIES_MAX_VALUE)
+                                    .build());
+
+                    if (!deploy.isFound()) {
+                        logWarning(routineLogBearTrapLine(
+                                "Deploy button not detected after selecting flag. Cancelling join."));
+                        pressBack();
+                        sleepTask(500);
+                        continue scanCycle;
+                    }
+
+                    tapInside(deploy);
+                    sleepTask(500);
+
+                    if (deploymentHelper.isMarchQueueFull()) {
+                        logWarning(routineLogBearTrapLine("March queue is full after tapping deploy."));
+                        pressBack();
+                        navigationHelper.ensureCorrectScreenLocation(LaunchPoint.ANY);
+                        return;
+                    }
+
+                    if (deploymentHelper.isSameTargetDialog()) {
+                        logWarning(routineLogBearTrapLine(
+                                "A march is already targeting this rally; cancelling duplicate deployment."));
+                        positionalDedupCache.markJoined(scope, positionalKey);
+                        pressBack();
+                        sleepTask(300);
+                        pressBack();
+                        sleepTask(500);
+                        continue scanCycle;
+                    }
+
+                    if (!confirmBearDeployment()) {
+                        logWarning(routineLogBearTrapLine(
+                                "Deploy button remained visible; deployment was not confirmed."));
+                        pressBack();
+                        sleepTask(500);
+                        continue scanCycle;
+                    }
+
+                    if (dedupEligible) {
+                        dedupCache.markJoined(scope, key);
+                    } else {
+                        positionalDedupCache.markJoined(scope, positionalKey);
+                    }
+                    logInfo(routineLogBearTrapLine(
+                            "Deployment successful for candidate at card y="
+                                    + candidate.joinButtonPoint().getY()));
+                    navigationHelper.ensureCorrectScreenLocation(LaunchPoint.ANY);
+                    return; // Only join one per iteration to avoid spamming and UI states
+                } else {
+                    logDebug(routineLogBearTrapLine("Skipping candidate at card y="
+                            + candidate.joinButtonPoint().getY() + " due to: " + decision.reason()));
+                }
+            }
+
+            break;
+        }
+
+        navigationHelper.ensureCorrectScreenLocation(LaunchPoint.ANY);
+    }
+
+    private AreaData expandToScreen(AreaData area, int margin) {
+        PointData topLeft = area.topLeft();
+        PointData bottomRight = area.bottomRight();
+        return new AreaData(
+                new PointData(Math.max(0, topLeft.getX() - margin), Math.max(0, topLeft.getY() - margin)),
+                new PointData(Math.min(720, bottomRight.getX() + margin),
+                        Math.min(1280, bottomRight.getY() + margin)));
+    }
+
+    private boolean confirmBearDeployment() {
+        ImageSearchResultData deployStillVisible = templateSearchHelper.locatePattern(
+                BEAR_DEPLOY_BUTTON,
+                SearchConfig.builder().withThreshold(90).withMaxAttempts(2).build());
+        return !deployStillVisible.isFound();
     }
 
 private void logTrapTimingFlow(TrapTimingShape timing) {
@@ -896,31 +1068,34 @@ private boolean hasInsideWindow() {
         return result.getState() == BearTrapHelper.WindowState.INSIDE;
     }
 
-private List<Integer> decodeJoinFlags() {
-        String flagConfig = profile.getConfig(BEAR_TRAP_JOIN_FLAG_INT, String.class);
+    private List<Integer> decodeJoinFlags() {
         List<Integer> flags = new ArrayList<>();
+        ConfigurationKeyEnum[] flagKeys = {
+            BEAR_TRAP_JOIN_MARCH_1_FLAG_STRING,
+            BEAR_TRAP_JOIN_MARCH_2_FLAG_STRING,
+            BEAR_TRAP_JOIN_MARCH_3_FLAG_STRING,
+            BEAR_TRAP_JOIN_MARCH_4_FLAG_STRING,
+            BEAR_TRAP_JOIN_MARCH_5_FLAG_STRING,
+            BEAR_TRAP_JOIN_MARCH_6_FLAG_STRING
+        };
 
-        if (flagConfig != null && !flagConfig.trim().isEmpty()) {
-            String[] parts = flagConfig.split(",");
-            for (String part : parts) {
+        for (ConfigurationKeyEnum key : flagKeys) {
+            String flagStr = profile.getConfig(key, String.class);
+            if (flagStr != null && !flagStr.equals("No Flag") && !flagStr.trim().isEmpty()) {
                 try {
-                    int flag = Integer.parseInt(part.trim());
+                    int flag = Integer.parseInt(flagStr.trim());
                     if (FormationSlots.supports(flag)) {
                         flags.add(flag);
                     }
                 } catch (NumberFormatException e) {
-                    logWarning(routineLogBearTrapLine("Invalid join flag value: " + part));
+                    logWarning(routineLogBearTrapLine("Invalid join flag value: " + flagStr));
                 }
             }
         }
 
-
         if (flags.isEmpty()) {
             flags.add(DEFAULT_JOIN_RALLY_FLAG_VALUE);
         }
-
-
-        flags.sort(Integer::compareTo);
 
         return flags;
     }

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearRallyCandidateTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearRallyCandidateTest.java
@@ -1,0 +1,29 @@
+package dev.frostguard.tasks.combat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.frostguard.api.domain.AreaData;
+import dev.frostguard.api.domain.PointData;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class BearRallyCandidateTest {
+
+    @Test
+    void keepsSignatureStableAsCountdownAdvances() {
+        Instant firstObservation = Instant.parse("2026-08-18T10:00:00Z");
+        BearRallyCandidate first = candidate(firstObservation, Duration.ofMinutes(4));
+        BearRallyCandidate second = candidate(firstObservation.plusSeconds(20), Duration.ofSeconds(220));
+
+        assertEquals(first.getCandidateKey(), second.getCandidateKey());
+    }
+
+    private BearRallyCandidate candidate(Instant observedAt, Duration countdown) {
+        return new BearRallyCandidate(
+                new PointData(100, 100),
+                new AreaData(new PointData(0, 0), new PointData(200, 200)),
+                " Host1 ", 2, 6, 25_000L, 100_000L, 75_000L,
+                countdown, observedAt, true);
+    }
+}

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearRallyDecisionPolicyTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearRallyDecisionPolicyTest.java
@@ -1,0 +1,142 @@
+package dev.frostguard.tasks.combat;
+
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.AreaData;
+import dev.frostguard.api.domain.PointData;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BearRallyDecisionPolicyTest {
+
+    @Test
+    public void testDisabledAdvancedJoinUsesDefaultPath() {
+        AccountDescriptor account = new AccountDescriptor(1L);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_ADVANCED_JOIN_ENABLED_BOOL, false);
+
+        BearRallyCandidate candidate = new BearRallyCandidate(
+                new PointData(100, 100), new AreaData(new PointData(0, 0), new PointData(200, 200)),
+                "Host1", 1, 6, 25_000L, 100_000L, 75_000L, Duration.ofMinutes(4), Instant.now(), true);
+
+        BearRallyDecisionPolicy.Decision decision = BearRallyDecisionPolicy.evaluate(
+                candidate, account, LocalDateTime.now(), Clock.systemUTC());
+
+        assertEquals(BearRallyDecisionPolicy.DecisionResult.JOIN, decision.result());
+        assertFalse(decision.frenzyActive());
+    }
+
+    @Test
+    public void testFrenzyModeBypassesMemberThreshold() {
+        AccountDescriptor account = new AccountDescriptor(1L);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_ADVANCED_JOIN_ENABLED_BOOL, true);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_FRENZY_MODE_ENABLED_BOOL, true);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_FRENZY_START_MINUTE_INT, 22);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_MIN_MEMBER_COUNT_INT, 5);
+
+        Instant fixedNow = Instant.parse("2026-08-14T10:25:00Z");
+        Clock fixedClock = Clock.fixed(fixedNow, ZoneId.of("UTC"));
+        LocalDateTime trapStartTime = LocalDateTime.ofInstant(Instant.parse("2026-08-14T10:00:00Z"), ZoneId.of("UTC"));
+
+        BearRallyCandidate candidate = new BearRallyCandidate(
+                new PointData(100, 100), new AreaData(new PointData(0, 0), new PointData(200, 200)),
+                "Host1", 1, 6, 25_000L, 100_000L, 75_000L, Duration.ofMinutes(4), fixedNow, true);
+
+        BearRallyDecisionPolicy.Decision decision = BearRallyDecisionPolicy.evaluate(
+                candidate, account, trapStartTime, fixedClock);
+
+        assertEquals(BearRallyDecisionPolicy.DecisionResult.JOIN, decision.result());
+        assertTrue(decision.frenzyActive());
+    }
+
+    @Test
+    void frenzyStillEnforcesRemainingCapacity() {
+        AccountDescriptor account = new AccountDescriptor(1L);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_ADVANCED_JOIN_ENABLED_BOOL, true);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_FRENZY_MODE_ENABLED_BOOL, true);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_FRENZY_START_MINUTE_INT, 22);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_MIN_MEMBER_COUNT_INT, 5);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_MIN_REMAINING_CAPACITY_INT, 80_000);
+        Instant fixedNow = Instant.parse("2026-08-14T10:25:00Z");
+        Clock fixedClock = Clock.fixed(fixedNow, ZoneId.of("UTC"));
+        LocalDateTime start = LocalDateTime.ofInstant(
+                Instant.parse("2026-08-14T10:00:00Z"), ZoneId.of("UTC"));
+        BearRallyCandidate candidate = new BearRallyCandidate(
+                new PointData(100, 100), new AreaData(new PointData(0, 0), new PointData(200, 200)),
+                "Host1", 1, 6, 50_000L, 100_000L, 50_000L,
+                Duration.ofMinutes(4), fixedNow, true);
+
+        BearRallyDecisionPolicy.Decision decision = BearRallyDecisionPolicy.evaluate(
+                candidate, account, start, fixedClock);
+
+        assertEquals(BearRallyDecisionPolicy.DecisionResult.SKIP_MIN_REMAINING_CAPACITY_NOT_MET,
+                decision.result());
+    }
+
+    @Test
+    public void rejectsCandidateWhenCurrentMembersAreBelowThreshold() {
+        AccountDescriptor account = new AccountDescriptor(1L);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_ADVANCED_JOIN_ENABLED_BOOL, true);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_MIN_MEMBER_COUNT_INT, 5);
+
+        BearRallyCandidate candidate = new BearRallyCandidate(
+                new PointData(100, 100), new AreaData(new PointData(0, 0), new PointData(200, 200)),
+                "Host1", 1, 6, 25_000L, 100_000L, 75_000L, Duration.ofMinutes(4), Instant.now(), true);
+
+        BearRallyDecisionPolicy.Decision decision = BearRallyDecisionPolicy.evaluate(
+                candidate, account, null, Clock.systemUTC());
+
+        assertEquals(BearRallyDecisionPolicy.DecisionResult.SKIP_MIN_MEMBERS_NOT_MET, decision.result());
+    }
+
+    @Test
+    void evaluatesTroopCapacityIndependentlyFromMemberCount() {
+        AccountDescriptor account = new AccountDescriptor(1L);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_ADVANCED_JOIN_ENABLED_BOOL, true);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_MIN_MEMBER_COUNT_INT, 2);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_MIN_RALLY_CAPACITY_INT, 90_000);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_MIN_REMAINING_CAPACITY_INT, 40_000);
+
+        BearRallyCandidate candidate = new BearRallyCandidate(
+                new PointData(100, 100), new AreaData(new PointData(0, 0), new PointData(200, 200)),
+                "Host1", 3, 6, 80_000L, 100_000L, 20_000L, Duration.ofMinutes(4), Instant.now(), true);
+
+        BearRallyDecisionPolicy.Decision decision = BearRallyDecisionPolicy.evaluate(
+                candidate, account, null, Clock.systemUTC());
+
+        assertEquals(BearRallyDecisionPolicy.DecisionResult.SKIP_MIN_REMAINING_CAPACITY_NOT_MET, decision.result());
+    }
+
+    @Test
+    void rejectsInternallyInconsistentCandidate() {
+        AccountDescriptor account = new AccountDescriptor(1L);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_ADVANCED_JOIN_ENABLED_BOOL, true);
+        BearRallyCandidate candidate = new BearRallyCandidate(
+                new PointData(100, 100), new AreaData(new PointData(0, 0), new PointData(200, 200)),
+                "Host1", 7, 6, 120_000L, 100_000L, -20_000L, Duration.ofMinutes(4), Instant.now(), true);
+
+        BearRallyDecisionPolicy.Decision decision = BearRallyDecisionPolicy.evaluate(
+                candidate, account, null, Clock.systemUTC());
+
+        assertEquals(BearRallyDecisionPolicy.DecisionResult.SKIP_INVALID_CANDIDATE, decision.result());
+    }
+
+    @Test
+    void rejectsUnknownCapacityInsteadOfPrioritizingIt() {
+        AccountDescriptor account = new AccountDescriptor(1L);
+        account.setConfig(ConfigurationKeyEnum.BEAR_TRAP_ADVANCED_JOIN_ENABLED_BOOL, true);
+        BearRallyCandidate candidate = new BearRallyCandidate(
+                new PointData(100, 100), new AreaData(new PointData(0, 0), new PointData(200, 200)),
+                "Host1", 1, 6, -1L, -1L, -1L,
+                Duration.ofMinutes(4), Instant.now(), true);
+
+        BearRallyDecisionPolicy.Decision decision = BearRallyDecisionPolicy.evaluate(
+                candidate, account, null, Clock.systemUTC());
+
+        assertEquals(BearRallyDecisionPolicy.DecisionResult.SKIP_INVALID_CANDIDATE, decision.result());
+    }
+}

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearRallyDedupCacheTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearRallyDedupCacheTest.java
@@ -1,0 +1,173 @@
+package dev.frostguard.tasks.combat;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class BearRallyDedupCacheTest {
+
+    @Test
+    void entryExpiresAtExactTtlBoundary() {
+        Instant start = Instant.parse("2026-08-18T10:00:00Z");
+        MutableClock clock = new MutableClock(start);
+        BearRallyDedupCache cache = new BearRallyDedupCache(clock, Duration.ofMinutes(5));
+        BearRallyDedupCache.Scope scope = new BearRallyDedupCache.Scope("profile-1", "trap-1");
+
+        cache.markJoined(scope, "host-1");
+        assertTrue(cache.isDuplicate(scope, "host-1"));
+
+        clock.instant = start.plus(Duration.ofMinutes(5));
+        assertFalse(cache.isDuplicate(scope, "host-1"));
+    }
+
+    @Test
+    void scopesEntriesByProfileAndActivity() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-18T10:00:00Z"));
+        BearRallyDedupCache cache = new BearRallyDedupCache(clock, Duration.ofMinutes(5));
+        BearRallyDedupCache.Scope first = new BearRallyDedupCache.Scope("profile-1", "trap-1");
+        BearRallyDedupCache.Scope second = new BearRallyDedupCache.Scope("profile-1", "trap-2");
+
+        cache.markJoined(first, "candidate");
+
+        assertTrue(cache.isDuplicate(first, "candidate"));
+        assertFalse(cache.isDuplicate(second, "candidate"));
+    }
+
+    @Test
+    void toleratesSmallClockCorrection() {
+        Instant start = Instant.parse("2026-08-18T10:00:00Z");
+        MutableClock clock = new MutableClock(start);
+        BearRallyDedupCache cache = new BearRallyDedupCache(clock, Duration.ofMinutes(5));
+        BearRallyDedupCache.Scope scope = new BearRallyDedupCache.Scope("profile-1", "trap-1");
+        cache.markJoined(scope, "candidate");
+
+        clock.instant = start.minusSeconds(1);
+
+        assertTrue(cache.isDuplicate(scope, "candidate"));
+    }
+
+    @Test
+    void clearsConservativelyWhenClockMovesBackwardBeyondTolerance() {
+        Instant start = Instant.parse("2026-08-18T10:00:00Z");
+        MutableClock clock = new MutableClock(start);
+        BearRallyDedupCache cache = new BearRallyDedupCache(clock, Duration.ofMinutes(5));
+        BearRallyDedupCache.Scope scope = new BearRallyDedupCache.Scope("profile-1", "trap-1");
+        cache.markJoined(scope, "candidate");
+
+        clock.instant = start.minusSeconds(61);
+
+        assertFalse(cache.isDuplicate(scope, "candidate"));
+    }
+
+    @Test
+    void enforcesMaximumEntryCount() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-18T10:00:00Z"));
+        BearRallyDedupCache cache = new BearRallyDedupCache(clock, Duration.ofMinutes(5), 2);
+        BearRallyDedupCache.Scope scope = new BearRallyDedupCache.Scope("profile-1", "trap-1");
+
+        cache.markJoined(scope, "one");
+        clock.instant = clock.instant.plusSeconds(1);
+        cache.markJoined(scope, "two");
+        clock.instant = clock.instant.plusSeconds(1);
+        cache.markJoined(scope, "three");
+
+        assertEquals(2, cache.size());
+        assertFalse(cache.isDuplicate(scope, "one"));
+    }
+
+    @Test
+    void evictsLeastRecentlyUsedEntry() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-08-18T10:00:00Z"));
+        BearRallyDedupCache cache = new BearRallyDedupCache(clock, Duration.ofMinutes(5), 2);
+        BearRallyDedupCache.Scope scope = new BearRallyDedupCache.Scope("profile-1", "trap-1");
+        cache.markJoined(scope, "one");
+        cache.markJoined(scope, "two");
+        assertTrue(cache.isDuplicate(scope, "one"));
+
+        cache.markJoined(scope, "three");
+
+        assertTrue(cache.isDuplicate(scope, "one"));
+        assertFalse(cache.isDuplicate(scope, "two"));
+    }
+
+    @Test
+    void excludesCollidingCardsFromTtlDeduplication() {
+        Instant observedAt = Instant.parse("2026-08-18T10:00:00Z");
+        BearRallyCandidate first = candidate("SameHost", observedAt, Duration.ofMinutes(4));
+        BearRallyCandidate second = candidate("SameHost", observedAt, Duration.ofMinutes(4));
+
+        Set<String> uniqueKeys = BearRallyDedupCache.uniqueCandidateKeys(List.of(first, second));
+
+        assertTrue(uniqueKeys.isEmpty());
+    }
+
+    @Test
+    void keepsDifferentHostsOrCompletionTimesIndependentlyDeduplicated() {
+        Instant observedAt = Instant.parse("2026-08-18T10:00:00Z");
+        BearRallyCandidate first = candidate("FirstHost", observedAt, Duration.ofMinutes(4));
+        BearRallyCandidate second = candidate("SecondHost", observedAt, Duration.ofMinutes(4));
+        BearRallyCandidate third = candidate("FirstHost", observedAt, Duration.ofSeconds(260));
+
+        Set<String> uniqueKeys = BearRallyDedupCache.uniqueCandidateKeys(List.of(first, second, third));
+
+        assertEquals(3, uniqueKeys.size());
+    }
+
+    @Test
+    void positionalKeysSeparateCollidingCardsAtDifferentScreenRows() {
+        Instant observedAt = Instant.parse("2026-08-18T10:00:00Z");
+        BearRallyCandidate upper = candidate(
+                "SameHost", observedAt, Duration.ofMinutes(4), 300);
+        BearRallyCandidate lower = candidate(
+                "SameHost", observedAt, Duration.ofMinutes(4), 500);
+
+        assertFalse(BearRallyDedupCache.positionalCandidateKey(upper)
+                .equals(BearRallyDedupCache.positionalCandidateKey(lower)));
+    }
+
+    private static BearRallyCandidate candidate(String host, Instant observedAt, Duration countdown) {
+        return candidate(host, observedAt, countdown, 300);
+    }
+
+    private static BearRallyCandidate candidate(
+            String host, Instant observedAt, Duration countdown, int buttonY) {
+        return new BearRallyCandidate(
+                new dev.frostguard.api.domain.PointData(600, buttonY),
+                new dev.frostguard.api.domain.AreaData(
+                        new dev.frostguard.api.domain.PointData(0, 200),
+                        new dev.frostguard.api.domain.PointData(719, 360)),
+                host, 2, 6, 50_000L, 100_000L, 50_000L,
+                countdown, observedAt, true);
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneOffset getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(java.time.ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearRallyScannerTest.java
+++ b/modules/tasks/src/test/java/dev/frostguard/tasks/combat/BearRallyScannerTest.java
@@ -1,0 +1,162 @@
+package dev.frostguard.tasks.combat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.frostguard.api.domain.ImageSearchResultData;
+import dev.frostguard.api.domain.PointData;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class BearRallyScannerTest {
+
+    @Test
+    void returnsEmptyListWhenZeroJoinButtonsFound() {
+        BearRallyScanner scanner = new BearRallyScanner(
+                (template, config) -> List.of(),
+                (tl, br) -> null
+        );
+
+        List<BearRallyCandidate> candidates = scanner.scanCandidates(Instant.now());
+        assertTrue(candidates.isEmpty());
+    }
+
+    @Test
+    void parsesAndSortsCandidatesFromTopToBottom() {
+        ImageSearchResultData btnLower = ImageSearchResultData.hit(600, 600, 95.0);
+        ImageSearchResultData btnUpper = ImageSearchResultData.hit(600, 300, 95.0);
+
+        BearRallyScanner scanner = new BearRallyScanner(
+                (template, config) -> List.of(btnLower, btnUpper),
+                (tl, br) -> {
+                    // Extract based on region
+                    if (tl.getY() < 400) {
+                        // Upper card
+                        if (tl.getX() == 281) return "PlayerOne";
+                        if (tl.getX() == 626) return "3/6";
+                        if (tl.getX() == 284) return "100.0K/200.0K";
+                        if (tl.getX() == 571) return "04:30";
+                    } else {
+                        // Lower card
+                        if (tl.getX() == 281) return "PlayerTwo";
+                        if (tl.getX() == 626) return "1/6";
+                        if (tl.getX() == 284) return "50.0K/150.0K";
+                        if (tl.getX() == 571) return "02:15";
+                    }
+                    return null;
+                }
+        );
+
+        Instant now = Instant.parse("2026-08-19T10:00:00Z");
+        List<BearRallyCandidate> candidates = scanner.scanCandidates(now);
+
+        assertEquals(2, candidates.size());
+
+        // Verify sorted from top to bottom
+        BearRallyCandidate first = candidates.get(0);
+        assertEquals("PlayerOne", first.hostName());
+        assertEquals(3, first.currentMembers());
+        assertEquals(6, first.maxMembers());
+        assertEquals(200_000L, first.rallyCapacity());
+        assertEquals(100_000L, first.remainingCapacity());
+        assertEquals(100_000L, first.currentTroops());
+        assertEquals(Duration.ofSeconds(270), first.countdown());
+
+        BearRallyCandidate second = candidates.get(1);
+        assertEquals("PlayerTwo", second.hostName());
+        assertEquals(1, second.currentMembers());
+        assertEquals(6, second.maxMembers());
+        assertEquals(150_000L, second.rallyCapacity());
+        assertEquals(50_000L, second.remainingCapacity());
+        assertEquals(100_000L, second.currentTroops());
+        assertEquals(Duration.ofSeconds(135), second.countdown());
+    }
+
+    @Test
+    void requestsMultipleMatchesAndDropsDuplicateOrInvalidHits() {
+        ImageSearchResultData first = ImageSearchResultData.hit(600, 300, 95.0, 20, 40);
+        ImageSearchResultData duplicate = ImageSearchResultData.hit(604, 304, 94.0, 20, 40);
+        ImageSearchResultData invalid = ImageSearchResultData.hit(600, 50, 96.0, 20, 40);
+
+        BearRallyScanner scanner = new BearRallyScanner(
+                (template, config) -> {
+                    assertEquals(8, config.getMaxResults());
+                    return List.of(duplicate, invalid, first, ImageSearchResultData.miss());
+                },
+                (tl, br) -> {
+                    if (tl.getX() == 281) return "Host";
+                    if (tl.getX() == 626) return "1/6";
+                    if (tl.getX() == 284) return "50K/100K";
+                    return "04:00";
+                });
+
+        List<BearRallyCandidate> candidates = scanner.scanCandidates(
+                Instant.parse("2026-08-19T10:00:00Z"));
+
+        assertEquals(1, candidates.size());
+        assertEquals(first.getMatchedArea(), candidates.get(0).joinButtonArea());
+    }
+
+    @Test
+    void anchorsOcrRegionsFromMatchedTemplateTopEdge() {
+        ImageSearchResultData button = ImageSearchResultData.hit(600, 300, 95.0, 20, 40);
+        List<PointData> observedTopLefts = new ArrayList<>();
+        BearRallyScanner scanner = new BearRallyScanner(
+                (template, config) -> List.of(button),
+                (tl, br) -> {
+                    observedTopLefts.add(tl);
+                    if (tl.getX() == 281) return "Host";
+                    if (tl.getX() == 626) return "1/6";
+                    if (tl.getX() == 284) return "50K/100K";
+                    return "04:00";
+                });
+
+        scanner.scanCandidates(Instant.parse("2026-08-19T10:00:00Z"));
+
+        assertEquals(280 + dev.frostguard.engine.nav.CommonGameAreas.BEAR_TRAP_INITIATOR_DY1,
+                observedTopLefts.get(0).getY());
+    }
+
+    @Test
+    void aFreshScanDoesNotRetainCandidatesThatDisappeared() {
+        AtomicInteger scans = new AtomicInteger();
+        BearRallyScanner scanner = new BearRallyScanner(
+                (template, config) -> scans.getAndIncrement() == 0
+                        ? List.of(ImageSearchResultData.hit(600, 300, 95.0, 20, 40))
+                        : List.of(),
+                BearRallyScannerTest::validCardText);
+
+        assertEquals(1, scanner.scanCandidates(Instant.now()).size());
+        assertTrue(scanner.scanCandidates(Instant.now()).isEmpty());
+    }
+
+    @Test
+    void aFreshScanUsesTheReplacementCardsCurrentPosition() {
+        AtomicInteger scans = new AtomicInteger();
+        BearRallyScanner scanner = new BearRallyScanner(
+                (template, config) -> scans.getAndIncrement() == 0
+                        ? List.of(
+                                ImageSearchResultData.hit(600, 300, 95.0, 20, 40),
+                                ImageSearchResultData.hit(600, 500, 95.0, 20, 40))
+                        : List.of(ImageSearchResultData.hit(600, 300, 95.0, 20, 40)),
+                BearRallyScannerTest::validCardText);
+
+        List<BearRallyCandidate> staleScan = scanner.scanCandidates(Instant.now());
+        List<BearRallyCandidate> freshScan = scanner.scanCandidates(Instant.now());
+
+        assertEquals(2, staleScan.size());
+        assertEquals(1, freshScan.size());
+        assertEquals(300, freshScan.get(0).joinButtonPoint().getY());
+    }
+
+    private static String validCardText(PointData topLeft, PointData bottomRight) {
+        if (topLeft.getX() == 281) return "Host";
+        if (topLeft.getX() == 626) return "1/6";
+        if (topLeft.getX() == 284) return "50K/100K";
+        return "04:00";
+    }
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/convert/CompactGameNumberParser.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/convert/CompactGameNumberParser.java
@@ -1,0 +1,67 @@
+package dev.frostguard.vision.convert;
+
+import java.math.BigDecimal;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Robust parser for compact and formatted numbers in game UI text (e.g. "1200", "1,200", "1.2K", "1.5M").
+ * Converts formatted string representation into an exact long value safely without numeric overflow.
+ */
+public final class CompactGameNumberParser {
+
+    private static final Pattern COMPACT_NUMBER_PATTERN = Pattern.compile("^([0-9]+(?:\\.[0-9]+)?)\\s*([KMkm])?$");
+
+    private CompactGameNumberParser() {
+        // Utility class
+    }
+
+    /**
+     * Parses a string representation of a compact game number.
+     *
+     * @param input the raw OCR text string, e.g. "1.2K", "500", "3.5M"
+     * @return parsed value as a non-negative long, or -1 if invalid/unparseable
+     */
+    public static long parseCompactNumber(String input) {
+        if (input == null || input.isBlank()) {
+            return -1L;
+        }
+
+        String trimmed = input.trim();
+        if (trimmed.contains(",") && !trimmed.matches("[0-9]{1,3}(?:,[0-9]{3})+(?:\\.[0-9]+)?\\s*[KMkm]?")) {
+            return -1L;
+        }
+        String cleaned = trimmed.replace(",", "").toUpperCase(Locale.ROOT);
+        Matcher matcher = COMPACT_NUMBER_PATTERN.matcher(cleaned);
+        if (!matcher.matches()) {
+            return -1L;
+        }
+
+        try {
+            BigDecimal baseValue = new BigDecimal(matcher.group(1));
+            if (baseValue.compareTo(BigDecimal.ZERO) < 0) {
+                return -1L;
+            }
+
+            String unit = matcher.group(2);
+            if (unit != null) {
+                switch (unit) {
+                    case "K":
+                        baseValue = baseValue.multiply(BigDecimal.valueOf(1_000));
+                        break;
+                    case "M":
+                        baseValue = baseValue.multiply(BigDecimal.valueOf(1_000_000));
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            long result = baseValue.longValueExact();
+            return result >= 0 ? result : -1L;
+        } catch (Exception ex) {
+            return -1L;
+        }
+    }
+}

--- a/modules/vision/src/main/java/dev/frostguard/vision/convert/GameTimeUtils.java
+++ b/modules/vision/src/main/java/dev/frostguard/vision/convert/GameTimeUtils.java
@@ -477,4 +477,17 @@ private static final DateTimeFormatter STRICT_HMS =
         int sec = Integer.parseInt(segment);
         return sec >= 0 && sec <= 59;
     }
+
+    /**
+     * Parses an explicit {@code "mm:ss"} value without treating it as {@code "HH:mm"}.
+     *
+     * @param input raw OCR text, for example {@code "04:59"}
+     * @return a non-negative duration, or {@code null} when the value is invalid
+     */
+    public static Duration parseMinutesSeconds(String input) {
+        if (input == null || input.isBlank()) {
+            return null;
+        }
+        return attemptColonMinutesSeconds(input.replaceAll("\\s+", "").trim());
+    }
 }

--- a/modules/vision/src/test/java/dev/frostguard/vision/convert/CompactGameNumberParserTest.java
+++ b/modules/vision/src/test/java/dev/frostguard/vision/convert/CompactGameNumberParserTest.java
@@ -1,0 +1,37 @@
+package dev.frostguard.vision.convert;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CompactGameNumberParserTest {
+
+    @Test
+    public void testStandardIntegerNumbers() {
+        assertEquals(0L, CompactGameNumberParser.parseCompactNumber("0"));
+        assertEquals(500L, CompactGameNumberParser.parseCompactNumber("500"));
+        assertEquals(1200L, CompactGameNumberParser.parseCompactNumber("1200"));
+        assertEquals(1200L, CompactGameNumberParser.parseCompactNumber("1,200"));
+    }
+
+    @Test
+    public void testCompactKAndMUnits() {
+        assertEquals(1200L, CompactGameNumberParser.parseCompactNumber("1.2K"));
+        assertEquals(1200L, CompactGameNumberParser.parseCompactNumber("1.2k"));
+        assertEquals(1500000L, CompactGameNumberParser.parseCompactNumber("1.5M"));
+        assertEquals(1500000L, CompactGameNumberParser.parseCompactNumber("1.5m"));
+        assertEquals(10000L, CompactGameNumberParser.parseCompactNumber("10k"));
+    }
+
+    @Test
+    public void testInvalidAndNegativeInputs() {
+        assertEquals(-1L, CompactGameNumberParser.parseCompactNumber(""));
+        assertEquals(-1L, CompactGameNumberParser.parseCompactNumber(null));
+        assertEquals(-1L, CompactGameNumberParser.parseCompactNumber("-500"));
+        assertEquals(-1L, CompactGameNumberParser.parseCompactNumber("abc"));
+        assertEquals(-1L, CompactGameNumberParser.parseCompactNumber("1.2.3K"));
+        assertEquals(-1L, CompactGameNumberParser.parseCompactNumber("1,2,3"));
+        assertEquals(-1L, CompactGameNumberParser.parseCompactNumber("12,34"));
+        assertEquals(-1L, CompactGameNumberParser.parseCompactNumber("9223372036854775808"));
+        assertEquals(-1L, CompactGameNumberParser.parseCompactNumber("9223372036854.776M"));
+    }
+}


### PR DESCRIPTION
> [!WARNING]
> This advanced feature is still a work in progress. Formation selection currently follows the configured fixed order, does not account for different formation return times, and does not verify live hero/troop availability. The rotation cursor may also advance before deployment is confirmed. These limitations are planned for a later follow-up; this contribution should be reviewed as an opt-in initial foundation.
## Summary

- add opt-in same-frame scanning and filtering for visible Bear Trap rally cards
- add member/capacity thresholds, late-event Frenzy mode, six saved formation selectors, and scoped deduplication
- retain the existing upstream join flow when advanced mode is disabled

## Why

The existing flow joins the first detected rally without inspecting card capacity or membership. This contribution adds a conservative advanced mode for selecting suitable rallies while preventing stale-coordinate clicks and false successful joins.

Closes #305

## Validation

- mvn -pl modules/desktop -am compile -DskipTests: passed across 8 reactor modules
- targeted desktop reactor tests: 31 passed (configuration, compact-number parsing, Bear candidate/policy/dedup/scanner, and FXML controller bindings)
- full tasks reactor test attempt: blocked by the local missing 	ools/tesseract/eng.traineddata; unrelated saved-frame OCR tests reported 7 environment errors
- saved real-frame verification: not performed (no redacted 720x1280 Bear rally frame available)
- live account-log confirmation: not performed

## Contributor certification

- [x] Every commit includes a valid DCO Signed-off-by trailer.

## Risks

OCR regions and end-to-end deployment are covered by pure-logic tests but remain unverified against saved real frames and a live account. Advanced mode is disabled by default.