### PR TITLE
fix(ci): restore native Windows JDK setup

### DIFF
--- a/.github/workflows/signed-windows-channel-release.yml
+++ b/.github/workflows/signed-windows-channel-release.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "21.0.12+8.0"
+          java-version: "21.0.12+8.0.LTS"
           cache: maven
 
       - name: Install WiX Toolset 3

--- a/.github/workflows/windows-native-package.yml
+++ b/.github/workflows/windows-native-package.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "21.0.12+8.0"
+          java-version: "21.0.12+8.0.LTS"
           cache: maven
 
       # JDK 21 jpackage invokes the WiX 3 candle/light toolchain for an MSI.

--- a/build-support/verification/test_channel_packaging.py
+++ b/build-support/verification/test_channel_packaging.py
@@ -48,7 +48,7 @@ class ChannelPackagingTest(unittest.TestCase):
 
         self.assertIn("name: CI — Windows Installers", installers)
         self.assertIn("Build and smoke-test required Windows installers", installers)
-        self.assertIn('java-version: "21.0.12+8.0"', installers)
+        self.assertIn('java-version: "21.0.12+8.0.LTS"', installers)
         self.assertIn("windows_pr_channels.py", installers)
         self.assertIn("fetch-depth: 0", installers)
         self.assertGreaterEqual(
@@ -218,7 +218,7 @@ class ChannelPackagingTest(unittest.TestCase):
         self.assertIn("--changes-unchanged", workflow)
         self.assertIn("fetch-depth: 0", workflow)
         self.assertIn("Remove an abandoned draft release", workflow)
-        self.assertIn('java-version: "21.0.12+8.0"', workflow)
+        self.assertIn('java-version: "21.0.12+8.0.LTS"', workflow)
         for launcher_hash in (
             "5c728d3662d64c428d003874f6d62b798bbbe329f595b2b15a2ab5ab1fd1faa9",
             "9c7452d890f39c7f4fdb2e5519993514c84f071deef222fe49784acfd459c209",


### PR DESCRIPTION
## Summary

- use Temurin `21.0.12+8.0.LTS` in both native Windows workflows
- keep the exact JDK build pin required for reproducible, hash-checked launchers
- update the workflow packaging contract assertions

## Why

Temurin now exposes the pinned JDK build as `21.0.12+8.0.LTS`. The previous `21.0.12+8.0` selector no longer resolves, so PR #321, PR #322, and the September 4–6 scheduled Nightly runs all fail in `Set up JDK 21` before Maven starts.

The `actions/setup-java@v4` deprecation remains separate: it is logged as a warning, while the terminating error is the unsatisfied Java version. This PR does not broaden scope to an action upgrade.

Closes #324

## Validation

- `python3 build-support/verification/test_channel_packaging.py` — 7 tests passed
- `python3 build-support/verification/check_workflow_python.py` — all 3 inline snippets compile
- `python3 -m unittest discover -s build-support/verification -p 'test_*.py' -v` — 47 tests passed
- `git diff --check` — passed
- Required Windows installer CI — passed in 7m31s; JDK setup, Stable/Nightly images, launcher verification, launch smoke tests, MSI builds, installer-boundary checks, and artifact uploads all passed
- Linux CI — passed in 1m38s
- DCO — passed

Behavioral evidence level: automated tests and hosted Windows CI confirmation. No live account-log or saved-frame evidence applies to this CI-only change.

## Contributor certification

- [x] Every commit includes a valid DCO `Signed-off-by` trailer.

## Risks

The scheduled authenticated release workflow is not run from pull requests, so its identical selector is covered by the shared workflow contract and by the successful PR Windows resolver path. No release was published from this branch.