### PR TITLE
feat(pets): say which tile each pet-skill box drives, and that ticking it spends the skill

### DIFF
--- a/modules/desktop/src/main/resources/layout/PetsLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/PetsLayout.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
-<!-- Pet management — BorderPane with FlowPane-based skill toggles -->
+<!-- One line per control: what it is, then what it does. -->
 <BorderPane maxHeight="Infinity" maxWidth="Infinity"
             HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS"
             xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1">
@@ -13,53 +13,49 @@
                     styleClass="task-page-scroll">
             <VBox spacing="14" styleClass="task-page-root" maxWidth="Infinity">
 
-                <!-- Pet Activation -->
-                <VBox styleClass="content-card">
-                    <HBox alignment="CENTER_LEFT" maxWidth="Infinity" styleClass="header-orange">
-                        <Label text="Pet Automation" />
+                <VBox maxWidth="Infinity" styleClass="content-card">
+                    <HBox alignment="CENTER_LEFT" maxWidth="Infinity" styleClass="header-yellow">
+                        <Label style="-fx-font-weight: bold; -fx-text-fill: -fg-bg-app; -fx-font-size: 13px;"
+                               text="Pet Skills" />
                     </HBox>
-                    <VBox spacing="10" styleClass="task-section-inner">
-                        <Label styleClass="task-card-description"
-                               text="Configure automatic pet skill activation and management"
-                               wrapText="true" />
+                    <VBox spacing="9" styleClass="task-section-inner">
+                        <Label styleClass="task-card-description" wrapText="true"
+                               text="Ticked skills are used every time they come off cooldown. Each box drives one tile of the in-game Pet Skill panel; which skill sits there depends on the pets you own." />
+
                         <Separator style="-fx-opacity: 0.25;" />
+
+                        <CheckBox fx:id="checkboxFoodSkill" mnemonicParsing="false"
+                                  text="Tile 1 - the skill in the first slot (key: Food)" />
+                        <CheckBox fx:id="checkboxStaminaSkill" mnemonicParsing="false"
+                                  text="Tile 2 - the skill in the second slot (key: Stamina)" />
+                        <CheckBox fx:id="checkboxGatheringSkill" mnemonicParsing="false"
+                                  text="Tile 3 - the skill in the third slot (key: Gathering)" />
+
+                        <HBox alignment="CENTER_LEFT" spacing="10" style="-fx-padding: 0 0 0 22;">
+                            <Label styleClass="task-field-label" text="Gathers" minWidth="55" />
+                            <ComboBox fx:id="comboBoxGatheringResource" prefWidth="110.0" />
+                        </HBox>
+
+                        <CheckBox fx:id="checkboxTreasureSkill" mnemonicParsing="false"
+                                  text="Tile 4 - the skill in the fourth slot (key: Treasure)" />
+
+                        <Separator style="-fx-opacity: 0.25;" />
+
                         <CheckBox fx:id="checkBoxPetSkills" mnemonicParsing="false"
-                                  text="Enable Pet Management" />
-                        <CheckBox fx:id="checkBoxPetAllianceTreasure" mnemonicParsing="false"
-                                  text="Alliance Treasure" />
-                        <CheckBox fx:id="checkBoxPetPersonalTreasure" mnemonicParsing="false"
-                                  text="Personal Treasure" />
+                                  text="Enable pet skills - required for the Tile 3 gathering skill" />
                     </VBox>
                 </VBox>
 
-                <!-- Pet Skill Selection — FlowPane instead of GridPane -->
-                <VBox styleClass="content-card">
-                    <HBox alignment="CENTER_LEFT" maxWidth="Infinity" styleClass="header-blue">
-                        <Label text="Skill Configuration" />
+                <VBox maxWidth="Infinity" styleClass="content-card">
+                    <HBox alignment="CENTER_LEFT" maxWidth="Infinity" styleClass="header-yellow">
+                        <Label style="-fx-font-weight: bold; -fx-text-fill: -fg-bg-app; -fx-font-size: 13px;"
+                               text="Treasures" />
                     </HBox>
-                    <VBox spacing="10" styleClass="task-section-inner">
-                        <Label styleClass="task-card-description"
-                               text="Ticking a box makes the bot USE that skill every time it comes off cooldown. Each box drives one tile of the Pet Skill panel, counted left to right then down - which skill sits in a tile depends on the pets you own, so check the panel in game before enabling one. The Food, Stamina and Treasure names below are historical config keys, not the skills themselves."
-                               wrapText="true" />
-                        <Separator style="-fx-opacity: 0.25;" />
-
-                        <VBox spacing="9">
-                            <CheckBox fx:id="checkboxFoodSkill" mnemonicParsing="false" wrapText="true"
-                                      text="Tile 1 - use whichever skill sits in the first tile (key: Food)" />
-                            <CheckBox fx:id="checkboxStaminaSkill" mnemonicParsing="false" wrapText="true"
-                                      text="Tile 2 - use whichever skill sits in the second tile (key: Stamina)" />
-                            <CheckBox fx:id="checkboxGatheringSkill" mnemonicParsing="false" wrapText="true"
-                                      text="Tile 3 - use whichever skill sits in the third tile (key: Gathering)" />
-                            <CheckBox fx:id="checkboxTreasureSkill" mnemonicParsing="false" wrapText="true"
-                                      text="Tile 4 - use whichever skill sits in the fourth tile (key: Treasure)" />
-                        </VBox>
-                        
-                        <Separator style="-fx-opacity: 0.25;" />
-                        
-                        <HBox alignment="CENTER_LEFT" spacing="14">
-                            <Label styleClass="task-field-label" text="Gathering Resource" minWidth="140" />
-                            <ComboBox fx:id="comboBoxGatheringResource" prefWidth="120.0" />
-                        </HBox>
+                    <VBox spacing="9" styleClass="task-section-inner">
+                        <CheckBox fx:id="checkBoxPetAllianceTreasure" mnemonicParsing="false"
+                                  text="Alliance treasures - claims what your alliance shares (daily)" />
+                        <CheckBox fx:id="checkBoxPetPersonalTreasure" mnemonicParsing="false"
+                                  text="Pet adventures - runs adventure chests, 10 stamina each, 4 a day" />
                     </VBox>
                 </VBox>
 

--- a/modules/desktop/src/main/resources/layout/PetsLayout.fxml
+++ b/modules/desktop/src/main/resources/layout/PetsLayout.fxml
@@ -39,20 +39,20 @@
                     </HBox>
                     <VBox spacing="10" styleClass="task-section-inner">
                         <Label styleClass="task-card-description"
-                               text="Select which pet skills to activate automatically"
+                               text="Ticking a box makes the bot USE that skill every time it comes off cooldown. Each box drives one tile of the Pet Skill panel, counted left to right then down - which skill sits in a tile depends on the pets you own, so check the panel in game before enabling one. The Food, Stamina and Treasure names below are historical config keys, not the skills themselves."
                                wrapText="true" />
                         <Separator style="-fx-opacity: 0.25;" />
 
-                        <FlowPane hgap="18" vgap="10" alignment="CENTER_LEFT">
-                            <CheckBox fx:id="checkboxFoodSkill" mnemonicParsing="false"
-                                      text="Food Skill" />
-                            <CheckBox fx:id="checkboxGatheringSkill" mnemonicParsing="false"
-                                      text="Gathering Skill" />
-                            <CheckBox fx:id="checkboxStaminaSkill" mnemonicParsing="false"
-                                      text="Stamina Skill" />
-                            <CheckBox fx:id="checkboxTreasureSkill" mnemonicParsing="false"
-                                      text="Treasure Skill" />
-                        </FlowPane>
+                        <VBox spacing="9">
+                            <CheckBox fx:id="checkboxFoodSkill" mnemonicParsing="false" wrapText="true"
+                                      text="Tile 1 - use whichever skill sits in the first tile (key: Food)" />
+                            <CheckBox fx:id="checkboxStaminaSkill" mnemonicParsing="false" wrapText="true"
+                                      text="Tile 2 - use whichever skill sits in the second tile (key: Stamina)" />
+                            <CheckBox fx:id="checkboxGatheringSkill" mnemonicParsing="false" wrapText="true"
+                                      text="Tile 3 - use whichever skill sits in the third tile (key: Gathering)" />
+                            <CheckBox fx:id="checkboxTreasureSkill" mnemonicParsing="false" wrapText="true"
+                                      text="Tile 4 - use whichever skill sits in the fourth tile (key: Treasure)" />
+                        </VBox>
                         
                         <Separator style="-fx-opacity: 0.25;" />
                         


### PR DESCRIPTION
The Pet Skill checkboxes do not say what they control, and do not say that ticking one spends the skill. Both caught me out on my own account, and the natural reading of the panel is the wrong one.

### What Frostguard does currently

`PetsLayout.fxml` offers four boxes: **Food Skill**, **Gathering Skill**, **Stamina Skill**, **Treasure Skill**, under the description *"Select which pet skills to activate automatically"*.

Those are the names of the config keys (`PET_SKILL_FOOD_BOOL` and so on), not the names of any skill. Each one drives a fixed **tile position** in the Pet Skill dialog — `PetSkillsRoutine.PetSkill` carries the tap coordinates — and which skill sits in a tile depends entirely on which pets the account owns.

On my roster, tile 1 holds **Builder's Aide**, a +15% construction-speed buff for five minutes. So the box labelled "Food Skill" spends a construction buff. Tile 4 holds a combat debuff, not treasure. Nothing on the panel gives the operator any way to work that out.

The second problem is the description. *"Select which pet skills to activate automatically"* reads like a filter over skills the bot was going to handle anyway. It does not say that ticking a box makes the bot **use** the skill, consuming a 23-hour cooldown at whatever hour the task happens to run. Enabling one to see what it does is a destructive action presented as a preference.

### What this changes

Label each box by the tile it drives, keep the historical key name in brackets so existing settings stay recognisable:

```
Tile 1 - use whichever skill sits in the first tile (key: Food)
Tile 2 - use whichever skill sits in the second tile (key: Stamina)
Tile 3 - use whichever skill sits in the third tile (key: Gathering)
Tile 4 - use whichever skill sits in the fourth tile (key: Treasure)
```

And replace the description with one that states the consequence:

> Ticking a box makes the bot USE that skill every time it comes off cooldown. Each box drives one tile of the Pet Skill panel, counted left to right then down — which skill sits in a tile depends on the pets you own, so check the panel in game before enabling one. The Food, Stamina and Treasure names below are historical config keys, not the skills themselves.

No config keys are renamed, so stored settings are untouched.

### Why this is better

The current labels are actively misleading rather than merely vague — "Food Skill" names a thing that does not exist, and a reasonable operator will believe it. Tile numbering is the only description that is true for every roster. Naming the actual skills would be better still, but not by hardcoding them: they differ per account, so any fixed list mislabels everybody whose pets differ. Reading the name off the panel is the real fix — the description text in that dialog is OCR-legible, and `PetSkillsRoutine` already opens it — but that is a feature rather than a label change, so it is not in this PR.

The consequence line matters independently of the labels. Every other checkbox on that screen is a preference; these four spend a resource.

### Evidence level

The tile-to-key mapping was confirmed on a live 720x1280 panel by selecting each tile in turn and reading the skill name the game printed in the description pane — not inferred from the constants. The example skills quoted above are from one roster and are given as illustration only, which is exactly why the shipped labels do not name them.

This is a wording change with no behavioural component, so there is no test for it. `modules/desktop` builds and its 100 tests pass; the panel loads clean.
