### PR TITLE
test(automation): initialize workspaces independently of test order

### DIFF
--- a/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueFailureIncidentTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueFailureIncidentTest.java
@@ -5,12 +5,15 @@ import dev.frostguard.api.domain.ActionRequiredIncidentData;
 import dev.frostguard.api.domain.ActionRequiredIncidentState;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.LogMessageData;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.api.runtime.WorkspaceSession;
 import dev.frostguard.data.repository.TaskFailureStreakRepository;
 import dev.frostguard.engine.error.StartupCaptureException;
 import dev.frostguard.engine.service.ActionRequiredIncidentService;
 import dev.frostguard.engine.service.LoggingService;
 import dev.frostguard.engine.service.ProfileService;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
@@ -23,6 +26,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TaskQueueFailureIncidentTest {
+
+    @BeforeAll
+    static void initializeTestWorkspace() {
+        WorkspaceSession.initializeLayout(WorkspacePaths.current());
+    }
 
     @AfterEach
     void detachLogObserver() {

--- a/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueInitializeRecoveryTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueInitializeRecoveryTest.java
@@ -2,11 +2,14 @@ package dev.frostguard.engine.schedule;
 
 import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.AccountDescriptor;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.api.runtime.WorkspaceSession;
 import dev.frostguard.data.entity.DailyTask;
 import dev.frostguard.data.repository.DailyTaskRepository;
 import dev.frostguard.engine.error.ActionRequiredContext;
 import dev.frostguard.engine.error.ProfileCooldownException;
 import dev.frostguard.engine.service.ProfileService;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -19,6 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TaskQueueInitializeRecoveryTest {
+
+    @BeforeAll
+    static void initializeTestWorkspace() {
+        WorkspaceSession.initializeLayout(WorkspacePaths.current());
+    }
 
     @Test
     void unknownOverlayCooldownStopsOnlyGameAndDoesNotImmediatelyRetryInitialize() {

--- a/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueProfileCooldownTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/schedule/TaskQueueProfileCooldownTest.java
@@ -4,6 +4,8 @@ import dev.frostguard.api.configs.TpDailyTaskEnum;
 import dev.frostguard.api.domain.ActionRequiredIncidentData;
 import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.LogMessageData;
+import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.api.runtime.WorkspaceSession;
 import dev.frostguard.data.entity.DailyTask;
 import dev.frostguard.data.repository.DailyTaskRepository;
 import dev.frostguard.engine.error.ProfileCooldownException;
@@ -12,6 +14,7 @@ import dev.frostguard.engine.service.LoggingService;
 import dev.frostguard.engine.service.ActionRequiredIncidentService;
 import dev.frostguard.engine.service.ProfileService;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -19,6 +22,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,6 +30,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TaskQueueProfileCooldownTest {
+
+    @BeforeAll
+    static void initializeTestWorkspace() {
+        WorkspaceSession.initializeLayout(WorkspacePaths.current());
+    }
 
     @AfterEach
     void detachLogObserver() {
@@ -113,7 +122,10 @@ class TaskQueueProfileCooldownTest {
     }
 
     private static AccountDescriptor persistedProfile() {
-        return ProfileService.obtain().fetchAllAccounts().stream().findFirst().orElseThrow();
+        AccountDescriptor profile = new AccountDescriptor(
+                null, "Profile cooldown " + UUID.randomUUID(), "0", false, 100L, 30L);
+        assertTrue(ProfileService.obtain().createAccount(profile));
+        return profile;
     }
 
     private static void assertCloseTo(LocalDateTime expected, LocalDateTime actual) {


### PR DESCRIPTION
## Summary

- initialize the test workspace explicitly in the three scheduler test classes that access persistence
- create a unique persisted profile inside `TaskQueueProfileCooldownTest` instead of depending on data left by another test class

## Why

The automation suite was order-dependent: these scheduler tests passed after service tests had created `modules/automation/target/test-workspace`, but failed when CI executed them first. Each test class now establishes the runtime workspace invariant it relies on and creates its own fixture data.

Closes #317.

## Review structure

- Stack: 1 of 1 (not stacked)
- Parent PR: none
- Child PR: none
- Shared issue: #317
- Dependencies: none
- Merge order: this PR is independent and may merge directly

## Validation

- `./mvnw -pl modules/automation -am clean test -Dtest=TaskQueueProfileCooldownTest -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw -pl modules/automation -am clean test -Dtest=TaskQueueInitializeRecoveryTest -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw -pl modules/automation -am clean test -Dtest=TaskQueueFailureIncidentTest -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw -pl modules/automation -am clean test` (237 automation tests passed)
- `./mvnw package` reached and passed the automation module, then failed in unrelated desktop tests because this environment cannot lock Java user preferences and has no JavaFX toolkit

Evidence level: automated tests. Saved-frame and live-log validation are not applicable to this test-only change.

## Contributor certification

- [x] Every commit includes a `Signed-off-by` trailer matching the commit author (DCO 1.1).

## Risks

Low. The change affects test setup only; production runtime behavior is unchanged.
