### PR TITLE
docs(autostart): align Task Scheduler with MSI and source runs

### DIFF
--- a/docs/schedule-autostart/Frostguard-Startup_bot.xml
+++ b/docs/schedule-autostart/Frostguard-Startup_bot.xml
@@ -41,8 +41,8 @@
   <Actions Context="Author">
     <Exec>
       <Command>powershell.exe</Command>
-      <Arguments>-NoProfile -ExecutionPolicy Bypass -File &quot;C:\Frostguard\launch.ps1&quot; -JarPattern &quot;frostguard-*.jar&quot; -VmProcessName &quot;MuMuNxMain&quot;</Arguments>
-      <WorkingDirectory>C:\Frostguard</WorkingDirectory>
+      <Arguments>-NoProfile -ExecutionPolicy Bypass -File &quot;C:\Frostguard-Autostart\launch.ps1&quot; -Mode Installed -VmProcessName &quot;MuMuNxMain&quot;</Arguments>
+      <WorkingDirectory>C:\Frostguard-Autostart</WorkingDirectory>
     </Exec>
   </Actions>
 </Task>

--- a/docs/schedule-autostart/active-bot.md
+++ b/docs/schedule-autostart/active-bot.md
@@ -1,16 +1,45 @@
 # Scheduled Autostart
 
-This guide describes how to run Frostguard from Windows Task Scheduler and return the machine to standby after the run window.
+This guide describes how to run Frostguard from Windows Task Scheduler and
+return the machine to standby after the run window. The imported startup example
+targets a Stable installation created by the MSI. A separate development mode
+runs a source checkout through the Maven Wrapper.
 
 ## Files
 
-- `Frostguard-Startup_bot.xml`: example task that wakes the machine and starts Frostguard.
-- `Frostguard-SystemStandby.xml`: example task that returns the machine to standby.
-- `launch.ps1`: resolves the latest Frostguard JAR, starts it with `--autostart`, enforces a timeout, and stops the emulator process.
+- `Frostguard-Startup_bot.xml`: production example that wakes the machine and
+  starts an installed Stable release.
+- `Frostguard-SystemStandby.xml`: example task that returns the machine to
+  standby.
+- `launch.ps1`: starts an installed release or a source checkout with
+  `--autostart`, enforces a timeout, and stops the emulator process.
 
 ## Prerequisites
 
-Place `launch.ps1` next to the built `frostguard-<version>.jar`, or update the task action paths to match your installation.
+Prepare the launch mode that you intend to schedule:
+
+- For an installed release, install Frostguard with the Stable or Nightly MSI
+  and start that installation manually at least once.
+- For a development checkout, complete the
+  [developer setup](../development.md) and start it manually once with
+  `.\mvnw.cmd javafx:run`.
+
+In that same runtime, configure the profiles, emulator, and schedules that
+`--autostart` should run, then close Frostguard.
+
+Copy `launch.ps1` to a stable location that is not replaced by application
+updates, for example:
+
+```text
+C:\Frostguard-Autostart\launch.ps1
+```
+
+The supplied startup XML uses that example path. The script defaults to the
+Stable MSI location:
+
+```text
+%LOCALAPPDATA%\Frostguard\Frostguard.exe
+```
 
 Enable wake timers from an elevated PowerShell session:
 
@@ -21,21 +50,81 @@ powercfg /setactive SCHEME_CURRENT
 powercfg /query SCHEME_CURRENT SUB_SLEEP RTCWAKE
 ```
 
-Configure Frostguard so `--autostart` can begin automation without manual setup.
+The scheduled task starts a desktop application, so configure it to run only
+when your Windows user is logged on. Review local Windows security policy before
+storing credentials in Task Scheduler.
 
-## Create Tasks
+## Choose the launch mode
+
+### Installed Stable release
+
+The imported `Frostguard-Startup_bot.xml` already uses this mode:
+
+```text
+Program/script: powershell.exe
+Arguments: -NoProfile -ExecutionPolicy Bypass -File "C:\Frostguard-Autostart\launch.ps1" -Mode Installed -VmProcessName "MuMuNxMain"
+Start in: C:\Frostguard-Autostart
+```
+
+With no `-LauncherPath`, `launch.ps1` resolves the default Stable MSI path from
+the scheduled user's local application-data directory. MSI updates may replace
+the application files, but the launcher path remains stable.
+
+### Installed Nightly or custom location
+
+Nightly and custom MSI destinations require the absolute executable path:
+
+```text
+Arguments: -NoProfile -ExecutionPolicy Bypass -File "C:\Frostguard-Autostart\launch.ps1" -Mode Installed -LauncherPath "C:\Users\YOUR_NAME\AppData\Local\Frostguard Nightly\Frostguard Nightly.exe" -VmProcessName "MuMuNxMain"
+```
+
+Replace the example with the actual launcher path. Do not use the Start-menu or
+desktop shortcut path.
+
+### Development checkout
+
+Development mode runs the equivalent of this command from the prepared
+repository or worktree root:
+
+```powershell
+.\mvnw.cmd "-Djavafx.args=--autostart" javafx:run
+```
+
+Configure the task action with an absolute repository path:
+
+```text
+Program/script: powershell.exe
+Arguments: -NoProfile -ExecutionPolicy Bypass -File "C:\Frostguard-Autostart\launch.ps1" -Mode Development -RepositoryPath "C:\src\wosbot" -VmProcessName "MuMuNxMain"
+Start in: C:\Frostguard-Autostart
+```
+
+Each worktree uses its own `.frostguard-dev` workspace. A development task does
+not read the profiles or schedules from an installed Stable or Nightly
+workspace.
+
+## Create the tasks
 
 1. Open Windows Task Scheduler.
 2. Create a folder such as `Frostguard`.
 3. Import `Frostguard-Startup_bot.xml`.
-4. Edit the action and set the correct `launch.ps1` path and working directory.
-5. Adjust trigger times to your schedule.
-6. Import `Frostguard-SystemStandby.xml`.
-7. Adjust its trigger times so standby happens after the Frostguard run window.
+4. Select **Run only when user is logged on** for the task.
+5. Edit its action for the chosen launch mode, including the script path,
+   working directory, emulator process name, and any required launcher or
+   repository path.
+6. Adjust the trigger time and append a `-TimeoutSec <seconds>` argument when
+   the default 2,700-second (45-minute) run window is not suitable.
+7. Import `Frostguard-SystemStandby.xml`.
+8. Adjust its trigger times so standby happens after the Frostguard run window.
+
+Run the startup task manually once while observing Frostguard and the emulator.
+Confirm the configured profiles start, the timeout closes Frostguard and the
+emulator, and `launch.log` contains no error before enabling unattended runs.
 
 ## Notes
 
 - Disable the tasks while actively using the machine.
 - `launch.ps1` writes `launch.log` next to the script.
+- The production XML is an example for an MSI installation; it does not launch
+  an extracted PR-test bundle.
 - Task Scheduler repeat settings do not always wake a sleeping machine; explicit calendar triggers are more reliable.
 - Hardware wake behavior depends on BIOS and Windows power settings.

--- a/docs/schedule-autostart/launch.ps1
+++ b/docs/schedule-autostart/launch.ps1
@@ -1,16 +1,20 @@
 <#
 .SYNOPSIS
-    Starts the Frostguard JAR, waits for completion or timeout, and performs process cleanup.
+    Starts Frostguard, waits for completion or timeout, and performs process cleanup.
 
 .DESCRIPTION
-    The script resolves the latest Frostguard JAR by wildcard pattern, stops leftover Java processes
-    launched with that same JAR, starts a fresh Frostguard instance with --autostart, waits for the
-    configured timeout, then stops Frostguard and the configured emulator process.
+    Installed mode starts the native executable created by the Frostguard MSI. Development mode
+    starts the repository through mvnw.cmd javafx:run. Both modes pass --autostart, enforce the
+    configured timeout, then stop Frostguard and the configured emulator process.
 #>
 
 param(
-    [string]$JarPattern = "frostguard-*.jar",
+    [ValidateSet("Installed", "Development")]
+    [string]$Mode = "Installed",
+    [string]$LauncherPath = "",
+    [string]$RepositoryPath = "",
     [string]$VmProcessName = "MuMuNxMain",
+    [ValidateRange(1, 604800)]
     [int]$TimeoutSec = 2700
 )
 
@@ -33,6 +37,9 @@ function Stop-ProcessTreeByPid {
     try {
         Write-Log "Stopping process tree for PID=$ProcessId"
         cmd.exe /c "taskkill /PID $ProcessId /T /F" | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "taskkill exited with code $LASTEXITCODE"
+        }
         Write-Log "Process tree stopped for PID=$ProcessId"
     }
     catch {
@@ -40,69 +47,86 @@ function Stop-ProcessTreeByPid {
     }
 }
 
-function Resolve-FrostguardJar {
-    param(
-        [string]$SearchRoot,
-        [string]$Pattern
-    )
+function Resolve-FrostguardLaunch {
+    if ($Mode -eq "Installed") {
+        $resolvedLauncherPath = $LauncherPath
+        if ([string]::IsNullOrWhiteSpace($resolvedLauncherPath)) {
+            $localAppData = [Environment]::GetFolderPath("LocalApplicationData")
+            if ([string]::IsNullOrWhiteSpace($localAppData)) {
+                throw "Windows did not provide a LocalApplicationData directory"
+            }
+            $resolvedLauncherPath = Join-Path $localAppData "Frostguard\Frostguard.exe"
+        }
 
-    $matches = @(Get-ChildItem -Path $SearchRoot -Filter $Pattern -File -Recurse |
-        Sort-Object LastWriteTime -Descending)
+        if (-not [IO.Path]::IsPathRooted($resolvedLauncherPath)) {
+            throw "LauncherPath must be an absolute path: '$resolvedLauncherPath'"
+        }
+        if (-not (Test-Path -LiteralPath $resolvedLauncherPath -PathType Leaf)) {
+            throw "Frostguard launcher not found: '$resolvedLauncherPath'"
+        }
 
-    if ($matches.Count -eq 0) {
-        throw "No jar found matching pattern '$Pattern' under '$SearchRoot'"
+        $resolvedLauncherPath = (Get-Item -LiteralPath $resolvedLauncherPath).FullName
+        return [PSCustomObject]@{
+            FilePath = $resolvedLauncherPath
+            Arguments = [string[]]@("--autostart")
+            WorkingDirectory = Split-Path -Parent $resolvedLauncherPath
+            Display = "`"$resolvedLauncherPath`" --autostart"
+        }
     }
 
-    if ($matches.Count -gt 1) {
-        Write-Log "Multiple jar files matched '$Pattern'. Selecting: $($matches[0].FullName)"
+    if ([string]::IsNullOrWhiteSpace($RepositoryPath)) {
+        throw "RepositoryPath is required in Development mode"
     }
-    else {
-        Write-Log "Single jar matched '$Pattern': $($matches[0].FullName)"
+    if (-not [IO.Path]::IsPathRooted($RepositoryPath)) {
+        throw "RepositoryPath must be an absolute path: '$RepositoryPath'"
+    }
+    if (-not (Test-Path -LiteralPath $RepositoryPath -PathType Container)) {
+        throw "Repository directory not found: '$RepositoryPath'"
     }
 
-    return $matches[0]
+    $resolvedRepositoryPath = (Get-Item -LiteralPath $RepositoryPath).FullName
+    $mavenWrapper = Join-Path $resolvedRepositoryPath "mvnw.cmd"
+    if (-not (Test-Path -LiteralPath $mavenWrapper -PathType Leaf)) {
+        throw "Maven Wrapper not found: '$mavenWrapper'"
+    }
+
+    return [PSCustomObject]@{
+        FilePath = $mavenWrapper
+        Arguments = [string[]]@("-Djavafx.args=--autostart", "javafx:run")
+        WorkingDirectory = $resolvedRepositoryPath
+        Display = "`"$mavenWrapper`" `"-Djavafx.args=--autostart`" javafx:run"
+    }
 }
 
 Write-Log "============================================================"
 Write-Log "Script started"
-Write-Log "Parameters: JarPattern='$JarPattern', VmProcessName='$VmProcessName', TimeoutSec=$TimeoutSec"
+Write-Log "Parameters: Mode='$Mode', VmProcessName='$VmProcessName', TimeoutSec=$TimeoutSec"
 
 $proc = $null
 
 try {
-    $jarFile = Resolve-FrostguardJar -SearchRoot $PSScriptRoot -Pattern $JarPattern
-    $jarPath = $jarFile.FullName
-    $jarName = $jarFile.Name
-
-    Write-Log "Resolved Frostguard jar: $jarPath"
-
-    $oldJavaProcesses = Get-CimInstance Win32_Process -Filter "Name='java.exe' OR Name='javaw.exe'" |
-        Where-Object { $_.CommandLine -like "*$jarName*" }
-
-    foreach ($oldProcess in $oldJavaProcesses) {
-        Write-Log "Found leftover Frostguard Java process PID=$($oldProcess.ProcessId)"
-        Stop-ProcessTreeByPid -ProcessId $oldProcess.ProcessId
-    }
-
-    Write-Log "Starting Frostguard: java -jar `"$jarPath`" --autostart"
-    $proc = Start-Process -FilePath "java.exe" `
-        -ArgumentList @("-jar", $jarPath, "--autostart") `
+    $launch = Resolve-FrostguardLaunch
+    Write-Log "Starting Frostguard: $($launch.Display)"
+    $proc = Start-Process -FilePath $launch.FilePath `
+        -ArgumentList $launch.Arguments `
+        -WorkingDirectory $launch.WorkingDirectory `
         -PassThru
 
     Write-Log "Frostguard started with PID=$($proc.Id)"
 
-    try {
-        Write-Log "Waiting up to $TimeoutSec seconds for PID=$($proc.Id)"
-        $null = Wait-Process -Id $proc.Id -Timeout $TimeoutSec
+    Write-Log "Waiting up to $TimeoutSec seconds for PID=$($proc.Id)"
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSec)
+    while (-not $proc.HasExited -and [DateTime]::UtcNow -lt $deadline) {
+        Start-Sleep -Seconds 1
+        $proc.Refresh()
+    }
+
+    if ($proc.HasExited) {
         Write-Log "Frostguard PID=$($proc.Id) exited before timeout"
     }
-    catch {
-        Write-Log "Timeout reached or wait interrupted for PID=$($proc.Id)"
-    }
-    finally {
-        if ($null -ne $proc) {
-            Stop-ProcessTreeByPid -ProcessId $proc.Id
-        }
+    else {
+        Write-Log "Timeout reached for PID=$($proc.Id)"
+        Stop-ProcessTreeByPid -ProcessId $proc.Id
     }
 
     $vmProcesses = Get-Process -Name $VmProcessName -ErrorAction SilentlyContinue
@@ -119,5 +143,16 @@ catch {
     throw
 }
 finally {
+    if ($null -ne $proc) {
+        try {
+            $proc.Refresh()
+            if (-not $proc.HasExited) {
+                Stop-ProcessTreeByPid -ProcessId $proc.Id
+            }
+        }
+        catch {
+            Write-Log "Failed to inspect Frostguard PID=$($proc.Id): $($_.Exception.Message)"
+        }
+    }
     Write-Log "Script ended"
 }

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -189,9 +189,15 @@ Optional Task Scheduler templates are in `docs/schedule-autostart/`.
 
 Use them when the machine should wake, run Frostguard for a fixed window, stop the emulator, and return to standby. Edit imported task actions before enabling them:
 
-- Update the path to `launch.ps1`.
-- Update the working directory to your Frostguard installation.
+- Copy `launch.ps1` to a stable location and update its path and working
+  directory in the task action.
+- Keep the production example in `Installed` mode for the Stable MSI, or set an
+  explicit executable path for Nightly or a custom MSI destination.
+- For a source checkout, select `Development` mode and provide its repository or
+  worktree root; the script then uses `mvnw.cmd javafx:run`.
 - Adjust the schedule times.
 - Confirm the emulator process name, for example `MuMuNxMain`.
 
-The templates are examples and should be reviewed on the target Windows machine before unattended use.
+See the [scheduled autostart guide](schedule-autostart/active-bot.md) for the
+exact actions. The templates are examples and should be reviewed and tested on
+the target Windows machine before unattended use.


### PR DESCRIPTION
## Summary

- make the imported scheduler example launch the Stable MSI installation
- support explicit Installed and Development modes in launch.ps1
- document Stable, Nightly/custom, and Maven Wrapper startup paths
- preserve timeout-based Frostguard and emulator cleanup guidance

## Why

The existing scheduler workflow searched recursively for a versioned application JAR, which no longer matches the normal Frostguard runtime contract. The production example should use the stable MSI launcher, while source development needs an explicit Maven Wrapper path and isolated development workspace.

Closes #315

## Validation

- Passed: git diff --check origin/main...HEAD
- Passed: parsed both Task Scheduler XML files with Java DocumentBuilderFactory
- Passed: searched docs/schedule-autostart and docs/windows.md for obsolete JAR-discovery guidance; no matches
- Not run: PowerShell syntax or Windows Task Scheduler execution because PowerShell and a Windows host are unavailable here
- Not run: Maven tests because this change is limited to documentation, scheduler XML, and a Windows helper script
- Evidence level: automated/static validation only; Windows live-machine behavior remains unverified

## Contributor certification

- [ ] Every commit includes a valid DCO Signed-off-by trailer.

The current branch commit does not contain a Signed-off-by trailer and will need correction before merge.

## Dependencies and review structure

- Shared issue: #315
- Stack: not stacked (position 1 of 1)
- Parent/child PRs: none
- Dependencies: none
- Merge order: this PR only

## Risks

Absolute task paths, schedule times, emulator process names, power settings, and interactive-session behavior remain machine-specific. End-to-end wake, launch, timeout cleanup, and standby behavior still require validation on Windows.