### PR TITLE
feat(arena): make target filters reachable, and say what they do and cost

### DIFF
--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsExtraLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsExtraLayoutController.java
@@ -1,9 +1,12 @@
 package dev.frostguard.app.panel.city;
 
 import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.domain.ConfigData;
 import dev.frostguard.app.panel.profile.ProfileAux;
 import dev.frostguard.app.shared.AbstractProfileController;
 import dev.frostguard.app.shared.SettingValidators;
+import dev.frostguard.engine.service.ProfileService;
 import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -11,10 +14,12 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
 import javafx.scene.control.Tooltip;
 
 import java.time.LocalTime;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 public class CityEventsExtraLayoutController extends AbstractProfileController {
 
@@ -30,7 +35,12 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
         "Avoid profile alliance",
         "Never attack profile alliance"
     );
-    private static final String PROFILE_VALUE_NOT_SET = "Not set";
+    // The same input rules the profile editor enforces, so a value typed here
+    // cannot differ in shape from one typed there.
+    private static final UnaryOperator<TextFormatter.Change> DIGITS_ONLY = change ->
+        change.getControlNewText().matches("\\d*") ? change : null;
+    private static final UnaryOperator<TextFormatter.Change> ALLIANCE_CODE = change ->
+        change.getControlNewText().length() <= 3 && change.getControlNewText().matches("[A-Za-z0-9]*") ? change : null;
 
     @FXML
     private CheckBox checkBoxDailyVipRewards;
@@ -55,9 +65,9 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
     @FXML
     private TextField textFieldArenaActivationHour;
     @FXML
-    private Label labelArenaProfileAlliance;
+    private TextField textFieldArenaProfileAlliance;
     @FXML
-    private Label labelArenaProfileServer;
+    private TextField textFieldArenaProfileServer;
     @FXML
     private Label labelArenaTargetingHint;
     @FXML
@@ -68,6 +78,8 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
     private ComboBox<String> comboBoxArenaServerPolicy;
     @FXML
     private Label labelDateTimeError;
+
+    private ProfileAux currentProfile;
 
     @FXML
     private void initialize() {
@@ -108,37 +120,113 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
         super.onProfileLoad(profile);
         isLoadingProfile = true;
         try {
-            String alliance = normalizeProfileValue(profile.getCharacterAllianceCode());
-            String server = normalizeProfileValue(profile.getCharacterServer());
-            labelArenaProfileAlliance.setText(alliance);
-            labelArenaProfileServer.setText(server);
-            if (PROFILE_VALUE_NOT_SET.equals(alliance)) {
+            this.currentProfile = profile;
+            String alliance = orBlank(profile.getCharacterAllianceCode());
+            String server = orBlank(profile.getCharacterServer());
+            textFieldArenaProfileAlliance.setText(alliance);
+            textFieldArenaProfileServer.setText(server);
+            if (alliance.isBlank()) {
                 comboBoxArenaAlliancePolicy.setValue("Any alliance");
             }
-            if (PROFILE_VALUE_NOT_SET.equals(server)) {
+            if (server.isBlank()) {
                 comboBoxArenaServerPolicy.setValue("Any server");
             }
-            labelArenaTargetingHint.setText(buildArenaTargetingHint(alliance, server));
+            refreshArenaTargetingHint();
         } finally {
             isLoadingProfile = false;
         }
     }
 
-    private String normalizeProfileValue(String value) {
-        return value == null || value.isBlank() ? PROFILE_VALUE_NOT_SET : value.trim();
+    private static String orBlank(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private void refreshArenaTargetingHint() {
+        labelArenaTargetingHint.setText(buildArenaTargetingHint(
+            orBlank(textFieldArenaProfileAlliance.getText()),
+            orBlank(textFieldArenaProfileServer.getText())));
     }
 
     private String buildArenaTargetingHint(String alliance, String server) {
-        if (!PROFILE_VALUE_NOT_SET.equals(alliance) && !PROFILE_VALUE_NOT_SET.equals(server)) {
-            return "Target filters use the selected profile's Character Information: Alliance and Server.";
+        if (!alliance.isBlank() && !server.isBlank()) {
+            return "Target filters use this profile's Alliance and Server, saved to the profile as you type them here.";
         }
-        if (PROFILE_VALUE_NOT_SET.equals(alliance) && PROFILE_VALUE_NOT_SET.equals(server)) {
-            return "Set Alliance and Server in Profile > Character Information to enable target filters.";
+        if (alliance.isBlank() && server.isBlank()) {
+            return "Enter this profile's Alliance and Server below to enable the target filters.";
         }
-        if (PROFILE_VALUE_NOT_SET.equals(alliance)) {
-            return "Set Alliance in Profile > Character Information to protect alliance members.";
+        if (alliance.isBlank()) {
+            return "Enter this profile's Alliance below to protect alliance members.";
         }
-        return "Set Server in Profile > Character Information to enable server preferences.";
+        return "Enter this profile's Server below to enable server preferences.";
+    }
+
+    /**
+     * Writes Alliance and Server straight back to the profile from this tab.
+     *
+     * <p>Both live on the profile rather than in task config, so they were
+     * reachable only through Profile &gt; Character Information -- while the two
+     * dropdowns they gate sit here, greyed out, telling you to go there. Editing
+     * them in place removes that round trip. Committed on Enter or focus loss,
+     * the same points every other field on this tab commits at.</p>
+     */
+    private void commitProfileCharacterInfo() {
+        if (currentProfile == null || isLoadingProfile) {
+            return;
+        }
+        String storedAlliance = orBlank(currentProfile.getCharacterAllianceCode());
+        String storedServer = orBlank(currentProfile.getCharacterServer());
+        // Uppercased to match the profile editor, which stores tags in caps.
+        String alliance = orBlank(textFieldArenaProfileAlliance.getText()).toUpperCase();
+        String server = orBlank(textFieldArenaProfileServer.getText());
+
+        if (alliance.equals(storedAlliance) && server.equals(storedServer)) {
+            return;
+        }
+
+        currentProfile.setCharacterAllianceCode(alliance.isBlank() ? null : alliance);
+        currentProfile.setCharacterServer(server.isBlank() ? null : server);
+
+        isLoadingProfile = true;
+        try {
+            if (persistCurrentProfile()) {
+                textFieldArenaProfileAlliance.setText(alliance);
+                textFieldArenaProfileServer.setText(server);
+            } else {
+                // Put the stored values back rather than leave the fields showing
+                // something the next arena run would not actually use.
+                currentProfile.setCharacterAllianceCode(storedAlliance.isBlank() ? null : storedAlliance);
+                currentProfile.setCharacterServer(storedServer.isBlank() ? null : storedServer);
+                textFieldArenaProfileAlliance.setText(storedAlliance);
+                textFieldArenaProfileServer.setText(storedServer);
+            }
+        } finally {
+            isLoadingProfile = false;
+        }
+        refreshArenaTargetingHint();
+    }
+
+    private boolean persistCurrentProfile() {
+        if (currentProfile.getId() == null) {
+            return false;
+        }
+        AccountDescriptor descriptor = new AccountDescriptor(
+            currentProfile.getId(),
+            currentProfile.getName(),
+            currentProfile.getEmulatorNumber(),
+            currentProfile.isEnabled(),
+            currentProfile.getPriority(),
+            currentProfile.getReconnectionTime(),
+            currentProfile.getCharacterId(),
+            currentProfile.getCharacterName(),
+            currentProfile.getCharacterAllianceCode(),
+            currentProfile.getCharacterServer()
+        );
+        currentProfile.getConfigs().forEach(config ->
+            descriptor.getConfigs().add(new ConfigData(currentProfile.getId(), config.getName(), config.getValue())));
+        descriptor.setTags(currentProfile.getTags());
+        // persistAccount broadcasts the change itself, so the profile editor and
+        // any other open panel pick the new values up without a reload.
+        return ProfileService.obtain().persistAccount(descriptor);
     }
 
     private record ToggleBinding(CheckBox control, ConfigurationKeyEnum configKey) {
@@ -147,20 +235,41 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
     private final class ArenaSection {
         private void install() {
             List.of(checkBoxArenaAttackQuickDeploy, checkBoxArenaRefreshWithGems,
-                    textFieldArenaActivationHour, comboBoxArenaExtraAttempts)
+                    textFieldArenaActivationHour, comboBoxArenaExtraAttempts,
+                    textFieldArenaProfileAlliance, textFieldArenaProfileServer)
                 .forEach(CityEventsExtraLayoutController.this::disableWhenArenaOff);
+
+            textFieldArenaProfileAlliance.setTextFormatter(new TextFormatter<>(ALLIANCE_CODE));
+            textFieldArenaProfileServer.setTextFormatter(new TextFormatter<>(DIGITS_ONLY));
+            installProfileFieldCommit(textFieldArenaProfileAlliance);
+            installProfileFieldCommit(textFieldArenaProfileServer);
+
+            // The dropdowns follow what is typed above, so they ungrey the moment
+            // a value is entered rather than waiting for the profile to reload.
             comboBoxArenaAlliancePolicy.disableProperty().bind(
                 checkBoxArena.selectedProperty().not()
                     .or(Bindings.createBooleanBinding(
-                        () -> PROFILE_VALUE_NOT_SET.equals(labelArenaProfileAlliance.getText()),
-                        labelArenaProfileAlliance.textProperty())));
+                        () -> orBlank(textFieldArenaProfileAlliance.getText()).isBlank(),
+                        textFieldArenaProfileAlliance.textProperty())));
             comboBoxArenaServerPolicy.disableProperty().bind(
                 checkBoxArena.selectedProperty().not()
                     .or(Bindings.createBooleanBinding(
-                        () -> PROFILE_VALUE_NOT_SET.equals(labelArenaProfileServer.getText()),
-                        labelArenaProfileServer.textProperty())));
-            comboBoxArenaAlliancePolicy.setTooltip(new Tooltip("Set Alliance in Profile > Character Information to enable alliance preferences."));
-            comboBoxArenaServerPolicy.setTooltip(new Tooltip("Set Server in Profile > Character Information to enable server preferences."));
+                        () -> orBlank(textFieldArenaProfileServer.getText()).isBlank(),
+                        textFieldArenaProfileServer.textProperty())));
+
+            textFieldArenaProfileAlliance.setTooltip(new Tooltip("This profile's alliance tag, saved to the profile. Enables the alliance filter."));
+            textFieldArenaProfileServer.setTooltip(new Tooltip("This profile's server (state) number, saved to the profile. Enables the server policy."));
+            comboBoxArenaAlliancePolicy.setTooltip(new Tooltip("Enter this profile's Alliance above to enable alliance preferences."));
+            comboBoxArenaServerPolicy.setTooltip(new Tooltip("Enter this profile's Server above to enable server preferences."));
+        }
+
+        private void installProfileFieldCommit(TextField field) {
+            field.setOnAction(event -> commitProfileCharacterInfo());
+            field.focusedProperty().addListener((observable, hadFocus, hasFocus) -> {
+                if (hadFocus && !hasFocus) {
+                    commitProfileCharacterInfo();
+                }
+            });
         }
     }
 

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsExtraLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsExtraLayoutController.java
@@ -7,6 +7,7 @@ import dev.frostguard.app.panel.profile.ProfileAux;
 import dev.frostguard.app.shared.AbstractProfileController;
 import dev.frostguard.app.shared.SettingValidators;
 import dev.frostguard.engine.service.ProfileService;
+import dev.frostguard.tasks.combat.ArenaRoutine;
 import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -70,6 +71,10 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
     private TextField textFieldArenaProfileServer;
     @FXML
     private Label labelArenaTargetingHint;
+    @FXML
+    private Label labelArenaExtraAttemptsHelp;
+    @FXML
+    private Label labelArenaListRefreshHelp;
     @FXML
     private Label labelArenaAlliancePolicyHelp;
     @FXML
@@ -180,6 +185,47 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
         return "No state check. Opponents in " + state + " are attacked like anyone else.";
     }
 
+    /**
+     * What the attempt and refresh settings cost, in the units the game charges.
+     *
+     * <p>Both are budgets rather than switches, and neither stated its size
+     * anywhere: extra attempts are bought with gems on a rising scale, and a run
+     * gets a fixed number of free list refreshes before any gem is spent. Read
+     * from the routine that spends them rather than restated here, so the screen
+     * cannot quote a price the run does not charge.</p>
+     */
+    private String describeExtraAttempts(Integer attempts) {
+        int[] prices = ArenaRoutine.extraAttemptGemPrices();
+        int wanted = attempts == null ? 0 : Math.min(attempts, prices.length);
+        if (wanted <= 0) {
+            return "Off. Only the free daily attempts are used and no gems are spent on attempts.";
+        }
+        StringBuilder breakdown = new StringBuilder();
+        int total = 0;
+        for (int i = 0; i < wanted; i++) {
+            total += prices[i];
+            breakdown.append(i == 0 ? "" : " + ").append(prices[i]);
+        }
+        String sum = wanted == 1
+            ? total + " gems"
+            : breakdown + " = " + total + " gems";
+        return "Buys " + wanted + (wanted == 1 ? " attempt" : " attempts")
+            + " once the free ones are gone, at a rising price: " + sum
+            + ". Bought only when an eligible opponent is actually on the list.";
+    }
+
+    private String describeListRefresh(boolean paidAllowed) {
+        String free = "Every run gets " + ArenaRoutine.maxFreeListRefreshes()
+            + " free list refreshes, used first, whenever no opponent on the list is eligible.";
+        if (paidAllowed) {
+            return free + " After those, up to " + ArenaRoutine.maxPaidListRefreshes()
+                + " more are bought with gems at the game's price.";
+        }
+        return free + " After those the run stops with its remaining attempts unused."
+            + " Tick to allow up to " + ArenaRoutine.maxPaidListRefreshes()
+            + " more, paid for in gems.";
+    }
+
     private void refreshPolicyHelp() {
         labelArenaAlliancePolicyHelp.setText(describeAlliancePolicy(
             comboBoxArenaAlliancePolicy.getValue(),
@@ -187,6 +233,8 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
         labelArenaServerPolicyHelp.setText(describeServerPolicy(
             comboBoxArenaServerPolicy.getValue(),
             orBlank(textFieldArenaProfileServer.getText())));
+        labelArenaExtraAttemptsHelp.setText(describeExtraAttempts(comboBoxArenaExtraAttempts.getValue()));
+        labelArenaListRefreshHelp.setText(describeListRefresh(checkBoxArenaRefreshWithGems.isSelected()));
     }
 
     private static String orBlank(String value) {
@@ -206,6 +254,8 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
         comboBoxArenaServerPolicy.valueProperty().addListener((o, before, after) -> refreshPolicyHelp());
         textFieldArenaProfileAlliance.textProperty().addListener((o, before, after) -> refreshPolicyHelp());
         textFieldArenaProfileServer.textProperty().addListener((o, before, after) -> refreshPolicyHelp());
+        comboBoxArenaExtraAttempts.valueProperty().addListener((o, before, after) -> refreshPolicyHelp());
+        checkBoxArenaRefreshWithGems.selectedProperty().addListener((o, before, after) -> refreshPolicyHelp());
         refreshPolicyHelp();
     }
 

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsExtraLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/city/CityEventsExtraLayoutController.java
@@ -71,6 +71,10 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
     @FXML
     private Label labelArenaTargetingHint;
     @FXML
+    private Label labelArenaAlliancePolicyHelp;
+    @FXML
+    private Label labelArenaServerPolicyHelp;
+    @FXML
     private ComboBox<Integer> comboBoxArenaExtraAttempts;
     @FXML
     private ComboBox<String> comboBoxArenaAlliancePolicy;
@@ -132,9 +136,57 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
                 comboBoxArenaServerPolicy.setValue("Any server");
             }
             refreshArenaTargetingHint();
+            refreshPolicyHelp();
         } finally {
             isLoadingProfile = false;
         }
+    }
+
+    /**
+     * What the selected filter actually does to a scanned opponent.
+     *
+     * <p>Every option here reads as a preference, but two of them are hard
+     * skips and the rest only reorder a list the routine still attacks all of.
+     * "Avoid" in particular still attacks your own alliance when nothing else
+     * is eligible, which is the opposite of what the word suggests to someone
+     * turning it on to protect teammates. The wording below says which opponents
+     * are removed outright, and names the unreadable case, because a strict
+     * filter drops rows the OCR could not resolve and that is what empties a
+     * list and leaves attempts unused.</p>
+     */
+    private String describeAlliancePolicy(String policy, String alliance) {
+        String tag = alliance.isBlank() ? "your alliance" : alliance;
+        if ("Never attack profile alliance".equals(policy)) {
+            return "Skips every " + tag + " member outright, and any opponent whose tag cannot be read.";
+        }
+        if ("Avoid profile alliance".equals(policy)) {
+            return "Ranks " + tag + " members last. Still attacks them when no one else is eligible.";
+        }
+        return "No alliance check. " + tag + " members are attacked like anyone else.";
+    }
+
+    private String describeServerPolicy(String policy, String server) {
+        String state = server.isBlank() ? "your state" : "state " + server;
+        if ("Never attack profile server".equals(policy)) {
+            return "Skips everyone in " + state + " outright, plus any row whose state cannot be read"
+                + " -- including the compact row layout, which shows no state at all.";
+        }
+        if ("Avoid profile server".equals(policy)) {
+            return "Ranks " + state + " last. Still attacks it when no one else is eligible.";
+        }
+        if ("Prefer profile server".equals(policy)) {
+            return "Ranks " + state + " first, so points stay inside your own state.";
+        }
+        return "No state check. Opponents in " + state + " are attacked like anyone else.";
+    }
+
+    private void refreshPolicyHelp() {
+        labelArenaAlliancePolicyHelp.setText(describeAlliancePolicy(
+            comboBoxArenaAlliancePolicy.getValue(),
+            orBlank(textFieldArenaProfileAlliance.getText())));
+        labelArenaServerPolicyHelp.setText(describeServerPolicy(
+            comboBoxArenaServerPolicy.getValue(),
+            orBlank(textFieldArenaProfileServer.getText())));
     }
 
     private static String orBlank(String value) {
@@ -145,6 +197,16 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
         labelArenaTargetingHint.setText(buildArenaTargetingHint(
             orBlank(textFieldArenaProfileAlliance.getText()),
             orBlank(textFieldArenaProfileServer.getText())));
+    }
+
+    private void installPolicyHelp() {
+        // Driven by both the dropdown and the field above it, so the description
+        // names the actual tag and state rather than a placeholder.
+        comboBoxArenaAlliancePolicy.valueProperty().addListener((o, before, after) -> refreshPolicyHelp());
+        comboBoxArenaServerPolicy.valueProperty().addListener((o, before, after) -> refreshPolicyHelp());
+        textFieldArenaProfileAlliance.textProperty().addListener((o, before, after) -> refreshPolicyHelp());
+        textFieldArenaProfileServer.textProperty().addListener((o, before, after) -> refreshPolicyHelp());
+        refreshPolicyHelp();
     }
 
     private String buildArenaTargetingHint(String alliance, String server) {
@@ -256,6 +318,8 @@ public class CityEventsExtraLayoutController extends AbstractProfileController {
                     .or(Bindings.createBooleanBinding(
                         () -> orBlank(textFieldArenaProfileServer.getText()).isBlank(),
                         textFieldArenaProfileServer.textProperty())));
+
+            installPolicyHelp();
 
             textFieldArenaProfileAlliance.setTooltip(new Tooltip("This profile's alliance tag, saved to the profile. Enables the alliance filter."));
             textFieldArenaProfileServer.setTooltip(new Tooltip("This profile's server (state) number, saved to the profile. Enables the server policy."));

--- a/modules/desktop/src/main/resources/layout/CityEventsExtraLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/CityEventsExtraLayout.fxml
@@ -73,16 +73,16 @@
                                     </columnConstraints>
 
                                     <Label styleClass="task-field-label" text="Profile alliance" GridPane.columnIndex="0" GridPane.rowIndex="0" />
-                                    <Label fx:id="labelArenaProfileAlliance" maxWidth="Infinity" text="Not set" wrapText="true"
-                                           GridPane.columnIndex="1" GridPane.rowIndex="0" />
+                                    <TextField fx:id="textFieldArenaProfileAlliance" maxWidth="260.0" prefWidth="220.0"
+                                               promptText="ABC" GridPane.columnIndex="1" GridPane.rowIndex="0" />
 
                                     <Label styleClass="task-field-label" text="Alliance filter" GridPane.columnIndex="0" GridPane.rowIndex="1" />
                                     <ComboBox fx:id="comboBoxArenaAlliancePolicy" maxWidth="260.0" prefWidth="220.0"
                                               promptText="Any alliance" GridPane.columnIndex="1" GridPane.rowIndex="1" />
 
                                     <Label styleClass="task-field-label" text="Profile server" GridPane.columnIndex="0" GridPane.rowIndex="2" />
-                                    <Label fx:id="labelArenaProfileServer" maxWidth="Infinity" text="Not set" wrapText="true"
-                                           GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                                    <TextField fx:id="textFieldArenaProfileServer" maxWidth="260.0" prefWidth="220.0"
+                                               promptText="1234" GridPane.columnIndex="1" GridPane.rowIndex="2" />
 
                                     <Label styleClass="task-field-label" text="Server policy" GridPane.columnIndex="0" GridPane.rowIndex="3" />
                                     <ComboBox fx:id="comboBoxArenaServerPolicy" maxWidth="260.0" prefWidth="220.0"

--- a/modules/desktop/src/main/resources/layout/CityEventsExtraLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/CityEventsExtraLayout.fxml
@@ -77,16 +77,24 @@
                                                promptText="ABC" GridPane.columnIndex="1" GridPane.rowIndex="0" />
 
                                     <Label styleClass="task-field-label" text="Alliance filter" GridPane.columnIndex="0" GridPane.rowIndex="1" />
-                                    <ComboBox fx:id="comboBoxArenaAlliancePolicy" maxWidth="260.0" prefWidth="220.0"
-                                              promptText="Any alliance" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                                    <VBox maxWidth="Infinity" spacing="4" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                                        <ComboBox fx:id="comboBoxArenaAlliancePolicy" maxWidth="260.0" prefWidth="220.0"
+                                                  promptText="Any alliance" />
+                                        <Label fx:id="labelArenaAlliancePolicyHelp" maxWidth="Infinity"
+                                               styleClass="task-card-description" wrapText="true" />
+                                    </VBox>
 
                                     <Label styleClass="task-field-label" text="Profile server" GridPane.columnIndex="0" GridPane.rowIndex="2" />
                                     <TextField fx:id="textFieldArenaProfileServer" maxWidth="260.0" prefWidth="220.0"
                                                promptText="1234" GridPane.columnIndex="1" GridPane.rowIndex="2" />
 
                                     <Label styleClass="task-field-label" text="Server policy" GridPane.columnIndex="0" GridPane.rowIndex="3" />
-                                    <ComboBox fx:id="comboBoxArenaServerPolicy" maxWidth="260.0" prefWidth="220.0"
-                                              promptText="Any server" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                                    <VBox maxWidth="Infinity" spacing="4" GridPane.columnIndex="1" GridPane.rowIndex="3">
+                                        <ComboBox fx:id="comboBoxArenaServerPolicy" maxWidth="260.0" prefWidth="220.0"
+                                                  promptText="Any server" />
+                                        <Label fx:id="labelArenaServerPolicyHelp" maxWidth="Infinity"
+                                               styleClass="task-card-description" wrapText="true" />
+                                    </VBox>
                                 </GridPane>
                             </VBox>
 

--- a/modules/desktop/src/main/resources/layout/CityEventsExtraLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/CityEventsExtraLayout.fxml
@@ -22,9 +22,8 @@
                 <TabPane maxWidth="Infinity" styleClass="horizontal-tab-pane" tabClosingPolicy="UNAVAILABLE">
                     <Tab text="Arena">
                         <VBox maxWidth="Infinity" spacing="14" styleClass="task-section-inner">
-                            <Label styleClass="task-card-description"
-                                   text="Arena target filters use the selected profile's Character Information: Alliance and Server."
-                                   wrapText="true" />
+                            <Label styleClass="task-card-description" wrapText="true"
+                                   text="Once a day the arena is opened and every free challenge attempt is spent on the safest opponent showing. An opponent whose power is printed in green is weaker than you; red is stronger and is never attacked." />
 
                             <Separator style="-fx-opacity: 0.25;" />
 
@@ -35,28 +34,45 @@
                                 </columnConstraints>
 
                                 <Label styleClass="task-field-label" text="Status" GridPane.columnIndex="0" GridPane.rowIndex="0" />
-                                <CheckBox fx:id="checkBoxArena" mnemonicParsing="false" text="Enable arena"
-                                          GridPane.columnIndex="1" GridPane.rowIndex="0" />
+                                <VBox maxWidth="Infinity" spacing="4" GridPane.columnIndex="1" GridPane.rowIndex="0">
+                                    <CheckBox fx:id="checkBoxArena" mnemonicParsing="false" text="Enable arena" />
+                                    <Label maxWidth="Infinity" styleClass="task-card-description" wrapText="true"
+                                           text="Runs once a day, then reschedules itself for the next day." />
+                                </VBox>
 
                                 <Label styleClass="task-field-label" text="Activation time (UTC)" GridPane.columnIndex="0" GridPane.rowIndex="1" />
-                                <TextField fx:id="textFieldArenaActivationHour" maxWidth="100.0" prefWidth="90.0"
-                                           promptText="HH:mm" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                                <VBox maxWidth="Infinity" spacing="4" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                                    <TextField fx:id="textFieldArenaActivationHour" maxWidth="100.0" prefWidth="90.0"
+                                               promptText="HH:mm" />
+                                    <Label maxWidth="Infinity" styleClass="task-card-description" wrapText="true"
+                                           text="UTC, not your local time, and no later than 23:55 — attempts you have not spent are lost when the arena day rolls over." />
+                                </VBox>
                                 <Label fx:id="labelDateTimeError" maxWidth="Infinity" wrapText="true"
                                        GridPane.columnIndex="0" GridPane.columnSpan="2" GridPane.rowIndex="2" />
 
                                 <Label styleClass="task-field-label" text="Extra attempts" GridPane.columnIndex="0" GridPane.rowIndex="3" />
-                                <ComboBox fx:id="comboBoxArenaExtraAttempts" maxWidth="100.0" prefWidth="90.0"
-                                          promptText="0" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                                <VBox maxWidth="Infinity" spacing="4" GridPane.columnIndex="1" GridPane.rowIndex="3">
+                                    <ComboBox fx:id="comboBoxArenaExtraAttempts" maxWidth="100.0" prefWidth="90.0"
+                                              promptText="0" />
+                                    <Label fx:id="labelArenaExtraAttemptsHelp" maxWidth="Infinity"
+                                           styleClass="task-card-description" wrapText="true" />
+                                </VBox>
 
                                 <Label styleClass="task-field-label" text="List refresh" GridPane.columnIndex="0" GridPane.rowIndex="4" />
-                                <CheckBox fx:id="checkBoxArenaRefreshWithGems" mnemonicParsing="false"
-                                          text="Allow paid list refreshes"
-                                          GridPane.columnIndex="1" GridPane.rowIndex="4" />
+                                <VBox maxWidth="Infinity" spacing="4" GridPane.columnIndex="1" GridPane.rowIndex="4">
+                                    <CheckBox fx:id="checkBoxArenaRefreshWithGems" mnemonicParsing="false"
+                                              text="Allow paid list refreshes" />
+                                    <Label fx:id="labelArenaListRefreshHelp" maxWidth="Infinity"
+                                           styleClass="task-card-description" wrapText="true" />
+                                </VBox>
 
                                 <Label styleClass="task-field-label" text="Attack formation" GridPane.columnIndex="0" GridPane.rowIndex="5" />
-                                <CheckBox fx:id="checkBoxArenaAttackQuickDeploy" mnemonicParsing="false"
-                                          text="Use Quick Deploy for attacks"
-                                          GridPane.columnIndex="1" GridPane.rowIndex="5" />
+                                <VBox maxWidth="Infinity" spacing="4" GridPane.columnIndex="1" GridPane.rowIndex="5">
+                                    <CheckBox fx:id="checkBoxArenaAttackQuickDeploy" mnemonicParsing="false"
+                                              text="Use Quick Deploy for attacks" />
+                                    <Label maxWidth="Infinity" styleClass="task-card-description" wrapText="true"
+                                           text="Attacks with the lineup the game suggests. Untick to attack with the formation you saved instead. Your defence formation is never touched." />
+                                </VBox>
                             </GridPane>
 
                             <Separator style="-fx-opacity: 0.15;" />
@@ -66,6 +82,8 @@
                                        text="Target filters use the selected profile's Character Information: Alliance and Server."
                                        wrapText="true" />
 
+                                <Label styleClass="task-field-label" text="Target filters" />
+
                                 <GridPane hgap="14" maxWidth="Infinity" vgap="12">
                                     <columnConstraints>
                                         <ColumnConstraints halignment="LEFT" maxWidth="170.0" minWidth="140.0" prefWidth="155.0" />
@@ -73,8 +91,12 @@
                                     </columnConstraints>
 
                                     <Label styleClass="task-field-label" text="Profile alliance" GridPane.columnIndex="0" GridPane.rowIndex="0" />
-                                    <TextField fx:id="textFieldArenaProfileAlliance" maxWidth="260.0" prefWidth="220.0"
-                                               promptText="ABC" GridPane.columnIndex="1" GridPane.rowIndex="0" />
+                                    <VBox maxWidth="Infinity" spacing="4" GridPane.columnIndex="1" GridPane.rowIndex="0">
+                                        <TextField fx:id="textFieldArenaProfileAlliance" maxWidth="260.0" prefWidth="220.0"
+                                                   promptText="ABC" />
+                                        <Label maxWidth="Infinity" styleClass="task-card-description" wrapText="true"
+                                               text="Your own three-letter alliance tag, saved to this profile. The filter below has nothing to compare against until it is set." />
+                                    </VBox>
 
                                     <Label styleClass="task-field-label" text="Alliance filter" GridPane.columnIndex="0" GridPane.rowIndex="1" />
                                     <VBox maxWidth="Infinity" spacing="4" GridPane.columnIndex="1" GridPane.rowIndex="1">
@@ -85,8 +107,12 @@
                                     </VBox>
 
                                     <Label styleClass="task-field-label" text="Profile server" GridPane.columnIndex="0" GridPane.rowIndex="2" />
-                                    <TextField fx:id="textFieldArenaProfileServer" maxWidth="260.0" prefWidth="220.0"
-                                               promptText="1234" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                                    <VBox maxWidth="Infinity" spacing="4" GridPane.columnIndex="1" GridPane.rowIndex="2">
+                                        <TextField fx:id="textFieldArenaProfileServer" maxWidth="260.0" prefWidth="220.0"
+                                                   promptText="1234" />
+                                        <Label maxWidth="Infinity" styleClass="task-card-description" wrapText="true"
+                                               text="Your own state number, saved to this profile. The policy below has nothing to compare against until it is set." />
+                                    </VBox>
 
                                     <Label styleClass="task-field-label" text="Server policy" GridPane.columnIndex="0" GridPane.rowIndex="3" />
                                     <VBox maxWidth="Infinity" spacing="4" GridPane.columnIndex="1" GridPane.rowIndex="3">

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/city/ArenaTargetFilterUxTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/city/ArenaTargetFilterUxTest.java
@@ -1,0 +1,148 @@
+package dev.frostguard.app.panel.city;
+
+import dev.frostguard.api.configs.ConfigurationKeyEnum;
+import dev.frostguard.app.panel.profile.ConfigAux;
+import dev.frostguard.app.panel.profile.ProfileAux;
+import dev.frostguard.app.shared.JavaFxToolkit;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Arena target filters are gated on the profile's Alliance and Server, which are
+ * profile fields rather than task settings. They used to be rendered here as two
+ * read-only "Not set" labels beside two permanently greyed dropdowns, and the
+ * only way to act on them was to leave the screen for Profile &gt; Character
+ * Information — a round trip the hint text described but the tab could not
+ * perform.
+ *
+ * <p>These checks hold the fields editable in place and the dropdowns following
+ * what is typed, so a state number entered on this tab arms the server policy
+ * without a profile reload.</p>
+ */
+class ArenaTargetFilterUxTest {
+
+    @BeforeAll
+    static void startJavaFx() throws Exception {
+        JavaFxToolkit.start();
+    }
+
+    @Test
+    void profileAllianceAndServerAreEditableOnTheArenaTab() throws Exception {
+        LoadedArenaView view = loadArenaView();
+
+        view.controller.onProfileLoad(arenaProfile("ABC", "4527"));
+
+        assertEquals("ABC", view.alliance.getText());
+        assertEquals("4527", view.server.getText());
+        assertTrue(view.alliance.isEditable(), "alliance must be typable, not a read-only label");
+        assertTrue(view.server.isEditable(), "server must be typable, not a read-only label");
+    }
+
+    @Test
+    void blankProfileValuesLeaveTheMatchingPolicyDisabled() throws Exception {
+        LoadedArenaView view = loadArenaView();
+
+        view.controller.onProfileLoad(arenaProfile("", ""));
+
+        assertTrue(view.alliancePolicy.isDisabled(), "alliance filter must stay disabled without an alliance");
+        assertTrue(view.serverPolicy.isDisabled(), "server policy must stay disabled without a server");
+        assertEquals("Any alliance", view.alliancePolicy.getValue());
+        assertEquals("Any server", view.serverPolicy.getValue());
+    }
+
+    @Test
+    void typingAServerArmsTheServerPolicyWithoutReloadingTheProfile() throws Exception {
+        LoadedArenaView view = loadArenaView();
+        view.controller.onProfileLoad(arenaProfile("", ""));
+        assertTrue(view.serverPolicy.isDisabled());
+
+        view.server.setText("4527");
+
+        assertFalse(view.serverPolicy.isDisabled(), "server policy must arm as soon as a state number is typed");
+        assertTrue(view.alliancePolicy.isDisabled(), "the alliance filter is gated separately and stays disabled");
+    }
+
+    @Test
+    void clearingTheServerDisarmsTheServerPolicyAgain() throws Exception {
+        LoadedArenaView view = loadArenaView();
+        view.controller.onProfileLoad(arenaProfile("ABC", "4527"));
+        assertFalse(view.serverPolicy.isDisabled());
+
+        view.server.setText("");
+
+        assertTrue(view.serverPolicy.isDisabled());
+        assertFalse(view.alliancePolicy.isDisabled(), "clearing the server must not disturb the alliance filter");
+    }
+
+    @Test
+    void theHintStopsSendingUsersToTheProfileScreenOnceBothValuesAreSet() throws Exception {
+        LoadedArenaView view = loadArenaView();
+
+        view.controller.onProfileLoad(arenaProfile("", ""));
+        assertTrue(view.hint.getText().contains("below"), "an empty tab must point at the fields on it");
+
+        view.controller.onProfileLoad(arenaProfile("ABC", "4527"));
+        assertFalse(view.hint.getText().contains("below"),
+                "a configured tab must not keep asking for values that are already set");
+    }
+
+    @Test
+    void bothPoliciesStayDisabledWhileArenaIsOff() throws Exception {
+        LoadedArenaView view = loadArenaView();
+        view.controller.onProfileLoad(arenaProfile("ABC", "4527"));
+        assertFalse(view.serverPolicy.isDisabled());
+
+        view.arenaEnabled.setSelected(false);
+
+        assertTrue(view.alliancePolicy.isDisabled());
+        assertTrue(view.serverPolicy.isDisabled());
+        assertTrue(view.alliance.isDisabled(), "the profile fields follow the arena toggle too");
+        assertTrue(view.server.isDisabled());
+    }
+
+    private static ProfileAux arenaProfile(String alliance, String server) {
+        ProfileAux profile = new ProfileAux(1L, "Default", "0", true, 50L, "", 0L,
+                "", "", alliance, server);
+        profile.setConfigs(List.of(new ConfigAux(ConfigurationKeyEnum.ARENA_TASK_BOOL.name(), "true")));
+        return profile;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static LoadedArenaView loadArenaView() throws Exception {
+        FXMLLoader loader = new FXMLLoader(
+                CityEventsExtraLayoutController.class.getResource("/layout/CityEventsExtraLayout.fxml"));
+        CityEventsExtraLayoutController controller = new CityEventsExtraLayoutController();
+        loader.setController(controller);
+        loader.load();
+        Map<String, Object> namespace = loader.getNamespace();
+        return new LoadedArenaView(
+                controller,
+                (TextField) namespace.get("textFieldArenaProfileAlliance"),
+                (TextField) namespace.get("textFieldArenaProfileServer"),
+                (ComboBox<String>) namespace.get("comboBoxArenaAlliancePolicy"),
+                (ComboBox<String>) namespace.get("comboBoxArenaServerPolicy"),
+                (CheckBox) namespace.get("checkBoxArena"),
+                (Label) namespace.get("labelArenaTargetingHint"));
+    }
+
+    private record LoadedArenaView(CityEventsExtraLayoutController controller,
+                                   TextField alliance,
+                                   TextField server,
+                                   ComboBox<String> alliancePolicy,
+                                   ComboBox<String> serverPolicy,
+                                   CheckBox arenaEnabled,
+                                   Label hint) {
+    }
+}

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/city/ArenaTargetFilterUxTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/city/ArenaTargetFilterUxTest.java
@@ -4,6 +4,7 @@ import dev.frostguard.api.configs.ConfigurationKeyEnum;
 import dev.frostguard.app.panel.profile.ConfigAux;
 import dev.frostguard.app.panel.profile.ProfileAux;
 import dev.frostguard.app.shared.JavaFxToolkit;
+import dev.frostguard.tasks.combat.ArenaRoutine;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
@@ -157,6 +158,49 @@ class ArenaTargetFilterUxTest {
                 "typing a state must be reflected in the description straight away");
     }
 
+    @Test
+    void extraAttemptsQuoteTheRisingGemPriceTheRoutineActuallyCharges() throws Exception {
+        LoadedArenaView view = loadArenaView();
+        view.controller.onProfileLoad(arenaProfile("INF", "4527"));
+
+        view.extraAttempts.setValue(2);
+
+        int[] prices = ArenaRoutine.extraAttemptGemPrices();
+        String expectedSum = prices[0] + " + " + prices[1] + " = " + (prices[0] + prices[1]) + " gems";
+        assertTrue(view.extraAttemptsHelp.getText().contains(expectedSum),
+                "the cost must be broken down and totalled, was: " + view.extraAttemptsHelp.getText());
+    }
+
+    @Test
+    void zeroExtraAttemptsSaysPlainlyThatNoGemsAreSpent() throws Exception {
+        LoadedArenaView view = loadArenaView();
+        view.controller.onProfileLoad(arenaProfile("INF", "4527"));
+
+        view.extraAttempts.setValue(0);
+
+        assertTrue(view.extraAttemptsHelp.getText().contains("no gems are spent"),
+                "the off state must say what it costs, was: " + view.extraAttemptsHelp.getText());
+    }
+
+    @Test
+    void theRefreshBudgetIsStatedWhetherOrNotPaidRefreshesAreAllowed() throws Exception {
+        LoadedArenaView view = loadArenaView();
+        view.controller.onProfileLoad(arenaProfile("INF", "4527"));
+        String free = String.valueOf(ArenaRoutine.maxFreeListRefreshes());
+        String paid = String.valueOf(ArenaRoutine.maxPaidListRefreshes());
+
+        view.paidRefreshes.setSelected(false);
+        String off = view.listRefreshHelp.getText();
+        view.paidRefreshes.setSelected(true);
+        String on = view.listRefreshHelp.getText();
+
+        assertTrue(off.contains(free) && on.contains(free), "the free allowance is stated either way");
+        assertTrue(off.contains("attempts unused"),
+                "unticked must warn that the run can stop early, was: " + off);
+        assertTrue(on.contains(paid) && on.contains("gems"),
+                "ticked must state the paid ceiling and that it costs gems, was: " + on);
+    }
+
     private static ProfileAux arenaProfile(String alliance, String server) {
         ProfileAux profile = new ProfileAux(1L, "Default", "0", true, 50L, "", 0L,
                 "", "", alliance, server);
@@ -181,7 +225,11 @@ class ArenaTargetFilterUxTest {
                 (CheckBox) namespace.get("checkBoxArena"),
                 (Label) namespace.get("labelArenaTargetingHint"),
                 (Label) namespace.get("labelArenaAlliancePolicyHelp"),
-                (Label) namespace.get("labelArenaServerPolicyHelp"));
+                (Label) namespace.get("labelArenaServerPolicyHelp"),
+                (ComboBox<Integer>) namespace.get("comboBoxArenaExtraAttempts"),
+                (Label) namespace.get("labelArenaExtraAttemptsHelp"),
+                (CheckBox) namespace.get("checkBoxArenaRefreshWithGems"),
+                (Label) namespace.get("labelArenaListRefreshHelp"));
     }
 
     private record LoadedArenaView(CityEventsExtraLayoutController controller,
@@ -192,6 +240,10 @@ class ArenaTargetFilterUxTest {
                                    CheckBox arenaEnabled,
                                    Label hint,
                                    Label alliancePolicyHelp,
-                                   Label serverPolicyHelp) {
+                                   Label serverPolicyHelp,
+                                   ComboBox<Integer> extraAttempts,
+                                   Label extraAttemptsHelp,
+                                   CheckBox paidRefreshes,
+                                   Label listRefreshHelp) {
     }
 }

--- a/modules/desktop/src/test/java/dev/frostguard/app/panel/city/ArenaTargetFilterUxTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/panel/city/ArenaTargetFilterUxTest.java
@@ -112,6 +112,51 @@ class ArenaTargetFilterUxTest {
         assertTrue(view.server.isDisabled());
     }
 
+    @Test
+    void eachPolicyExplainsItselfUsingThisProfilesOwnTagAndState() throws Exception {
+        LoadedArenaView view = loadArenaView();
+        view.controller.onProfileLoad(arenaProfile("INF", "4527"));
+
+        view.alliancePolicy.setValue("Never attack profile alliance");
+        view.serverPolicy.setValue("Never attack profile server");
+
+        assertTrue(view.alliancePolicyHelp.getText().contains("INF"),
+                "the description must name the tag being protected, not a placeholder");
+        assertTrue(view.serverPolicyHelp.getText().contains("4527"),
+                "the description must name the state being protected, not a placeholder");
+    }
+
+    @Test
+    void hardSkipsAndSoftRankingsReadDifferently() throws Exception {
+        LoadedArenaView view = loadArenaView();
+        view.controller.onProfileLoad(arenaProfile("INF", "4527"));
+
+        view.serverPolicy.setValue("Never attack profile server");
+        String never = view.serverPolicyHelp.getText();
+        view.serverPolicy.setValue("Avoid profile server");
+        String avoid = view.serverPolicyHelp.getText();
+
+        assertTrue(never.startsWith("Skips"), "a hard skip must say it skips");
+        assertTrue(avoid.contains("Still attacks"),
+                "avoid must admit it still attacks your own state as a last resort");
+        assertTrue(never.contains("cannot be read"),
+                "a hard skip must warn that unreadable rows are dropped too");
+    }
+
+    @Test
+    void theDescriptionFollowsTheStateTypedAboveIt() throws Exception {
+        LoadedArenaView view = loadArenaView();
+        view.controller.onProfileLoad(arenaProfile("INF", ""));
+        view.serverPolicy.setValue("Never attack profile server");
+        assertTrue(view.serverPolicyHelp.getText().contains("your state"),
+                "with no state entered the description stays generic");
+
+        view.server.setText("4527");
+
+        assertTrue(view.serverPolicyHelp.getText().contains("state 4527"),
+                "typing a state must be reflected in the description straight away");
+    }
+
     private static ProfileAux arenaProfile(String alliance, String server) {
         ProfileAux profile = new ProfileAux(1L, "Default", "0", true, 50L, "", 0L,
                 "", "", alliance, server);
@@ -134,7 +179,9 @@ class ArenaTargetFilterUxTest {
                 (ComboBox<String>) namespace.get("comboBoxArenaAlliancePolicy"),
                 (ComboBox<String>) namespace.get("comboBoxArenaServerPolicy"),
                 (CheckBox) namespace.get("checkBoxArena"),
-                (Label) namespace.get("labelArenaTargetingHint"));
+                (Label) namespace.get("labelArenaTargetingHint"),
+                (Label) namespace.get("labelArenaAlliancePolicyHelp"),
+                (Label) namespace.get("labelArenaServerPolicyHelp"));
     }
 
     private record LoadedArenaView(CityEventsExtraLayoutController controller,
@@ -143,6 +190,8 @@ class ArenaTargetFilterUxTest {
                                    ComboBox<String> alliancePolicy,
                                    ComboBox<String> serverPolicy,
                                    CheckBox arenaEnabled,
-                                   Label hint) {
+                                   Label hint,
+                                   Label alliancePolicyHelp,
+                                   Label serverPolicyHelp) {
     }
 }

--- a/modules/desktop/src/test/java/dev/frostguard/app/shared/BearTrapTimerDateTimeUxTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/shared/BearTrapTimerDateTimeUxTest.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.controlsfx.control.CheckComboBox;
@@ -40,20 +39,9 @@ import javafx.scene.control.TextField;
 
 class BearTrapTimerDateTimeUxTest {
 
-    private static final AtomicBoolean TOOLKIT_STARTED = new AtomicBoolean();
-
     @BeforeAll
     static void startJavaFx() throws Exception {
-        if (TOOLKIT_STARTED.compareAndSet(false, true)) {
-            CountDownLatch started = new CountDownLatch(1);
-            Platform.startup(started::countDown);
-            assertTrue(started.await(10, TimeUnit.SECONDS), "JavaFX toolkit did not start");
-        }
-    }
-
-    @AfterAll
-    static void stopJavaFx() {
-        Platform.exit();
+        JavaFxToolkit.start();
     }
 
     @Test

--- a/modules/desktop/src/test/java/dev/frostguard/app/shared/JavaFxToolkit.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/shared/JavaFxToolkit.java
@@ -1,0 +1,40 @@
+package dev.frostguard.app.shared;
+
+import javafx.application.Platform;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * One JavaFX toolkit per surefire JVM, shared by every UX test.
+ *
+ * <p>The toolkit is process-wide and cannot be restarted: a second
+ * {@code Platform.startup} throws "Toolkit already initialized", and a
+ * {@code Platform.exit} in one test class leaves every class scheduled after it
+ * failing with "Platform.exit has been called". A per-class {@code @BeforeAll}
+ * latch is therefore only correct while exactly one class needs a toolkit, which
+ * stopped being true when the arena target filters grew a UX test of their
+ * own.</p>
+ *
+ * <p>Start through here and never exit — the forked JVM is torn down by surefire
+ * when the run finishes.</p>
+ */
+public final class JavaFxToolkit {
+
+    private static final AtomicBoolean STARTED = new AtomicBoolean();
+
+    private JavaFxToolkit() {
+    }
+
+    public static void start() throws InterruptedException {
+        if (!STARTED.compareAndSet(false, true)) {
+            return;
+        }
+        CountDownLatch started = new CountDownLatch(1);
+        Platform.startup(started::countDown);
+        assertTrue(started.await(10, TimeUnit.SECONDS), "JavaFX toolkit did not start");
+    }
+}

--- a/modules/tasks/src/main/java/dev/frostguard/tasks/combat/ArenaRoutine.java
+++ b/modules/tasks/src/main/java/dev/frostguard/tasks/combat/ArenaRoutine.java
@@ -497,6 +497,26 @@ public class ArenaRoutine extends DelayedTask {
         return remainingAttempts > 0;
     }
 
+    /**
+      * Gem price of each successive extra attempt, cheapest first.
+      *
+      * <p>Exposed so the settings screen can price the option it offers instead
+      * of restating the figures and drifting from them.</p>
+      */
+    public static int[] extraAttemptGemPrices() {
+        return ATTEMPT_PRICES.clone();
+    }
+
+    /** List refreshes granted per run at no cost, always spent before any paid one. */
+    public static int maxFreeListRefreshes() {
+        return MAX_FREE_REFRESHES;
+    }
+
+    /** Further list refreshes available per run once the free ones are gone, each paid for in gems. */
+    public static int maxPaidListRefreshes() {
+        return MAX_GEM_REFRESHES;
+    }
+
     private OpponentCandidate findEligibleOpponent() {
         List<OpponentCandidate> opponents = scanOpponents();
         List<OpponentCandidate> eligible = opponents.stream()


### PR DESCRIPTION
<!-- BEARGUARD-TRACKING-START -->

**Tracking:** Closes #314.

<!-- BEARGUARD-TRACKING-END -->

## Summary

- The Arena tab's **Profile alliance** and **Profile server** become editable fields that write back to the profile, instead of read-only `Not set` labels.
- The two policy dropdowns bind to what is typed above them, so they enable immediately rather than after a profile reload.
- Every control on the tab gains a description line, including the gem cost of **Extra attempts** and the free/paid split of **List refresh**.
- `ArenaRoutine` exposes `extraAttemptGemPrices()`, `maxFreeListRefreshes()` and `maxPaidListRefreshes()` so the screen reads those figures instead of restating them.

No change to opponent selection, scanning, purchasing or refreshing behavior. The routine's only diff is three static accessors over existing private constants.

## Why

`ARENA_TASK_ALLIANCE_POLICY_STRING` and `ARENA_TASK_SERVER_POLICY_STRING` are gated on `characterAllianceCode` and `characterServer`, which are profile fields rather than task settings. The tab therefore rendered them as two read-only labels beside two permanently disabled dropdowns and a hint pointing at Profile > Character Information. Every path to arming a target filter left the screen, and the tab could not act on its own instructions.

The failure mode is silent. With the fields blank, `ArenaRoutine` logs a warning and downgrades both policies to `ANY`, so the routine never OCRs an opponent's tag or server and attacks alliance members and same-state players while the UI still shows the policy the user selected. On the setup that prompted this, arena had been running that way since it was enabled.

Two further things were invisible in the UI:

- **Nothing said what the options do.** `Avoid profile alliance` ranks your own alliance last but still attacks it when nothing else is eligible — the opposite of what someone enabling it to protect teammates expects. `Never attack profile alliance` and `Never attack profile server` are hard skips that also drop rows whose tag or server could not be read, and the compact row layout renders no server number at all. That difference decides whether a run spends its attempts or stops early with attempts unused.
- **Nothing said what the budgets cost.** "Extra attempts: 2" reads like a switch; it is a 300-gem purchase, since `ATTEMPT_PRICES` charges 100/200/400/600/800 for the first through fifth. "Allow paid list refreshes" reads like the only refreshes available, when a run already gets `MAX_FREE_REFRESHES` free ones and the checkbox governs `MAX_GEM_REFRESHES` beyond them.

Descriptions name the profile's actual tag and state rather than a generic gloss ("Skips everyone in state 4527 outright"), and update as either the dropdown or the field above it changes.

## Validation

Run on the branch, JDK 21.0.12+8, Windows:

- `./mvnw -pl modules/desktop,modules/tasks -am -o test -Dtest='ArenaTargetFilterUxTest,ArenaRoutine*,FxmlControllerBindingTest'` — **16 tests, 0 failures**. Covers `ArenaTargetFilterUxTest` (12, new), `ArenaRoutineAttemptFlowTest` / `ArenaRoutinePowerFrameTest` / `ArenaRoutineQuickDeployTest` / `ArenaRoutineSearchConfigTest` (9), `FxmlControllerBindingTest` (4).
- `./mvnw -pl modules/desktop,modules/tasks -am -o test` — **153 tests, 1 failure**: `IntelCycleSchedulingOrchestrationTest.activeCycleFollowUpPersistsFutureScheduleAndDoesNotHotLoopOrReleaseResources`. That failure reproduces on pristine `upstream/main` with the same command and is unrelated to this change.

`ArenaTargetFilterUxTest` loads the real `CityEventsExtraLayout.fxml` through `FXMLLoader` and asserts the fields are editable, that each policy enables and disables as its field is filled and cleared, that both stay disabled while arena is off, that each description names the configured tag and state, that a hard skip reads differently from a soft ranking, and that the quoted attempt price matches `ArenaRoutine.extraAttemptGemPrices()`.

Not performed: no live emulator run of the arena routine on this branch, and no screenshot is attached. The change was exercised by hand on a packaged local build — typing a state number enabled the server policy, and both values persisted to the profile and survived a restart — but that was on a downstream build, so it is reported as manual observation rather than as a check on this branch.

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

- Profile persistence now happens from a task panel. `persistCurrentProfile()` builds an `AccountDescriptor` the same way `ProfileManagerActionController#toDescriptor` does and calls `ProfileService.persistAccount`, which broadcasts the change so an open profile editor stays in sync. A failed save restores the stored values into the fields rather than leaving a value the run would not use.
- The alliance and server text formatters duplicate the ones in `EditProfileController`; they are held equal by intent, not by a shared constant.
- `BearTrapTimerDateTimeUxTest` is touched: its per-class toolkit latch and `Platform.exit()` were only correct while exactly one test class needed JavaFX. A second class made whichever ran later fail with "Platform.exit has been called". Both now start through `JavaFxToolkit` and neither exits.
- The tab is taller than before. It sits in a `ScrollPane`, so the added descriptions scroll rather than clip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEARGUARD-CI-NOTE-START -->

## Why the checks show red

Both required workflows fail inside `Check out repository`, before anything is compiled:

```
failed to fetch some objects from 'https://github.com/Shederator/wosbot.git/info/lfs'
The process '/usr/bin/git' failed with exit code 2
```

Not specific to this branch — filed as #310. Maintainer branches fail identically, and the LFS pointers involved are the repository's own binaries. No branch can go green until that is fixed.

<!-- BEARGUARD-CI-NOTE-END -->

<!-- BEARGUARD-COMPARE-START -->

## Frostguard today vs. this PR

*Upstream behaviour below was checked against `upstream/main`, not recalled.*

### What Frostguard does today

The Arena tab shows **Profile alliance** and **Profile server** as read-only `Not set` labels,
so the two values the target-filter policies depend on cannot be entered from the screen that uses
them. The policy dropdowns stay disabled until a profile reload supplies those values from
elsewhere. Nothing on the tab states what a filter does, what **Extra attempts** costs in gems, or
how the free/paid split on **List refresh** works; `extraAttemptGemPrices()`,
`maxFreeListRefreshes()` and `maxPaidListRefreshes()` do not exist upstream, so those figures are
not available to the UI at all.

### What this PR does

Makes both fields editable and write back to the profile, binds the dropdowns to what is typed
so they enable immediately instead of after a reload, and gives every control a description line
including the gem cost of extra attempts and the free/paid refresh split. `ArenaRoutine` exposes the
three accessors so the screen reads the real figures instead of restating them in the layout.

### The difference

Upstream has the settings but no way to reach them from the tab they govern, and no statement
of what any of them costs.

### Why this is an improvement

A setting you cannot set from the screen that uses it is effectively not a setting — the
dropdowns being disabled until an unrelated reload is a dead end with no on-screen explanation. The
costs matter more: **Extra attempts spends gems**, and a control that spends a hard currency without
saying so is one an operator can trigger without understanding the price. Reading the figures from
`ArenaRoutine` rather than restating them in the FXML means the displayed price cannot drift away
from the price actually charged.

Opponent selection, scanning, purchasing and refreshing behaviour are unchanged; this is reachability
and disclosure, not a policy change.

### Verification status

3 commits / 6 files, including `ArenaTargetFilterUxTest` and a shared `JavaFxToolkit` test
helper. Java CI has never run — see below.

<!-- BEARGUARD-COMPARE-END -->