### PR TITLE
feat(task-builder): add shop navigation node

### DIFF
--- a/modules/api/src/main/java/dev/frostguard/api/configs/FlowStepKind.java
+++ b/modules/api/src/main/java/dev/frostguard/api/configs/FlowStepKind.java
@@ -12,6 +12,7 @@ public enum FlowStepKind {
     BACK_BUTTON("Back Button", "Press the Android back button"),
     OCR_READ("OCR Read", "Read text from a screen region"),
     TEMPLATE_SEARCH("Template Search", "Search for an image on screen"),
+    SHOP_NAVIGATION("Shop Navigation", "Open a selected Shop tab"),
     NAVIGATE("Navigate", "Ensure correct screen location (Home/World)");
 
     private final String label;

--- a/modules/api/src/main/java/dev/frostguard/api/domain/AutomationStep.java
+++ b/modules/api/src/main/java/dev/frostguard/api/domain/AutomationStep.java
@@ -22,6 +22,7 @@ import java.util.Map;
  *   <li><b>BACK_BUTTON</b> — (none)</li>
  *   <li><b>OCR_READ</b> — tlX, tlY, brX, brY, condition, expectedValue</li>
  *   <li><b>TEMPLATE_SEARCH</b> — templatePath, threshold, grayscale, tlX, brX</li>
+ *   <li><b>SHOP_NAVIGATION</b> — shopTab</li>
  *   <li><b>NAVIGATE</b> — location</li>
  * </ul>
  *
@@ -45,6 +46,7 @@ import java.util.Map;
         creatorVisibility = JsonAutoDetect.Visibility.NONE)
 public class AutomationStep {
     public static final String PARAM_NODE_NAME = "nodeName";
+    public static final String PARAM_SHOP_TAB = "shopTab";
     public static final int NODE_NAME_MAX_LENGTH = 30;
 
     @JsonAlias("id")
@@ -342,6 +344,9 @@ public class AutomationStep {
                         tplPath, threshold, suffix);
             }
 
+            case SHOP_NAVIGATION -> String.format("Shop: %s",
+                    humanizeEnumValue(resolveAttrOr(PARAM_SHOP_TAB, "MYSTERY_SHOP")));
+
             case NAVIGATE -> String.format("Navigate: %s",
                     resolveAttrOr("location", "HOME"));
         };
@@ -360,6 +365,18 @@ public class AutomationStep {
     private String resolveAttrOr(String key, String fallback) {
         String val = getAttribute(key);
         return val != null ? val : fallback;
+    }
+
+    private String humanizeEnumValue(String value) {
+        String normalized = value.replace('_', ' ').toLowerCase(java.util.Locale.ROOT);
+        StringBuilder display = new StringBuilder(normalized.length());
+        boolean capitalize = true;
+        for (int index = 0; index < normalized.length(); index++) {
+            char character = normalized.charAt(index);
+            display.append(capitalize ? Character.toUpperCase(character) : character);
+            capitalize = character == ' ';
+        }
+        return display.toString();
     }
 
     @Override

--- a/modules/api/src/test/java/dev/frostguard/api/domain/AutomationBlueprintSerializationTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/domain/AutomationBlueprintSerializationTest.java
@@ -124,6 +124,21 @@ class AutomationBlueprintSerializationTest {
         assertEquals("wait for panel", reloaded.getSteps().get(1).getNodeName());
     }
 
+    @Test
+    void preservesSelectedShopTabAcrossSaveAndReload() throws Exception {
+        AutomationBlueprint blueprint = new AutomationBlueprint("shop probe");
+        AutomationStep shop = new AutomationStep(3, FlowStepKind.SHOP_NAVIGATION);
+        shop.setParam(AutomationStep.PARAM_SHOP_TAB, "LABYRINTH_SHOP");
+        blueprint.addNode(shop);
+
+        AutomationBlueprint reloaded =
+                mapper.readValue(mapper.writeValueAsString(blueprint), AutomationBlueprint.class);
+
+        assertEquals(FlowStepKind.SHOP_NAVIGATION, reloaded.getSteps().get(0).getKind());
+        assertEquals("LABYRINTH_SHOP",
+                reloaded.getSteps().get(0).getParam(AutomationStep.PARAM_SHOP_TAB));
+    }
+
     /** Flows saved by earlier builds used the duplicated legacy key spellings. */
     @Test
     void loadsFlowsSavedWithLegacyKeyNames() throws Exception {

--- a/modules/api/src/test/java/dev/frostguard/api/domain/AutomationStepTest.java
+++ b/modules/api/src/test/java/dev/frostguard/api/domain/AutomationStepTest.java
@@ -34,6 +34,14 @@ class AutomationStepTest {
         assertEquals("Find: HOME_DEALS_BUTTON @85%  GS [area]", step.describeBriefly());
     }
 
+    @Test
+    void summarizesSelectedShopTabForTheEditor() {
+        AutomationStep step = new AutomationStep(1, FlowStepKind.SHOP_NAVIGATION);
+        step.setParam(AutomationStep.PARAM_SHOP_TAB, "ALLIANCE_CHAMPIONSHIP_SHOP");
+
+        assertEquals("Shop: Alliance Championship Shop", step.describeBriefly());
+    }
+
     /** Every kind must produce a summary; none may throw. */
     @Test
     void summarizesEveryStepKind() {

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TaskBuilderService.java
@@ -4,6 +4,9 @@ import dev.frostguard.vision.ocr.OcrEngine;
 import dev.frostguard.api.configs.FlowStepKind;
 import dev.frostguard.api.configs.TemplatesEnum;
 import dev.frostguard.engine.emulator.EmulatorController;
+import dev.frostguard.engine.helper.NavigationHelper;
+import dev.frostguard.engine.nav.ShopTab;
+import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.ImageSearchResultData;
 import dev.frostguard.api.domain.PointData;
 import dev.frostguard.api.domain.RawImageData;
@@ -26,6 +29,7 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Objects;
 
 /**
  * Service that manages a Task Builder recording session.
@@ -45,9 +49,11 @@ public class TaskBuilderService {
     private final EmulatorController emuManager;
     private final Path customTasksDir;
     private final ObjectMapper mapper;
+    private final ShopNavigationAction shopNavigationAction;
     private AutomationBlueprint currentDefinition;
     private Path currentDefinitionDirectory;
     private String activeEmulatorNumber;
+    private AccountDescriptor activeProfile;
     private TapInteractionService tapService;
 
     public TaskBuilderService() {
@@ -55,9 +61,16 @@ public class TaskBuilderService {
     }
 
     TaskBuilderService(ObjectMapper mapper) {
+        this(mapper, (emulatorNumber, profile, target) ->
+                new NavigationHelper(EmulatorController.getInstance(), emulatorNumber, profile)
+                        .navigateToShop(target));
+    }
+
+    TaskBuilderService(ObjectMapper mapper, ShopNavigationAction shopNavigationAction) {
         this.emuManager = EmulatorController.getInstance();
         this.customTasksDir = WorkspacePaths.current().customTasks();
         this.mapper = mapper;
+        this.shopNavigationAction = Objects.requireNonNull(shopNavigationAction);
         try {
             Files.createDirectories(customTasksDir);
         } catch (IOException e) {
@@ -66,6 +79,11 @@ public class TaskBuilderService {
     }
 
     public record CustomTaskSaveResult(Path javaFile, Path builderFile, String className) {}
+
+    @FunctionalInterface
+    interface ShopNavigationAction {
+        boolean navigate(String emulatorNumber, AccountDescriptor profile, ShopTab target);
+    }
 
     private static ObjectMapper defaultMapper() {
         return new ObjectMapper()
@@ -87,8 +105,16 @@ public class TaskBuilderService {
         this.currentDefinition = new AutomationBlueprint(taskName);
         this.currentDefinitionDirectory = customTasksDir;
         this.activeEmulatorNumber = emulatorNumber;
+        this.activeProfile = null;
         this.tapService = TapInteractionService.forController(emuManager, emulatorNumber);
         logger.info("Task Builder session started: '{}' on emulator {}", taskName, emulatorNumber);
+    }
+
+    /** Starts a session with the profile context required by reusable navigation helpers. */
+    public void startSession(String taskName, AccountDescriptor profile) {
+        Objects.requireNonNull(profile, "Task Builder profile is required");
+        startSession(taskName, profile.getEmulatorNumber());
+        this.activeProfile = profile;
     }
 
     /**
@@ -108,7 +134,17 @@ public class TaskBuilderService {
         this.currentDefinition = loaded;
         this.currentDefinitionDirectory = file.toPath().toAbsolutePath().normalize().getParent();
         this.activeEmulatorNumber = emulatorNumber;
+        this.activeProfile = null;
+        this.tapService = null;
         logger.info("Task Builder definition imported: '{}' from {}", loaded.getName(), file.getAbsolutePath());
+        return loaded;
+    }
+
+    /** Loads a definition with the profile context required by reusable navigation helpers. */
+    public AutomationBlueprint loadDefinition(File file, AccountDescriptor profile) throws IOException {
+        Objects.requireNonNull(profile, "Task Builder profile is required");
+        AutomationBlueprint loaded = loadDefinition(file, profile.getEmulatorNumber());
+        setActiveProfile(profile);
         return loaded;
     }
 
@@ -302,12 +338,13 @@ public class TaskBuilderService {
 
         try {
             boolean success = performNodeAction(node);
+            node.setExecuted(success);
             if (success) {
-                node.setExecuted(true);
                 logger.info("Node executed successfully: {}", node.getSummary());
             }
             return success;
         } catch (Exception e) {
+            node.setExecuted(false);
             logger.error("Failed to execute node: {}", node.getSummary(), e);
             return false;
         }
@@ -363,8 +400,34 @@ public class TaskBuilderService {
             case BACK_BUTTON     -> executeBackButton();
             case OCR_READ        -> executeOcr(node);
             case TEMPLATE_SEARCH -> executeTemplateSearch(node);
+            case SHOP_NAVIGATION -> executeShopNavigation(node);
             case NAVIGATE        -> { logger.info("Navigate node recorded"); yield true; }
         };
+    }
+
+    private boolean executeShopNavigation(AutomationStep node) {
+        String configuredTab = node.getParam(AutomationStep.PARAM_SHOP_TAB);
+        ShopTab target;
+        try {
+            target = ShopTab.valueOf(configuredTab);
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            logger.warn("Shop Navigation node has invalid shopTab: '{}'", configuredTab);
+            return false;
+        }
+
+        if (activeProfile == null) {
+            logger.warn("Cannot navigate to {}: no Task Builder profile is selected", target.displayName());
+            return false;
+        }
+        if (!Objects.equals(activeProfile.getEmulatorNumber(), activeEmulatorNumber)) {
+            logger.warn("Cannot navigate to {}: selected profile emulator {} does not match active emulator {}",
+                    target.displayName(), activeProfile.getEmulatorNumber(), activeEmulatorNumber);
+            return false;
+        }
+
+        logger.info("Task Builder navigating profile '{}' on emulator {} to {}",
+                activeProfile.getName(), activeEmulatorNumber, target.displayName());
+        return shopNavigationAction.navigate(activeEmulatorNumber, activeProfile, target);
     }
 
     // ── Tap ────────────────────────────────────────────────────────────────
@@ -608,6 +671,20 @@ public class TaskBuilderService {
 
     public void setActiveEmulatorNumber(String emulatorNumber) {
         this.activeEmulatorNumber = emulatorNumber;
+        this.tapService = null;
+        if (activeProfile != null
+                && !Objects.equals(activeProfile.getEmulatorNumber(), emulatorNumber)) {
+            this.activeProfile = null;
+        }
+    }
+
+    /** Selects the profile used by live Task Builder actions and its emulator. */
+    public void setActiveProfile(AccountDescriptor profile) {
+        this.activeProfile = profile;
+        if (profile != null) {
+            this.activeEmulatorNumber = profile.getEmulatorNumber();
+            this.tapService = null;
+        }
     }
 
     public boolean hasActiveSession() {

--- a/modules/automation/src/main/java/dev/frostguard/engine/service/TaskCodeGenerator.java
+++ b/modules/automation/src/main/java/dev/frostguard/engine/service/TaskCodeGenerator.java
@@ -3,6 +3,7 @@ package dev.frostguard.engine.service;
 import dev.frostguard.api.configs.FlowStepKind;
 import dev.frostguard.api.domain.AutomationBlueprint;
 import dev.frostguard.api.domain.AutomationStep;
+import dev.frostguard.engine.nav.ShopTab;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -69,6 +70,7 @@ public class TaskCodeGenerator {
         out.append("import dev.frostguard.api.configs.TemplatesEnum;\n");
         out.append("import dev.frostguard.api.domain.ImageSearchResultData;\n");
         out.append("import dev.frostguard.engine.helper.TemplateSearchHelper;\n");
+        out.append("import dev.frostguard.engine.nav.ShopTab;\n");
         out.append("import dev.frostguard.engine.schedule.DelayedTask;\n");
         out.append("import dev.frostguard.engine.schedule.LaunchPoint;\n");
         out.append("import dev.frostguard.engine.service.TemplatePathResolver;\n");
@@ -178,11 +180,13 @@ public class TaskCodeGenerator {
             case BACK_BUTTON     -> writeBack(out, node);
             case OCR_READ        -> writeOcr(out, node, nodeEdges);
             case TEMPLATE_SEARCH -> writeTemplateSearch(out, node, nodeEdges);
+            case SHOP_NAVIGATION -> writeShopNavigation(out, node, nodeEdges);
             default              -> out.append(i5).append("// Unrecognised action\n");
         }
 
         if (node.getType() != FlowStepKind.OCR_READ
-                && node.getType() != FlowStepKind.TEMPLATE_SEARCH) {
+                && node.getType() != FlowStepKind.TEMPLATE_SEARCH
+                && node.getType() != FlowStepKind.SHOP_NAVIGATION) {
             int nextId = node.getNextNodeId();
             LoopDetector.BackEdge edge = pickEdge(nodeEdges, false);
             if (edge != null && nextId > 0) {
@@ -238,6 +242,35 @@ public class TaskCodeGenerator {
 
     private void writeBack(StringBuilder out, AutomationStep node) {
         out.append(indent(5)).append("pressBack();\n");
+    }
+
+    private void writeShopNavigation(StringBuilder out, AutomationStep node,
+                                     List<LoopDetector.BackEdge> nodeEdges) {
+        String configuredTab = node.getParam(AutomationStep.PARAM_SHOP_TAB);
+        ShopTab target;
+        try {
+            target = ShopTab.valueOf(configuredTab);
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            throw new IllegalArgumentException("Shop Navigation node #" + node.getId()
+                    + " has invalid shopTab: " + configuredTab, exception);
+        }
+
+        String i5 = indent(5), i6 = indent(6);
+        out.append(i5).append("if (!navigationHelper.navigateToShop(ShopTab.")
+                .append(target.name()).append(")) {\n");
+        out.append(i6).append("logWarning(\"Shop navigation failed: ")
+                .append(escapeJavaString(target.displayName())).append("\");\n");
+        out.append(i6).append("__state = -1;\n");
+        out.append(i5).append("} else {\n");
+
+        int nextId = node.getNextNodeId();
+        LoopDetector.BackEdge edge = pickEdge(nodeEdges, false);
+        if (edge != null && nextId > 0) {
+            writeLoopGuard(out, node, edge, nextId, -1, 6);
+        } else {
+            out.append(i6).append("__state = ").append(nextId > 0 ? nextId : -1).append(";\n");
+        }
+        out.append(i5).append("}\n");
     }
 
     // ── OCR branching ─────────────────────────────────────────────────

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/TaskBuilderServiceTest.java
@@ -9,6 +9,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,14 +18,72 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import dev.frostguard.api.configs.FlowStepKind;
+import dev.frostguard.api.domain.AccountDescriptor;
 import dev.frostguard.api.domain.AutomationBlueprint;
 import dev.frostguard.api.domain.AutomationStep;
 import dev.frostguard.api.runtime.WorkspacePaths;
+import dev.frostguard.engine.nav.ShopTab;
 
 class TaskBuilderServiceTest {
 
     @TempDir
     Path tempDir;
+
+    @Test
+    void executesShopNavigationWithTheSelectedProfileAndTab() {
+        String originalWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+        try {
+            AtomicReference<String> emulator = new AtomicReference<>();
+            AtomicReference<AccountDescriptor> selectedProfile = new AtomicReference<>();
+            AtomicReference<ShopTab> selectedTab = new AtomicReference<>();
+            TaskBuilderService service = new TaskBuilderService(new ObjectMapper(),
+                    (device, profile, target) -> {
+                        emulator.set(device);
+                        selectedProfile.set(profile);
+                        selectedTab.set(target);
+                        return true;
+                    });
+            AccountDescriptor profile = new AccountDescriptor(
+                    42L, "Test Profile", "3", true, 1L, 30L);
+            service.startSession("Shop probe", profile);
+            AutomationStep step = new AutomationStep(1, FlowStepKind.SHOP_NAVIGATION);
+            step.setParam(AutomationStep.PARAM_SHOP_TAB, ShopTab.CANYON_SHOP.name());
+
+            assertTrue(service.executeNode(step));
+
+            assertEquals("3", emulator.get());
+            assertEquals(profile, selectedProfile.get());
+            assertEquals(ShopTab.CANYON_SHOP, selectedTab.get());
+            assertTrue(step.isExecuted());
+        } finally {
+            restoreWorkspace(originalWorkspace);
+        }
+    }
+
+    @Test
+    void refusesShopNavigationWithoutProfileContext() {
+        String originalWorkspace = System.getProperty(WorkspacePaths.WORKSPACE_PROPERTY);
+        System.setProperty(WorkspacePaths.WORKSPACE_PROPERTY, tempDir.toString());
+        try {
+            AtomicBoolean called = new AtomicBoolean();
+            TaskBuilderService service = new TaskBuilderService(new ObjectMapper(),
+                    (device, profile, target) -> {
+                        called.set(true);
+                        return true;
+                    });
+            service.startSession("Shop probe", "0");
+            AutomationStep step = new AutomationStep(1, FlowStepKind.SHOP_NAVIGATION);
+            step.setParam(AutomationStep.PARAM_SHOP_TAB, ShopTab.VIP_SHOP.name());
+
+            assertFalse(service.executeNode(step));
+
+            assertFalse(called.get());
+            assertFalse(step.isExecuted());
+        } finally {
+            restoreWorkspace(originalWorkspace);
+        }
+    }
 
     @Test
     void savesBuilderJsonAndGeneratedJavaBesideIt() throws Exception {

--- a/modules/automation/src/test/java/dev/frostguard/engine/service/TaskCodeGeneratorTest.java
+++ b/modules/automation/src/test/java/dev/frostguard/engine/service/TaskCodeGeneratorTest.java
@@ -65,4 +65,30 @@ class TaskCodeGeneratorTest {
 
         assertTrue(source.contains("// pause before bag"));
     }
+
+    @Test
+    void generatesSharedShopNavigationWithSafeFailureHandling() {
+        AutomationBlueprint blueprint = new AutomationBlueprint("Open Gem Shop");
+        AutomationStep step = new AutomationStep(1, FlowStepKind.SHOP_NAVIGATION);
+        step.setParam(AutomationStep.PARAM_SHOP_TAB, "GEM_SHOP");
+        blueprint.addNode(step);
+
+        String source = new TaskCodeGenerator().generate(blueprint, "open_gem_shop", "Open Gem Shop");
+
+        assertTrue(source.contains("import dev.frostguard.engine.nav.ShopTab;"));
+        assertTrue(source.contains("if (!navigationHelper.navigateToShop(ShopTab.GEM_SHOP))"));
+        assertTrue(source.contains("logWarning(\"Shop navigation failed: Gem Shop\")"));
+        assertTrue(source.contains("__state = -1;"));
+    }
+
+    @Test
+    void rejectsShopNavigationWithoutAValidTab() {
+        AutomationBlueprint blueprint = new AutomationBlueprint("Invalid Shop");
+        AutomationStep step = new AutomationStep(7, FlowStepKind.SHOP_NAVIGATION);
+        step.setParam(AutomationStep.PARAM_SHOP_TAB, "NOT_A_SHOP");
+        blueprint.addNode(step);
+
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new TaskCodeGenerator().generate(blueprint, "invalid_shop", "Invalid Shop"));
+    }
 }

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/taskbuilder/TaskBuilderLayoutController.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/taskbuilder/TaskBuilderLayoutController.java
@@ -13,6 +13,7 @@ import dev.frostguard.engine.service.ProfileService;
 import dev.frostguard.engine.service.TaskBuilderService;
 import dev.frostguard.engine.service.TaskCodeGenerator;
 import dev.frostguard.engine.service.TemplatePathResolver;
+import dev.frostguard.engine.nav.ShopTab;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.event.ActionEvent;
@@ -89,6 +90,8 @@ public class TaskBuilderLayoutController {
     @FXML private VBox waitPropsBox;
     @FXML private TextField waitMsField;
     @FXML private VBox backPropsBox;
+    @FXML private VBox shopNavigationPropsBox;
+    @FXML private ComboBox<ShopTab> shopTabCombo;
     @FXML private VBox ocrPropsBox;
     @FXML private TextField ocrTlXField, ocrTlYField, ocrBrXField, ocrBrYField;
     @FXML private ComboBox<String> ocrConditionCombo;
@@ -222,6 +225,24 @@ public class TaskBuilderLayoutController {
             ocrConditionCombo.setItems(FXCollections.observableArrayList("CONTAINS", "EQUALS", "STARTS_WITH", "ENDS_WITH", "NOT_CONTAINS"));
             ocrConditionCombo.setValue("CONTAINS");
         }
+        if (shopTabCombo != null) {
+            shopTabCombo.setItems(FXCollections.observableArrayList(ShopTab.values()));
+            shopTabCombo.setConverter(new javafx.util.StringConverter<>() {
+                @Override
+                public String toString(ShopTab tab) {
+                    return tab == null ? "" : tab.displayName();
+                }
+
+                @Override
+                public ShopTab fromString(String displayName) {
+                    return Arrays.stream(ShopTab.values())
+                            .filter(tab -> tab.displayName().equals(displayName))
+                            .findFirst()
+                            .orElse(null);
+                }
+            });
+            shopTabCombo.setValue(ShopTab.MYSTERY_SHOP);
+        }
         addAutoApplyListeners();
         setStatus("Ready — add nodes from the toolbox");
     }
@@ -269,6 +290,11 @@ public class TaskBuilderLayoutController {
         if (ocrExpectedField != null) ocrExpectedField.textProperty().addListener(ocrListener);
         if (ocrConditionCombo != null) {
             ocrConditionCombo.valueProperty().addListener((obs, oldV, newV) -> { if (!isBinding) handleApplyOcrProps(null); });
+        }
+        if (shopTabCombo != null) {
+            shopTabCombo.valueProperty().addListener((obs, oldV, newV) -> {
+                if (!isBinding) handleApplyShopNavigationProps(null);
+            });
         }
 
         javafx.beans.value.ChangeListener<String> tplListener = (obs, oldV, newV) -> { if (!isBinding) handleApplyTemplateProps(null); };
@@ -425,7 +451,7 @@ public class TaskBuilderLayoutController {
         AccountDescriptor sel = profileComboBox.getValue();
         if (sel == null) { setStatus("⚠ Select a profile"); return; }
         handleClearAll(null);
-        builderService.startSession(name.trim(), sel.getEmulatorNumber());
+        builderService.startSession(name.trim(), sel);
         applyStartLocation(null); // reset start location for new session
         updateNodeCount();
         setStatus("🆕 Session: \"" + name.trim() + "\"");
@@ -538,7 +564,9 @@ public class TaskBuilderLayoutController {
         }
 
         try {
-            AutomationBlueprint imported = builderService.loadDefinition(file, emulator);
+            AutomationBlueprint imported = selected != null
+                    ? builderService.loadDefinition(file, selected)
+                    : builderService.loadDefinition(file, emulator);
             renderImportedDefinition(imported);
             setStatus("Imported builder task: " + imported.getName());
         } catch (Exception ex) {
@@ -900,6 +928,7 @@ public class TaskBuilderLayoutController {
     @FXML private void handleAddBackNode(ActionEvent e) { addNodeToCanvas(FlowStepKind.BACK_BUTTON); }
     @FXML private void handleAddOcrNode(ActionEvent e) { addNodeToCanvas(FlowStepKind.OCR_READ); }
     @FXML private void handleAddTemplateNode(ActionEvent e) { addNodeToCanvas(FlowStepKind.TEMPLATE_SEARCH); }
+    @FXML private void handleAddShopNavigationNode(ActionEvent e) { addNodeToCanvas(FlowStepKind.SHOP_NAVIGATION); }
 
     private void addNodeToCanvas(FlowStepKind type) {
         ensureSession();
@@ -910,6 +939,8 @@ public class TaskBuilderLayoutController {
             case WAIT -> node.setParam("durationMs", "1000");
             case SWIPE -> { node.setParam("startX","0"); node.setParam("startY","0");
                            node.setParam("endX","0"); node.setParam("endY","0"); }
+            case SHOP_NAVIGATION -> node.setParam(
+                    AutomationStep.PARAM_SHOP_TAB, ShopTab.MYSTERY_SHOP.name());
             default -> {}
         }
 
@@ -1554,6 +1585,10 @@ public class TaskBuilderLayoutController {
         if (swipePropsBox != null) { swipePropsBox.setVisible(false); swipePropsBox.setManaged(false); }
         waitPropsBox.setVisible(false); waitPropsBox.setManaged(false);
         backPropsBox.setVisible(false); backPropsBox.setManaged(false);
+        if (shopNavigationPropsBox != null) {
+            shopNavigationPropsBox.setVisible(false);
+            shopNavigationPropsBox.setManaged(false);
+        }
         ocrPropsBox.setVisible(false); ocrPropsBox.setManaged(false);
         if (templatePropsBox != null) { templatePropsBox.setVisible(false); templatePropsBox.setManaged(false); }
         
@@ -1584,6 +1619,20 @@ public class TaskBuilderLayoutController {
                 waitMsField.setText(node.getParam("durationMs") != null ? node.getParam("durationMs") : "1000");
             }
             case BACK_BUTTON -> { backPropsBox.setVisible(true); backPropsBox.setManaged(true); }
+            case SHOP_NAVIGATION -> {
+                if (shopNavigationPropsBox != null) {
+                    shopNavigationPropsBox.setVisible(true);
+                    shopNavigationPropsBox.setManaged(true);
+                }
+                if (shopTabCombo != null) {
+                    String configuredTab = node.getParam(AutomationStep.PARAM_SHOP_TAB);
+                    try {
+                        shopTabCombo.setValue(ShopTab.valueOf(configuredTab));
+                    } catch (IllegalArgumentException | NullPointerException exception) {
+                        shopTabCombo.setValue(null);
+                    }
+                }
+            }
             case OCR_READ -> {
                 ocrPropsBox.setVisible(true); ocrPropsBox.setManaged(true);
                 ocrTlXField.setText(node.getParam("tlX") != null ? node.getParam("tlX") : "0");
@@ -1694,6 +1743,12 @@ public class TaskBuilderLayoutController {
     @FXML private void handleApplyWaitProps(ActionEvent e) {
         if (selectedNode == null) return;
         selectedNode.setParam("durationMs", waitMsField.getText());
+        refreshCard(selectedNode);
+    }
+
+    @FXML private void handleApplyShopNavigationProps(ActionEvent e) {
+        if (selectedNode == null || shopTabCombo == null || shopTabCombo.getValue() == null) return;
+        selectedNode.setParam(AutomationStep.PARAM_SHOP_TAB, shopTabCombo.getValue().name());
         refreshCard(selectedNode);
     }
 
@@ -1953,6 +2008,8 @@ public class TaskBuilderLayoutController {
     @FXML private void handleExecuteAll(ActionEvent e) {
         AutomationBlueprint def = builderService.getCurrentDefinition();
         if (def == null || def.getNodes().isEmpty()) { setStatus("⚠ No nodes"); return; }
+        AccountDescriptor profile = profileComboBox.getValue();
+        if (profile == null) { setStatus("⚠ Select a profile"); return; }
 
         // Build id→node map for O(1) lookup
         Map<Integer, AutomationStep> nodeMap = new LinkedHashMap<>();
@@ -1962,7 +2019,7 @@ public class TaskBuilderLayoutController {
         int firstId = def.getNodes().get(0).getId();
 
         setStatus("▶ Executing DAG...");
-        AccountDescriptor profile = profileComboBox.getValue();
+        builderService.setActiveProfile(profile);
         Thread t = new Thread(() -> {
             try {
                 String startLocStr = def.getStartLocation();
@@ -1984,6 +2041,7 @@ public class TaskBuilderLayoutController {
             }
 
             int currentId = firstId;
+            int failedNodeId = -1;
             while (currentId > 0) {
                 AutomationStep current = nodeMap.get(currentId);
                 if (current == null) break;
@@ -1997,6 +2055,7 @@ public class TaskBuilderLayoutController {
                 });
 
                 if (!ok) {
+                    failedNodeId = nodeRef.getId();
                     Platform.runLater(() -> setStatus("❌ Failed at node #" + nodeRef.getId()));
                     break;
                 }
@@ -2006,14 +2065,20 @@ public class TaskBuilderLayoutController {
 
                 try { Thread.sleep(400); } catch (InterruptedException ignored) { return; }
             }
+            final int failure = failedNodeId;
             capturePreview();
-            Platform.runLater(() -> setStatus("✅ DAG execution complete"));
+            Platform.runLater(() -> setStatus(failure < 0
+                    ? "✅ DAG execution complete"
+                    : "❌ Failed at node #" + failure));
         });
         t.setDaemon(true); t.start();
     }
 
 
     private void execNode(AutomationStep node) {
+        AccountDescriptor profile = profileComboBox.getValue();
+        if (profile == null) { setStatus("⚠ Select a profile"); return; }
+        builderService.setActiveProfile(profile);
         setStatus("▶ " + node.getSummary() + "...");
         Thread t = new Thread(() -> {
             boolean ok = builderService.executeNode(node);
@@ -2100,10 +2165,13 @@ public class TaskBuilderLayoutController {
     private void ensureSession() {
         if (!builderService.hasActiveSession()) {
             AccountDescriptor sel = profileComboBox.getValue();
-            String emu = sel != null ? sel.getEmulatorNumber() : "0";
             String name = taskNameField.getText();
             if (name == null || name.trim().isEmpty()) name = "Untitled Task";
-            builderService.startSession(name.trim(), emu);
+            if (sel != null) {
+                builderService.startSession(name.trim(), sel);
+            } else {
+                builderService.startSession(name.trim(), "0");
+            }
         }
     }
 

--- a/modules/desktop/src/main/java/dev/frostguard/app/panel/taskbuilder/TaskBuilderNodeCardFactory.java
+++ b/modules/desktop/src/main/java/dev/frostguard/app/panel/taskbuilder/TaskBuilderNodeCardFactory.java
@@ -37,6 +37,7 @@ public class TaskBuilderNodeCardFactory {
             case BACK_BUTTON     -> "🔙";
             case OCR_READ        -> "📝";
             case TEMPLATE_SEARCH -> "🔍";
+            case SHOP_NAVIGATION -> "🛒";
             case NAVIGATE        -> "🏠";
         };
     }
@@ -49,6 +50,7 @@ public class TaskBuilderNodeCardFactory {
             case BACK_BUTTON     -> "flow-node-header-back";
             case OCR_READ        -> "flow-node-header-ocr";
             case TEMPLATE_SEARCH -> "flow-node-header-template";
+            case SHOP_NAVIGATION -> "flow-node-header-shop";
             case NAVIGATE        -> "flow-node-header-tap";
         };
     }
@@ -61,6 +63,7 @@ public class TaskBuilderNodeCardFactory {
             case BACK_BUTTON     -> "#ff8c42";
             case OCR_READ        -> "#59ba59";
             case TEMPLATE_SEARCH -> "#ef4444";
+            case SHOP_NAVIGATION -> "#fcd176";
             case NAVIGATE        -> "#7c3aed";
         };
     }

--- a/modules/desktop/src/main/resources/layout/TaskBuilderLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/TaskBuilderLayout.fxml
@@ -88,13 +88,16 @@
                 <Button text="🔍" onAction="#handleAddTemplateNode" styleClass="tb-icon-btn"
                         maxWidth="Infinity" GridPane.rowIndex="5">
                     <tooltip><Tooltip text="Find Image"/></tooltip></Button>
+                <Button text="🛒" onAction="#handleAddShopNavigationNode" styleClass="tb-icon-btn"
+                        maxWidth="Infinity" GridPane.rowIndex="6">
+                    <tooltip><Tooltip text="Open Shop Tab"/></tooltip></Button>
 
                 <!-- Spacer row -->
-                <Region GridPane.rowIndex="6" GridPane.vgrow="ALWAYS"/>
+                <Region GridPane.rowIndex="7" GridPane.vgrow="ALWAYS"/>
 
                 <!-- Bottom action buttons -->
                 <Button onAction="#handleExecuteAll" styleClass="tb-icon-btn-green"
-                        maxWidth="Infinity" GridPane.rowIndex="7">
+                        maxWidth="Infinity" GridPane.rowIndex="8">
                     <graphic>
                         <javafx.scene.shape.SVGPath content="M 8 5 L 19 12 L 8 19 Z"
                                                      scaleX="0.8" scaleY="0.8" />
@@ -102,7 +105,7 @@
                     <tooltip><Tooltip text="Execute All"/></tooltip>
                 </Button>
                 <Button onAction="#handleClearAll" styleClass="tb-icon-btn-red"
-                        maxWidth="Infinity" GridPane.rowIndex="8">
+                        maxWidth="Infinity" GridPane.rowIndex="9">
                     <graphic>
                         <javafx.scene.shape.SVGPath content="M 6 19 C 6 20.1 6.9 21 8 21 L 16 21 C 17.1 21 18 20.1 18 19 L 18 7 L 6 7 L 6 19 Z M 19 4 L 15.5 4 L 14.5 3 L 9.5 3 L 8.5 4 L 5 4 L 5 6 L 19 6 L 19 4 Z"
                                                      scaleX="0.55" scaleY="0.55"/>
@@ -198,6 +201,16 @@
                     <!-- BACK properties -->
                     <VBox fx:id="backPropsBox" spacing="10" visible="false" managed="false">
                         <FlowPane hgap="14" vgap="10" alignment="CENTER_LEFT">
+                        </FlowPane>
+                    </VBox>
+
+                    <!-- SHOP NAVIGATION properties -->
+                    <VBox fx:id="shopNavigationPropsBox" spacing="10" visible="false" managed="false">
+                        <FlowPane hgap="14" vgap="10" alignment="CENTER_LEFT">
+                            <Label text="Shop tab:" styleClass="tb-props-label"/>
+                            <ComboBox fx:id="shopTabCombo" prefWidth="260" styleClass="tb-combo"/>
+                            <Label text="Opens Shop and selects this tab through the shared navigation helper."
+                                   styleClass="tb-props-hint"/>
                         </FlowPane>
                     </VBox>
 

--- a/modules/desktop/src/main/resources/layout/taskbuilder.css
+++ b/modules/desktop/src/main/resources/layout/taskbuilder.css
@@ -501,6 +501,7 @@
 .flow-node-header-back     { -fx-background-color: #d97706; }
 .flow-node-header-ocr      { -fx-background-color: #059669; }
 .flow-node-header-template { -fx-background-color: #dc2626; }
+.flow-node-header-shop     { -fx-background-color: #a16207; }
 
 .flow-node-type-label { -fx-text-fill: #fff; -fx-font-weight: 700; -fx-font-size: 12px; }
 .flow-node-id-label   { -fx-text-fill: rgba(255,255,255,0.5); -fx-font-weight: 500; -fx-font-size: 10px; }

--- a/modules/desktop/src/test/java/dev/frostguard/app/arch/FxmlControllerBindingTest.java
+++ b/modules/desktop/src/test/java/dev/frostguard/app/arch/FxmlControllerBindingTest.java
@@ -153,6 +153,16 @@ class FxmlControllerBindingTest {
                 "TaskBuilderLayout.fxml must declare nodeNameField so node names can be edited");
     }
 
+    @Test
+    void taskBuilderDocumentDeclaresShopNavigationNodeControls() throws IOException {
+        String document = Files.readString(layoutDirectory.resolve("TaskBuilderLayout.fxml"));
+        Set<String> declaredIds = matches(FX_ID, document);
+
+        assertTrue(declaredIds.contains("shopNavigationPropsBox"));
+        assertTrue(declaredIds.contains("shopTabCombo"));
+        assertTrue(document.contains("onAction=\"#handleAddShopNavigationNode\""));
+    }
+
     /**
      * The opposite mismatch is louder — an unresolved handler makes
      * {@code FXMLLoader.load} throw — but it still escapes compilation, so it is


### PR DESCRIPTION
## Summary

- Add a dedicated Shop Navigation node and shop icon to the Task Builder palette.
- Let the node select any ordered `ShopTab`, show the selection in its summary, and preserve it through blueprint serialization.
- Execute the node live with the selected profile through `NavigationHelper.navigateToShop(...)` and stop safely when navigation fails.
- Generate equivalent custom-task Java using the same shared helper and enum value.

## Why

The reusable navigation from #321 needs a direct emulator-facing test surface. This node allows any shop tab to be calibrated and exercised without adding temporary task-specific routines or duplicating navigation logic.

## Stack

- Native stack: #323
- Position: 2 of 2
- Parent: #321
- Child: none
- Shared planning issue: #320 (depends on #319 / #321)
- Merge order: merge #321 first, then this PR.

Closes #320

## Validation

- GitHub `CI — Java Build and Tests` attempt 2: passed the complete Linux Maven reactor on commit `b384f86`.
- Current rebased tip: `./mvnw -pl modules/desktop -am -Dtest=AutomationBlueprintSerializationTest,AutomationStepTest,TaskBuilderServiceTest,TaskCodeGeneratorTest,FxmlControllerBindingTest -Dsurefire.failIfNoSpecifiedTests=false test`: passed (34 focused tests; zero failures/errors).
- Earlier full affected-reactor run: `./mvnw -pl modules/desktop -am test`: passed (620 tests; two expected Windows-specific update-test skips). This was run before the latest parent-only navigation/Mystery Shop updates; the child implementation itself is unchanged.
- GitHub `CI — Windows Installers`: currently fails during `actions/setup-java`, before project build/test execution, because the workflow requests Temurin `21.0.12+8.0` while the runner now lists `21.0.12+8.0.LTS`.
- Live emulator: the user confirmed the dedicated node and button work and used the node to calibrate multiple shop tabs. It works most of the time; an intermittent first swipe that does not place VIP at the far-left position remains accepted for now.
- Not yet verified: saved account-log evidence for representative beginning, middle, and end tabs.

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

- This PR intentionally depends on #321 and inherits its English 720x1280 OCR/geometry assumptions and remaining live-validation risk.
- Live execution requires a selected Task Builder profile; absence is reported and fails safely.
